### PR TITLE
fix(privacy): close two secret-egress leaks and unify the secret-shape catalogue (ADR-123)

### DIFF
--- a/Classes/Service/Guardrail/RedactsSecretsTrait.php
+++ b/Classes/Service/Guardrail/RedactsSecretsTrait.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service\Guardrail;
 
 use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
-use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
+use Netresearch\NrLlm\Utility\SecretShapeRedactorTrait;
 
 /**
  * Secret-masking shared by the output ({@see SecretRedactionGuardrail}) and
@@ -20,10 +20,15 @@ use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
  * The two guardrails are separate classes — a single class cannot implement both
  * {@see GuardrailInterface} and {@see InputGuardrailInterface}, whose ``TAG_NAME``
  * constants would collide — but the masking is identical, so it lives here once.
+ *
+ * The shapes themselves live in {@see SecretShapeRedactorTrait}, shared with the
+ * privacy redactor and the environment-listing tool (ADR-123). Guardrails use the
+ * fail-OPEN variant: losing a model response to a regex that gave up would be
+ * worse than missing one pattern.
  */
 trait RedactsSecretsTrait
 {
-    use ErrorMessageSanitizerTrait;
+    use SecretShapeRedactorTrait;
 
     /**
      * REDACT when the masking changed something, otherwise ALLOW (a pass-through)
@@ -31,55 +36,12 @@ trait RedactsSecretsTrait
      */
     private function redactionResult(string $content, string $where): GuardrailResult
     {
-        $redacted = $this->redactSecrets($content);
+        $redacted = $this->redactSecretShapes($content);
 
         if ($redacted === $content) {
             return GuardrailResult::allow();
         }
 
         return GuardrailResult::redact($redacted, sprintf('Redacted secret-shaped strings from the %s.', $where));
-    }
-
-    private function redactSecrets(string $content): string
-    {
-        $redacted = $this->sanitizeErrorMessage($content);
-        // Best-effort masking of common secret shapes the URL sanitiser does not
-        // cover — unknown formats still pass through. Each preg_replace is
-        // guarded: on failure (e.g. a backtrack-limit hit on a huge payload) it
-        // returns null, which a bare (string) cast would turn into '' — silently
-        // wiping the whole content; keep the last good string instead.
-        //
-        // The sk- class allows hyphens/underscores so modern project keys
-        // (sk-proj-…) match.
-        $withoutApiKeys = preg_replace('/\bsk-[A-Za-z0-9_\-]{16,}/', 'sk-***', (string)$redacted);
-        if (is_string($withoutApiKeys)) {
-            $redacted = $withoutApiKeys;
-        }
-        // Bearer token — the class covers base64-standard chars (+ / =) so a
-        // token's tail is not left behind (parity with {@see ContentRedactor}).
-        $withoutBearer = preg_replace('/\b(Bearer\s+)[A-Za-z0-9._~+\/\-]+=*/i', '$1***', (string)$redacted);
-        if (is_string($withoutBearer)) {
-            $redacted = $withoutBearer;
-        }
-        // High-signal vendor secret shapes. A JWT is the canonical bearer secret
-        // even without a `Bearer ` prefix; the rest are fixed-prefix provider
-        // tokens. All patterns are anchored and linear (no ReDoS).
-        $withoutVendor = preg_replace(
-            [
-                '/\beyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+/', // JWT (header.payload.signature)
-                '/\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}/',            // GitHub token
-                '/\bgithub_pat_[A-Za-z0-9_]{22,}/',                        // GitHub fine-grained PAT
-                '/\bAKIA[0-9A-Z]{16,}/',                                   // AWS access-key id
-                '/\bAIza[0-9A-Za-z_\-]{35,}/',                             // Google API key
-                '/\bxox[baprs]-[A-Za-z0-9\-]{10,}/',                       // Slack token
-            ],
-            '***',
-            (string)$redacted,
-        );
-        if (is_string($withoutVendor)) {
-            $redacted = $withoutVendor;
-        }
-
-        return $redacted;
     }
 }

--- a/Classes/Service/Guardrail/SecretRedactionGuardrail.php
+++ b/Classes/Service/Guardrail/SecretRedactionGuardrail.php
@@ -45,8 +45,8 @@ final readonly class SecretRedactionGuardrail implements GuardrailInterface, Str
         // context is echoed into the `thinking` block as readily as the content
         // (ADR-089). Tool-call arguments are NOT redacted — they are functional
         // parameters the tool consumes, and masking them would break the call.
-        $redactedContent  = $this->redactSecrets($response->content);
-        $redactedThinking = $response->thinking !== null ? $this->redactSecrets($response->thinking) : null;
+        $redactedContent  = $this->redactSecretShapes($response->content);
+        $redactedThinking = $response->thinking !== null ? $this->redactSecretShapes($response->thinking) : null;
 
         $contentChanged  = $redactedContent !== $response->content;
         $thinkingChanged = $redactedThinking !== $response->thinking;

--- a/Classes/Service/Privacy/ContentRedactor.php
+++ b/Classes/Service/Privacy/ContentRedactor.php
@@ -9,23 +9,33 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Privacy;
 
