### PR TITLE
fix(agent): clear the write fence when a run is requeued

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- A requeued agent run no longer inherits the write fence of its previous
+  attempt. The requeue cleared the worker claim and the lease but left
+  `pending_effect` standing, so a later failure could be judged against a write
+  that was no longer running — and a standing non-idempotent write dead-letters
+  a run whatever its retry budget says. Narrow but reachable: a step naming a
+  tool the registry no longer knows resolves fail-closed to non-idempotent, so
+  a tool removed or renamed between attempts stamps the fence for real. See
+  ADR-122.
+
 - A configuration preset that cannot be imported now says what to do about it,
   and no longer renders a disabled button that looks exactly like the working
   one. Both branches used `btn btn-primary btn-sm` with the same "Import" label

--- a/Classes/Service/Tool/AgentRunRepository.php
+++ b/Classes/Service/Tool/AgentRunRepository.php
@@ -765,7 +765,8 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
      * caller adds the WHERE guard that distinguishes an ownership requeue
      * ({@see requeue()}) from a staleness reclaim ({@see requeueStale()}).
      * queued_request is deliberately left untouched — the stored request is what
-     * the re-dispatched worker re-executes.
+     * the re-dispatched worker re-executes. pending_effect IS cleared: it
+     * describes a write that was in flight during the previous attempt.
      */
     private function applyRequeueSet(QueryBuilder $builder): QueryBuilder
     {
@@ -777,6 +778,13 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
             ->set('requeue_count', 'requeue_count + 1', false)
             ->set('claimed_by', $builder->createNamedParameter(''), false)
             ->set('lease_expires', $builder->createNamedParameter(0, Connection::PARAM_INT), false)
+            // The fence belongs to the attempt that set it, not to the run. A
+            // requeued run has not started its next attempt, so carrying the
+            // previous attempt's pending effect forward would let a later
+            // failure be judged against a write that is no longer in flight —
+            // and a NON_IDEMPOTENT_WRITE left standing dead-letters the run
+            // (ADR-111/112) whatever the retry budget says.
+            ->set('pending_effect', $builder->createNamedParameter(''), false)
             ->set('tstamp', $builder->createNamedParameter($now, Connection::PARAM_INT), false);
     }
 

--- a/Documentation/Adr/Adr122ToolEffectContractDeferred.rst
+++ b/Documentation/Adr/Adr122ToolEffectContractDeferred.rst
@@ -1,0 +1,100 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-122:
+
+============================================================================
+ADR-122: The side-effecting tool contract waits for a side-effecting tool
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-29
+:Authors: Netresearch DTT GmbH
+
+.. _adr-122-context:
+
+Context
+=======
+
+The roadmap asked to promote the tool effect declaration (:ref:`adr-111`) into
+a tool-facing interface with an idempotency scope and an optional preview, "so
+writing tools can be built against a contract instead of a convention".
+
+Three facts decided this differently.
+
+**No tool writes.** All 44 builtin tools read. None implements
+:php:`ToolEffectInterface`; every one takes the ``READ_ONLY`` default. The write
+path exists and is correct — the lease-before-op fence, the fail-closed audit,
+the retry refusal — but nothing exercises it with a real tool.
+
+**The idempotency scope has no reader.** The only place an effect crosses a
+process boundary is the ``pending_effect`` column, and its single consumer
+reduces it to one bit: may this run be retried. A scope value would be a field
+nothing branches on.
+
+**The preview has no caller and no display.** The one surface that could show it
+is the approval card, and that is reachable only for tools implementing a
+separate marker interface, which declaring an effect does not imply. It would
+also have to run inside the reviewing administrator's request rather than the
+run's actor context, which :ref:`adr-083` forbids reading around.
+
+Promoting :php:`getEffect()` onto :php:`ToolInterface` would additionally break
+every builtin and every third-party tool built against the public DI tag, for no
+behavioural gain.
+
+.. _adr-122-decision:
+
+Decision
+========
+
+Do not build the interface, the scope or the preview yet. A contract designed
+before the first writing tool guesses at the shape that tool needs, and this
+codebase has just spent three changes removing exactly that kind of guess: an
+argument that looked like enforcement and was read by nothing.
+
+Do the three things that are real today.
+
+**Clear the write fence on requeue.** ``applyRequeueSet`` cleared the claim and
+the lease but left ``pending_effect`` standing. A requeued run has not started
+its next attempt, so the fence describes a write that is no longer in flight —
+and a standing ``NON_IDEMPOTENT_WRITE`` dead-letters the run whatever the retry
+budget says. Narrow but reachable: a step naming a tool the registry no longer
+knows resolves fail-closed to ``NON_IDEMPOTENT_WRITE``, so a tool removed or
+renamed between attempts stamps the fence for real.
+
+**Pin which tools write.** A new coverage test asserts the set of tools
+resolving to a write effect, currently empty. The declaration is opt-in, so
+forgetting it is silent and costs the tool its fence and its audit. The test
+turns that silence into a failing assertion the first time someone adds a
+writer.
+
+**Correct the roadmap.** It claimed "at-least-once queue delivery with
+idempotent tool effects" as shipped. What shipped is a declared effect
+classification and a fail-closed write audit, with no writing tool to exercise
+either.
+
+.. _adr-122-consequences:
+
+Consequences
+============
+
+Nothing changes for the 44 existing tools.
+
+The first writing tool will find the machinery waiting for it and the coverage
+test asking it to declare itself. Whether it then needs an idempotency scope, a
+preview, or something neither of those describes is a question that tool can
+answer and this one cannot.
+
+.. _adr-122-revisit:
+
+Revisit when
+============
+
+A tool that mutates is proposed. At that point the three deferred pieces should
+be reconsidered against what it actually needs — starting from the tool, not
+from this ADR.
+
+One design constraint surfaced while investigating and is worth recording so it
+is not rediscovered: making a completed non-idempotent write safely replayable
+would require a tool-result dedup store, and that in turn changes the stale-run
+reaper's unconditional dead-letter policy. Those two move together or not at
+all.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -419,3 +419,4 @@ Tools
    Adr119BackendModulePlacement
    Adr120RequiredToolGate
    Adr121ConversationContextWindow
