### PR TITLE
feat(conversation): bound the replayed transcript against the context window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,26 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the prompt and stay that way; the interface serves callers that want the
   service's own defaults, and makes the two mockable.
 
+- A long conversation now shortens instead of failing. `ConversationService`
+  replays the whole history on every turn, so it was the one path that grew
+  without bound until the provider refused it. It is now bounded against the
+  model's context window, the same mechanism the agent loop already used: the
+  oldest exchanges drop out of what is sent, while the system prompt, the
+  opening exchange and the newest turn always survive.
+
+  The stored history is never shortened — it is the audit record. What the model
+  actually saw is recorded separately, as a count of dropped turns on the user
+  row of each turn (`tx_nrllm_ai_session_message.dropped_turns`). NULL there
+  means no fit was evaluated, 0 means it ran and kept everything. Without that
+  a reader could not tell why an answer ignored an earlier turn. Run
+  `extension:setup` or the Database Analyzer for the new column; no data
+  migration is involved.
+
+  When even the shortest permissible transcript does not fit, the request is
+  sent anyway and a warning is logged. The estimate errs high on purpose, so
+  this often succeeds; when it does not, the provider's own error is what the
+  caller would have got before. See ADR-121.
+
 ### Changed
 
 - The agent loop's tool gate is no longer something a wiring can omit. The

--- a/Classes/Domain/ValueObject/AiSessionMessage.php
+++ b/Classes/Domain/ValueObject/AiSessionMessage.php
@@ -30,6 +30,9 @@ final readonly class AiSessionMessage
         public int $completionTokens,
         public int $totalTokens,
         public int $crdate,