-use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
+use Netresearch\NrLlm\Utility\SecretShapeRedactorTrait;
 
 /**
  * Bounded, best-effort redactor for content stored at the REDACTED privacy
  * level (ADR-064).
  *
- * This is a heuristic, NOT a guaranteed PII scrubber. It masks a small set of
- * high-signal secrets — credential-bearing URL query parameters (via the shared
- * {@see ErrorMessageSanitizerTrait}), obvious bearer / API tokens, and email
- * addresses — and caps the payload length. It does not attempt to find names,
- * postal addresses, free-form personal data, or secrets in shapes it does not
- * know. When content must not be stored at all, choose PrivacyLevel::NONE or
- * METADATA instead of relying on this class.
+ * This is a heuristic, NOT a guaranteed PII scrubber. It masks the secret shapes
+ * in {@see SecretShapeRedactorTrait} plus email addresses, and caps the payload
+ * length. It does not attempt to find names, postal addresses, free-form personal
+ * data, or secrets in shapes it does not know. When content must not be stored at
+ * all, choose PrivacyLevel::NONE or METADATA instead of relying on this class.
+ *
+ * It used to carry its own, weaker copy of the secret patterns, which missed
+ * seven shapes the response guardrail already caught — modern OpenAI project
+ * keys, GitHub PATs (classic and fine-grained), AWS and Google keys, Slack
+ * tokens and bare JWTs. A secret masked on its way to a provider was therefore
+ * still written to the database in cleartext. Both now read the same catalogue
+ * (ADR-123).
+ *
+ * Email masking stays here rather than moving into the shared trait: an address
+ * is personal data rather than a secret, and the guardrails must NOT start
+ * stripping addresses out of prompts and responses, where removing one changes
+ * what the text says.
  */
 final class ContentRedactor
 {
-    use ErrorMessageSanitizerTrait;
+    use SecretShapeRedactorTrait;
 
     /** Hard cap on stored length in characters; longer content is truncated. */
     private const MAX_LENGTH = 2000;
@@ -34,37 +44,25 @@ final class ContentRedactor
 
     private const MASK = '***';
 
+    private const EMAIL_PATTERN = '/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/';
+
     public function redact(?string $content): ?string
     {
         if ($content === null) {
             return null;
         }
 
-        // 1. Credential query parameters (?key=, ?token=, …) — reuse the shared
-        //    trait rather than duplicating its regex.
-        $redacted = $this->sanitizeErrorMessage($content);
+        // 1. Every secret shape the extension knows, from the shared catalogue.
+        //    Fail-open: a pattern that gives up must not blank the stored content.
+        $redacted = $this->redactSecretShapes($content);
 
-        // 2. Obvious bearer / API tokens in free text.
-        $redacted = (string)preg_replace(
-            [
-                '/\bBearer\s+[A-Za-z0-9._~+\/-]+=*/i',
-                '/\bsk-[A-Za-z0-9]{20,}/',
-            ],
-            [
-                'Bearer ' . self::MASK,
-                self::MASK,
-            ],
-            $redacted,
-        );
+        // 2. Email addresses — this redactor's own concern, see the class docblock.
+        $withoutEmails = preg_replace(self::EMAIL_PATTERN, self::MASK, $redacted);
+        if (is_string($withoutEmails)) {
+            $redacted = $withoutEmails;
+        }
 
-        // 3. Email addresses.
-        $redacted = (string)preg_replace(
-            '/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/',
-            self::MASK,
-            $redacted,
-        );
-
-        // 4. Cap the stored length.
+        // 3. Cap the stored length.
         if (mb_strlen($redacted) > self::MAX_LENGTH) {
             return mb_substr($redacted, 0, self::MAX_LENGTH) . self::TRUNCATION_MARKER;
         }

--- a/Classes/Service/Tool/Builtin/GetEnvTool.php
+++ b/Classes/Service/Tool/Builtin/GetEnvTool.php
@@ -14,14 +14,24 @@ use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
+use Netresearch\NrLlm\Utility\SecretShapeRedactorTrait;
 
 /**
  * Return the process environment variables with secret VALUES redacted.
  *
- * Security contract (see {@see ToolInterface}): every variable whose NAME
- * matches {@see self::SECRET_PATTERN} (passwords, tokens, keys, salts, DSNs,
- * the TYPO3 encryption key, the nr-vault master key, …) has its value replaced
- * by {@see self::REDACTED} before the listing egresses to the provider.
+ * Security contract (see {@see ToolInterface}): a variable's value is withheld
+ * when EITHER test says secret, because each catches what the other misses:
+ *
+ * - its NAME matches {@see self::SECRET_PATTERN} (passwords, tokens, keys,
+ *   salts, DSNs, the TYPO3 encryption key, the nr-vault master key, …);
+ * - or its VALUE carries a recognised secret shape
+ *   ({@see SecretShapeRedactorTrait}).
+ *
+ * The value test is not redundant. Matching on names alone leaked any variable
+ * whose name gives nothing away: `GITHUB_PAT=ghp_…` and `STRIPE_LIVE=sk_live_…`
+ * both egressed verbatim to the provider, because neither name contains
+ * "TOKEN", "KEY" or "SECRET" (ADR-123).
+ *
  * Non-secret variables show their value so the model can reason about the host
  * (paths, hostnames, the TYPO3 context) without leaking credentials. The
  * unredacted variant is the separate, default-disabled {@see GetEnvRawTool}.
@@ -30,14 +40,20 @@ final readonly class GetEnvTool implements ToolInterface
 {
     use CollectsEnvironmentTrait;
     use SafeCastTrait;
+    use SecretShapeRedactorTrait;
 
     private const SECRET_PATTERN = '/PASS|PASSWORD|PWD|SECRET|TOKEN|KEY|SALT|CREDENTIAL|AUTH|PRIVATE|MASTER|ENCRYPT|DSN|DATABASE_URL|APIKEY|API_KEY/i';
 
     /**
-     * Matches the `user:password@` userinfo of a URL/URI value so credentials
-     * embedded in a non-secret-named connection-string variable (a scheme URL
-     * carrying a password before the `@`) are redacted while the host/path
-     * stays visible for context.
+     * Matches the whole `user:password@` userinfo of a URL/URI value so
+     * credentials embedded in a non-secret-named connection-string variable are
+     * redacted while the host/path stays visible for context.
+     *
+     * Deliberately stricter than the shared trait's equivalent, which masks only
+     * the password and keeps the username: in an error message a username is
+     * useful context, but in a tool listing that egresses to a third party it is
+     * half a credential. Kept here rather than tightened in the shared trait,
+     * which would silently change what provider error messages disclose.
      */
     private const INLINE_CREDENTIAL_PATTERN = '#([a-z][a-z0-9+.\-]*://)[^:@/\s]*:[^@/\s]+@#i';
 
@@ -66,19 +82,38 @@ final readonly class GetEnvTool implements ToolInterface
         ksort($env);
         $lines = [];
         foreach ($env as $name => $value) {
-            if (preg_match(self::SECRET_PATTERN, $name) === 1) {
-                $masked = self::REDACTED;
-            } else {
-                // Even a non-secret-named variable may carry credentials inside
-                // a connection-string value; strip any inline userinfo. Fail
-                // closed: a PCRE error (null) redacts the whole value rather
-                // than egressing a possibly-credential-bearing string.
-                $masked = preg_replace(self::INLINE_CREDENTIAL_PATTERN, '$1' . self::REDACTED . '@', $value) ?? self::REDACTED;
-            }
-            $lines[] = $name . '=' . $masked;
+            $lines[] = $name . '=' . $this->maskValue($name, $value);
         }
 
         return ToolResult::text(implode("\n", $lines));
+    }
+
+    /**
+     * Withhold the whole value when its NAME says secret; otherwise mask any
+     * secret SHAPE inside it.
+     *
+     * Fails CLOSED, unlike the guardrails: this listing egresses to a third-party
+     * provider, so a value the redactor could not fully inspect is withheld
+     * entirely rather than forwarded. Losing one line of host context is cheaper
+     * than leaking a credential.
+     */
+    private function maskValue(string $name, string $value): string
+    {
+        if (preg_match(self::SECRET_PATTERN, $name) === 1) {
+            return self::REDACTED;
+        }
+
+        // Whole userinfo first, so the username is gone before the shared pass
+        // (which would keep it) ever sees the value.
+        $masked = preg_replace(self::INLINE_CREDENTIAL_PATTERN, '$1' . self::REDACTED . '@', $value);
+        if (!is_string($masked)) {
+            return self::REDACTED;
+        }
+
+        // Then every recognised secret shape, masked in place: a connection-string
+        // variable still shows its host and path, which is the context this tool
+        // exists to provide, while a standalone secret leaves nothing but the mask.
+        return $this->redactSecretShapesStrict($masked) ?? self::REDACTED;
     }
 
     public function isEnabledByDefault(): bool

--- a/Classes/Utility/ErrorMessageSanitizerTrait.php
+++ b/Classes/Utility/ErrorMessageSanitizerTrait.php
@@ -15,8 +15,8 @@ namespace Netresearch\NrLlm\Utility;
  *
  * HTTP client exceptions may include the full request URL (e.g., Gemini's
  * `?key=...` pattern). This redacts two shapes:
- * - the values of the well-known credential query parameters (`key`, `api_key`,
- *   `apikey`, `token`, `secret`, `access_token`);
+ * - the values of credential query parameters, including vendor-prefixed names
+ *   such as `client_secret` and `x_api_key`;
  * - the password in a `scheme://user:password@host` userinfo component
  *   (database/service connection strings such as `postgres://…`, `redis://…`).
  * It deliberately does NOT scrub other secret material such as header values —
@@ -25,19 +25,45 @@ namespace Netresearch\NrLlm\Utility;
 trait ErrorMessageSanitizerTrait
 {
     /**
+     * Parameter names whose value is a credential.
+     *
+     * The optional leading `(?:[a-z0-9]+[_\-])?` group is what makes
+     * `client_secret` — the name RFC 6749 §2.3.1 defines — match at all. Without
+     * it the alternation had to match immediately after the `?` or `&`, so an
+     * OAuth client secret in a query string passed through untouched. A name like
+     * `monkey` still cannot match: the prefixed form needs a `_`/`-` separator,
+     * and the bare form has to account for the whole name.
+     */
+    private const CREDENTIAL_PARAMETER_PATTERN = '/([?&])((?:[a-z0-9]+[_\-])?(?:api[_\-]?key|apikey|access[_\-]?token|refresh[_\-]?token|id[_\-]?token|client[_\-]?secret|auth[_\-]?token|key|secret|token|password|passwd|pwd|credential|signature))=[^&\s"\'<>{}\[\](),;#]+/i';
+
+    /**
+     * The password of a `scheme://user:password@host` userinfo. The username may
+     * be empty (`redis://:password@host`). A `~` delimiter is used because the
+     * pattern itself contains `#`.
+     */
+    private const USERINFO_PASSWORD_PATTERN = '~(\b[a-z][a-z0-9+.\-]*://[^:/?#\s@]*):[^@/?#\s"\'<>{}\[\](),;]+@~i';
+
+    /**
      * Redact credential query parameters and connection-string passwords from
      * URLs in the message.
+     *
+     * Both value classes stop at structural characters, not merely at `&` and
+     * whitespace. Bounded only by those, the patterns ran off the end of the URL
+     * and ate the rest of the line: a `?token=…` inside a JSON payload swallowed
+     * the closing quote and the following key. Worse, a URL with a port followed
+     * later by an e-mail address was read as one giant userinfo component: a JSON
+     * message holding both a `https://example.com:8080` url and a contact address
+     * collapsed into a single `https://example.com:***(at)example.org`. That does
+     * not merely lose the port and the contact field, it fabricates a
+     * credentialled URL to a host that was never contacted, misleading whoever
+     * reads the message.
      */
     protected function sanitizeErrorMessage(string $message): string
     {
         return (string)preg_replace(
             [
-                // credential query parameters (?key=, ?token=, …)
-                '/([?&])(key|api_key|apikey|token|secret|access_token)=[^&\s]+/i',
-                // the password in a `scheme://user:password@host` userinfo (the
-                // username may be empty, e.g. `redis://:password@host`). Uses a ~
-                // delimiter because the pattern itself contains '#'.
-                '~(\b[a-z][a-z0-9+.\-]*://[^:/?#\s@]*):[^@/?#\s]+@~i',
+                self::CREDENTIAL_PARAMETER_PATTERN,
+                self::USERINFO_PASSWORD_PATTERN,
             ],
             [
                 '$1$2=***',

--- a/Classes/Utility/SecretShapeRedactorTrait.php
+++ b/Classes/Utility/SecretShapeRedactorTrait.php
@@ -1,0 +1,143 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Utility;
+
+/**
+ * The single catalogue of secret shapes this extension recognises (ADR-123).
+ *
+ * Three places used to mask secrets and each knew a different subset: the
+ * response/prompt guardrails knew modern OpenAI project keys, GitHub PATs, AWS,
+ * Google and Slack tokens and JWTs; the privacy redactor that decides what gets
+ * WRITTEN to the database knew none of those; and the environment-listing tool
+ * matched on variable NAMES only. So a secret correctly masked on its way to a
+ * provider was still persisted in cleartext, and a variable whose name gave
+ * nothing away — ``GITHUB_PAT``, ``STRIPE_LIVE`` — egressed its value verbatim.
+ *
+ * The masks are deliberately not uniform: ``sk-`` and ``Bearer`` keep their
+ * prefix so a reader can tell WHAT was removed, while opaque vendor tokens
+ * collapse to a bare mask.
+ *
+ * Two entry points, because the two kinds of caller need opposite behaviour when
+ * the regex engine gives up — see {@see redactSecretShapes()} (fail open) and
+ * {@see redactSecretShapesStrict()} (fail closed).
+ *
+ * This is best-effort: it recognises these shapes and nothing else, and does not
+ * replace keeping secrets in nr-vault.
+ */
+trait SecretShapeRedactorTrait
+{
+    use ErrorMessageSanitizerTrait;
+
+    private const SECRET_SHAPE_MASK = '***';
+
+    /**
+     * Mask every recognised secret shape, keeping the content when a pattern
+     * fails.
+     *
+     * For paths where losing the text is worse than missing one pattern: a
+     * guardrail rewriting a model response or an outgoing prompt must not replace
+     * the whole payload with an empty string because the regex engine hit a
+     * backtrack limit on a large input.
+     */
+    protected function redactSecretShapes(string $content): string
+    {
+        $failed = false;
+
+        return $this->applySecretShapePatterns($content, $failed);
+    }
+
+    /**
+     * Mask every recognised secret shape, or return null if any pattern failed.
+     *
+     * For egress paths where leaking is worse than losing the value: a caller
+     * listing environment variables to a language model should substitute a mask
+     * rather than forward a possibly secret-bearing string it could not fully
+     * inspect.
+     */
+    protected function redactSecretShapesStrict(string $content): ?string
+    {
+        $failed = false;
+        $redacted = $this->applySecretShapePatterns($content, $failed);
+
+        return $failed ? null : $redacted;
+    }
+
+    /**
+     * Run the pattern list in order, recording whether any pattern failed.
+     *
+     * `preg_replace()` returns null when the engine gives up (a backtrack limit
+     * hit on a huge payload, for instance). A bare (string) cast would turn that
+     * into '' — silently wiping the content, which on a redaction path looks
+     * exactly like a successful, very thorough redaction. The last good string is
+     * kept instead and the failure is reported through $failed so a caller that
+     * must fail closed can.
+     *
+     * Order matters: credential-bearing URLs are masked first, so ``?token=<jwt>``
+     * collapses to one masked parameter rather than a masked JWT behind a
+     * dangling parameter name.
+     */
+    private function applySecretShapePatterns(string $content, bool &$failed): string
+    {
+        // Credential query parameters and connection-string userinfo.
+        $redacted = $this->sanitizeErrorMessage($content);
+
+        foreach (self::secretShapePatterns() as [$pattern, $replacement]) {
+            $result = preg_replace($pattern, $replacement, (string)$redacted);
+
+            if (is_string($result)) {
+                $redacted = $result;
+
+                continue;
+            }
+
+            $failed = true;
+        }
+
+        return $redacted;
+    }
+
+    /**
+     * Secret shapes that survive the URL sanitiser, as [pattern, replacement].
+     *
+     * All patterns are bounded character classes separated by literals — no
+     * nested quantifiers, so none is vulnerable to catastrophic backtracking.
+     *
+     * @return list<array{string, string}>
+     */
+    private static function secretShapePatterns(): array
+    {
+        return [
+            // Bearer credentials FIRST: a 'Bearer <token>' match subsumes whatever
+            // the token is, so running it before the prefix-specific shapes makes
+            // 'Bearer sk-…' collapse to a single mask. The other way round, the
+            // OpenAI rule rewrote the key to 'sk-***' and the Bearer rule then
+            // matched the leftover 'Bearer sk-', yielding 'Bearer ******'.
+            // The class covers base64-standard characters (+ / =) so a token's
+            // tail is not left behind after the mask.
+            ['/\b(Bearer\s+)[A-Za-z0-9._~+\/\-]+=*/i', '$1' . self::SECRET_SHAPE_MASK],
+            // OpenAI. The class allows '-' and '_' so modern project keys
+            // (sk-proj-…) match; the mask keeps the prefix.
+            ['/\bsk-[A-Za-z0-9_\-]{16,}/', 'sk-' . self::SECRET_SHAPE_MASK],
+            // A JWT is the canonical bearer secret even without a 'Bearer '
+            // prefix. Only the header segment must start with 'eyJ'.
+            ['/\beyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+/', self::SECRET_SHAPE_MASK],
+            // GitHub: classic tokens, then fine-grained PATs.
+            ['/\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}/', self::SECRET_SHAPE_MASK],
+            ['/\bgithub_pat_[A-Za-z0-9_]{22,}/', self::SECRET_SHAPE_MASK],
+            ['/\bAKIA[0-9A-Z]{16,}/', self::SECRET_SHAPE_MASK],
+            ['/\bAIza[0-9A-Za-z_\-]{35,}/', self::SECRET_SHAPE_MASK],
+            ['/\bxox[baprs]-[A-Za-z0-9\-]{10,}/', self::SECRET_SHAPE_MASK],
+            // Stripe secret and publishable keys. Note the underscore: these do
+            // not collide with the hyphenated OpenAI shape above.
+            ['/\b[sp]k_(?:live|test)_[A-Za-z0-9]{24,}/', self::SECRET_SHAPE_MASK],
+            ['/\bSG\.[A-Za-z0-9_\-]{22}\.[A-Za-z0-9_\-]{43}/', self::SECRET_SHAPE_MASK],
+        ];
+    }
+}

--- a/Documentation/Adr/Adr114EncryptAgentStateAtRest.rst
+++ b/Documentation/Adr/Adr114EncryptAgentStateAtRest.rst
@@ -81,8 +81,42 @@ Consequences
   resuming a forged or corrupt state.
 - The columns stay ``mediumtext``; the base64 JSON envelope is larger than the
   plaintext but well within the 16 MB bound.
-- **Key rotation is the vault's**, not a reserved future slot: rotating the
-  master key re-wraps the DEKs without touching the row ciphertext. The
-  privacy-retention policy (:ref:`ADR-064 <adr-064>`) still governs how long
+- The privacy-retention policy (:ref:`ADR-064 <adr-064>`) still governs how long
   state is kept — encryption protects it while it exists, it does not extend its
   life.
+
+.. _adr-114-rotation:
+
+Key rotation: not yet covered
+=============================
+
+.. warning::
+
+   An earlier revision of this ADR stated that "key rotation is the vault's …
+   rotating the master key re-wraps the DEKs without touching the row
+   ciphertext", citing nr-vault's rotate command and its
+   :php:`MasterKeyRotatedEvent`. **That was wrong on both counts**, and the
+   correction is recorded here rather than quietly edited away.
+
+   nr-vault's ``vault:rotate-master-key`` re-wraps the DEKs it finds by iterating
+   its own ``tx_nrvault_secret`` table. The DEK of an agent-state envelope lives
+   in ``tx_nrllm_agentrun``, where that iteration never reaches it. And
+   :php:`MasterKeyRotatedEvent`, though declared and documented upstream, was
+   never dispatched from anywhere — so this extension could not have subscribed
+   to learn a rotation had happened either.
+
+   **Consequence today:** if an operator rotates the nr-vault master key, every
+   encrypted QUEUED or suspended agent-run row becomes permanently undecryptable.
+   The fail-soft read path treats such a run as unreadable, so nothing crashes —
+   in-flight runs are lost, not the installation. Rows written before ADR-114
+   landed (plaintext JSON, no ``v2:`` marker) are unaffected, and no other
+   nr-llm data is encrypted this way.
+
+   **Fix in progress:** nr-vault gained a
+   :php:`ForeignEnvelopeRotatorInterface` (nr-vault ADR-033) that re-wraps a
+   consumer's envelopes inside the rotation's own transaction. This extension
+   registers a rotator for ``tx_nrllm_agentrun`` as soon as a released nr-vault
+   version contains it; this section is replaced when that lands.
+
+   **Until then:** treat a master-key rotation as draining the agent queue. Let
+   queued and suspended runs finish first, or accept losing them.

--- a/Documentation/Adr/Adr123OneSecretShapeCatalogue.rst
+++ b/Documentation/Adr/Adr123OneSecretShapeCatalogue.rst
@@ -1,0 +1,129 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-123:
+
+============================================================================
+ADR-123: One catalogue of secret shapes for every masking path
+============================================================================
+
+:Status: Accepted
+:Date: 2026-07-29
+:Authors: Netresearch DTT GmbH
+
+.. _adr-123-context:
+
+Context
+=======
+
+Three places in this extension masked secrets, and each knew a different subset
+of what a secret looks like:
+
+- :php:`RedactsSecretsTrait`, behind the response and prompt guardrails
+  (:ref:`ADR-085 <adr-085>` / :ref:`ADR-087 <adr-087>`), knew modern OpenAI
+  project keys, classic and fine-grained GitHub PATs, AWS and Google keys, Slack
+  tokens and bare JWTs.
+- :php:`ContentRedactor`, which decides what gets **written to the database** at
+  privacy level REDACTED (:ref:`ADR-064 <adr-064>`), knew only credential-bearing
+  URLs, ``Bearer`` headers, a narrower ``sk-`` pattern and e-mail addresses.
+- :php:`GetEnvTool` matched on variable **names** only.
+
+Measured against twelve secret shapes, the guardrail masked eleven and the
+privacy redactor seven fewer. The consequence was not theoretical: a secret
+correctly stripped from a prompt on its way to a provider was still persisted in
+cleartext, because the two paths disagreed about what a secret is.
+
+``GetEnvTool``'s name-only rule had a second version of the same problem. The
+tool is admin-only but **enabled by default**, and its output egresses to the
+configured LLM provider. A variable whose name gives nothing away leaked its
+value verbatim:
+
+.. code-block:: text
+
+   GITHUB_PAT=ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+   STRIPE_LIVE=sk_live_<24 alphanumerics>
+
+Neither name contains ``PASS``, ``KEY``, ``SECRET`` or ``TOKEN``, so neither was
+redacted.
+
+.. _adr-123-decision:
+
+Decision
+========
+
+Move the shapes into one place, :php:`Netresearch\\NrLlm\\Utility\\SecretShapeRedactorTrait`,
+next to the :php:`ErrorMessageSanitizerTrait` it builds on, and have all three
+consumers read from it.
+
+Two entry points, opposite failure modes
+----------------------------------------
+
+``preg_replace()`` returns ``null`` when the regex engine gives up, and a bare
+``(string)`` cast turns that into ``''``. On a redaction path, wiping the entire
+content looks exactly like a successful, very thorough redaction. The two kinds
+of caller need opposite handling, so the trait offers both explicitly:
+
+- :php:`redactSecretShapes()` — **fails open**, keeping the text. For the
+  guardrails: losing a model's whole response, or an outgoing prompt, because one
+  pattern hit a backtrack limit is worse than missing that pattern.
+- :php:`redactSecretShapesStrict()` — **fails closed**, returning null. For
+  :php:`GetEnvTool`: a value the redactor could not fully inspect is withheld
+  rather than forwarded to a third party.
+
+``GetEnvTool`` checks both name and value
+-----------------------------------------
+
+The name rule is kept and the value rule is added, because each catches what the
+other misses: a name rule catches an empty or unrecognised-format secret
+(``DB_PASSWORD=hunter2``) that no shape pattern would match, and a value rule
+catches a recognised secret under a neutral name. A test asserts that the three
+neutral fixture names are **not** matched by the name pattern, so the value path
+cannot silently stop being exercised if someone widens the name rule later.
+
+The tool keeps its own, stricter URL-userinfo pattern, which masks the whole
+``user:password@`` rather than just the password. In a provider error message a
+username is useful context; in a listing that egresses to a third party it is
+half a credential. Tightening the shared trait instead would have silently
+changed what every provider error message discloses.
+
+E-mail masking stays with the privacy redactor
+----------------------------------------------
+
+An address is personal data, not a secret, and the guardrails must not begin
+stripping addresses out of prompts and responses — removing one changes what the
+text says. :php:`ContentRedactor` masks them because it writes to storage; the
+guardrails do not.
+
+.. _adr-123-consequences:
+
+Consequences
+============
+
+- The privacy redactor now masks every shape the guardrails do, so the
+  persist path can no longer be weaker than the egress path.
+- ``GetEnvTool`` no longer leaks secret-shaped values under harmless names. A
+  connection-string variable still shows its host and path — the context the
+  tool exists to provide.
+- New shapes (Stripe secret and publishable keys, SendGrid) were added while
+  consolidating, so all three consumers gained them at once.
+- Adding the next shape is a one-line change in one file instead of three
+  edits by someone who has to know all three places exist.
+- This remains best-effort. It recognises these shapes and nothing else, and does
+  not weaken the rule that secrets belong in nr-vault, never in a prompt, a
+  column or an environment variable.
+
+.. _adr-123-upstream:
+
+Relationship to nr-vault
+========================
+
+nr-vault carries the same knowledge for its plaintext scanner, and it had drifted
+the other way — it knew Stripe, SendGrid, Twilio, Mailchimp and PayPal but not
+OpenAI project keys or fine-grained PATs. The merged superset now lives upstream
+in :php:`Netresearch\\NrVault\\Secret\\SecretPatternLibrary` (nr-vault ADR-031),
+which is the right long-term home: one catalogue for every Netresearch extension
+rather than one per extension.
+
+This trait is deliberately shaped so that adopting the upstream library is a
+change to :php:`applySecretShapePatterns()` alone, with the two failure-mode
+entry points and every call site unchanged. That swap waits on a released
+nr-vault version that contains the library.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -420,3 +420,4 @@ Tools
    Adr120RequiredToolGate
    Adr121ConversationContextWindow
    Adr122ToolEffectContractDeferred
+   Adr123OneSecretShapeCatalogue

--- a/Tests/Unit/Service/Privacy/ContentRedactorTest.php
+++ b/Tests/Unit/Service/Privacy/ContentRedactorTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Service\Privacy;
 
 use Netresearch\NrLlm\Service\Privacy\ContentRedactor;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -63,5 +64,48 @@ final class ContentRedactorTest extends TestCase
         self::assertIsString($out);
         self::assertLessThan(mb_strlen($long), mb_strlen($out));
         self::assertStringEndsWith('[truncated]', $out);
+    }
+
+    /**
+     * The shapes this redactor used to miss while the response guardrail already
+     * caught them — so a secret masked on the way to a provider was still written
+     * to the database in cleartext (ADR-123).
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function previouslyMissedShapeProvider(): iterable
+    {
+        yield 'OpenAI project key' => ['sk-proj-AbCdEf01234567890abcdefGHIJKL'];
+        yield 'GitHub PAT' => ['ghp_' . str_repeat('a', 36)];
+        yield 'GitHub fine-grained PAT' => ['github_pat_' . str_repeat('b', 30)];
+        yield 'AWS access key' => ['AKIAIOSFODNN7EXAMPLE'];
+        yield 'Google API key' => ['AIza' . str_repeat('c', 35)];
+        yield 'Slack bot token' => ['xoxb-1234567890-abcdefghij'];
+        yield 'bare JWT' => ['eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abcDEF123'];
+    }
+
+    #[Test]
+    #[DataProvider('previouslyMissedShapeProvider')]
+    public function redactsTheShapesTheGuardrailAlreadyCaught(string $secret): void
+    {
+        $out = (new ContentRedactor())->redact('the value is ' . $secret . ' — keep it safe');
+
+        self::assertIsString($out);
+        self::assertStringNotContainsString($secret, $out);
+        self::assertStringStartsWith('the value is ', $out);
+    }
+
+    #[Test]
+    public function ordinaryContentIsStoredUnchanged(): void
+    {
+        $content = 'Summarise the following page about our opening hours.';
+
+        self::assertSame($content, (new ContentRedactor())->redact($content));
+    }
+
+    #[Test]
+    public function nullStaysNull(): void
+    {
+        self::assertNull((new ContentRedactor())->redact(null));
     }
 }

--- a/Tests/Unit/Service/Tool/Builtin/GetEnvToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/GetEnvToolTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Builtin;
 use Netresearch\NrLlm\Service\Tool\Builtin\GetEnvTool;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -38,6 +39,17 @@ final class GetEnvToolTest extends TestCase
     // Same, but with an EMPTY username (redis://:password@host).
     private const NOUSER_URL_KEY = 'NRLLM_TEST_NOUSER_URL';
     private const NOUSER_URL_VALUE = 'redis://:s3cr3tnouser@cache-02:6379/0';
+    // Names that give NOTHING away — no PASS/KEY/SECRET/TOKEN substring — whose
+    // values are unmistakable secrets. Matching on names alone egressed both
+    // verbatim to the provider (ADR-123).
+    private const SHAPED_PAT_KEY = 'NRLLM_TEST_GITHUB_PAT';
+    private const SHAPED_PAT_VALUE = 'ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    private const SHAPED_STRIPE_KEY = 'NRLLM_TEST_STRIPE_LIVE';
+    // Assembled rather than written out: a complete Stripe-shaped literal in a
+    // committed file trips GitHub's push protection, even as an obvious fixture.
+    private const SHAPED_STRIPE_VALUE = 'sk_live_' . '999999999999999999999999';
+    private const SHAPED_JWT_KEY = 'NRLLM_TEST_SESSION_BLOB';
+    private const SHAPED_JWT_VALUE = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abcDEF123';
 
     protected function setUp(): void
     {
@@ -68,6 +80,9 @@ final class GetEnvToolTest extends TestCase
             self::PWD_KEY         => self::PWD_VALUE,
             self::URL_KEY         => self::URL_VALUE,
             self::NOUSER_URL_KEY  => self::NOUSER_URL_VALUE,
+            self::SHAPED_PAT_KEY  => self::SHAPED_PAT_VALUE,
+            self::SHAPED_STRIPE_KEY => self::SHAPED_STRIPE_VALUE,
+            self::SHAPED_JWT_KEY  => self::SHAPED_JWT_VALUE,
         ];
     }
 
@@ -122,6 +137,50 @@ final class GetEnvToolTest extends TestCase
         // stripped rather than leaking to the provider.
         self::assertStringNotContainsString('s3cr3tnouser', $output);
         self::assertStringContainsString(self::NOUSER_URL_KEY . '=redis://***redacted***@cache-02:6379/0', $output);
+    }
+
+    /**
+     * The name rule cannot see these: nothing in GITHUB_PAT, STRIPE_LIVE or
+     * SESSION_BLOB says secret, so before the value-shape pass all three values
+     * were listed verbatim to the LLM provider.
+     *
+     * @return iterable<string, array{string, string}>
+     */
+    public static function shapedSecretProvider(): iterable
+    {
+        yield 'GitHub PAT under a neutral name' => [self::SHAPED_PAT_KEY, self::SHAPED_PAT_VALUE];
+        yield 'Stripe key under a neutral name' => [self::SHAPED_STRIPE_KEY, self::SHAPED_STRIPE_VALUE];
+        yield 'JWT under a neutral name' => [self::SHAPED_JWT_KEY, self::SHAPED_JWT_VALUE];
+    }
+
+    #[Test]
+    #[DataProvider('shapedSecretProvider')]
+    public function aSecretShapedValueIsRedactedEvenWhenItsNameLooksHarmless(
+        string $name,
+        string $value,
+    ): void {
+        $output = (new GetEnvTool())->execute([], ToolExecutionContext::none())->content;
+
+        self::assertStringNotContainsString($value, $output);
+        self::assertStringContainsString($name . '=', $output, 'The variable itself should still be listed.');
+    }
+
+    #[Test]
+    public function theNameRuleAloneWouldNotHaveCaughtTheseNames(): void
+    {
+        // Guards the premise of the test above: if someone later adds "PAT" or
+        // "STRIPE" to the name pattern, these cases would start passing for the
+        // wrong reason and stop covering the value-shape path.
+        foreach ([self::SHAPED_PAT_KEY, self::SHAPED_STRIPE_KEY, self::SHAPED_JWT_KEY] as $name) {
+            self::assertSame(
+                0,
+                preg_match(
+                    '/PASS|PASSWORD|PWD|SECRET|TOKEN|KEY|SALT|CREDENTIAL|AUTH|PRIVATE|MASTER|ENCRYPT|DSN|DATABASE_URL|APIKEY|API_KEY/i',
+                    $name,
+                ),
+                sprintf('"%s" is now matched by the NAME rule, so it no longer tests the value rule.', $name),
+            );
+        }
     }
 
     #[Test]

--- a/Tests/Unit/Utility/Fixtures/SecretShapeRedactorFixture.php
+++ b/Tests/Unit/Utility/Fixtures/SecretShapeRedactorFixture.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Utility\Fixtures;
+
+use Netresearch\NrLlm\Utility\SecretShapeRedactorTrait;
+
+/**
+ * Exposes {@see SecretShapeRedactorTrait}'s protected API for testing, following
+ * the same fixture convention as the other trait tests in this suite.
+ */
+final class SecretShapeRedactorFixture
+{
+    use SecretShapeRedactorTrait;
+
+    public function redact(string $content): string
+    {
+        return $this->redactSecretShapes($content);
+    }
+
+    public function redactStrict(string $content): ?string
+    {
+        return $this->redactSecretShapesStrict($content);
+    }
+}

--- a/Tests/Unit/Utility/SecretShapeRedactorTraitTest.php
+++ b/Tests/Unit/Utility/SecretShapeRedactorTraitTest.php
@@ -1,0 +1,280 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Utility;
+
+use Netresearch\NrLlm\Tests\Unit\Utility\Fixtures\SecretShapeRedactorFixture;
+use Netresearch\NrLlm\Utility\SecretShapeRedactorTrait;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversTrait(SecretShapeRedactorTrait::class)]
+final class SecretShapeRedactorTraitTest extends TestCase
+{
+    private SecretShapeRedactorFixture $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new SecretShapeRedactorFixture();
+    }
+
+    /**
+     * Every secret shape the extension claims to know, with the material that
+     * must not survive.
+     *
+     * The rows marked GAP are the ones that used to reach the database in
+     * cleartext: the response guardrail masked them, the privacy redactor that
+     * decides what gets PERSISTED did not.
+     *
+     * @return iterable<string, array{string, string}>
+     */
+    public static function secretShapeProvider(): iterable
+    {
+        // The OpenAI mask keeps its 'sk-' prefix on purpose, so these assert on
+        // the key body rather than the prefix.
+        yield 'OpenAI legacy key' => ['sk-abcdefghijklmnopqrstuvwxyz012345', 'abcdefghijklmnop'];
+        yield 'OpenAI project key (GAP)' => ['sk-proj-AbCdEf01234567890abcdefGHIJKL', 'AbCdEf01234567890'];
+        yield 'GitHub PAT (GAP)' => ['ghp_' . self::fill('a', 36), 'ghp_'];
+        yield 'GitHub fine-grained PAT (GAP)' => ['github_pat_' . self::fill('b', 30), 'github_pat_'];
+        yield 'GitHub server token' => ['ghs_' . self::fill('c', 36), 'ghs_'];
+        yield 'GitHub OAuth token' => ['gho_' . self::fill('d', 36), 'gho_'];
+        yield 'AWS access key (GAP)' => ['AKIAIOSFODNN7EXAMPLE', 'AKIA'];
+        yield 'Google API key (GAP)' => ['AIza' . self::fill('e', 35), 'AIza'];
+        yield 'Slack bot token (GAP)' => ['xoxb-1234567890-abcdefghij', 'xoxb-'];
+        yield 'JWT (GAP)' => ['eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abcDEF123', 'eyJ'];
+        yield 'Stripe secret key' => ['sk_live_' . self::fill('9', 24), 'sk_live_'];
+        yield 'Stripe publishable key' => ['pk_test_' . self::fill('8', 24), 'pk_test_'];
+        yield 'SendGrid key' => ['SG.' . self::fill('a', 22) . '.' . self::fill('b', 43), 'SG.'];
+        yield 'Bearer header' => ['Authorization: Bearer abc.def-ghi_jkl+mno/pqr=', 'abc.def'];
+        yield 'URL credential parameter' => ['https://api.example.com/v1?key=SUPERSECRET123&x=1', 'SUPERSECRET123'];
+        yield 'connection string password' => ['postgres://user:hunter2@db.internal:5432/app', 'hunter2'];
+        yield 'passwordless userinfo' => ['redis://:s3cr3tpw@cache:6379/0', 's3cr3tpw'];
+    }
+
+    #[Test]
+    #[DataProvider('secretShapeProvider')]
+    public function everyKnownShapeIsMasked(string $input, string $mustNotRemain): void
+    {
+        $redacted = $this->subject->redact($input);
+
+        self::assertStringNotContainsString($mustNotRemain, $redacted);
+        self::assertNotSame($input, $redacted);
+    }
+
+    #[Test]
+    #[DataProvider('secretShapeProvider')]
+    public function maskingIsIdempotent(string $input, string $mustNotRemain): void
+    {
+        $once = $this->subject->redact($input);
+
+        self::assertSame($once, $this->subject->redact($once));
+        self::assertStringNotContainsString($mustNotRemain, $once);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function innocuousProvider(): iterable
+    {
+        yield 'prose' => ['The quick brown fox jumps over the lazy dog.'];
+        yield 'german prose' => ['Der Schlüssel liegt unter der Fußmatte.'];
+        yield 'plain url' => ['https://example.com/page?id=42&sort=name'];
+        yield 'md5 digest' => ['d41d8cd98f00b204e9800998ecf8427e'];
+        yield 'uuid' => ['01937b6e-4b6c-7abc-8def-0123456789ab'];
+        yield 'code' => ['$config = [\'timeout\' => 30];'];
+        yield 'short sk- word' => ['sk-short'];
+        yield 'model id' => ['claude-opus-4-5-20251101'];
+        yield 'file path' => ['/var/www/html/typo3conf/ext/nr_llm/Classes'];
+    }
+
+    /**
+     * A redactor that mangles ordinary text is worse than useless on a path that
+     * rewrites prompts and model answers.
+     */
+    #[Test]
+    #[DataProvider('innocuousProvider')]
+    public function ordinaryTextIsUntouched(string $input): void
+    {
+        self::assertSame($input, $this->subject->redact($input));
+    }
+
+    #[Test]
+    public function emailAddressesAreNotMasked(): void
+    {
+        // Deliberate: the guardrails rewrite prompts and responses, where removing
+        // an address changes what the text says. ContentRedactor masks them for
+        // storage as its own concern.
+        $text = 'Write to person@example.com about it.';
+
+        self::assertSame($text, $this->subject->redact($text));
+    }
+
+    #[Test]
+    public function surroundingTextSurvivesInPlaceMasking(): void
+    {
+        $redacted = $this->subject->redact('key ghp_' . self::fill('a', 36) . ' then more text');
+
+        self::assertStringStartsWith('key ', $redacted);
+        self::assertStringEndsWith(' then more text', $redacted);
+        self::assertStringNotContainsString('ghp_', $redacted);
+    }
+
+    /**
+     * The fail-OPEN contract, for the guardrail path: `preg_replace()` returns null
+     * when the engine gives up, and casting that to string yields '' — wiping the
+     * model's whole response, which on a redaction path looks like a very thorough
+     * redaction. The content must survive instead.
+     */
+    #[Test]
+    public function aFailingRegexEngineKeepsTheContent(): void
+    {
+        $original = ini_get('pcre.backtrack_limit');
+        ini_set('pcre.backtrack_limit', '1');
+
+        try {
+            $text = 'Bearer ' . self::fill('a', 5000);
+
+            // Precondition: the crushed limit really does make the engine give up
+            // on this pattern. preg_replace() signals that by returning null and
+            // setting preg_last_error(), silently — no diagnostic to suppress.
+            self::assertNull(
+                preg_replace('/\b(Bearer\s+)[A-Za-z0-9._~+\/\-]+=*/i', '$1***', $text),
+                'Precondition: the crushed limit must make this pattern fail.',
+            );
+            self::assertSame(PREG_BACKTRACK_LIMIT_ERROR, preg_last_error());
+
+            $result = $this->subject->redact($text);
+
+            self::assertNotSame('', $result, 'Content was wiped when the engine failed.');
+            self::assertSame($text, $result);
+        } finally {
+            ini_set('pcre.backtrack_limit', $original === false ? '1000000' : $original);
+        }
+    }
+
+    /**
+     * The fail-CLOSED contract, for the egress path: a value the redactor could
+     * not fully inspect must be reported as such, so the caller can withhold it
+     * rather than forward a possibly secret-bearing string to a provider.
+     */
+    #[Test]
+    public function theStrictVariantReportsAFailedPattern(): void
+    {
+        $original = ini_get('pcre.backtrack_limit');
+        ini_set('pcre.backtrack_limit', '1');
+
+        try {
+            self::assertNull($this->subject->redactStrict('Bearer ' . self::fill('a', 5000)));
+        } finally {
+            ini_set('pcre.backtrack_limit', $original === false ? '1000000' : $original);
+        }
+    }
+
+    #[Test]
+    public function theStrictVariantBehavesLikeTheOpenOneWhenNothingFails(): void
+    {
+        $input = 'token ghp_' . self::fill('a', 36);
+
+        self::assertSame($this->subject->redact($input), $this->subject->redactStrict($input));
+    }
+
+    #[Test]
+    public function emptyContentStaysEmpty(): void
+    {
+        self::assertSame('', $this->subject->redact(''));
+        self::assertSame('', $this->subject->redactStrict(''));
+    }
+
+    private static function fill(string $char, int $times): string
+    {
+        return str_repeat($char, $times);
+    }
+
+    /**
+     * Credential query parameters that used to pass through untouched because the
+     * name alternation had no prefix allowance. ``client_secret`` is the name
+     * RFC 6749 §2.3.1 defines, so an OAuth client secret in a URL — which reaches
+     * these paths through provider error messages — was written out verbatim.
+     *
+     * @return iterable<string, array{string, string}>
+     */
+    public static function credentialParameterProvider(): iterable
+    {
+        yield 'client_secret' => ['https://idp.example/token?client_secret=s3cr3tvalue&x=1', 's3cr3tvalue'];
+        yield 'password' => ['https://api.example/login?password=hunter2', 'hunter2'];
+        yield 'api-key hyphenated' => ['https://api.example/v1?api-key=SUPERSECRET123', 'SUPERSECRET123'];
+        yield 'refresh_token' => ['https://api.example/?refresh_token=rt_abcdef123456', 'rt_abcdef123456'];
+        yield 'x_api_key vendor prefix' => ['https://api.example/?x_api_key=abc123def', 'abc123def'];
+    }
+
+    #[Test]
+    #[DataProvider('credentialParameterProvider')]
+    public function credentialQueryParametersAreMasked(string $input, string $secret): void
+    {
+        self::assertStringNotContainsString($secret, $this->subject->redact($input));
+    }
+
+    /**
+     * The URL patterns must stop at structural characters. Unbounded, they ran
+     * past the end of the URL and consumed the rest of the line.
+     */
+    #[Test]
+    public function maskingAQueryParameterKeepsTheSurroundingPayload(): void
+    {
+        $redacted = $this->subject->redact('{"url":"https://x.example/?token=abc","next":"keepme"}');
+
+        self::assertStringContainsString('"next":"keepme"', $redacted);
+        self::assertStringNotContainsString('=abc', $redacted);
+    }
+
+    #[Test]
+    public function maskingAQueryParameterKeepsTheFragment(): void
+    {
+        $redacted = $this->subject->redact('https://x.example/?token=abc#section-two');
+
+        self::assertStringContainsString('#section-two', $redacted);
+        self::assertStringNotContainsString('=abc', $redacted);
+    }
+
+    /**
+     * A URL with a port, followed later by an unrelated address, is not a userinfo
+     * component. Treating it as one deleted the port and everything up to the
+     * address, and fabricated a credentialled URL to a host that was never
+     * contacted — actively misleading whoever reads the redacted message.
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function notUserinfoProvider(): iterable
+    {
+        yield 'JSON url and contact' => ['{"url":"https://example.com:8080","contact":"support@example.org"}'];
+        yield 'port comma address' => ['https://host.example:1234,mail@x.com'];
+        yield 'port space address' => ['https://host.example:8080 mail@x.com'];
+    }
+
+    #[Test]
+    #[DataProvider('notUserinfoProvider')]
+    public function aPortIsNotMistakenForACredential(string $input): void
+    {
+        self::assertSame($input, $this->subject->redact($input));
+    }
+
+    /**
+     * Bearer runs before the prefix-specific shapes, so a bearer-carried vendor
+     * key collapses to ONE mask instead of 'Bearer ******'.
+     */
+    #[Test]
+    public function aBearerCarriedVendorKeyCollapsesToASingleMask(): void
+    {
+        self::assertSame('Bearer ***', $this->subject->redact('Bearer sk-abcdefghijklmnopqrst'));
+    }
+}


### PR DESCRIPTION
Two secret-egress leaks, both caused by the same thing: three places in this
extension masked secrets and each knew a different subset of what a secret looks
like, so the weakest one decided what actually reached storage and the provider.

## The leaks

**Secrets were persisted in cleartext that the guardrail had already masked.**
`ContentRedactor` decides what gets WRITTEN to the database at privacy level
REDACTED (ADR-064). Measured against twelve shapes it missed seven the response
guardrail catches: OpenAI project keys (`sk-proj-…`), classic and fine-grained
GitHub PATs, AWS and Google keys, Slack tokens and bare JWTs. So a secret
correctly stripped from a prompt on its way to a provider was still written to
the database verbatim.

**`GetEnvTool` matched on variable NAMES only.** It is admin-only but **enabled by
default**, and its output egresses to the configured LLM provider. A variable
whose name gives nothing away leaked its value:

```
GITHUB_PAT=ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
STRIPE_LIVE=sk_live_<24 alphanumerics>
```

Neither name contains `PASS`, `KEY`, `SECRET` or `TOKEN`.

**The URL patterns ran off the end of the URL.** `ErrorMessageSanitizerTrait`
feeds provider exception messages and logs, so this was visible in production
output. `?token=…` inside a JSON payload swallowed the closing quote and the
following key. Worse, a URL carrying a port followed later by an address was read
as one giant userinfo component, so a message holding both collapsed into a
fabricated `https://example.com:***(at)example.org` — not merely losing the port
and the contact field, but **inventing a credentialled request to a host that was
never contacted**, so whoever reads the sanitised message draws a wrong
conclusion. And `client_secret` — the name RFC 6749 §2.3.1 defines — never
matched at all, because the alternation had to match immediately after the `?`.
`password` and the hyphenated `api-key` were missing for the same reason.

## The fix

One catalogue, in `Classes/Utility/SecretShapeRedactorTrait`, with **two entry
points because the callers need opposite failure behaviour**:

- `redactSecretShapes()` **fails open** — for the guardrails, where losing a whole
  model response to a backtrack limit is worse than missing one pattern.
- `redactSecretShapesStrict()` **fails closed** — for the environment listing,
  where a value the redactor could not fully inspect is withheld rather than
  forwarded to a third party.

`GetEnvTool` now checks name **and** value shape. The name rule stays, because it
catches a secret in a format no shape pattern knows (`DB_PASSWORD=hunter2`). A
test asserts the three neutral fixture names are **not** matched by the name rule,
so the value path cannot silently stop being exercised if someone widens that rule
later.

Details in [ADR-123](Documentation/Adr/Adr123OneSecretShapeCatalogue.rst).

## Decisions worth reviewing

- **E-mail masking stays with `ContentRedactor`.** An address is personal data,
  not a secret, and the guardrails must not start stripping addresses out of
  prompts and responses — removing one changes what the text says.
- **`GetEnvTool` keeps its own stricter URL-userinfo pattern**, which masks the
  whole `user:password@` rather than just the password. In a provider error message
  a username is useful context; in a listing that egresses to a third party it is
  half a credential. Tightening the shared trait instead would have silently
  changed what every provider error message discloses.
- **`Bearer` runs before the prefix-specific shapes**, so `Bearer sk-…` collapses
  to one mask rather than `Bearer ******`.
- A connection-string variable still shows its host and path — the context the
  tool exists to provide.

## ADR-114 correction

ADR-114 claimed nr-vault's master-key rotation covers the encrypted agent-state
columns. It does not, and **the claim shipped in 0.24.0**: rotation walks
`tx_nrvault_secret` only, and the `MasterKeyRotatedEvent` it cited was never
dispatched from anywhere. So a master-key rotation today makes every encrypted
queued and suspended run permanently unreadable (fail-soft on read, so nothing
crashes — the runs are lost, not the installation).

The correction is recorded as a warning with the real consequence and the
workaround (drain the queue before rotating) rather than quietly edited away.
The actual fix needs nr-vault's new rotator interface
([t3x-nr-vault#230](https://github.com/netresearch/t3x-nr-vault/pull/230)) and is
stacked on this branch, blocked on that release. The nr-vault side is merged
(859bea99); it still needs a tagged release before the follow-up can go green.

## Verification

Full six-suite gate, PHP 8.4:

| Suite | Result |
|---|---|
| cgl | clean |
| PHPStan level 10 | clean |
| unit | **5749** tests, 15989 assertions |
| functional (sqlite) | **1301** tests, 14269 assertions |
| rector | clean |
| fuzzy | 79 tests, 15076 assertions |

Every leak above was reproduced against the real classes before being fixed, and
each has a regression test.


---

Rebased onto `main` after #556 landed. That commit took ADR number 122
(`Adr122ToolEffectContractDeferred`), so this ADR is renumbered **123** and every
reference in code, tests and docs moved with it.