+   Adr122ToolEffectContractDeferred

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,17 +10,20 @@ the quality gate, not when a calendar says so.
 
 The security-hardening arc is shipped: explicit actor context and fail-closed
 authorization through the whole agent runtime, at-least-once queue delivery
-with idempotent tool effects, tool data-class enforcement on by default, agent
-state encrypted at rest, and an operations dashboard with a queryable
-governance audit trail.
+with a declared tool-effect classification and a fail-closed write audit, tool
+data-class enforcement on by default, agent state encrypted at rest, and an
+operations dashboard with a queryable governance audit trail.
 
 ## Next — agent runtime maturity
 
-1. **A first-class contract for side-effecting tools.** Promote the tool
-   effect declaration (read-only / idempotent write / non-idempotent write,
-   ADR-111) into a tool-facing interface with an idempotency scope and an
-   optional preview, so writing tools can be built against a contract instead
-   of a convention.
+1. **A first-class contract for side-effecting tools — when one exists.**
+   The effect classification, the write fence and the fail-closed audit are in
+   place, but all 44 builtin tools read; nothing exercises the write path. The
+   proposed interface, idempotency scope and preview each had no reader and no
+   display, so they are deferred rather than guessed at (ADR-122). The
+   machinery and a coverage test that forces a new writer to declare itself are
+   waiting; the shape of the contract is a question the first writing tool
+   answers.
 
 ## Toward 1.0
 

--- a/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
+++ b/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
+use Netresearch\NrLlm\Service\Agent\AgentRuntime;
 use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
 use Netresearch\NrLlm\Service\Tool\AgentRunRepository;
 use Netresearch\NrLlm\Service\Tool\AgentStateCodec;
@@ -584,6 +585,35 @@ final class AgentRunPersisterTest extends AbstractFunctionalTestCase
         self::assertSame('', $requeued->claimedBy);
         self::assertSame(0, $requeued->leaseExpires);
         self::assertSame('{"messages":[]}', $requeued->queuedRequest);
+    }
+
+    #[Test]
+    public function aRequeuedRunDoesNotInheritThePreviousAttemptsWriteFence(): void
+    {
+        // The fence describes a write that was in flight during ONE attempt. A
+        // requeued run has not started its next attempt, so carrying the value
+        // forward would let a later failure be judged against a write that is
+        // no longer running — and a standing NON_IDEMPOTENT_WRITE dead-letters
+        // the run whatever the retry budget says (ADR-111/112).
+        $handle = $this->persister->enqueue(null, 7, '{"messages":[]}');
+        self::assertNotNull($handle);
+        $run = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($run);
+        self::assertTrue($this->persister->claimQueued($run, 'worker-a:1', time() + 60));
+
+        self::assertTrue($this->persister->markPendingEffect($handle, 'worker-a:1', 'non_idempotent_write', time() + 999));
+        $fenced = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($fenced);
+        self::assertSame('non_idempotent_write', $fenced->pendingEffect);
+
+        self::assertTrue($this->persister->requeue($handle, 'worker-a:1'));
+
+        $requeued = $this->repository->findByUuid($handle->uuid);
+        self::assertNotNull($requeued);
+        self::assertSame('', $requeued->pendingEffect, 'a requeued run must start its next attempt unfenced');
+        // The retry decision reads that value; a stale fence would refuse the
+        // retry the requeue just granted.
+        self::assertTrue(AgentRuntime::mayRetryAfterFence($requeued->pendingEffect));
     }
 
     #[Test]

