### PR TITLE
refactor(tool): make the agent loop's tool gate a required collaborator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,24 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- The agent loop's tool gate is no longer something a wiring can omit. The
+  composite tool-call policy is a required constructor argument on
+  `ToolLoopService`, the per-configuration allow-list resolver is gone, and the
+  input schema validator is defaulted rather than optional. An absent policy
+  used to fall through to a narrower legacy chain with no trust-zone axis — a
+  weaker gate that nothing made visible. That chain is deleted, and with it the
+  resolver, which only ever ran inside it and whose check the policy performs
+  itself. The availability service also leaves the constructor: nothing in the
+  loop read it once the chain was gone.
+
+  No `Null` gate implementation was written — an allow-all one would have been
+  weaker than the `null` it replaced, which is the failure mode the change
+  exists to remove. Tests construct the real policy instead. Doing so revealed
+  that fixtures passing a provider-less configuration were relying on a gate
+  that was never wired: such a configuration fails closed to the external trust
+  zone, so a real run withholds tools above the editor-content class. See
+  ADR-120.
+
 - The model backend controller no longer carries the provider round trips.
   Probing a model and discovering what a provider offers moved into
   `ModelTestController` and `ModelDiscoveryController`; `ModelController` keeps

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -85,7 +85,11 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
     public function __construct(
         private LlmServiceManagerInterface $mgr,
         private ToolRegistry $registry,
-        private ToolAvailabilityServiceInterface $availability,
+        // The composite gate (ADR-094): the single authority on which tools a
+        // run may be offered. Required — an absent gate used to fall through to
+        // a narrower legacy chain with no trust-zone axis, which is a weaker
+        // gate that nothing made visible (ADR-120).
+        private ToolCallPolicyInterface $toolPolicy,
         private ?LoggerInterface $logger = null,
         private int $defaultMaxIterations = 5,
         // Optional collaborators (autowired in production), mirroring the
@@ -94,27 +98,20 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         // the existing lean test wiring keep working unchanged.
         private ?SkillInjectionService $skillInjection = null,
         private ?PromptSnippetComposer $snippetComposer = null,
-        // The per-configuration skill and tool-group gate. Optional so the lean
-        // test wiring keeps working; absent it the run is gated by the global
-        // enablement and admin filters alone, exactly as before.
-        private ?AllowedToolsResolver $allowedTools = null,
-        // The composite gate (ADR-094). When wired it is the single authority;
-        // absent it the loop falls back to the gates it applied before, which
-        // is what the lean unit-test wiring exercises.
-        private ?ToolCallPolicyInterface $toolPolicy = null,
         // Validates a user's typed input against a tool's declared schema
-        // (ADR-105). Optional for the lean test wiring; production always wires
-        // it. Absent it, resumeWithInput() skips its defence-in-depth
-        // re-validation (the runtime already validated before the claim).
-        private ?JsonSchemaValidator $schemaValidator = null,
+        // (ADR-105). Defaulted rather than optional: the validator is stateless
+        // and has no constructor, so there is no wiring under which the
+        // defence-in-depth re-validation can be absent.
+        private JsonSchemaValidator $schemaValidator = new JsonSchemaValidator(),
         // Bounds the growing transcript against the model's context window
         // (ADR-107). Optional so the lean test wiring is unchanged; absent it the
         // loop sends the full transcript exactly as before, and every
         // enforcement site below is a no-op.
         private ?ContextWindowManagerInterface $contextWindow = null,
         // Records tool-gate denials so "tool denials by reason / by tool" become
-        // queryable. Nullable, matching the optional $toolPolicy above: absent it
-        // (the lean test wiring) the gate still logs, it just does not persist.
+        // queryable. Optional because it is an observability sink, not a gate:
+        // absent it the denial is still decided and still logged, it just does
+        // not become a queryable row.
         private ?GovernanceEventRepositoryInterface $governanceEvents = null,
     ) {}
 