+        // Older turns dropped from the transcript sent for this turn (ADR-121).
+        // null = no fit evaluated; 0 = evaluated, nothing dropped.
+        public ?int $droppedTurns = null,
     ) {}
 
     /**

--- a/Classes/Service/Context/TranscriptEstimator.php
+++ b/Classes/Service/Context/TranscriptEstimator.php
@@ -20,6 +20,11 @@ use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
  * Latin text vs the house 4.0), while DENSE segments — tool-call JSON arguments,
  * tool_result payloads, ids and the tool-schema block — divide by 2.5, because
  * minified JSON and code tokenize denser and were the previous overflow vector.
+ * Counts are UTF-8 BYTES, not characters, and deliberately so (ADR-121): bytes
+ * per token stay roughly comparable across scripts while characters per token do
+ * not — Latin runs about one byte per character, CJK about three, and tokens
+ * track the byte count. Counting characters instead would under-count CJK by
+ * roughly a factor of three, which is the direction that fails at the provider.
  * A per-message and per-tool-call overhead covers the role/wrapper tokens the
  * provider adds. The whole estimate is finally scaled by a calibration factor
  * (>= 1.0) the manager grows toward the real prompt-token counts.

--- a/Classes/Service/Feature/ConversationService.php
+++ b/Classes/Service/Feature/ConversationService.php
@@ -20,9 +20,11 @@ use Netresearch\NrLlm\Exception\ConfigurationInactiveException;
 use Netresearch\NrLlm\Exception\ConfigurationNotFoundException;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Netresearch\NrLlm\Service\ConfigurationResolver;
+use Netresearch\NrLlm\Service\Context\ContextWindowManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Service\Session\AiSessionRepositoryInterface;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Symfony\Component\Uid\Uuid;
 
@@ -49,6 +51,11 @@ final readonly class ConversationService implements ConversationServiceInterface
         private LlmServiceManagerInterface $llmManager,
         private AiSessionRepositoryInterface $sessions,
         private ConfigurationResolver $configurationResolver,
+        // Bounds the replayed transcript against the model's context window
+        // (ADR-121). Optional so the existing lean test wiring keeps working;
+        // absent it a conversation grows unbounded exactly as before.
+        private ?ContextWindowManagerInterface $contextWindow = null,
+        private ?LoggerInterface $logger = null,
     ) {}
 
     public function startSession(AiActorContext $actor, string $title = '', ?LlmConfiguration $configuration = null): AiSession
@@ -102,6 +109,45 @@ final readonly class ConversationService implements ConversationServiceInterface
         }
         $messages[] = ChatMessage::user($userMessage);
 
+        // A conversation replays its whole history on every turn, so it is the
+        // one path that grows without bound. Bound it here (ADR-121): the
+        // oldest turns are dropped from what is SENT, never from what is
+        // stored. The count is persisted on the user row below so a trimmed
+        // turn is not merely a log line.
+        $configuration = $this->resolveTurnConfiguration($session, $actor);
+        $droppedTurns  = null;
+        if ($this->contextWindow !== null && $configuration !== null) {
+            // lastUsage is null: each turn is a fresh assembly, so the
+            // manager's calibration starts from its seed rather than carrying a
+            // ratio over from an unrelated turn.
+            $fit          = $this->contextWindow->fit($messages, $configuration, $options, null, []);
+            $messages     = $fit->messages;
+            $droppedTurns = $fit->droppedTurns;
+
+            if ($fit->overflowAtFloor) {
+                // Nothing left to drop and it still does not fit. Send it: the
+                // estimate errs high, so this may well succeed, and if it does
+                // not the provider's own error is what the caller would have
+                // got anyway. Refusing here would end a conversation that the
+                // provider might still have answered.
+                $this->logger?->warning('Conversation transcript does not fit even at its floor; sending it unpruned', [
+                    'session'         => $session->uid,
+                    'droppedTurns'    => $fit->droppedTurns,
+                    'keptTurns'       => $fit->keptTurns,
+                    'estimatedTokens' => $fit->estimatedTokens,
+                    'budget'          => $fit->budget,
+                ]);
+            } elseif ($fit->pruned) {
+                $this->logger?->info('Conversation transcript trimmed to fit the context window', [
+                    'session'         => $session->uid,
+                    'droppedTurns'    => $fit->droppedTurns,
+                    'keptTurns'       => $fit->keptTurns,
+                    'estimatedTokens' => $fit->estimatedTokens,
+                    'budget'          => $fit->budget,
+                ]);
+            }
+        }
+
         // Persist the user turn before the call: it is a real turn regardless of
         // whether the provider then succeeds. The repository allocates the
         // sequence, so two concurrent turns cannot collide on one slot.
@@ -113,10 +159,11 @@ final readonly class ConversationService implements ConversationServiceInterface
             0,
             0,
             0,
+            $droppedTurns,
         );
         $this->sessions->touch($session->uid, $userSequence + 1);
 
-        $response = $this->dispatch($messages, $session, $actor, $options);
+        $response = $this->dispatch($messages, $configuration, $options);
 
         $assistantSequence = $this->sessions->appendMessageAtNextSequence(
             $session->uid,
@@ -133,24 +180,41 @@ final readonly class ConversationService implements ConversationServiceInterface
     }
 
     /**
-     * Run the turn against the session's bound configuration.
+     * Run the turn against the configuration resolved for it.
      *
-     * A session opened without one (the identifier is empty) keeps the generic
-     * path, which resolves the installation default — the pre-ADR-083 behaviour
-     * for callers that never chose a configuration.
+     * A null configuration is a session opened without one: it keeps the
+     * generic path, which resolves the installation default — the pre-ADR-083
+     * behaviour for callers that never chose a configuration.
      *
-     * @param list<ChatMessage> $messages
-     *
-     * @throws AccessDeniedException when the bound configuration is gone, deactivated, or no longer open to the actor
+     * @param list<ChatMessage|array<string, mixed>> $messages
      */