--- a/Tests/Functional/Service/Tool/ToolEffectCoverageTest.php
+++ b/Tests/Functional/Service/Tool/ToolEffectCoverageTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Domain\Enum\ToolEffect;
+use Netresearch\NrLlm\Service\Tool\ToolEffectResolver;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Which registered tools declare a write effect (ADR-111).
+ *
+ * A tool that declares nothing resolves to READ_ONLY, which is the right
+ * default for the forty-odd read-only builtins but is exactly the wrong one for
+ * a tool that mutates. Nothing in the type system catches that: the declaration
+ * is an opt-in interface, so forgetting it is silent and the run loses its
+ * write fence and its fail-closed audit.
+ *
+ * This test is the reminder. It pins the current answer — no builtin writes —
+ * so the first tool that does forces a conscious edit here, and with it a look
+ * at the fence in the run executor and at the retry decision that reads the
+ * persisted effect.
+ */
+#[CoversClass(ToolEffectResolver::class)]
+final class ToolEffectCoverageTest extends AbstractFunctionalTestCase
+{
+    /**
+     * Tools known to mutate something. Empty on purpose: every builtin reads.
+     *
+     * Adding a name here is a decision, not bookkeeping — see the class
+     * docblock.
+     *
+     * @var list<string>
+     */
+    private const DECLARED_WRITERS = [];
+
+    #[Test]
+    public function onlyToolsListedAsWritersResolveToAWriteEffect(): void
+    {
+        $registry = $this->get(ToolRegistry::class);
+        self::assertInstanceOf(ToolRegistry::class, $registry);
+        self::assertNotSame([], $registry->names(), 'The registry must not be empty, or this test proves nothing.');
+
+        $resolver = new ToolEffectResolver($registry);
+
+        $writers = [];
+        foreach ($registry->names() as $name) {
+            if ($resolver->effectFor($name)->isWrite()) {
+                $writers[] = $name;
+            }
+        }
+        sort($writers);
+
+        $expected = self::DECLARED_WRITERS;
+        sort($expected);
+
+        self::assertSame(
+            $expected,
+            $writers,
+            "The set of writing tools changed. A new writer must be listed here deliberately, and a tool that\n"
+            . "stopped being listed has lost its write fence and its fail-closed audit silently:\n"
+            . implode("\n", $writers),
+        );
+    }
+
+    #[Test]
+    public function anUnknownToolNameIsTreatedAsTheStrictestEffect(): void
+    {
+        // Fail-closed: a step naming a tool the registry no longer knows — one
+        // removed or renamed between attempts — must not be judged safe to
+        // retry just because it can no longer be resolved.
+        $registry = $this->get(ToolRegistry::class);
+        self::assertInstanceOf(ToolRegistry::class, $registry);
+
+        $resolver = new ToolEffectResolver($registry);
+
+        self::assertSame(ToolEffect::NON_IDEMPOTENT_WRITE, $resolver->effectFor('a_tool_that_was_removed'));
+    }
+}


### PR DESCRIPTION
The last open roadmap item asked to promote the tool effect declaration into a tool-facing interface with an idempotency scope and an optional preview. Investigating it produced one real bug, one missing guard, and a decision not to build the interface yet. Reasoning in [ADR-122](Documentation/Adr/Adr122ToolEffectContractDeferred.rst).

## The bug

`applyRequeueSet` released the worker claim and the lease but left `pending_effect` standing. The fence belongs to the *attempt* that set it, not to the run. A requeued run has not started its next attempt, so a later failure could be judged against a write that is no longer in flight — and a standing non-idempotent write dead-letters the run whatever its retry budget says (ADR-111/112).

**Narrow but reachable.** No builtin declares a write effect, so the fence is normally never stamped. But a step naming a tool the registry no longer knows resolves fail-closed to non-idempotent, so a tool removed or renamed between attempts stamps it for real.

Regression test included, and verified to bite: removing the one-line fix turns it red.

## The guard

A coverage test pins the set of tools resolving to a write effect. It is currently empty, and that is the point — the declaration is an opt-in interface, so forgetting it on a writing tool is silent and costs that tool its write fence and its fail-closed audit. The test turns the silence into a failing assertion the first time someone adds a writer, and points them at the fence and the retry decision.

A second case pins the fail-closed answer for an unknown tool name, which is the path that makes the bug above reachable.

## Why the contract is not built

Three facts, each verified against the code:

**No tool writes.** All 44 builtins read. None implements the effect interface; every one takes the read-only default. The write path — fence, fail-closed audit, retry refusal — exists and is correct, but nothing exercises it with a real tool.

**The idempotency scope has no reader.** The effect crosses a process boundary in exactly one column, and its single consumer reduces it to one bit: may this run be retried. A scope value would be a field nothing branches on.

**The preview has no caller and no display.** The one surface that could show it is the approval card, reachable only for tools implementing a separate marker interface — which declaring an effect does not imply. It would also have to run in the reviewing administrator's request rather than the run's actor context, which ADR-083 forbids reading around.

Promoting `getEffect()` onto `ToolInterface` would additionally break every builtin and every third-party tool built against the public DI tag, for no behavioural gain.

This is the same shape as the argument removed in [#554](https://github.com/netresearch/t3x-nr-llm/pull/554): a member that looks like enforcement and is read by nothing. A contract designed before the first writing tool guesses at what that tool needs.

## Roadmap correction

It claimed "at-least-once queue delivery with idempotent tool effects" as shipped. What shipped is a declared effect classification and a fail-closed write audit, with no writing tool to exercise either. The wording now says that, and the open item says what is actually waiting.

## Gates

Locally on PHP 8.4: unit (5676), functional sqlite (1301), phpstan, cgl, rector, fuzzy.