@@ -568,7 +565,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         ?int $beUserUid = null,
     ): ToolLoopResult {
         // Defence in depth: do not trust the caller's "already validated" claim.
-        if ($this->schemaValidator !== null && !$this->schemaValidator->validate($inputData, $state->inputSchema)) {
+        if (!$this->schemaValidator->validate($inputData, $state->inputSchema)) {
             throw new LogicException('resumeWithInput received input that does not match the declared schema.', 1784600106);
         }
 
@@ -714,11 +711,11 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
      * @return ToolResult
      */
     /**
-     * Resolve the tool names offered for a run: the caller's per-run allow-list
-     * intersected with the globally-enabled set, then admin-only tools filtered
-     * out unless the acting backend user is an admin. Both gates are fail-closed.
-     * Reused by {@see self::resume()} so a resume re-applies the gate at approval
-     * time — a tool disabled or restricted while suspended is not executed.
+     * Resolve the tool names offered for a run by asking the composite gate
+     * (ADR-094): global enablement, the admin filter, the configuration's own
+     * group grant and the trust-zone ceiling, all fail-closed. Reused by
+     * {@see self::resume()} so a resume re-applies the gate at approval time — a
+     * tool disabled or restricted while suspended is not executed.
      *
      * @param list<string>|null $allowedToolNames null ⇒ the globally-enabled set;
      *                                            a list ⇒ that set ∩ enabled;
@@ -728,83 +725,45 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
      */
     private function resolveOfferedNames(?array $allowedToolNames, LlmConfiguration $configuration, ToolExecutionContext $context): array
     {
-        if ($this->toolPolicy !== null) {
-            $user = $context->actingBackendUser();
+        $user = $context->actingBackendUser();
 
-            foreach ($this->toolPolicy->explain($allowedToolNames, $configuration, $user) as $decision) {
-                if (!$decision->allowed || $decision->observedOnly) {
-                    $this->logger?->info('Tool gate: ' . $decision->message(), [
-                        'tool'   => $decision->toolName,
-                        'reason' => $decision->reason->value,
-                        'zone'   => $decision->zone->value,
-                    ]);
-                    // Persist the denial (or observe-mode flag) so it is queryable
-                    // by tool name and reason (the log line is not). This gate is
-                    // the one place tool_name is structurally available. The run's
-                    // correlation id / uid are not in scope at this seam, so a
-                    // tool-denied row carries neither — its value is the by-tool /
-                    // by-reason breakdown, not a per-run join. observed-mode rows
-                    // are recorded too (flagged in detail) so the trust-zone
-                    // rollout is measurable before it is enforced.
-                    $this->governanceEvents?->record(new GovernanceEvent(
-                        correlationId: '',
-                        decision: GovernanceDecision::TOOL_DENIED->value,
-                        reason: $decision->reason->value,
-                        provider: $configuration->getProviderType(),
-                        model: $configuration->getModelId(),
-                        configurationIdentifier: $configuration->getIdentifier(),
-                        beUser: $context->actor->backendUserUid,
-                        toolName: $decision->toolName,
-                        agentrunUid: 0,
-                        guardrail: '',
-                        detail: sprintf(
-                            'zone=%s;ceiling=%s;observedOnly=%d',
-                            $decision->zone->value,
-                            $decision->ceiling->value,
-                            $decision->observedOnly ? 1 : 0,
-                        ),
-                    ));
-                }
+        foreach ($this->toolPolicy->explain($allowedToolNames, $configuration, $user) as $decision) {
+            if (!$decision->allowed || $decision->observedOnly) {
+                $this->logger?->info('Tool gate: ' . $decision->message(), [
+                    'tool'   => $decision->toolName,
+                    'reason' => $decision->reason->value,
+                    'zone'   => $decision->zone->value,
+                ]);
+                // Persist the denial (or observe-mode flag) so it is queryable
+                // by tool name and reason (the log line is not). This gate is
+                // the one place tool_name is structurally available. The run's
+                // correlation id / uid are not in scope at this seam, so a
+                // tool-denied row carries neither — its value is the by-tool /
+                // by-reason breakdown, not a per-run join. observed-mode rows
+                // are recorded too (flagged in detail) so the trust-zone
+                // rollout is measurable before it is enforced.
+                $this->governanceEvents?->record(new GovernanceEvent(
+                    correlationId: '',
+                    decision: GovernanceDecision::TOOL_DENIED->value,
+                    reason: $decision->reason->value,
+                    provider: $configuration->getProviderType(),
+                    model: $configuration->getModelId(),
+                    configurationIdentifier: $configuration->getIdentifier(),
+                    beUser: $context->actor->backendUserUid,
+                    toolName: $decision->toolName,
+                    agentrunUid: 0,
+                    guardrail: '',
+                    detail: sprintf(
+                        'zone=%s;ceiling=%s;observedOnly=%d',
+                        $decision->zone->value,
+                        $decision->ceiling->value,
+                        $decision->observedOnly ? 1 : 0,
+                    ),
+                ));
             }
-
-            return $this->toolPolicy->filterOfferable($allowedToolNames, $configuration, $user);
         }
 
-        // Fail-closed global gate: the effective allow-set is always intersected
-        // with the globally-enabled tools. A null caller list means "no per-run
-        // restriction" and collapses to the enabled set (NOT every registered
-        // tool); a disabled tool can therefore never be offered, even when a
-        // caller — or a model steered by injected skill prose — names it.
-        $enabled   = $this->availability->enabledNames();
-        $effective = $allowedToolNames === null
-            ? $enabled
-            : array_values(array_intersect($allowedToolNames, $enabled));
-
-        // Fail-closed RBAC gate: admin-only tools (logs, environment, phpinfo,
-        // backend user/group listings) are never offered unless the ACTING
-        // backend user is an admin — enforced here in the runtime, not just the
-        // (admin-only) playground, so the public service cannot be invoked on a
-        // non-admin's behalf to reach them. An unknown tool name is treated as
-        // admin-only (fail-closed).
-        if (!$context->isAdmin()) {
-            $effective = array_values(array_filter(
-                $effective,
-                fn(string $name): bool => $this->registry->get($name)?->requiresAdmin() === false,
-            ));
-        }
-
-        // Fail-closed per-configuration gate: the skills' declared allow-list
-        // intersected with the configuration's allowed_tool_groups. This lived
-        // in the tool playground until ADR-093, which meant every other consumer
-        // of the now-public ToolLoopServiceInterface — a scheduler task, a
-        // downstream extension — bypassed the configuration's own restriction
-        // entirely. The caller's list is a request; this is the grant.
-        $configurationAllowed = $this->allowedTools?->resolve($configuration);
-        if ($configurationAllowed !== null) {
-            $effective = array_values(array_intersect($effective, $configurationAllowed));
-        }
-
-        return $effective;
+        return $this->toolPolicy->filterOfferable($allowedToolNames, $configuration, $user);
     }
 
     /**

--- a/Documentation/Adr/Adr120RequiredToolGate.rst
+++ b/Documentation/Adr/Adr120RequiredToolGate.rst
@@ -1,0 +1,116 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-120:
+
+============================================================================
+ADR-120: The agent loop's tool gate is a required collaborator
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-29
+:Authors: Netresearch DTT GmbH
+
+.. _adr-120-context:
+
+Context
+=======
+
+:php:`ToolLoopService` took three security collaborators as optional
+constructor arguments: the composite tool-call policy (:ref:`adr-094`), the
+per-configuration allow-list resolver, and the input schema validator
+(:ref:`adr-105`). Each defaulted to ``null``, and each ``null`` changed what the
+loop enforced without changing anything a test or a linter could see.
+
+The roadmap named the fix as "make them required, and give tests an explicit
+lean wiring (``Null*`` implementations plus a ``Testing`` builder) instead of
+implicit absence". Working it through, two of the three premises turned out to
+be wrong, both in the unsafe direction. They are recorded here because the
+change deliberately does something other than what the roadmap said.
+
+**The allow-list resolver was already dead code in production.**
+:php:`resolveOfferedNames()` returns the policy's verdict as soon as a policy is
+wired. Everything after that return — the enabled-set intersection, the
+admin filter, the allow-list intersection — is unreachable, and the resolver was
+read at exactly one line inside it. Production always wires a policy, so the
+argument enforced nothing there. Making it *required* would have added a
+mandatory argument that no production code path consults, while
+:php:`ToolCallPolicy` performs the identical check itself.
+
+**A ``Null`` policy would have been weaker than the status quo.**
+Today a ``null`` policy falls through to that legacy chain, which — narrower
+than the composite gate, but real — still intersects with the enabled set, still
+drops admin-only tools for a non-admin, still applies the configuration's
+grant. An allow-all :php:`NullToolCallPolicy` returns the caller's requested
+list unfiltered and disables all three at once. It would have been the exact
+failure mode the item exists to remove, shipped as its remedy. A deny-all
+``Null`` is unusable by the tests that motivated it.
+
+.. _adr-120-decision:
+
+Decision
+========
+
+The composite policy becomes a **required** constructor argument. The allow-list
+resolver is **deleted** along with the now-unreachable legacy chain. The schema
+validator becomes non-nullable with a ``new JsonSchemaValidator()`` default — it
+is stateless and has no constructor, so there is no wiring under which the
+defence-in-depth re-validation can be absent.
+
+**No ``Null`` implementation of any gate is written**, in ``Classes/``,
+``Classes/Testing/`` or ``Tests/``. A gate that does not exist cannot be wired
+by accident. Tests that need a loop construct the real
+:php:`ToolCallPolicy` — it needs only a registry, an availability service and
+three stateless resolvers, so this costs a helper rather than a fixture.
+
+The availability service is no longer a constructor argument either. Deleting
+the legacy chain left nothing in the loop reading it; the policy owns that check
+now.
+
+.. _adr-120-consequences:
+
+Consequences
+============
+
+The loop can no longer be constructed in a state where it enforces less than
+production does. Every test that exercises it exercises the real gate, including
+the trust-zone axis that the legacy chain never had.
+
+That axis was immediately load-bearing. Tests that passed a bare
+:php:`LlmConfiguration` were relying on a configuration with no provider, which
+fails closed to the ``EXTERNAL_GLOBAL`` zone and a ``EDITOR_CONTENT`` ceiling —
+so the real gate withholds every tool above that class. Those configurations now
+declare a ``LOCAL``-zone provider. This is a finding about the fixtures, not a
+concession: a run with a provider-less configuration really does get
+``fetch_logs`` withheld in production today, and no functional test noticed
+because no functional test wired the gate.
+
+A new container test pins the production wiring: that the loop resolves at all
+proves the required argument is autowirable, and that the bound policy is the
+composite :php:`ToolCallPolicy` proves the container does not reach a narrower
+implementation that would satisfy the type while deciding less.
+
+**What this does not close.** :php:`ToolCallPolicyInterface` is a public alias, so
+an install may bind its own implementation. That is an extension point, not a
+hole, and a test in this package cannot observe a downstream container. Required
+arguments turn "absent wiring silently weakens the gate" into "substituted
+wiring deliberately replaces it" — a smaller and much more visible surface, not
+an eliminated one.
+
+.. _adr-120-alternatives:
+
+Alternatives considered
+=======================
+
+**Follow the roadmap literally** — ``Null*`` implementations plus a ``Testing``
+builder. Rejected: see the context above. The ``Testing`` builder would also
+have had to construct the ``Null`` gates, which merely moves the choice of a
+weakened gate from the constructor into the builder.
+
+**Keep the allow-list resolver required rather than deleting it.** Rejected: a
+required argument that no code path reads is worse than an optional one, because
+it reads as enforcement.
+
+**Give tests a permissive double instead of the real policy.** Rejected. The one
+functional test that wires real collaborators would then assert a double's
+behaviour — reproducing, inside the test suite, the substitution this change
+removes from the constructor.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -417,3 +417,4 @@ Tools
    Adr117WithdrawCapabilityPermissions
    Adr118SpecializedServiceVerification
    Adr119BackendModulePlacement
+   Adr120RequiredToolGate

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,18 +16,12 @@ governance audit trail.
 
 ## Next — agent runtime maturity
 
-1. **Make the tool loop's security collaborators mandatory.** The
-   `ToolLoopService` gates (tool-call policy, per-configuration allow-list,
-   input schema validation) are optional constructor arguments today — absent
-   wiring silently weakens the gate. Make them required, and give tests an
-   explicit lean wiring (`Null*` implementations plus a `Testing` builder)
-   instead of implicit absence. A container test pins the production wiring.
-2. **Conversation-level context-window management.** The tool loop already
+1. **Conversation-level context-window management.** The tool loop already
    bounds its transcript (ADR-107); conversations do not. Plan against the
    smallest reachable model window in the fallback chain — or re-fit when a
    fallback actually fires — so a long conversation degrades predictably
    instead of failing on the provider.
-3. **A first-class contract for side-effecting tools.** Promote the tool
+2. **A first-class contract for side-effecting tools.** Promote the tool
    effect declaration (read-only / idempotent write / non-idempotent write,
    ADR-111) into a tool-facing interface with an idempotency scope and an
    optional preview, so writing tools can be built against a contract instead

--- a/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;
 use GuzzleHttp\Psr7\ServerRequest as GuzzleServerRequest;
 use Netresearch\NrLlm\Controller\Backend\ToolPlaygroundController;
 use Netresearch\NrLlm\Domain\Enum\PrivacyLevel;
+use Netresearch\NrLlm\Domain\Enum\TrustZone;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
@@ -33,14 +34,19 @@ use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\Guardrail\GuardrailInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Netresearch\NrLlm\Service\Skill\SkillComposer;
 use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
 use Netresearch\NrLlm\Service\Tool\AgentRunRepository;
 use Netresearch\NrLlm\Service\Tool\AgentStateCodec;
+use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
 use Netresearch\NrLlm\Service\Tool\ToolAvailabilityService;
+use Netresearch\NrLlm\Service\Tool\ToolCallPolicy;
+use Netresearch\NrLlm\Service\Tool\ToolDataClassResolver;
 use Netresearch\NrLlm\Service\Tool\ToolGroupStateRepository;
 use Netresearch\NrLlm\Service\Tool\ToolLoopService;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 use Netresearch\NrLlm\Service\Tool\ToolStateRepository;
+use Netresearch\NrLlm\Service\Tool\TrustZoneResolver;
 use Netresearch\NrLlm\Tests\Fixture\FixedPrivacyPolicy;
 use Netresearch\NrLlm\Tests\Fixture\GuardrailIdentityDoubleTrait;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
@@ -109,7 +115,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $controller = $this->makeController(
             $configurationRepository,
             $toolRegistry,
-            new ToolLoopService(self::createStub(LlmServiceManagerInterface::class), new ToolRegistry([]), $availability),
+            $this->loopFor(self::createStub(LlmServiceManagerInterface::class), new ToolRegistry([]), null, $availability),
         );
         $this->setPrivateProperty($controller, 'request', $this->createBackendRequest());
 
@@ -148,7 +154,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $controller    = $this->makeController(
             $configurationRepository,
             $emptyRegistry,
-            new ToolLoopService(self::createStub(LlmServiceManagerInterface::class), $emptyRegistry, $this->availabilityFor($emptyRegistry)),
+            $this->loopFor(self::createStub(LlmServiceManagerInterface::class), $emptyRegistry),
         );
 
         $request = (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/run'))
@@ -175,6 +181,11 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $provider = new Provider();
         $provider->setIdentifier('fake-provider');
         $provider->setAdapterType('openai');
+        // The playground is an admin surface run against a locally-trusted
+        // provider; without a zone the configuration fails closed to
+        // EXTERNAL_GLOBAL and the tool gate (ADR-094) withholds the fake tool,
+        // which is not what these controller tests are about.
+        $provider->setTrustZoneEnum(TrustZone::LOCAL);
         $provider->setApiKey('nr_tools_vault_key');
 
         $model = new Model();
@@ -207,7 +218,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         );
 
         $toolRegistry    = new ToolRegistry([new FakeTool('fetch_logs')]);
-        $toolLoopService = new ToolLoopService($manager, $toolRegistry, $this->availabilityFor($toolRegistry), new NullLogger());
+        $toolLoopService = $this->loopFor($manager, $toolRegistry, new NullLogger());
 
         $controller = $this->makeController($configurationRepository, $toolRegistry, $toolLoopService);
 
@@ -267,6 +278,11 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $provider = new Provider();
         $provider->setIdentifier('fake-provider');
         $provider->setAdapterType('openai');
+        // The playground is an admin surface run against a locally-trusted
+        // provider; without a zone the configuration fails closed to
+        // EXTERNAL_GLOBAL and the tool gate (ADR-094) withholds the fake tool,
+        // which is not what these controller tests are about.
+        $provider->setTrustZoneEnum(TrustZone::LOCAL);
         $provider->setApiKey('nr_tools_vault_key');
 
         $model = new Model();
@@ -295,7 +311,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         );
 
         $toolRegistry    = new ToolRegistry([new FakeTool('fetch_logs')]);
-        $toolLoopService = new ToolLoopService($manager, $toolRegistry, $this->availabilityFor($toolRegistry), new NullLogger());
+        $toolLoopService = $this->loopFor($manager, $toolRegistry, new NullLogger());
 
         // Wire the real persister (ADR-081): the batch runAction path must open a
         // run, record each step, and settle it COMPLETED.
@@ -334,6 +350,11 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $provider = new Provider();
         $provider->setIdentifier('fake-provider');
         $provider->setAdapterType('openai');
+        // The playground is an admin surface run against a locally-trusted
+        // provider; without a zone the configuration fails closed to
+        // EXTERNAL_GLOBAL and the tool gate (ADR-094) withholds the fake tool,
+        // which is not what these controller tests are about.
+        $provider->setTrustZoneEnum(TrustZone::LOCAL);
         $provider->setApiKey('nr_tools_vault_key');
 
         $model = new Model();
@@ -367,7 +388,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         );
 
         $toolRegistry    = new ToolRegistry([new FakeTool('fetch_logs')]);
-        $toolLoopService = new ToolLoopService($manager, $toolRegistry, $this->availabilityFor($toolRegistry), new NullLogger());
+        $toolLoopService = $this->loopFor($manager, $toolRegistry, new NullLogger());
         $controller      = $this->makeController($configurationRepository, $toolRegistry, $toolLoopService);
 
         $request = (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/run'))
@@ -401,7 +422,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $manager->expects(self::never())->method('chatWithToolsForConfiguration');
 
         $toolRegistry = new ToolRegistry([new FakeTool('fetch_logs')]);
-        $toolLoop     = new ToolLoopService($manager, $toolRegistry, $this->availabilityFor($toolRegistry), new NullLogger());
+        $toolLoop     = $this->loopFor($manager, $toolRegistry, new NullLogger());
         $controller   = $this->makeController($configurationRepository, $toolRegistry, $toolLoop);
 
         $request = (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/run'))
@@ -430,6 +451,11 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $provider = new Provider();
         $provider->setIdentifier('fake-provider');
         $provider->setAdapterType('openai');
+        // The playground is an admin surface run against a locally-trusted
+        // provider; without a zone the configuration fails closed to
+        // EXTERNAL_GLOBAL and the tool gate (ADR-094) withholds the fake tool,
+        // which is not what these controller tests are about.
+        $provider->setTrustZoneEnum(TrustZone::LOCAL);
         $provider->setApiKey('nr_tools_vault_key');
 
         $model = new Model();
@@ -459,7 +485,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         );
 
         $toolRegistry    = new ToolRegistry([new FakeTool('fetch_logs')]);
-        $toolLoopService = new ToolLoopService($manager, $toolRegistry, $this->availabilityFor($toolRegistry), new NullLogger());
+        $toolLoopService = $this->loopFor($manager, $toolRegistry, new NullLogger());
         $controller      = $this->makeController($configurationRepository, $toolRegistry, $toolLoopService);
 
         $request = (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/run'))
@@ -693,7 +719,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $manager->expects(self::never())->method('chatWithConfiguration');
 
         $registry        = new ToolRegistry([new FakeTool('safe_tool')]);
-        $toolLoopService = new ToolLoopService($manager, $registry, $this->availabilityFor($registry), new NullLogger());
+        $toolLoopService = $this->loopFor($manager, $registry, new NullLogger());
         $controller      = $this->makeController($configurationRepository, $registry, $toolLoopService, $persister);
 
         $request  = (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/resume'))
@@ -735,7 +761,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $manager->expects(self::never())->method('chatWithConfiguration');
 
         $registry        = new ToolRegistry([new FakeTool('ask_user')]);
-        $toolLoopService = new ToolLoopService($manager, $registry, $this->availabilityFor($registry), new NullLogger());
+        $toolLoopService = $this->loopFor($manager, $registry, new NullLogger());
         $controller      = $this->makeController($configurationRepository, $registry, $toolLoopService, $persister);
 
         $request  = (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/submit-input'))
@@ -782,7 +808,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $manager->expects(self::never())->method('chatWithConfiguration');
 
         $registry        = new ToolRegistry([new FakeTool('ask_user')]);
-        $toolLoopService = new ToolLoopService($manager, $registry, $this->availabilityFor($registry), new NullLogger());
+        $toolLoopService = $this->loopFor($manager, $registry, new NullLogger());
         $controller      = $this->makeController($configurationRepository, $registry, $toolLoopService, $persister);
 
         $request  = (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/submit-input'))
@@ -806,6 +832,11 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $provider = new Provider();
         $provider->setIdentifier('fake-provider');
         $provider->setAdapterType('openai');
+        // The playground is an admin surface run against a locally-trusted
+        // provider; without a zone the configuration fails closed to
+        // EXTERNAL_GLOBAL and the tool gate (ADR-094) withholds the fake tool,
+        // which is not what these controller tests are about.
+        $provider->setTrustZoneEnum(TrustZone::LOCAL);
         $provider->setApiKey('nr_tools_vault_key');
 
         $model = new Model();
@@ -834,7 +865,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         );
 
         $toolRegistry    = new ToolRegistry([new FakeTool('fetch_logs')]);
-        $toolLoopService = new ToolLoopService($manager, $toolRegistry, $this->availabilityFor($toolRegistry), new NullLogger());
+        $toolLoopService = $this->loopFor($manager, $toolRegistry, new NullLogger());
 
         return [$this->makeController($configurationRepository, $toolRegistry, $toolLoopService), $config];
     }
@@ -851,6 +882,11 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $provider = new Provider();
         $provider->setIdentifier('fake-provider');
         $provider->setAdapterType('openai');
+        // The playground is an admin surface run against a locally-trusted
+        // provider; without a zone the configuration fails closed to
+        // EXTERNAL_GLOBAL and the tool gate (ADR-094) withholds the fake tool,
+        // which is not what these controller tests are about.
+        $provider->setTrustZoneEnum(TrustZone::LOCAL);
         $provider->setApiKey('nr_tools_vault_key');
 
         $model = new Model();
@@ -879,7 +915,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         );
 
         $toolRegistry    = new ToolRegistry([new FakeTool('fetch_logs')]);
-        $toolLoopService = new ToolLoopService($manager, $toolRegistry, $this->availabilityFor($toolRegistry), new NullLogger());
+        $toolLoopService = $this->loopFor($manager, $toolRegistry, new NullLogger());
 
         return [$this->makeController($configurationRepository, $toolRegistry, $toolLoopService), $config];
     }
@@ -926,6 +962,35 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
      * Build the real availability service over the given registry, backed by the
      * functional database — so the fail-closed gate is exercised end-to-end.
      */
+    /**
+     * The tool loop wired with the REAL composite gate (ADR-094), which is a
+     * required collaborator (ADR-120). These tests are about the playground
+     * controller, not the gate, so the gate is real rather than doubled — a
+     * permissive double here would be the same silent weakening the required
+     * argument exists to prevent.
+     */
+    private function loopFor(
+        LlmServiceManagerInterface $mgr,
+        ToolRegistry $registry,
+        ?NullLogger $logger = null,
+        ?ToolAvailabilityService $availability = null,
+    ): ToolLoopService {
+        $availability ??= $this->availabilityFor($registry);
+
+        return new ToolLoopService(
+            $mgr,
+            $registry,
+            new ToolCallPolicy(
+                $registry,
+                $availability,
+                new AllowedToolsResolver(new SkillComposer(), $registry),
+                new ToolDataClassResolver($registry),
+                new TrustZoneResolver(),
+            ),
+            $logger,
+        );
+    }
+
     private function availabilityFor(ToolRegistry $toolRegistry): ToolAvailabilityService
     {
         return new ToolAvailabilityService($toolRegistry, new ToolStateRepository($this->toolConnectionPool()), new ToolGroupStateRepository($this->toolConnectionPool()));

--- a/Tests/Functional/DependencyInjection/ToolLoopGateWiringTest.php
+++ b/Tests/Functional/DependencyInjection/ToolLoopGateWiringTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\DependencyInjection;
+
+use Netresearch\NrLlm\Service\Tool\ToolCallPolicy;
+use Netresearch\NrLlm\Service\Tool\ToolCallPolicyInterface;
+use Netresearch\NrLlm\Service\Tool\ToolLoopService;
+use Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Pins the production wiring of the agent loop's tool gate (ADR-120).
+ *
+ * {@see ToolLoopService} takes its {@see ToolCallPolicyInterface} as a required
+ * constructor argument, so an install whose container cannot resolve one fails
+ * to compile rather than running with a weaker gate. Nothing else asserts that:
+ * every other test hand-constructs the loop, which is exactly the wiring this
+ * test exists to be independent of.
+ *
+ * Two things are checked, and the second is the one with teeth. That the loop
+ * resolves at all proves the required argument is autowirable. That the bound
+ * policy is the real {@see ToolCallPolicy} proves the container reaches the
+ * composite gate — the trust-zone axis included — and not some narrower
+ * implementation that would satisfy the type while deciding less.
+ *
+ * Extends {@see FunctionalTestCase} directly rather than the project base,
+ * whose setUp() converts a container-compile failure into a skipped test — the
+ * precise regression this test exists to catch. Same rationale, and the same
+ * scoped HashService warning suppression, as
+ * {@see DashboardWidgetRegistrationTest}.
+ */
+final class ToolLoopGateWiringTest extends FunctionalTestCase
+{
+    /** @var non-empty-string[] */
+    protected array $testExtensionsToLoad = [
+        'netresearch/nr-vault',
+        'netresearch/nr-llm',
+    ];
+
+    /** @var non-empty-string[] */
+    protected array $coreExtensionsToLoad = [
+        'extbase',
+        'fluid',
+    ];
+
+    protected function setUp(): void
+    {
+        set_error_handler(
+            static fn(int $errno, string $errstr, string $errfile): bool => str_contains($errfile, 'Crypto/HashService.php')
+                && (str_contains($errstr, 'TYPO3_CONF_VARS') || str_contains($errstr, 'array offset')),
+            \E_WARNING,
+        );
+
+        try {
+            parent::setUp();
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    #[Test]
+    public function theAgentLoopResolvesWithItsRequiredToolGate(): void
+    {
+        $loop = $this->get(ToolLoopServiceInterface::class);
+
+        self::assertInstanceOf(ToolLoopService::class, $loop);
+    }
+
+    #[Test]
+    public function productionBindsTheCompositeToolCallPolicy(): void
+    {
+        // A narrower implementation would satisfy the type hint while deciding
+        // less; the loop cannot tell the difference, so the container is pinned
+        // here instead.
+        $policy = $this->get(ToolCallPolicyInterface::class);
+
+        self::assertInstanceOf(ToolCallPolicy::class, $policy);
+    }
+}

--- a/Tests/Functional/Service/Tool/ToolLoopServiceBuiltinTest.php
+++ b/Tests/Functional/Service/Tool/ToolLoopServiceBuiltinTest.php
@@ -9,18 +9,26 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
 
+use Netresearch\NrLlm\Domain\Enum\TrustZone;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Skill\SkillComposer;
+use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
 use Netresearch\NrLlm\Service\Tool\Builtin\FetchLogsTool;
 use Netresearch\NrLlm\Service\Tool\ToolAvailabilityService;
+use Netresearch\NrLlm\Service\Tool\ToolCallPolicy;
+use Netresearch\NrLlm\Service\Tool\ToolDataClassResolver;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolGroupStateRepository;
 use Netresearch\NrLlm\Service\Tool\ToolLoopService;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 use Netresearch\NrLlm\Service\Tool\ToolStateRepository;
+use Netresearch\NrLlm\Service\Tool\TrustZoneResolver;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -103,7 +111,7 @@ final class ToolLoopServiceBuiltinTest extends AbstractFunctionalTestCase
             });
 
         $service = $this->buildService($mgr);
-        $result  = $service->runLoop([$this->userTurn('show me the logs')], new LlmConfiguration(), $this->contextFor($this->actingUser), null);
+        $result  = $service->runLoop([$this->userTurn('show me the logs')], $this->localConfiguration(), $this->contextFor($this->actingUser), null);
 
         // The real builtin tool ran exactly once and its REAL output is in the trace.
         self::assertCount(1, $result->trace);
@@ -140,7 +148,7 @@ final class ToolLoopServiceBuiltinTest extends AbstractFunctionalTestCase
 
         $service = $this->buildService($mgr);
         // The caller even explicitly allows the tool — the admin gate still wins.
-        $result = $service->runLoop([$this->userTurn('show me the logs')], new LlmConfiguration(), $this->contextFor($nonAdmin), ['fetch_logs']);
+        $result = $service->runLoop([$this->userTurn('show me the logs')], $this->localConfiguration(), $this->contextFor($nonAdmin), ['fetch_logs']);
 
         self::assertSame('plain answer', $result->finalContent);
         self::assertSame([], $result->trace);
@@ -156,7 +164,41 @@ final class ToolLoopServiceBuiltinTest extends AbstractFunctionalTestCase
         $registry     = new ToolRegistry([new FetchLogsTool($this->connectionPool)]);
         $availability = new ToolAvailabilityService($registry, new ToolStateRepository($this->connectionPool), new ToolGroupStateRepository($this->connectionPool));
 
-        return new ToolLoopService($mgr, $registry, $availability);
+        // The REAL composite gate (ADR-094), not a double: this test exists to
+        // run production code, and the gate is production code.
+        $policy = new ToolCallPolicy(
+            $registry,
+            $availability,
+            new AllowedToolsResolver(new SkillComposer(), $registry),
+            new ToolDataClassResolver($registry),
+            new TrustZoneResolver(),
+        );
+
+        return new ToolLoopService($mgr, $registry, $policy);
+    }
+
+    /**
+     * A configuration whose provider sits in the LOCAL trust zone.
+     *
+     * `fetch_logs` is SYSTEM_DIAGNOSTICS by group, and a configuration without a
+     * provider fails closed to EXTERNAL_GLOBAL, whose ceiling is EDITOR_CONTENT
+     * — so the composite gate denies the tool there, correctly. The bare
+     * `new LlmConfiguration()` these tests used was a placeholder that only ever
+     * passed because no gate was wired; stating the zone says what they always
+     * assumed, and lets the trust-zone axis genuinely run and allow.
+     */
+    private function localConfiguration(): LlmConfiguration
+    {
+        $provider = new Provider();
+        $provider->setTrustZoneEnum(TrustZone::LOCAL);
+
+        $model = new Model();
+        $model->setProvider($provider);
+
+        $configuration = new LlmConfiguration();
+        $configuration->setLlmModel($model);
+
+        return $configuration;
     }
 
     /**

--- a/Tests/Unit/Service/Tool/ToolLoopServiceAugmentationTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceAugmentationTest.php
@@ -9,9 +9,12 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
 
+use Netresearch\NrLlm\Domain\Enum\TrustZone;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\PromptSnippet;
+use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
@@ -19,11 +22,15 @@ use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Prompt\PromptSnippetComposer;
 use Netresearch\NrLlm\Service\Skill\SkillComposer;
 use Netresearch\NrLlm\Service\Skill\SkillInjectionService;
+use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
 use Netresearch\NrLlm\Service\Tool\RunAugmentation;
 use Netresearch\NrLlm\Service\Tool\RunTrace;
+use Netresearch\NrLlm\Service\Tool\ToolCallPolicy;
+use Netresearch\NrLlm\Service\Tool\ToolDataClassResolver;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolLoopService;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Service\Tool\TrustZoneResolver;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeToolAvailability;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -44,7 +51,7 @@ final class ToolLoopServiceAugmentationTest extends TestCase
         $trace  = new RunTrace();
         $result = $this->service($mgr)->runLoop(
             [['role' => 'user', 'content' => 'hi']],
-            new LlmConfiguration(),
+            $this->localConfiguration(),
             ToolExecutionContext::none(),
             null,
             null,
@@ -76,7 +83,7 @@ final class ToolLoopServiceAugmentationTest extends TestCase
         $trace = new RunTrace();
         $this->service($mgr)->runLoop(
             [['role' => 'user', 'content' => 'translate this']],
-            new LlmConfiguration(),
+            $this->localConfiguration(),
             ToolExecutionContext::none(),
             null,
             null,
@@ -108,7 +115,7 @@ final class ToolLoopServiceAugmentationTest extends TestCase
         $trace  = new RunTrace();
         $result = $this->service($mgr)->runLoop(
             [['role' => 'user', 'content' => 'hi']],
-            new LlmConfiguration(),
+            $this->localConfiguration(),
             ToolExecutionContext::none(),
             null,
             null,
@@ -150,20 +157,25 @@ final class ToolLoopServiceAugmentationTest extends TestCase
 
         // A tool echoing raw bytes (log/env/phpinfo output) that are not valid UTF-8.
         $registry = new ToolRegistry([new FakeTool('bad', "before \xFF\xFE after")]);
-        $service  = new ToolLoopService(
+        $availability = new FakeToolAvailability($registry->names());
+        $service      = new ToolLoopService(
             $mgr,
             $registry,
-            new FakeToolAvailability($registry->names()),
-            null,
-            5,
-            new SkillInjectionService(new SkillComposer(), new NullLogger()),
-            new PromptSnippetComposer(),
+            new ToolCallPolicy(
+                $registry,
+                $availability,
+                new AllowedToolsResolver(new SkillComposer(), $registry),
+                new ToolDataClassResolver($registry),
+                new TrustZoneResolver(),
+            ),
+            skillInjection: new SkillInjectionService(new SkillComposer(), new NullLogger()),
+            snippetComposer: new PromptSnippetComposer(),
         );
 
         $trace  = new RunTrace();
         $result = $service->runLoop(
             [['role' => 'user', 'content' => 'go']],
-            new LlmConfiguration(),
+            $this->localConfiguration(),
             ToolExecutionContext::none(),
             ['bad'],
             null,
@@ -192,14 +204,44 @@ final class ToolLoopServiceAugmentationTest extends TestCase
     {
         $registry = new ToolRegistry([new FakeTool('noop')]);
 
+        $availability = new FakeToolAvailability($registry->names());
+
         return new ToolLoopService(
             $mgr,
             $registry,
-            new FakeToolAvailability($registry->names()),
-            null,
-            5,
-            new SkillInjectionService(new SkillComposer(), new NullLogger()),
-            new PromptSnippetComposer(),
+            new ToolCallPolicy(
+                $registry,
+                $availability,
+                new AllowedToolsResolver(new SkillComposer(), $registry),
+                new ToolDataClassResolver($registry),
+                new TrustZoneResolver(),
+            ),
+            skillInjection: new SkillInjectionService(new SkillComposer(), new NullLogger()),
+            snippetComposer: new PromptSnippetComposer(),
         );
     }
+
+    /**
+     * A configuration whose provider sits in the LOCAL trust zone.
+     *
+     * {@see FakeTool} declares the group `test`, absent from the data-class
+     * group defaults and therefore failing closed to SECRET_ADJACENT. A
+     * configuration without a provider fails closed to EXTERNAL_GLOBAL, whose
+     * ceiling is EDITOR_CONTENT, so the composite gate would withhold every fake
+     * tool for a reason these tests are not about (ADR-094).
+     */
+    private function localConfiguration(): LlmConfiguration
+    {
+        $provider = new Provider();
+        $provider->setTrustZoneEnum(TrustZone::LOCAL);
+
+        $model = new Model();
+        $model->setProvider($provider);
+
+        $configuration = new LlmConfiguration();
+        $configuration->setLlmModel($model);
+
+        return $configuration;
+    }
+
 }

--- a/Tests/Unit/Service/Tool/ToolLoopServiceGovernanceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceGovernanceTest.php
@@ -15,6 +15,8 @@ use Netresearch\NrLlm\Domain\Enum\ToolDenialReason;
 use Netresearch\NrLlm\Domain\Enum\TrustZone;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
 use Netresearch\NrLlm\Domain\ValueObject\ToolPolicyDecision;
@@ -25,7 +27,6 @@ use Netresearch\NrLlm\Service\Tool\ToolLoopService;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 use Netresearch\NrLlm\Tests\Unit\Command\Fixture\InMemoryGovernanceEventRepository;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
-use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeToolAvailability;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -56,13 +57,12 @@ final class ToolLoopServiceGovernanceTest extends TestCase
         $service  = new ToolLoopService(
             $mgr,
             $registry,
-            new FakeToolAvailability(['fetch_logs']),
-            toolPolicy: $policy,
+            $policy,
             governanceEvents: $recorder,
         );
 
         $context = ToolExecutionContext::forBackendUser(AiActorContext::backendUser(42, true), null);
-        $service->runLoop([['role' => 'user', 'content' => 'show logs']], new LlmConfiguration(), $context, null);
+        $service->runLoop([['role' => 'user', 'content' => 'show logs']], $this->localConfiguration(), $context, null);
 
         self::assertCount(1, $recorder->recorded);
         $event = $recorder->recorded[0];
@@ -90,12 +90,11 @@ final class ToolLoopServiceGovernanceTest extends TestCase
         $service  = new ToolLoopService(
             $mgr,
             $registry,
-            new FakeToolAvailability(['fetch_logs']),
-            toolPolicy: $policy,
+            $policy,
             governanceEvents: $recorder,
         );
 
-        $service->runLoop([['role' => 'user', 'content' => 'hi']], new LlmConfiguration(), ToolExecutionContext::none(), null);
+        $service->runLoop([['role' => 'user', 'content' => 'hi']], $this->localConfiguration(), ToolExecutionContext::none(), null);
 
         self::assertSame([], $recorder->recorded);
     }
@@ -167,4 +166,28 @@ final class ToolLoopServiceGovernanceTest extends TestCase
             }
         };
     }