-    private function dispatch(array $messages, AiSession $session, AiActorContext $actor, ChatOptions $options): CompletionResponse
+    private function dispatch(array $messages, ?LlmConfiguration $configuration, ChatOptions $options): CompletionResponse
     {
-        if ($session->configurationIdentifier === '') {
+        if ($configuration === null) {
             return $this->llmManager->chat($messages, $options);
         }
 
+        return $this->llmManager->chatForConfiguration($messages, $configuration, $options);
+    }
+
+    /**
+     * The configuration this turn runs against, or null for a session opened
+     * without one (the pre-ADR-083 generic path, which resolves the
+     * installation default inside the manager).
+     *
+     * Resolved once per turn and before the transcript is assembled, because
+     * the context bound depends on the model it will actually be sent to.
+     *
+     * @throws AccessDeniedException when the bound configuration is gone, deactivated, or no longer open to the actor
+     */
+    private function resolveTurnConfiguration(AiSession $session, AiActorContext $actor): ?LlmConfiguration
+    {
+        if ($session->configurationIdentifier === '') {
+            return null;
+        }
+
         try {
-            $configuration = $this->configurationResolver->getActiveByIdentifierForActor($session->configurationIdentifier, $actor);
+            return $this->configurationResolver->getActiveByIdentifierForActor($session->configurationIdentifier, $actor);
         } catch (ConfigurationNotFoundException|ConfigurationInactiveException $unusable) {
             // Not found or deactivated: the conversation was opened against a
             // configuration that no longer exists or was switched off. Silently
@@ -166,8 +230,6 @@ final readonly class ConversationService implements ConversationServiceInterface
                 $unusable,
             );
         }
-
-        return $this->llmManager->chatForConfiguration($messages, $configuration, $options);
     }
 
     /**

--- a/Classes/Service/Session/AiSessionRepository.php
+++ b/Classes/Service/Session/AiSessionRepository.php
@@ -72,6 +72,7 @@ final readonly class AiSessionRepository implements AiSessionRepositoryInterface
         int $promptTokens,
         int $completionTokens,
         int $totalTokens,
+        ?int $droppedTurns = null,
     ): void {
         $this->connectionPool->getConnectionForTable(self::TABLE_MESSAGE)->insert(self::TABLE_MESSAGE, [
             'pid'               => 0,
@@ -83,6 +84,7 @@ final readonly class AiSessionRepository implements AiSessionRepositoryInterface
             'prompt_tokens'     => $promptTokens,
             'completion_tokens' => $completionTokens,
             'total_tokens'      => $totalTokens,
+            'dropped_turns'     => $droppedTurns,
             'crdate'            => time(),
         ]);
     }
@@ -95,6 +97,7 @@ final readonly class AiSessionRepository implements AiSessionRepositoryInterface
         int $promptTokens,
         int $completionTokens,
         int $totalTokens,
+        ?int $droppedTurns = null,
     ): int {
         // Two concurrent turns in one session must not share a sequence. The
         // unique key on (session, sequence) is the authority: read the next free
@@ -105,7 +108,7 @@ final readonly class AiSessionRepository implements AiSessionRepositoryInterface
             $sequence = $this->nextSequence($sessionUid);
 
             try {
-                $this->appendMessage($sessionUid, $sequence, $role, $content, $model, $promptTokens, $completionTokens, $totalTokens);
+                $this->appendMessage($sessionUid, $sequence, $role, $content, $model, $promptTokens, $completionTokens, $totalTokens, $droppedTurns);
 
                 return $sequence;
             } catch (UniqueConstraintViolationException) {
@@ -219,6 +222,9 @@ final readonly class AiSessionRepository implements AiSessionRepositoryInterface
             completionTokens: self::toInt($row['completion_tokens'] ?? 0),
             totalTokens: self::toInt($row['total_tokens'] ?? 0),
             crdate: self::toInt($row['crdate'] ?? 0),
+            // Null stays null: "no fit was evaluated" is a different fact from
+            // "evaluated, nothing dropped".
+            droppedTurns: isset($row['dropped_turns']) ? self::toInt($row['dropped_turns']) : null,
         ), $rows);
     }
 

--- a/Classes/Service/Session/AiSessionRepositoryInterface.php
+++ b/Classes/Service/Session/AiSessionRepositoryInterface.php
@@ -63,6 +63,10 @@ interface AiSessionRepositoryInterface
         int $promptTokens,
         int $completionTokens,
         int $totalTokens,
+        // How many older turns were dropped from the transcript sent for this
+        // turn (ADR-121). Trailing and defaulted so existing callers are
+        // unaffected; null records that no fit was evaluated.
+        ?int $droppedTurns = null,
     ): int;
 
     /**

--- a/Documentation/Adr/Adr121ConversationContextWindow.rst
+++ b/Documentation/Adr/Adr121ConversationContextWindow.rst
@@ -1,0 +1,116 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-121:
+
+============================================================================
+ADR-121: Conversations are bounded where they are assembled
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-29
+:Authors: Netresearch DTT GmbH
+
+.. _adr-121-context:
+
+Context
+=======
+
+The agent loop bounds its transcript against the model's context window
+(:ref:`adr-107`). Conversations do not. :php:`ConversationService::send()`
+replays the whole persisted history on every turn — system prompt, every stored
+message, then the new one — so a long conversation grows until the provider
+refuses it. The user gets an error instead of an answer, and gets it abruptly:
+the turn before worked.
+
+.. _adr-121-decision:
+
+Decision
+========
+
+Bound the transcript in :php:`ConversationService::send()`, using the existing
+:php:`ContextWindowManager`. The configuration for the turn is resolved before
+the transcript is assembled, because the bound depends on the model the request
+will actually go to.
+
+**Not in the shared completion path.** The obvious-looking alternative was to
+put the fit into the terminal that every configuration-driven call passes
+through, so conversations and everything else would be covered at once. That
+would have broken working callers. Document analysis, translation and plain
+completion all funnel through it, and they send a single large message. The
+manager drops whole older turns; with one turn there is nothing to drop, so it
+reports that the request does not fit and the caller throws. Those calls work
+today. A conversation is the only path that grows across turns, and it is the
+only path bounded here.
+
+**No re-fit on fallback.** The roadmap offered planning against the smallest
+model in the fallback chain, or re-fitting when a fallback fires. The second
+cannot work as the code stands: a context overflow is not classified as
+retryable, so the fallback chain is never walked for it. The first was rejected
+as too costly for the benefit — it would shrink every conversation to the
+smallest model that *might* serve it, including the overwhelming majority of
+turns that never leave the primary.
+
+**When even the floor does not fit, send it anyway.** The manager keeps the
+system prompt, the opening exchange and the newest turn; if that still exceeds
+the budget it says so. The request is sent regardless, and a warning is logged.
+The estimate deliberately errs high, so this often succeeds. When it does not,
+the provider's own error is exactly what the caller would have received before.
+Refusing here would end a conversation the provider might still have answered.
+
+.. _adr-121-visibility:
+
+A trim is recorded, not just logged
+===================================
+
+Trimming means the model answers without part of the history. A reader who
+cannot see that will misread the answer.
+
+The number of dropped turns is persisted on the **user** row of the turn, in
+``tx_nrllm_ai_session_message.dropped_turns``. The user row is written before
+the provider call, so the fact survives a failed call; the assistant row only
+exists on success. ``NULL`` means no fit was evaluated — a row from before this
+change, or a session without a bound configuration. ``0`` means the fit ran and
+kept everything.
+
+The stored history is never shortened. It is the audit record, and it stays
+complete; the column records what the model *saw*, which is a different fact.
+
+A log line alone was not enough. The agent loop can rely on one because a run
+also carries a termination reason and an inspector view; a conversation has
+neither.
+
+The count is not written into a governance event. That table's decisions are
+denials and gates, and the dashboards render them as blocks. A routine, working
+degradation does not belong in a chart operators read as "things that were
+refused".
+
+.. _adr-121-consequences:
+
+Consequences
+============
+
+A long conversation now shortens instead of failing. The oldest exchanges are
+the ones the model stops seeing, which is the least surprising thing to lose.
+
+Nothing reads ``dropped_turns`` yet — there is no conversation UI in the
+backend. It is written because the fact cannot be reconstructed afterwards,
+while a reader can be added whenever one is needed.
+
+Two conversation shapes are still unbounded, and both are follow-ups rather than
+oversights: a session opened without a bound configuration (there is no model to
+measure against, so the manager has no window to fit), and a turn whose options
+pin a provider directly rather than naming a configuration.
+
+.. _adr-121-estimator:
+
+On the token estimate
+=====================
+
+The estimator counts UTF-8 **bytes**, not characters, and this was reviewed and
+kept. Bytes per token stay roughly comparable across scripts while characters
+per token do not: Latin text runs about one byte per character, CJK about three,
+and tokens track the byte count far more closely than the character count.
+Dividing bytes by 3.5 lands within a modest margin for both. Counting characters
+instead would under-estimate CJK by roughly a factor of three — the direction
+that fails at the provider — so the apparently obvious fix would have been a
+significant regression.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -418,3 +418,4 @@ Tools
    Adr118SpecializedServiceVerification
    Adr119BackendModulePlacement
    Adr120RequiredToolGate
+   Adr121ConversationContextWindow

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,12 +16,7 @@ governance audit trail.
 
 ## Next — agent runtime maturity
 
-1. **Conversation-level context-window management.** The tool loop already
-   bounds its transcript (ADR-107); conversations do not. Plan against the
-   smallest reachable model window in the fallback chain — or re-fit when a
-   fallback actually fires — so a long conversation degrades predictably
-   instead of failing on the provider.
-2. **A first-class contract for side-effecting tools.** Promote the tool
+1. **A first-class contract for side-effecting tools.** Promote the tool
    effect declaration (read-only / idempotent write / non-idempotent write,
    ADR-111) into a tool-facing interface with an idempotency scope and an
    optional preview, so writing tools can be built against a contract instead

--- a/Tests/Unit/Command/Fixture/InMemoryAiSessionRepository.php
+++ b/Tests/Unit/Command/Fixture/InMemoryAiSessionRepository.php
@@ -39,6 +39,7 @@ final class InMemoryAiSessionRepository implements AiSessionRepositoryInterface
         int $promptTokens,
         int $completionTokens,
         int $totalTokens,
+        ?int $droppedTurns = null,
     ): void {
         // Not needed by the command tests.
     }
@@ -51,6 +52,7 @@ final class InMemoryAiSessionRepository implements AiSessionRepositoryInterface
         int $promptTokens,
         int $completionTokens,
         int $totalTokens,
+        ?int $droppedTurns = null,
     ): int {
         return 0;
     }

--- a/Tests/Unit/Service/Feature/ConversationServiceTest.php
+++ b/Tests/Unit/Service/Feature/ConversationServiceTest.php
@@ -16,9 +16,11 @@ use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\ContextFitResult;
 use Netresearch\NrLlm\Exception\AccessDeniedException;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
 use Netresearch\NrLlm\Service\ConfigurationResolver;
+use Netresearch\NrLlm\Service\Context\ContextWindowManagerInterface;
 use Netresearch\NrLlm\Service\Feature\ConversationService;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
@@ -366,6 +368,125 @@ final class ConversationServiceTest extends TestCase
         $repository->method('findOneByIdentifier')->willReturn($configuration);
 
         return new ConfigurationResolver($repository);
+    }
+
+    #[Test]
+    public function aTrimmedTurnRecordsHowManyOlderTurnsTheModelDidNotSee(): void
+    {
+        // The persisted history is the audit record and is never shortened. What
+        // the model actually saw is a different fact, and without it a reader
+        // cannot tell why an answer ignored an earlier turn (ADR-121).
+        $repository    = new RecordingAiSessionRepository();
+        $configuration = $this->configuration('editorial');
+
+        $sent    = null;
+        $trimmed = [ChatMessage::user('only the newest turn survived')];
+
+        $contextWindow = $this->createMock(ContextWindowManagerInterface::class);
+        $contextWindow->method('fit')->willReturn(
+            new ContextFitResult($trimmed, true, 4, 1, 900, 1000, false, 1.15),
+        );
+
+        $llmManager = $this->createMock(LlmServiceManagerInterface::class);
+        $llmManager->method('chatForConfiguration')->willReturnCallback(
+            function (array $messages) use (&$sent): CompletionResponse {
+                $sent = $messages;
+
+                return $this->response('answered');
+            },
+        );
+
+        $service = new ConversationService($llmManager, $repository, $this->resolverReturning($configuration), $contextWindow);
+        $actor   = $this->owner();
+        $session = $service->startSession($actor, '', $configuration);
+        $service->send($actor, $session->uuid, 'and now?');
+
+        // The provider saw the trimmed transcript, not the assembled one.
+        self::assertSame($trimmed, $sent);
+
+        $userRow = $this->firstRowWithRole($repository, 'user');
+        self::assertSame(4, $userRow['droppedTurns']);
+    }
+
+    #[Test]
+    public function aTurnThatFitsRecordsZeroDroppedRatherThanNothing(): void
+    {
+        // Zero and "not evaluated" are different facts: zero says the fit ran
+        // and kept everything.
+        $repository    = new RecordingAiSessionRepository();
+        $configuration = $this->configuration('editorial');
+
+        $kept          = [ChatMessage::user('hi')];
+        $contextWindow = $this->createMock(ContextWindowManagerInterface::class);
+        $contextWindow->method('fit')->willReturn(
+            new ContextFitResult($kept, false, 0, 1, 10, 1000, false, 1.15),
+        );
+
+        $llmManager = $this->createMock(LlmServiceManagerInterface::class);
+        $llmManager->method('chatForConfiguration')->willReturn($this->response('short'));
+
+        $service = new ConversationService($llmManager, $repository, $this->resolverReturning($configuration), $contextWindow);
+        $actor   = $this->owner();
+        $session = $service->startSession($actor, '', $configuration);
+        $service->send($actor, $session->uuid, 'hi');
+
+        self::assertSame(0, $this->firstRowWithRole($repository, 'user')['droppedTurns']);
+    }
+
+    #[Test]
+    public function aConversationWithoutAContextManagerRecordsNoFitAndIsUnchanged(): void
+    {
+        $repository    = new RecordingAiSessionRepository();
+        $configuration = $this->configuration('editorial');
+
+        $llmManager = $this->createMock(LlmServiceManagerInterface::class);
+        $llmManager->expects(self::once())->method('chatForConfiguration')->willReturn($this->response('as before'));
+
+        $service = new ConversationService($llmManager, $repository, $this->resolverReturning($configuration));
+        $actor   = $this->owner();
+        $session = $service->startSession($actor, '', $configuration);
+
+        self::assertSame('as before', $service->send($actor, $session->uuid, 'hi')->content);
+        self::assertNull($this->firstRowWithRole($repository, 'user')['droppedTurns']);
+    }
+
+    #[Test]
+    public function aTranscriptThatCannotBeTrimmedAnyFurtherIsStillSent(): void
+    {
+        // Refusing here would end a conversation the provider might still have
+        // answered — the estimate errs high on purpose. If it really is too
+        // large the provider says so, which is what the caller got before.
+        $repository    = new RecordingAiSessionRepository();
+        $configuration = $this->configuration('editorial');
+
+        $floor         = [ChatMessage::user('a very long turn')];
+        $contextWindow = $this->createMock(ContextWindowManagerInterface::class);
+        $contextWindow->method('fit')->willReturn(
+            new ContextFitResult($floor, false, 0, 1, 99999, 1000, true, 1.15),
+        );
+
+        $llmManager = $this->createMock(LlmServiceManagerInterface::class);
+        $llmManager->expects(self::once())->method('chatForConfiguration')->willReturn($this->response('answered anyway'));
+
+        $service = new ConversationService($llmManager, $repository, $this->resolverReturning($configuration), $contextWindow);
+        $actor   = $this->owner();
+        $session = $service->startSession($actor, '', $configuration);
+
+        self::assertSame('answered anyway', $service->send($actor, $session->uuid, 'a very long turn')->content);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function firstRowWithRole(RecordingAiSessionRepository $repository, string $role): array
+    {
+        foreach ($repository->messages as $row) {
+            if ($row['role'] === $role) {
+                return $row;
+            }
+        }
+
+        self::fail(sprintf('No %s row was recorded.', $role));
     }
 
     private function configuration(string $identifier): LlmConfiguration

--- a/Tests/Unit/Service/Session/Fixtures/RecordingAiSessionRepository.php
+++ b/Tests/Unit/Service/Session/Fixtures/RecordingAiSessionRepository.php
@@ -59,12 +59,14 @@ final class RecordingAiSessionRepository implements AiSessionRepositoryInterface
         int $promptTokens,
         int $completionTokens,
         int $totalTokens,
+        ?int $droppedTurns = null,
     ): void {
         $this->messages[] = [
             'session'    => $sessionUid,
             'sequence'   => $sequence,
             'role'       => $role,
             'content'    => $content,
+            'droppedTurns' => $droppedTurns,
             'model'      => $model,
             'prompt'     => $promptTokens,
             'completion' => $completionTokens,
@@ -80,6 +82,7 @@ final class RecordingAiSessionRepository implements AiSessionRepositoryInterface
         int $promptTokens,
         int $completionTokens,
         int $totalTokens,
+        ?int $droppedTurns = null,
     ): int {
         $sequence = 0;
         foreach ($this->messages as $row) {
@@ -88,7 +91,7 @@ final class RecordingAiSessionRepository implements AiSessionRepositoryInterface
             }
         }
 
-        $this->appendMessage($sessionUid, $sequence, $role, $content, $model, $promptTokens, $completionTokens, $totalTokens);
+        $this->appendMessage($sessionUid, $sequence, $role, $content, $model, $promptTokens, $completionTokens, $totalTokens, $droppedTurns);
 
         return $sequence;
     }

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -798,6 +798,13 @@ CREATE TABLE tx_nrllm_ai_session_message (
     prompt_tokens int(11) unsigned DEFAULT '0' NOT NULL,
     completion_tokens int(11) unsigned DEFAULT '0' NOT NULL,
     total_tokens int(11) unsigned DEFAULT '0' NOT NULL,
+    -- How many older turns were dropped from the transcript SENT for this turn
+    -- so it would fit the model's context window (ADR-121). NULL means no fit
+    -- was evaluated (a pre-feature row, or a turn without a bound
+    -- configuration); 0 means it was evaluated and nothing had to go. The
+    -- persisted history itself is never trimmed -- this records what the model
+    -- saw, not what was kept.
+    dropped_turns int(11) unsigned DEFAULT NULL,
 
     crdate int(11) unsigned DEFAULT '0' NOT NULL,
 


### PR DESCRIPTION
A conversation replays its whole history on every turn, so it grew until the provider refused it. The turn before worked; this one returns an error. It is now bounded with the same manager the agent loop already uses (ADR-107). Reasoning in [ADR-121](Documentation/Adr/Adr121ConversationContextWindow.rst).

## Where the bound sits, and where it deliberately does not

In `ConversationService::send()`. The oldest exchanges drop out of what is sent; the system prompt, the opening exchange and the newest turn always survive.

**Not in the shared completion terminal**, which was the first design and would have broken working callers. Document analysis, translation and plain completion all funnel through it and send a *single large message*. The manager drops whole older turns — with one turn there is nothing to drop, so it reports that the request does not fit and the caller throws. A conversation is the only path that grows across turns.

**No re-fit on fallback.** The roadmap offered that as an option. It cannot work as the code stands: a context overflow is not classified as retryable, so the fallback chain is never walked for it. Planning against the smallest reachable model instead was rejected as too expensive for the benefit — it would shrink every conversation to a model that usually never serves it.

The turn's configuration is now resolved *before* the transcript is assembled, rather than at dispatch. The bound depends on the model the request actually goes to.

## A trim is recorded, not just logged

Trimming means the model answers without part of the history. A reader who cannot see that will misread the answer.

The dropped-turn count goes on the **user** row of the turn, `tx_nrllm_ai_session_message.dropped_turns`. That row is written before the provider call, so the fact survives a failed call; the assistant row only exists on success. `NULL` = no fit evaluated (a pre-change row, or a session without a bound configuration). `0` = the fit ran and kept everything.

The stored history is never shortened. It is the audit record; the column records what the model *saw*, which is a different fact.

A log line alone was not enough here. The agent loop can rely on one because a run also carries a termination reason and an inspector view — a conversation has neither. The count is deliberately *not* a governance event: that table holds denials and gates, and the dashboards render them as blocks. A routine, working degradation does not belong in a chart operators read as "things that were refused".

## When even the floor does not fit

The request is sent anyway and a warning is logged. The estimate errs high on purpose, so this often succeeds. When it does not, the provider's own error is exactly what the caller received before. Refusing would end a conversation the provider might still have answered.

## The estimator finding, closed as won't-fix

An earlier review flagged that `TranscriptEstimator` counts UTF-8 bytes rather than characters. Recalculated, switching would be a significant regression: bytes per token stay roughly comparable across scripts while characters per token do not. Latin runs ~1 byte/char, CJK ~3, and tokens track the byte count. Dividing bytes by 3.5 lands within a modest margin for both; dividing *characters* by 3.5 would under-count CJK by roughly a factor of three — the direction that fails at the provider. The reasoning is now in the class docblock so it is not "fixed" later.

## Schema

One nullable column, additive, no data migration and no upgrade wizard. `extension:setup` or the Database Analyzer applies it.

## Tests

Four new unit tests: a trimmed turn records the count and sends the trimmed transcript; a fitting turn records `0` rather than nothing; a service without the manager behaves exactly as before and records `NULL`; a transcript that cannot be trimmed further is still sent.

Verified they bite — breaking the implementation turns two of them red, so they are not passing by coincidence.

Gates locally on PHP 8.4: unit (5676), functional sqlite (1298), phpstan, cgl, rector, fuzzy.

## Still unbounded, as follow-ups

A session opened without a bound configuration has no model to measure against, so no window to fit. A turn whose options pin a provider directly rather than naming a configuration takes the same path. Both are named in the ADR.