+
+    /**
+     * A configuration whose provider sits in the LOCAL trust zone.
+     *
+     * {@see FakeTool} declares the group `test`, absent from the data-class
+     * group defaults and therefore failing closed to SECRET_ADJACENT. A
+     * configuration without a provider fails closed to EXTERNAL_GLOBAL, whose
+     * ceiling is EDITOR_CONTENT, so the composite gate would withhold every fake
+     * tool for a reason these tests are not about (ADR-094).
+     */
+    private function localConfiguration(): LlmConfiguration
+    {
+        $provider = new Provider();
+        $provider->setTrustZoneEnum(TrustZone::LOCAL);
+
+        $model = new Model();
+        $model->setProvider($provider);
+
+        $configuration = new LlmConfiguration();
+        $configuration->setLlmModel($model);
+
+        return $configuration;
+    }
+
 }

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -14,8 +14,11 @@ use LogicException;
 use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
 use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
 use Netresearch\NrLlm\Domain\Enum\ArtifactType;
+use Netresearch\NrLlm\Domain\Enum\TrustZone;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ContextFitResult;
@@ -30,7 +33,6 @@ use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Service\Context\ContextWindowManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
-use Netresearch\NrLlm\Service\Schema\JsonSchemaValidator;
 use Netresearch\NrLlm\Service\Skill\SkillComposer;
 use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
 use Netresearch\NrLlm\Service\Tool\Exception\ToolApprovalRequiredException;
@@ -38,10 +40,13 @@ use Netresearch\NrLlm\Service\Tool\Exception\ToolInputRequiredException;
 use Netresearch\NrLlm\Service\Tool\RequiresApprovalInterface;
 use Netresearch\NrLlm\Service\Tool\RunAugmentation;
 use Netresearch\NrLlm\Service\Tool\RunTrace;
+use Netresearch\NrLlm\Service\Tool\ToolCallPolicy;
+use Netresearch\NrLlm\Service\Tool\ToolDataClassResolver;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Service\Tool\ToolLoopService;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Service\Tool\TrustZoneResolver;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeInputTool;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeToolAvailability;
@@ -68,7 +73,7 @@ final class ToolLoopServiceTest extends TestCase
         // A registered tool keeps the loop on the tools path (an empty registry
         // would short-circuit to a plain completion — covered separately).
         $service = $this->service($mgr, new ToolRegistry([new FakeTool('noop')]));
-        $result  = $service->runLoop([$this->userTurn('hi')], new LlmConfiguration(), ToolExecutionContext::none(), null);
+        $result  = $service->runLoop([$this->userTurn('hi')], $this->localConfiguration(), ToolExecutionContext::none(), null);
 
         self::assertSame('the answer', $result->finalContent);
         self::assertSame([], $result->trace);
@@ -89,7 +94,7 @@ final class ToolLoopServiceTest extends TestCase
             ->willReturnCallback($this->queueCallback($queue));
 
         $service = $this->service($mgr, new ToolRegistry([new FakeTool('fetch_logs', 'LOGS')]));
-        $result  = $service->runLoop([$this->userTurn('show logs')], new LlmConfiguration(), ToolExecutionContext::none(), null);
+        $result  = $service->runLoop([$this->userTurn('show logs')], $this->localConfiguration(), ToolExecutionContext::none(), null);
 
         self::assertCount(1, $result->trace);
         self::assertSame('fetch_logs', $result->trace[0]->name);
@@ -121,7 +126,7 @@ final class ToolLoopServiceTest extends TestCase
         ], $captured));
 
         $service = $this->service($mgr, new ToolRegistry([$tool]));
-        $result  = $service->runLoop([$this->userTurn('go')], new LlmConfiguration(), ToolExecutionContext::none(), null);
+        $result  = $service->runLoop([$this->userTurn('go')], $this->localConfiguration(), ToolExecutionContext::none(), null);
 
         // The second provider call carries the tool-result turn: content only.
         self::assertArrayHasKey(1, $captured);
@@ -150,7 +155,7 @@ final class ToolLoopServiceTest extends TestCase
             $this->response('done'),
         ]));
 
-        $result   = $this->service($mgr, new ToolRegistry([$tool]))->runLoop([$this->userTurn('go')], new LlmConfiguration(), ToolExecutionContext::none(), null);
+        $result   = $this->service($mgr, new ToolRegistry([$tool]))->runLoop([$this->userTurn('go')], $this->localConfiguration(), ToolExecutionContext::none(), null);
         $artifact = $result->trace[0]->artifacts[0];
 
         // The label and every nested string leaf are valid UTF-8, and the raw
@@ -174,7 +179,7 @@ final class ToolLoopServiceTest extends TestCase
             $this->response('done'),
         ]));
 
-        $result    = $this->service($mgr, new ToolRegistry([$tool]))->runLoop([$this->userTurn('go')], new LlmConfiguration(), ToolExecutionContext::none(), null);
+        $result    = $this->service($mgr, new ToolRegistry([$tool]))->runLoop([$this->userTurn('go')], $this->localConfiguration(), ToolExecutionContext::none(), null);
         $artifacts = $result->trace[0]->artifacts;
 
         self::assertCount(1, $artifacts);
@@ -197,7 +202,7 @@ final class ToolLoopServiceTest extends TestCase
             $this->response('done'),
         ]));
 
-        $result    = $this->service($mgr, new ToolRegistry([$tool]))->runLoop([$this->userTurn('go')], new LlmConfiguration(), ToolExecutionContext::none(), null);
+        $result    = $this->service($mgr, new ToolRegistry([$tool]))->runLoop([$this->userTurn('go')], $this->localConfiguration(), ToolExecutionContext::none(), null);
         $artifacts = $result->trace[0]->artifacts;
 
         self::assertCount(1, $artifacts);
@@ -218,7 +223,7 @@ final class ToolLoopServiceTest extends TestCase
             $this->response('done'),
         ]));
 
-        $result   = $this->service($mgr, new ToolRegistry([$tool]))->runLoop([$this->userTurn('go')], new LlmConfiguration(), ToolExecutionContext::none(), null);
+        $result   = $this->service($mgr, new ToolRegistry([$tool]))->runLoop([$this->userTurn('go')], $this->localConfiguration(), ToolExecutionContext::none(), null);
         $artifact = $result->trace[0]->artifacts[0];
 
         self::assertSame(ArtifactType::TABLE, $artifact->type);
@@ -241,7 +246,7 @@ final class ToolLoopServiceTest extends TestCase
         // path; the model then requests the unregistered name "nope", which
         // registry->get() resolves to null (the unknown-tool branch).
         $service = $this->service($mgr, new ToolRegistry([new FakeTool('real_tool')]));
-        $result  = $service->runLoop([$this->userTurn('do it')], new LlmConfiguration(), ToolExecutionContext::none(), null);
+        $result  = $service->runLoop([$this->userTurn('do it')], $this->localConfiguration(), ToolExecutionContext::none(), null);
 
         self::assertCount(1, $result->trace);
         self::assertTrue($result->trace[0]->isError);
@@ -292,7 +297,7 @@ final class ToolLoopServiceTest extends TestCase
             ->willReturnCallback($this->queueCallback($queue));
 
         $service = $this->service($mgr, new ToolRegistry([$throwing]));
-        $result  = $service->runLoop([$this->userTurn('blow up')], new LlmConfiguration(), ToolExecutionContext::none(), null);
+        $result  = $service->runLoop([$this->userTurn('blow up')], $this->localConfiguration(), ToolExecutionContext::none(), null);
 
         self::assertCount(1, $result->trace);
         self::assertTrue($result->trace[0]->isError);
@@ -359,7 +364,7 @@ final class ToolLoopServiceTest extends TestCase
             );
 
         $service = $this->service($mgr, new ToolRegistry([$throwing]), $logger);
-        $service->runLoop([$this->userTurn('blow up')], new LlmConfiguration(), ToolExecutionContext::none(), null);
+        $service->runLoop([$this->userTurn('blow up')], $this->localConfiguration(), ToolExecutionContext::none(), null);
     }
 
     #[Test]
@@ -376,7 +381,7 @@ final class ToolLoopServiceTest extends TestCase
             ->willReturnCallback($this->queueCallback($queue, $captured));
 
         $service = $this->service($mgr, new ToolRegistry([new FakeTool('fetch_logs', 'LOGS')]));
-        $service->runLoop([$this->userTurn('show logs')], new LlmConfiguration(), ToolExecutionContext::none(), null);
+        $service->runLoop([$this->userTurn('show logs')], $this->localConfiguration(), ToolExecutionContext::none(), null);
 
         // The second round must carry the appended assistant + tool turns as
         // typed ChatMessage VOs whose wire form stays OpenAI-compatible.
@@ -416,7 +421,7 @@ final class ToolLoopServiceTest extends TestCase
 
         $runTrace = new RunTrace();
         $service  = $this->service($mgr, new ToolRegistry([new FakeTool('loop_tool')]));
-        $result   = $service->runLoop([$this->userTurn('loop')], new LlmConfiguration(), ToolExecutionContext::none(), null, null, 2, $runTrace);
+        $result   = $service->runLoop([$this->userTurn('loop')], $this->localConfiguration(), ToolExecutionContext::none(), null, null, 2, $runTrace);
 
         self::assertSame(2, $result->iterations);
         self::assertTrue($result->truncated);
@@ -471,7 +476,7 @@ final class ToolLoopServiceTest extends TestCase
 
         $registry = new ToolRegistry([new FakeTool('fetch_logs'), new FakeTool('read_meta')]);
         $service  = $this->service($mgr, $registry);
-        $service->runLoop([$this->userTurn('hi')], new LlmConfiguration(), ToolExecutionContext::none(), ['fetch_logs']);
+        $service->runLoop([$this->userTurn('hi')], $this->localConfiguration(), ToolExecutionContext::none(), ['fetch_logs']);
 
         $specs = self::arr($capturedTools[0] ?? null);
         $names = array_map(
@@ -501,7 +506,7 @@ final class ToolLoopServiceTest extends TestCase
             });
 
         $service = $this->service($mgr, new ToolRegistry([new FakeTool('fetch_logs', 'LOGS')]));
-        $result  = $service->runLoop([$this->userTurn('show logs')], new LlmConfiguration(), ToolExecutionContext::none(), null);
+        $result  = $service->runLoop([$this->userTurn('show logs')], $this->localConfiguration(), ToolExecutionContext::none(), null);
 
         self::assertTrue($result->truncated);
         self::assertSame(AgentRunTerminationReason::BUDGET_EXHAUSTED, $result->terminationReason);
@@ -533,7 +538,7 @@ final class ToolLoopServiceTest extends TestCase
             );
 
         $service = $this->service($mgr, new ToolRegistry([new FakeTool('fetch_logs', 'LOGS')]), $logger);
-        $result  = $service->runLoop([$this->userTurn('show logs')], new LlmConfiguration(), ToolExecutionContext::none(), null);
+        $result  = $service->runLoop([$this->userTurn('show logs')], $this->localConfiguration(), ToolExecutionContext::none(), null);
 
         self::assertTrue($result->truncated);
     }
@@ -554,7 +559,7 @@ final class ToolLoopServiceTest extends TestCase
         $mgr->method('chatWithToolsForConfiguration')->willReturnCallback($this->queueCallback($queue));
 
         $service = $this->service($mgr, new ToolRegistry([new FakeTool('big_tool', $big)]));
-        $result  = $service->runLoop([$this->userTurn('go')], new LlmConfiguration(), ToolExecutionContext::none(), null);
+        $result  = $service->runLoop([$this->userTurn('go')], $this->localConfiguration(), ToolExecutionContext::none(), null);
 
         self::assertCount(1, $result->trace);
         $toolResult = $result->trace[0]->result;
@@ -585,7 +590,7 @@ final class ToolLoopServiceTest extends TestCase
         $mgr->method('chatWithToolsForConfiguration')->willReturnCallback($this->queueCallback($queue));
 
         $service = $this->service($mgr, new ToolRegistry([new FakeTool('edge_tool', $exact)]));
-        $result  = $service->runLoop([$this->userTurn('go')], new LlmConfiguration(), ToolExecutionContext::none(), null);
+        $result  = $service->runLoop([$this->userTurn('go')], $this->localConfiguration(), ToolExecutionContext::none(), null);
 
         self::assertCount(1, $result->trace);
         $toolResult = $result->trace[0]->result;
@@ -606,7 +611,7 @@ final class ToolLoopServiceTest extends TestCase
             ->willReturnCallback($this->queueCallback($queue));
 
         $service = $this->service($mgr, new ToolRegistry([new FakeTool('fetch_logs', 'LOGS')]));
-        $result  = $service->runLoop([$this->userTurn('show logs')], new LlmConfiguration(), ToolExecutionContext::none(), null);
+        $result  = $service->runLoop([$this->userTurn('show logs')], $this->localConfiguration(), ToolExecutionContext::none(), null);
 
         self::assertSame(13, $result->usage->promptTokens);
         self::assertSame(7, $result->usage->completionTokens);
@@ -625,7 +630,7 @@ final class ToolLoopServiceTest extends TestCase
 
         // A tool IS registered, but the empty allow-list offers none of them.
         $service = $this->service($mgr, new ToolRegistry([new FakeTool('fetch_logs')]));
-        $result  = $service->runLoop([$this->userTurn('hi')], new LlmConfiguration(), ToolExecutionContext::none(), []);
+        $result  = $service->runLoop([$this->userTurn('hi')], $this->localConfiguration(), ToolExecutionContext::none(), []);
 
         self::assertSame('plain answer', $result->finalContent);
         self::assertSame([], $result->trace);
@@ -681,7 +686,7 @@ final class ToolLoopServiceTest extends TestCase
 
         $registry = new ToolRegistry([new FakeTool('fetch_logs'), $spy]);
         $service  = $this->service($mgr, $registry);
-        $result   = $service->runLoop([$this->userTurn('go')], new LlmConfiguration(), ToolExecutionContext::none(), ['fetch_logs']);
+        $result   = $service->runLoop([$this->userTurn('go')], $this->localConfiguration(), ToolExecutionContext::none(), ['fetch_logs']);
 
         self::assertCount(1, $result->trace);
         self::assertTrue($result->trace[0]->isError);
@@ -702,13 +707,11 @@ final class ToolLoopServiceTest extends TestCase
         $mgr->expects(self::never())->method('chatWithToolsForConfiguration');
 
         // fetch_logs IS registered, but the global gate reports it disabled.
-        $service = new ToolLoopService(
-            $mgr,
-            new ToolRegistry([new FakeTool('fetch_logs')]),
-            new FakeToolAvailability([]),
-        );
+        $registry     = new ToolRegistry([new FakeTool('fetch_logs')]);
+        $availability = new FakeToolAvailability([]);
+        $service      = new ToolLoopService($mgr, $registry, $this->realPolicy($registry, $availability));
         // The caller explicitly lists the disabled tool — the gate still wins.
-        $result = $service->runLoop([$this->userTurn('hi')], new LlmConfiguration(), ToolExecutionContext::none(), ['fetch_logs']);
+        $result = $service->runLoop([$this->userTurn('hi')], $this->localConfiguration(), ToolExecutionContext::none(), ['fetch_logs']);
 
         self::assertSame('plain answer', $result->finalContent);
         self::assertSame([], $result->trace);
@@ -734,10 +737,11 @@ final class ToolLoopServiceTest extends TestCase
             });
 
         // Two tools registered, but only one is globally enabled.
-        $registry = new ToolRegistry([new FakeTool('fetch_logs'), new FakeTool('read_meta')]);
-        $service  = new ToolLoopService($mgr, $registry, new FakeToolAvailability(['fetch_logs']));
+        $registry     = new ToolRegistry([new FakeTool('fetch_logs'), new FakeTool('read_meta')]);
+        $availability = new FakeToolAvailability(['fetch_logs']);
+        $service      = new ToolLoopService($mgr, $registry, $this->realPolicy($registry, $availability));
         // null ⇒ "no per-run restriction" ⇒ collapses to the enabled set only.
-        $service->runLoop([$this->userTurn('hi')], new LlmConfiguration(), ToolExecutionContext::none(), null);
+        $service->runLoop([$this->userTurn('hi')], $this->localConfiguration(), ToolExecutionContext::none(), null);
 
         $specs = self::arr($capturedTools[0] ?? null);
         $names = array_map(
@@ -788,7 +792,7 @@ final class ToolLoopServiceTest extends TestCase
         $state = $this->suspend($service);
 
         $trace  = new RunTrace();
-        $result = $service->resume($state, true, new LlmConfiguration(), ToolExecutionContext::none(), null, $trace);
+        $result = $service->resume($state, true, $this->localConfiguration(), ToolExecutionContext::none(), null, $trace);
 
         self::assertSame('deleted and done', $result->finalContent);
         // The approved tool really executed (recorded on the trace) with its result.
@@ -815,7 +819,7 @@ final class ToolLoopServiceTest extends TestCase
         $state = $this->suspend($service);
 
         $trace  = new RunTrace();
-        $result = $service->resume($state, false, new LlmConfiguration(), ToolExecutionContext::none(), null, $trace);
+        $result = $service->resume($state, false, $this->localConfiguration(), ToolExecutionContext::none(), null, $trace);
 
         self::assertSame('ok, cancelled', $result->finalContent);
         // The pending tool was NOT executed; a denial result was fed back instead.
@@ -837,7 +841,7 @@ final class ToolLoopServiceTest extends TestCase
 
         $state = null;
         try {
-            $service->runLoop([$this->userTurn('go')], new LlmConfiguration(), ToolExecutionContext::none(), ['delete_thing'], $options);
+            $service->runLoop([$this->userTurn('go')], $this->localConfiguration(), ToolExecutionContext::none(), ['delete_thing'], $options);
         } catch (ToolApprovalRequiredException $e) {
             $state = $e->state;
         }
@@ -870,7 +874,7 @@ final class ToolLoopServiceTest extends TestCase
         );
 
         $trace  = new RunTrace();
-        $result = $service->resume($state, true, new LlmConfiguration(), ToolExecutionContext::none(), null, $trace);
+        $result = $service->resume($state, true, $this->localConfiguration(), ToolExecutionContext::none(), null, $trace);
 
         // Approved, but the tool is no longer offered → fail-closed, NOT executed.
         $toolSteps = array_values(array_filter($trace->getSteps(), static fn(RunStep $s): bool => $s->kind === RunStep::KIND_TOOL));
@@ -902,7 +906,7 @@ final class ToolLoopServiceTest extends TestCase
         // Only safe_tool is offered; delete_thing (an approval tool) is registered
         // but NOT in the allow-list. A model naming it must be refused by the gate,
         // not raise a spurious pending-approval suspension.
-        $result = $service->runLoop([$this->userTurn('go')], new LlmConfiguration(), ToolExecutionContext::none(), ['safe_tool']);
+        $result = $service->runLoop([$this->userTurn('go')], $this->localConfiguration(), ToolExecutionContext::none(), ['safe_tool']);
 
         self::assertSame('handled', $result->finalContent);
         self::assertCount(1, $result->trace);
@@ -934,7 +938,7 @@ final class ToolLoopServiceTest extends TestCase
 
         $second = null;
         try {
-            $service->resume($state, true, new LlmConfiguration(), ToolExecutionContext::none(), null, null, 7);
+            $service->resume($state, true, $this->localConfiguration(), ToolExecutionContext::none(), null, null, 7);
         } catch (ToolApprovalRequiredException $e) {
             $second = $e->state;
         }
@@ -963,7 +967,7 @@ final class ToolLoopServiceTest extends TestCase
         $service = $this->service($mgr, new ToolRegistry([new FakeTool('safe_tool')]));
         $state   = new SuspendedRunState([$this->userTurn('go')], [], 1, 5, 2, ['safe_tool'], []);
 
-        $service->resume($state, true, new LlmConfiguration(), ToolExecutionContext::none(), null, null, 42);
+        $service->resume($state, true, $this->localConfiguration(), ToolExecutionContext::none(), null, null, 42);
 
         // The resumed continuation carries the acting user's uid so BudgetMiddleware
         // gates it (the uid is not part of the persisted options).
@@ -974,7 +978,7 @@ final class ToolLoopServiceTest extends TestCase
     private function suspend(ToolLoopService $service): SuspendedRunState
     {
         try {
-            $service->runLoop([$this->userTurn('delete it')], new LlmConfiguration(), ToolExecutionContext::none(), null);
+            $service->runLoop([$this->userTurn('delete it')], $this->localConfiguration(), ToolExecutionContext::none(), null);
         } catch (ToolApprovalRequiredException $e) {
             return $e->state;
         }
@@ -1036,10 +1040,14 @@ final class ToolLoopServiceTest extends TestCase
             },
         );
 
-        $configuration = new LlmConfiguration();
+        // LOCAL zone so the trust-zone axis permits BOTH tools: the
+        // configuration's group restriction must then be the sole reason
+        // system_tool is withheld, not a second gate coincidentally agreeing.
+        $configuration = $this->localConfiguration();
         $configuration->setAllowedToolGroups('content');
 
-        $service = $this->service($mgr, $registry, null, new AllowedToolsResolver(new SkillComposer(), $registry));
+        $availability = new FakeToolAvailability($registry->names());
+        $service      = new ToolLoopService($mgr, $registry, $this->realPolicy($registry, $availability));
 
         // The caller explicitly asks for both, and both are globally enabled.
         $service->runLoop([$this->userTurn('go')], $configuration, ToolExecutionContext::none(), ['content_tool', 'system_tool']);
@@ -1059,7 +1067,7 @@ final class ToolLoopServiceTest extends TestCase
 
         $state = null;
         try {
-            $service->runLoop([$this->userTurn('weather?')], new LlmConfiguration(), ToolExecutionContext::none(), ['ask_user']);
+            $service->runLoop([$this->userTurn('weather?')], $this->localConfiguration(), ToolExecutionContext::none(), ['ask_user']);
             self::fail('Expected the run to suspend for input.');
         } catch (ToolInputRequiredException $e) {
             $state = $e->state;
@@ -1081,7 +1089,7 @@ final class ToolLoopServiceTest extends TestCase
         $service = $this->service($mgr, new ToolRegistry([new FakeInputTool('ask_user', [])]));
 
         $this->expectException(LogicException::class);
-        $service->runLoop([$this->userTurn('go')], new LlmConfiguration(), ToolExecutionContext::none(), ['ask_user']);
+        $service->runLoop([$this->userTurn('go')], $this->localConfiguration(), ToolExecutionContext::none(), ['ask_user']);
     }
 
     #[Test]
@@ -1096,7 +1104,7 @@ final class ToolLoopServiceTest extends TestCase
 
         // ask_user is registered but NOT offered: a model naming it is refused by
         // the gate, not turned into a spurious input suspension.
-        $result = $service->runLoop([$this->userTurn('go')], new LlmConfiguration(), ToolExecutionContext::none(), ['safe_tool']);
+        $result = $service->runLoop([$this->userTurn('go')], $this->localConfiguration(), ToolExecutionContext::none(), ['safe_tool']);
 
         self::assertSame('handled', $result->finalContent);
         self::assertTrue($result->trace[0]->isError);
@@ -1125,7 +1133,7 @@ final class ToolLoopServiceTest extends TestCase
         );
 
         // The human supplies the declared 'city' and an undeclared 'evil'.
-        $service->resumeWithInput($state, ['city' => 'Berlin', 'evil' => 'x'], new LlmConfiguration(), ToolExecutionContext::none());
+        $service->resumeWithInput($state, ['city' => 'Berlin', 'evil' => 'x'], $this->localConfiguration(), ToolExecutionContext::none());
 
         // 'city' comes from the human (model's guess stripped); 'note' (model,
         // undeclared) is kept; 'evil' (human, undeclared) is dropped.
@@ -1157,7 +1165,7 @@ final class ToolLoopServiceTest extends TestCase
         );
 
         $trace = new RunTrace();
-        $service->resumeWithInput($state, ['city' => 'Berlin'], new LlmConfiguration(), ToolExecutionContext::none(), null, $trace);
+        $service->resumeWithInput($state, ['city' => 'Berlin'], $this->localConfiguration(), ToolExecutionContext::none(), null, $trace);
 
         // The second input tool got no data — fail-closed refusal, never executed.
         self::assertNull($second->capturedArguments);
@@ -1185,7 +1193,7 @@ final class ToolLoopServiceTest extends TestCase
             [],
         );
 
-        $service->resume($state, true, new LlmConfiguration(), ToolExecutionContext::none());
+        $service->resume($state, true, $this->localConfiguration(), ToolExecutionContext::none());
 
         self::assertNull($tool->capturedArguments);
     }
@@ -1193,21 +1201,14 @@ final class ToolLoopServiceTest extends TestCase
     #[Test]
     public function resumeWithInputRejectsCallerUnvalidatedData(): void
     {
-        // Defence in depth: with a validator wired, resumeWithInput re-checks the
-        // input and refuses data that does not match the declared schema.
-        $mgr = self::createStub(LlmServiceManagerInterface::class);
-        $service = new ToolLoopService(
-            $mgr,
-            new ToolRegistry([new FakeInputTool('ask_user')]),
-            new FakeToolAvailability(['ask_user']),
-            null,
-            5,
-            null,
-            null,
-            null,
-            null,
-            new JsonSchemaValidator(),
-        );
+        // Defence in depth: resumeWithInput re-checks the input and refuses data
+        // that does not match the declared schema. The validator is no longer
+        // something a wiring can omit (ADR-120), so this holds for every
+        // instance rather than only for one that happens to be given one.
+        $mgr          = self::createStub(LlmServiceManagerInterface::class);
+        $registry     = new ToolRegistry([new FakeInputTool('ask_user')]);
+        $availability = new FakeToolAvailability(['ask_user']);
+        $service      = new ToolLoopService($mgr, $registry, $this->realPolicy($registry, $availability));
 
         $state = new SuspendedRunState(
             [$this->userTurn('go')],
@@ -1223,7 +1224,7 @@ final class ToolLoopServiceTest extends TestCase
 
         $this->expectException(LogicException::class);
         // Missing the required 'city'.
-        $service->resumeWithInput($state, [], new LlmConfiguration(), ToolExecutionContext::none());
+        $service->resumeWithInput($state, [], $this->localConfiguration(), ToolExecutionContext::none());
     }
 
     #[Test]
@@ -1245,7 +1246,7 @@ final class ToolLoopServiceTest extends TestCase
             new ContextFitResult($pruned, true, 2, 1, 10, 100, false, 1.15),
         ));
 
-        $service->runLoop([$this->userTurn('a'), $this->userTurn('b')], new LlmConfiguration(), ToolExecutionContext::none(), null);
+        $service->runLoop([$this->userTurn('a'), $this->userTurn('b')], $this->localConfiguration(), ToolExecutionContext::none(), null);
 
         self::assertSame($pruned, $captured);
     }
@@ -1262,7 +1263,7 @@ final class ToolLoopServiceTest extends TestCase
             new ContextFitResult([], false, 0, 1, 999999, 100, true, 1.15),
         ));
 
-        $result = $service->runLoop([$this->userTurn('x')], new LlmConfiguration(), ToolExecutionContext::none(), null);
+        $result = $service->runLoop([$this->userTurn('x')], $this->localConfiguration(), ToolExecutionContext::none(), null);
 
         self::assertSame(AgentRunTerminationReason::CONTEXT_TRUNCATED, $result->terminationReason);
         self::assertTrue($result->truncated);
@@ -1280,36 +1281,71 @@ final class ToolLoopServiceTest extends TestCase
     {
         $registry = new ToolRegistry([new FakeTool('noop')]);
 
+        $availability = new FakeToolAvailability($registry->names());
+
         return new ToolLoopService(
             $mgr,
             $registry,
-            new FakeToolAvailability($registry->names()),
-            null,
-            5,
-            null,
-            null,
-            null,
-            null,
-            null,
-            $contextWindow,
+            $this->realPolicy($registry, $availability),
+            contextWindow: $contextWindow,
         );
+    }
+
+    /**
+     * The REAL composite gate (ADR-094) over a registry and its availability.
+     *
+     * Tests whose subject IS the gate wire this rather than a double: a double
+     * would assert the double's behaviour, which is precisely the substitution
+     * the mandatory-collaborator work exists to remove.
+     */
+    private function realPolicy(ToolRegistry $registry, FakeToolAvailability $availability): ToolCallPolicy
+    {
+        return new ToolCallPolicy(
+            $registry,
+            $availability,
+            new AllowedToolsResolver(new SkillComposer(), $registry),
+            new ToolDataClassResolver($registry),
+            new TrustZoneResolver(),
+        );
+    }
+
+    /**
+     * A configuration whose provider sits in the LOCAL trust zone.
+     *
+     * {@see FakeTool} declares the group `test`, which is absent from the
+     * data-class group defaults and therefore fails closed to SECRET_ADJACENT.
+     * A configuration without a provider fails closed to EXTERNAL_GLOBAL, whose
+     * ceiling is EDITOR_CONTENT, so the gate would deny every fake tool for a
+     * reason these tests are not about. LOCAL's ceiling is SECRET_ADJACENT, so
+     * the trust-zone axis genuinely runs and permits, leaving the axis under
+     * test as the only possible denier.
+     */
+    private function localConfiguration(): LlmConfiguration
+    {
+        $provider = new Provider();
+        $provider->setTrustZoneEnum(TrustZone::LOCAL);
+
+        $model = new Model();
+        $model->setProvider($provider);
+
+        $configuration = new LlmConfiguration();
+        $configuration->setLlmModel($model);
+
+        return $configuration;
     }
 
     private function service(
         LlmServiceManagerInterface $mgr,
         ToolRegistry $registry,
         ?LoggerInterface $logger = null,
-        ?AllowedToolsResolver $allowedTools = null,
     ): ToolLoopService {
+        $availability = new FakeToolAvailability($registry->names());
+
         return new ToolLoopService(
             $mgr,
             $registry,
-            new FakeToolAvailability($registry->names()),
+            $this->realPolicy($registry, $availability),
             $logger,
-            5,
-            null,
-            null,
-            $allowedTools,
         );
     }
 
@@ -1408,12 +1444,10 @@ final class ToolLoopServiceTest extends TestCase
 
             // Tool is registered, globally enabled, AND explicitly allowed — but
             // it requiresAdmin and the acting user is not an admin.
-            $service = new ToolLoopService(
-                $mgr,
-                new ToolRegistry([new FakeTool('fetch_logs', 'ok', true, true)]),
-                new FakeToolAvailability(['fetch_logs']),
-            );
-            $result = $service->runLoop([$this->userTurn('hi')], new LlmConfiguration(), ToolExecutionContext::fromBackendUser($nonAdmin), ['fetch_logs']);
+            $registry     = new ToolRegistry([new FakeTool('fetch_logs', 'ok', true, true)]);
+            $availability = new FakeToolAvailability(['fetch_logs']);
+            $service      = new ToolLoopService($mgr, $registry, $this->realPolicy($registry, $availability));
+            $result       = $service->runLoop([$this->userTurn('hi')], $this->localConfiguration(), ToolExecutionContext::fromBackendUser($nonAdmin), ['fetch_logs']);
 
             self::assertSame('plain answer', $result->finalContent);
             self::assertSame([], $result->trace);
@@ -1445,12 +1479,10 @@ final class ToolLoopServiceTest extends TestCase
                 ->willReturnCallback($this->queueCallback($queue));
 
             // requiresAdmin = true; globally enabled; explicitly allowed.
-            $service = new ToolLoopService(
-                $mgr,
-                new ToolRegistry([new FakeTool('fetch_logs', 'LOGS', true, true)]),
-                new FakeToolAvailability(['fetch_logs']),
-            );
-            $result = $service->runLoop([$this->userTurn('show logs')], new LlmConfiguration(), ToolExecutionContext::fromBackendUser($admin), ['fetch_logs']);
+            $registry     = new ToolRegistry([new FakeTool('fetch_logs', 'LOGS', true, true)]);
+            $availability = new FakeToolAvailability(['fetch_logs']);
+            $service      = new ToolLoopService($mgr, $registry, $this->realPolicy($registry, $availability));
+            $result       = $service->runLoop([$this->userTurn('show logs')], $this->localConfiguration(), ToolExecutionContext::fromBackendUser($admin), ['fetch_logs']);
 
             self::assertCount(1, $result->trace);
             self::assertSame('fetch_logs', $result->trace[0]->name);
@@ -1484,12 +1516,10 @@ final class ToolLoopServiceTest extends TestCase
 
             // Tool requiresAdmin AND is registered, but the global gate reports
             // NO enabled tools — the caller even explicitly allows it.
-            $service = new ToolLoopService(
-                $mgr,
-                new ToolRegistry([new FakeTool('fetch_logs', 'LOGS', true, true)]),
-                new FakeToolAvailability([]),
-            );
-            $result = $service->runLoop([$this->userTurn('hi')], new LlmConfiguration(), ToolExecutionContext::fromBackendUser($admin), ['fetch_logs']);
+            $registry     = new ToolRegistry([new FakeTool('fetch_logs', 'LOGS', true, true)]);
+            $availability = new FakeToolAvailability([]);
+            $service      = new ToolLoopService($mgr, $registry, $this->realPolicy($registry, $availability));
+            $result       = $service->runLoop([$this->userTurn('hi')], $this->localConfiguration(), ToolExecutionContext::fromBackendUser($admin), ['fetch_logs']);
 
             self::assertSame('plain answer', $result->finalContent);
             self::assertSame([], $result->trace);
@@ -1504,10 +1534,12 @@ final class ToolLoopServiceTest extends TestCase
      */
     private function budgetMetadata(?ToolOptions $options): array
     {
-        $service = new ToolLoopService(
+        $registry     = new ToolRegistry([]);
+        $availability = new FakeToolAvailability([]);
+        $service      = new ToolLoopService(
             self::createStub(LlmServiceManagerInterface::class),
-            new ToolRegistry([]),
-            new FakeToolAvailability([]),
+            $registry,
+            $this->realPolicy($registry, $availability),
         );
         /** @var array<string, mixed> $result */
         $result = (new ReflectionClass($service))->getMethod('budgetMetadata')->invoke($service, $options);
@@ -1557,7 +1589,7 @@ final class ToolLoopServiceTest extends TestCase
             ->willReturn($this->response('SYNTHESISED'));
 
         $service = $this->service($mgr, new ToolRegistry([new FakeTool('loop_tool')]));
-        $result  = $service->runLoop([$this->userTurn('loop')], new LlmConfiguration(), ToolExecutionContext::none(), null);
+        $result  = $service->runLoop([$this->userTurn('loop')], $this->localConfiguration(), ToolExecutionContext::none(), null);
 
         self::assertSame(5, $result->iterations);
         self::assertTrue($result->truncated);
@@ -1579,7 +1611,7 @@ final class ToolLoopServiceTest extends TestCase
         $service = $this->service($mgr, new ToolRegistry([new FakeTool('noop')]));
         $result  = $service->runLoop(
             [$this->userTurn('hi')],
-            new LlmConfiguration(),
+            $this->localConfiguration(),
             ToolExecutionContext::none(),
             null,
             null,
@@ -1612,7 +1644,7 @@ final class ToolLoopServiceTest extends TestCase
         $service  = $this->service($mgr, new ToolRegistry([new FakeTool('noop')]));
         $service->runLoop(
             [$this->userTurn('hi')],
-            new LlmConfiguration(),
+            $this->localConfiguration(),
             ToolExecutionContext::none(),
             null,
             new ToolOptions(systemPrompt: 'OVERRIDE_SYS'),
@@ -1648,7 +1680,7 @@ final class ToolLoopServiceTest extends TestCase
 
         $runTrace = new RunTrace();
         $service  = $this->service($mgr, new ToolRegistry([new FakeTool('fetch_logs')]));
-        $service->runLoop([$this->userTurn('hi')], new LlmConfiguration(), ToolExecutionContext::none(), [], null, null, $runTrace);
+        $service->runLoop([$this->userTurn('hi')], $this->localConfiguration(), ToolExecutionContext::none(), [], null, null, $runTrace);
 
         $steps = $runTrace->getSteps();
         self::assertCount(2, $steps);


### PR DESCRIPTION
`ROADMAP.md` asked to make the tool loop's security collaborators mandatory, because an absent one silently weakens the gate. Working it through, two of the item's three premises did not survive contact with the code — both in the unsafe direction — so this does something else and says why. The reasoning is in [ADR-120](Documentation/Adr/Adr120RequiredToolGate.rst).

## What changed

`ToolLoopService`'s composite tool-call policy (ADR-094) is now a **required** constructor argument. An absent one used to fall through to a narrower legacy chain with no trust-zone axis: a weaker gate that nothing made visible.

The **allow-list resolver is deleted**, not made required. Its single read sat inside that legacy chain, which the policy branch returns before. Production always wires a policy, so the argument enforced nothing there, while `ToolCallPolicy` performs the identical check itself. A required argument that no code path consults reads as enforcement and is not.

**No `Null` gate implementation was written.** An allow-all `NullToolCallPolicy` returns the caller's requested list unfiltered and disables the enablement, admin and configuration filters in one step — strictly weaker than the `null` it would replace, which is the failure mode the item exists to remove. A deny-all one is unusable by the tests that motivated it. Tests construct the real `ToolCallPolicy` instead; it needs a registry, an availability service and three stateless resolvers, so this costs a helper rather than a fixture.

The **schema validator** becomes non-nullable with a `new JsonSchemaValidator()` default — stateless, no constructor, so no wiring can omit the ADR-105 re-validation.

The **availability service leaves the constructor** as well: with the legacy chain gone, nothing in the loop read it. PHPStan caught that; it was not in the plan.

## What wiring the real gate revealed

Fixtures passing a provider-less `LlmConfiguration` only ever passed because no gate was wired. Such a configuration fails closed to the `EXTERNAL_GLOBAL` zone, whose `EDITOR_CONTENT` ceiling sits below the data class of the tools those tests use — so the real gate withholds them. That is a finding about the fixtures, not a breakage: a run with a provider-less configuration really does get `fetch_logs` withheld in production today, and no functional test noticed.

Affected fixtures now declare their trust zone. The functional playground tests were the sharp case — with no tools offered the run takes the plain-completion path, which their scripted adapter refuses, so the controller answered 500.

**The gate was confirmed to be deciding, not merely present**: flipping the test zone back to `EXTERNAL_GLOBAL` turns 31 unit tests red. Green with the real gate wired is therefore not green-by-absence.

## Container test

New: `Tests/Functional/DependencyInjection/ToolLoopGateWiringTest.php`. Nothing previously asserted the wiring the whole change depends on — every other test hand-constructs the loop. It checks two things, and the second has the teeth: that the loop resolves proves the required argument is autowirable; that the bound policy is the composite `ToolCallPolicy` proves the container does not reach a narrower implementation that satisfies the type while deciding less. It extends `FunctionalTestCase` directly, because the project base turns a container-compile failure into a skipped test — the exact regression this test exists to catch.

## What this does not close

`ToolCallPolicyInterface` is a public alias, so an install may bind its own implementation. That is an extension point, not a hole, and a test in this package cannot observe a downstream container. Required arguments turn "absent wiring silently weakens the gate" into "substituted wiring deliberately replaces it" — a smaller and far more visible surface, not an eliminated one.

## Gates

Locally on PHP 8.4: unit (5672), functional sqlite (1298), phpstan, cgl, rector, fuzzy.