### PR TITLE
feat(agent): adopt nr-vault's envelope codec and join master-key rotation (ADR-114)

### DIFF
--- a/Classes/Service/Tool/AgentStateCodec.php
+++ b/Classes/Service/Tool/AgentStateCodec.php
@@ -10,10 +10,11 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service\Tool;
 
 use Netresearch\NrLlm\Service\Tool\Exception\AgentStateDecryptionException;
-use Netresearch\NrVault\Crypto\EncryptionServiceInterface;
+use Netresearch\NrVault\Crypto\EnvelopeCodecInterface;
 use Netresearch\NrVault\Exception\EncryptionException;
+use Netresearch\NrVault\Exception\EnvelopeFormatException;
+use Netresearch\NrVault\Exception\MasterKeyException;
 use SensitiveParameter;
-use Throwable;
 
 /**
  * Authenticated encryption for an agent run's state at rest (ADR-114).
@@ -24,25 +25,26 @@ use Throwable;
  * content in cleartext — readable by anyone with database access. This codec
  * encrypts them so the row carries ciphertext, not the conversation.
  *
- * It delegates to nr-vault's {@see EncryptionServiceInterface} — the same
- * managed-key envelope AEAD the vault uses — rather than hand-rolling crypto:
- * a per-value data key wrapped by a rotatable master key (so the master can be
- * rotated without re-encrypting every row), authenticated so a tampered row
- * fails to decrypt, and bound to a per-column ``identifier`` used as additional
- * authenticated data so a ciphertext cannot be moved between the two columns.
+ * Values written by nr-llm 0.24.0-0.25.x carry an older marker;
+ * {@see AgentStateEnvelopeMarker} maps them onto the current form so no data
+ * migration is needed.
  *
- * Stored form: ``v2:`` + base64( json({@see EncryptedData::toArray()}) ). The
- * version prefix distinguishes the envelope from the legacy cleartext it
- * replaces.
+ * The envelope is nr-vault's ({@see EnvelopeCodecInterface}, nr-vault ADR-032):
+ * a per-value data key wrapped by a rotatable master key, authenticated so a
+ * tampered row fails to decrypt, and bound to a per-column ``identifier`` used as
+ * additional authenticated data so a ciphertext cannot be moved between the two
+ * columns. What used to be a hundred lines of framing and field validation here
+ * now lives upstream, and this class is only the storage boundary: the marker
+ * compatibility below, and the mapping of vault exceptions onto the fail-soft
+ * contract the repository expects.
  *
- * Backwards compatible: {@see decode()} returns any value WITHOUT the ``v2:``
- * marker verbatim, so rows written before encryption landed (plaintext JSON)
- * still rehydrate. New writes are always encrypted.
+ * Rotation is covered by {@see AgentStateEnvelopeRotator}, registered with
+ * nr-vault so ``vault:rotate-master-key`` re-wraps these rows inside its own
+ * transaction (nr-vault ADR-033). Sealing without that registration would leave
+ * every encrypted row unreadable after the next rotation.
  */
 final readonly class AgentStateCodec
 {
-    private const VERSION_PREFIX = 'v2:';
-
     /** AAD identifier for the queued request payload (ADR-114). */
     public const PURPOSE_QUEUED_REQUEST = 'nrllm:agent-state:queued-request';
 
@@ -50,7 +52,7 @@ final readonly class AgentStateCodec
     public const PURPOSE_SUSPENDED_STATE = 'nrllm:agent-state:suspended-state';
 
     public function __construct(
-        private EncryptionServiceInterface $encryption,
+        private EnvelopeCodecInterface $envelopeCodec,
     ) {}
 
     /**
@@ -58,6 +60,12 @@ final readonly class AgentStateCodec
      * identifier (used as AAD). An empty string stores as empty (the "no state"
      * sentinel the columns already use), never as a ciphertext of the empty
      * string.
+     *
+     * @throws EncryptionException If encryption fails
+     * @throws MasterKeyException  If the master key is unavailable — a SIBLING of
+     *                             EncryptionException, not a subclass, so the
+     *                             fail-soft persister must catch both rather than
+     *                             storing cleartext
      */
     public function encode(#[SensitiveParameter] string $plaintext, string $identifier): string
     {
@@ -65,90 +73,32 @@ final readonly class AgentStateCodec
             return '';
         }
 
-        $encrypted = $this->encryption->encrypt($plaintext, $identifier);
-
-        return self::VERSION_PREFIX . base64_encode(
-            json_encode($encrypted->toArray(), JSON_THROW_ON_ERROR),
-        );
+        return $this->envelopeCodec->seal($plaintext, $identifier);
     }
 
     /**
-     * Decrypt a stored state payload. A value without the version marker is
-     * treated as legacy cleartext and returned verbatim (upgrade path); an empty
-     * value returns empty. A version-tagged value that fails authentication —
-     * tampered, truncated, moved to the wrong column, or written under a
-     * different key — throws rather than returning a forged plaintext.
+     * Decrypt a stored state payload. A value with neither the current nor the
+     * legacy marker is treated as pre-encryption cleartext and returned verbatim
+     * (upgrade path); an empty value returns empty. A marked value that fails
+     * authentication — tampered, truncated, moved to the wrong column, or written
+     * under a different key — throws rather than returning a forged plaintext.
      *
      * @throws AgentStateDecryptionException
      */
     public function decode(string $stored, string $identifier): string
     {
-        if ($stored === '' || !str_starts_with($stored, self::VERSION_PREFIX)) {
+        $sealed = AgentStateEnvelopeMarker::normalise($stored);
+        if ($sealed === null) {
             return $stored;
         }
 
-        $envelope = $this->parseEnvelope(substr($stored, strlen(self::VERSION_PREFIX)));
-
         try {
-            return $this->encryption->decrypt(
-                $envelope['encrypted_value'],
-                $envelope['encrypted_dek'],
-                $envelope['dek_nonce'],
-                $envelope['value_nonce'],
-                $identifier,
-                $envelope['encryption_version'],
-                $envelope['encryption_algorithm'],
-            );
-        } catch (EncryptionException $exception) {
+            return $this->envelopeCodec->open($sealed, $identifier);
+        } catch (EnvelopeFormatException $exception) {
+            throw AgentStateDecryptionException::corrupted($exception);
+        } catch (EncryptionException|MasterKeyException $exception) {
             throw AgentStateDecryptionException::authenticationFailed($exception);
         }
     }
 
-    /**
-     * Decode and validate the stored envelope fields.
-     *
-     *
-     * @throws AgentStateDecryptionException
-     *
-     * @return array{encrypted_value: string, encrypted_dek: string, dek_nonce: string, value_nonce: string, encryption_version: int, encryption_algorithm: string}
-     */
-    private function parseEnvelope(string $base64): array
-    {
-        $json = base64_decode($base64, true);
-        if ($json === false) {
-            throw AgentStateDecryptionException::corrupted();
-        }
-
-        try {
-            $decoded = json_decode($json, true, 8, JSON_THROW_ON_ERROR);
-        } catch (Throwable) {
-            throw AgentStateDecryptionException::corrupted();
-        }
-
-        if (!is_array($decoded)) {
-            throw AgentStateDecryptionException::corrupted();
-        }
-
-        $value     = $decoded['encrypted_value'] ?? null;
-        $dek       = $decoded['encrypted_dek'] ?? null;
-        $dekNonce  = $decoded['dek_nonce'] ?? null;
-        $valNonce  = $decoded['value_nonce'] ?? null;
-        $version   = $decoded['encryption_version'] ?? null;
-        $algorithm = $decoded['encryption_algorithm'] ?? null;
-
-        if (!is_string($value) || !is_string($dek) || !is_string($dekNonce)
-            || !is_string($valNonce) || !is_int($version) || !is_string($algorithm)
-        ) {
-            throw AgentStateDecryptionException::corrupted();
-        }
-
-        return [
-            'encrypted_value'      => $value,
-            'encrypted_dek'        => $dek,
-            'dek_nonce'            => $dekNonce,
-            'value_nonce'          => $valNonce,
-            'encryption_version'   => $version,
-            'encryption_algorithm' => $algorithm,
-        ];
-    }
 }

--- a/Classes/Service/Tool/AgentStateEnvelopeMarker.php
+++ b/Classes/Service/Tool/AgentStateEnvelopeMarker.php
@@ -39,10 +39,8 @@ final readonly class AgentStateEnvelopeMarker
      */
     public static function normalise(string $stored): ?string
     {
-        if ($stored === '') {
-            return null;
-        }
-
+        // No empty-string guard: '' starts with neither marker, so it already
+        // falls through to null.
         if (str_starts_with($stored, EnvelopeCodecInterface::MARKER)) {
             return $stored;
         }

--- a/Classes/Service/Tool/AgentStateEnvelopeMarker.php
+++ b/Classes/Service/Tool/AgentStateEnvelopeMarker.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+use Netresearch\NrVault\Crypto\EnvelopeCodecInterface;
+
+/**
+ * Tells an agent-state column value apart from cleartext, and brings a
+ * legacy-marked value into the current form (ADR-114).
+ *
+ * nr-llm 0.24.0 through 0.25.x wrote its own ``v2:`` marker before the envelope
+ * moved to nr-vault's codec. The body after the marker is byte-identical to what
+ * the vault writes, so a legacy row is read by swapping the marker rather than by
+ * migrating data.
+ *
+ * This lives in one class because BOTH the read path
+ * ({@see AgentStateCodec::decode()}) and the rotation path
+ * ({@see AgentStateEnvelopeRotator::rewrapAll()}) need it, and they must agree.
+ * They did not, at first: the rotator found legacy rows with its SQL predicate
+ * and then skipped every one of them, because the vault's ``isSealed()`` only
+ * recognises its own marker. The rows would have been left wrapped under the
+ * retired key — the precise failure the rotator exists to prevent.
+ */
+final readonly class AgentStateEnvelopeMarker
+{
+    /** Marker written by nr-llm 0.24.0-0.25.x. */
+    public const LEGACY_MARKER = 'v2:';
+
+    /**
+     * Return the value in the current marker form, or null when it is not an
+     * envelope at all (pre-encryption cleartext, or empty).
+     */
+    public static function normalise(string $stored): ?string
+    {
+        if ($stored === '') {
+            return null;
+        }
+
+        if (str_starts_with($stored, EnvelopeCodecInterface::MARKER)) {
+            return $stored;
+        }
+
+        if (str_starts_with($stored, self::LEGACY_MARKER)) {
+            return EnvelopeCodecInterface::MARKER
+                . substr($stored, \strlen(self::LEGACY_MARKER));
+        }
+
+        return null;
+    }
+
+    /**
+     * Every marker a stored envelope may start with, for a SQL prefix match.
+     *
+     * @return list<string>
+     */
+    public static function markers(): array
+    {
+        return [EnvelopeCodecInterface::MARKER, self::LEGACY_MARKER];
+    }
+}

--- a/Classes/Service/Tool/AgentStateEnvelopeRotator.php
+++ b/Classes/Service/Tool/AgentStateEnvelopeRotator.php
@@ -1,0 +1,198 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use Netresearch\NrVault\Crypto\EnvelopeRotationContext;
+use Netresearch\NrVault\Crypto\ForeignEnvelopeRotatorInterface;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Expression\CompositeExpression;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+
+/**
+ * Re-wraps the encrypted agent-state columns when the nr-vault master key is
+ * rotated (ADR-114, nr-vault ADR-033).
+ *
+ * Without this, encrypting those columns was a delayed data-loss bug rather than
+ * a security improvement. ``vault:rotate-master-key`` re-wraps the data keys it
+ * finds in ``tx_nrvault_secret``; the data keys for these two columns live in
+ * ``tx_nrllm_agentrun``, where that walk never reaches them. A rotation therefore
+ * left every queued and suspended run wrapped under a key the operator was told
+ * to destroy — silently, because the rotation genuinely succeeded at everything
+ * it knew about.
+ *
+ * Registered by tagging this service ``nrvault.foreign_envelope_rotator``, which
+ * makes the vault call {@see rewrapAll()} inside its own rotation transaction.
+ * A failure here rolls the whole rotation back, which is the point: a partial
+ * rotation is worse than none.
+ */
+final readonly class AgentStateEnvelopeRotator implements ForeignEnvelopeRotatorInterface
+{
+    use SafeCastTrait;
+
+    private const TABLE = 'tx_nrllm_agentrun';
+
+    /**
+     * The two sealed columns, each with the AAD identifier it was sealed under.
+     * Passing the wrong identifier would fail authentication, so this mapping is
+     * load-bearing rather than cosmetic.
+     */
+    private const SEALED_COLUMNS = [
+        'queued_request' => AgentStateCodec::PURPOSE_QUEUED_REQUEST,
+        'suspended_state' => AgentStateCodec::PURPOSE_SUSPENDED_STATE,
+    ];
+
+    /**
+     * Rows read per batch. The whole pass runs in the vault's single transaction,
+     * so the batch bounds memory, not transaction size.
+     */
+    private const BATCH_SIZE = 200;
+
+    public function __construct(
+        private ConnectionPool $connectionPool,
+    ) {}
+
+    public function getIdentifier(): string
+    {
+        return 'nr-llm: agent run state';
+    }
+
+    public function getTables(): array
+    {
+        return [self::TABLE];
+    }
+
+    public function countEnvelopes(): int
+    {
+        $connection = $this->connection();
+        $total = 0;
+
+        foreach (array_keys(self::SEALED_COLUMNS) as $column) {
+            $queryBuilder = $connection->createQueryBuilder();
+            $queryBuilder->getRestrictions()->removeAll();
+            $queryBuilder
+                ->count('uid')
+                ->from(self::TABLE)
+                ->where($this->sealedPredicate($queryBuilder, $column));
+
+            $total += self::toInt($queryBuilder->executeQuery()->fetchOne());
+        }
+
+        return $total;
+    }
+
+    public function rewrapAll(EnvelopeRotationContext $context): int
+    {
+        $connection = $this->connection();
+        $rewrapped = 0;
+
+        foreach (self::SEALED_COLUMNS as $column => $identifier) {
+            $lastUid = 0;
+
+            while (true) {
+                $rows = $this->fetchBatch($connection, $column, $lastUid);
+                if ($rows === []) {
+                    break;
+                }
+
+                foreach ($rows as $row) {
+                    $lastUid = $row['uid'];
+
+                    // Normalise BEFORE the guard. The vault's isSealed() only
+                    // recognises its own marker, so testing the raw value skipped
+                    // every legacy row — found by the SQL predicate, then silently
+                    // passed over, and left wrapped under the retired key.
+                    $sealed = AgentStateEnvelopeMarker::normalise($row['value']);
+                    if ($sealed === null || !$context->isSealed($sealed)) {
+                        continue;
+                    }
+
+                    // Writing back the normalised form means a rotation also
+                    // migrates the marker, so the legacy branch empties over time.
+                    $connection->update(
+                        self::TABLE,
+                        [$column => $context->rewrap($sealed, $identifier)],
+                        ['uid' => $row['uid']],
+                    );
+                    ++$rewrapped;
+                }
+            }
+        }
+
+        return $rewrapped;
+    }
+
+    /**
+     * One page of sealed values for a column, keyed by uid for a stable cursor.
+     *
+     * Paged by uid rather than by OFFSET because the rows are being rewritten as
+     * the walk proceeds; an OFFSET page would shift under it.
+     *
+     * @return list<array{uid: int, value: string}>
+     */
+    private function fetchBatch(Connection $connection, string $column, int $afterUid): array
+    {
+        $queryBuilder = $connection->createQueryBuilder();
+        $queryBuilder->getRestrictions()->removeAll();
+        $result = $queryBuilder
+            ->select('uid', $column)
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->gt('uid', $queryBuilder->createNamedParameter($afterUid, Connection::PARAM_INT)),
+                $this->sealedPredicate($queryBuilder, $column),
+            )
+            ->orderBy('uid', 'ASC')
+            ->setMaxResults(self::BATCH_SIZE)
+            ->executeQuery();
+
+        $rows = [];
+        while ($row = $result->fetchAssociative()) {
+            $value = $row[$column] ?? null;
+            if (!\is_string($value) || $value === '') {
+                continue;
+            }
+
+            $rows[] = ['uid' => self::toInt($row['uid'] ?? null), 'value' => $value];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Match a value that STARTS with either marker.
+     *
+     * Both are matched, not just the current one: rows written by nr-llm
+     * 0.24.0-0.25.x carry the legacy ``v2:`` marker and are sealed under the same
+     * master key, so leaving them out would be exactly the silent loss this class
+     * exists to prevent. Anchored at the start rather than searched for anywhere,
+     * so a plaintext payload that happens to contain a marker-like substring is
+     * not picked up.
+     */
+    private function sealedPredicate(QueryBuilder $queryBuilder, string $column): CompositeExpression
+    {
+        return $queryBuilder->expr()->or(
+            ...array_map(
+                static fn(string $prefix): string => $queryBuilder->expr()->like(
+                    $column,
+                    $queryBuilder->createNamedParameter(
+                        $queryBuilder->escapeLikeWildcards($prefix) . '%',
+                    ),
+                ),
+                AgentStateEnvelopeMarker::markers(),
+            ),
+        );
+    }
+
+    private function connection(): Connection
+    {
+        return $this->connectionPool->getConnectionForTable(self::TABLE);
+    }
+}

--- a/Classes/Service/Tool/AgentStateEnvelopeRotator.php
+++ b/Classes/Service/Tool/AgentStateEnvelopeRotator.php
@@ -134,7 +134,9 @@ final readonly class AgentStateEnvelopeRotator implements ForeignEnvelopeRotator
      * One page of sealed values for a column, keyed by uid for a stable cursor.
      *
      * Paged by uid rather than by OFFSET because the rows are being rewritten as
-     * the walk proceeds; an OFFSET page would shift under it.
+     * the walk proceeds; an OFFSET page would shift under it. The cursor advances
+     * over every returned row, so the loop terminates exactly when the query stops
+     * matching.
      *
      * @return list<array{uid: int, value: string}>
      */
@@ -155,12 +157,18 @@ final readonly class AgentStateEnvelopeRotator implements ForeignEnvelopeRotator
 
         $rows = [];
         while ($row = $result->fetchAssociative()) {
+            // Every row the query returned is kept, including any whose value does
+            // not coerce to a usable string. Dropping rows HERE would stop the
+            // cursor advancing past them, and a page that dropped entirely would
+            // end the walk early — leaving later rows un-rotated. The caller skips
+            // non-envelopes instead, so an empty batch means "no more rows", not
+            // "no more interesting rows".
             $value = $row[$column] ?? null;
-            if (!\is_string($value) || $value === '') {
-                continue;
-            }
 
-            $rows[] = ['uid' => self::toInt($row['uid'] ?? null), 'value' => $value];
+            $rows[] = [
+                'uid' => self::toInt($row['uid'] ?? null),
+                'value' => \is_string($value) ? $value : '',
+            ];
         }
 
         return $rows;

--- a/Classes/Service/Tool/Exception/AgentStateDecryptionException.php
+++ b/Classes/Service/Tool/Exception/AgentStateDecryptionException.php
@@ -29,8 +29,8 @@ final class AgentStateDecryptionException extends RuntimeException
         return new self('The stored agent run state failed authentication and was not decrypted.', 1785200001, $previous);
     }
 
-    public static function corrupted(): self
+    public static function corrupted(?Throwable $previous = null): self
     {
-        return new self('The stored agent run state is malformed and could not be decoded.', 1785200002);
+        return new self('The stored agent run state is malformed and could not be decoded.', 1785200002, $previous);
     }
 }

--- a/Classes/Utility/ErrorMessageSanitizerTrait.php
+++ b/Classes/Utility/ErrorMessageSanitizerTrait.php
@@ -9,67 +9,58 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Utility;
 
+use Netresearch\NrVault\Secret\SecretPatternLibrary;
+
 /**
- * Trait for redacting credential-bearing URLs from error messages (and, via the
- * secret guardrails, model output) before they are logged or surfaced.
+ * Trait for redacting credential-bearing URLs from error messages before they are
+ * logged or surfaced.
  *
  * HTTP client exceptions may include the full request URL (e.g., Gemini's
- * `?key=...` pattern). This redacts two shapes:
+ * `?key=...` pattern). This masks the two URL shapes in nr-vault's shared
+ * catalogue (ADR-123, nr-vault ADR-031):
  * - the values of credential query parameters, including vendor-prefixed names
  *   such as `client_secret` and `x_api_key`;
  * - the password in a `scheme://user:password@host` userinfo component
  *   (database/service connection strings such as `postgres://…`, `redis://…`).
- * It deliberately does NOT scrub other secret material such as header values —
- * callers must not write raw header dumps into error messages in the first place.
+ *
+ * It deliberately covers ONLY those two, not the full shape catalogue: this runs
+ * on error messages, where the aim is to strip the credential a client library
+ * put into a URL, not to scan arbitrary prose. Callers that want the whole
+ * catalogue use {@see SecretShapeRedactorTrait}. It also does not scrub header
+ * values — callers must not write raw header dumps into error messages at all.
  */
 trait ErrorMessageSanitizerTrait
 {
     /**
-     * Parameter names whose value is a credential.
-     *
-     * The optional leading `(?:[a-z0-9]+[_\-])?` group is what makes
-     * `client_secret` — the name RFC 6749 §2.3.1 defines — match at all. Without
-     * it the alternation had to match immediately after the `?` or `&`, so an
-     * OAuth client secret in a query string passed through untouched. A name like
-     * `monkey` still cannot match: the prefixed form needs a `_`/`-` separator,
-     * and the bare form has to account for the whole name.
-     */
-    private const CREDENTIAL_PARAMETER_PATTERN = '/([?&])((?:[a-z0-9]+[_\-])?(?:api[_\-]?key|apikey|access[_\-]?token|refresh[_\-]?token|id[_\-]?token|client[_\-]?secret|auth[_\-]?token|key|secret|token|password|passwd|pwd|credential|signature))=[^&\s"\'<>{}\[\](),;#]+/i';
-
-    /**
-     * The password of a `scheme://user:password@host` userinfo. The username may
-     * be empty (`redis://:password@host`). A `~` delimiter is used because the
-     * pattern itself contains `#`.
-     */
-    private const USERINFO_PASSWORD_PATTERN = '~(\b[a-z][a-z0-9+.\-]*://[^:/?#\s@]*):[^@/?#\s"\'<>{}\[\](),;]+@~i';
-
-    /**
      * Redact credential query parameters and connection-string passwords from
      * URLs in the message.
      *
-     * Both value classes stop at structural characters, not merely at `&` and
-     * whitespace. Bounded only by those, the patterns ran off the end of the URL
-     * and ate the rest of the line: a `?token=…` inside a JSON payload swallowed
-     * the closing quote and the following key. Worse, a URL with a port followed
-     * later by an e-mail address was read as one giant userinfo component: a JSON
-     * message holding both a `https://example.com:8080` url and a contact address
-     * collapsed into a single `https://example.com:***(at)example.org`. That does
-     * not merely lose the port and the contact field, it fabricates a
-     * credentialled URL to a host that was never contacted, misleading whoever
-     * reads the message.
+     * The patterns come from the shared catalogue, so the bounding that keeps them
+     * from running off the end of the URL is maintained in one place. Unbounded,
+     * they ate the rest of the message: a `?token=…` inside a JSON payload
+     * swallowed the closing quote and the following key, and a URL carrying a port
+     * followed later by an address collapsed into a single fabricated
+     * `https://host:***(at)example.org` — inventing a credentialled request to a
+     * host that was never contacted.
      */
     protected function sanitizeErrorMessage(string $message): string
     {
-        return (string)preg_replace(
-            [
-                self::CREDENTIAL_PARAMETER_PATTERN,
-                self::USERINFO_PASSWORD_PATTERN,
-            ],
-            [
-                '$1$2=***',
-                '$1:***@',
-            ],
-            $message,
-        );
+        $sanitised = $message;
+
+        foreach (SecretPatternLibrary::urlCredentials() as $pattern) {
+            if ($pattern->inlinePattern === null) {
+                continue;
+            }
+
+            $result = preg_replace($pattern->inlinePattern, $pattern->inlineReplacement, $sanitised);
+
+            // Keep the last good text: a pattern that gives up on a pathological
+            // message must not blank the message entirely.
+            if (\is_string($result)) {
+                $sanitised = $result;
+            }
+        }
+
+        return $sanitised;
     }
 }

--- a/Classes/Utility/SecretShapeRedactorTrait.php
+++ b/Classes/Utility/SecretShapeRedactorTrait.php
@@ -9,34 +9,30 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Utility;
 
+use Netresearch\NrVault\Secret\SecretPatternLibrary;
+
 /**
- * The single catalogue of secret shapes this extension recognises (ADR-123).
+ * Masks the secret shapes nr-vault's catalogue knows (ADR-123, nr-vault ADR-031).
  *
- * Three places used to mask secrets and each knew a different subset: the
- * response/prompt guardrails knew modern OpenAI project keys, GitHub PATs, AWS,
- * Google and Slack tokens and JWTs; the privacy redactor that decides what gets
- * WRITTEN to the database knew none of those; and the environment-listing tool
- * matched on variable NAMES only. So a secret correctly masked on its way to a
- * provider was still persisted in cleartext, and a variable whose name gave
- * nothing away — ``GITHUB_PAT``, ``STRIPE_LIVE`` — egressed its value verbatim.
+ * The shapes are no longer defined here. They live in
+ * {@see SecretPatternLibrary}, the org-wide catalogue shared with nr-vault's
+ * plaintext scanner, so a shape added for either extension is known to both —
+ * which is the whole point of moving it upstream. What stays here is the part
+ * specific to this extension: two entry points with opposite behaviour when the
+ * regex engine gives up.
  *
- * The masks are deliberately not uniform: ``sk-`` and ``Bearer`` keep their
- * prefix so a reader can tell WHAT was removed, while opaque vendor tokens
- * collapse to a bare mask.
+ * The library is read through STATIC methods rather than the injectable
+ * {@see \Netresearch\NrVault\Secret\SecretRedactorInterface}, because this trait is
+ * also used from objects the container never builds — a provider exception, a
+ * backend response DTO constructed with ``new``. A trait that reached into the DI
+ * container to mask a string would be a worse dependency than a static call to a
+ * pure pattern list.
  *
- * Two entry points, because the two kinds of caller need opposite behaviour when
- * the regex engine gives up — see {@see redactSecretShapes()} (fail open) and
- * {@see redactSecretShapesStrict()} (fail closed).
- *
- * This is best-effort: it recognises these shapes and nothing else, and does not
- * replace keeping secrets in nr-vault.
+ * This is best-effort: it recognises the catalogued shapes and nothing else, and
+ * does not replace keeping secrets in nr-vault.
  */
 trait SecretShapeRedactorTrait
 {
-    use ErrorMessageSanitizerTrait;
-
-    private const SECRET_SHAPE_MASK = '***';
-
     /**
      * Mask every recognised secret shape, keeping the content when a pattern
      * fails.
@@ -70,7 +66,8 @@ trait SecretShapeRedactorTrait
     }
 
     /**
-     * Run the pattern list in order, recording whether any pattern failed.
+     * Run every inline pattern in the shared catalogue, recording whether any
+     * failed.
      *
      * `preg_replace()` returns null when the engine gives up (a backtrack limit
      * hit on a huge payload, for instance). A bare (string) cast would turn that
@@ -79,19 +76,24 @@ trait SecretShapeRedactorTrait
      * kept instead and the failure is reported through $failed so a caller that
      * must fail closed can.
      *
-     * Order matters: credential-bearing URLs are masked first, so ``?token=<jwt>``
-     * collapses to one masked parameter rather than a masked JWT behind a
-     * dangling parameter name.
+     * The catalogue's own order is preserved: credential-bearing URLs first, then
+     * ``Bearer …``, then the prefix-specific vendor shapes. That is not cosmetic —
+     * masking ``?token=<jwt>`` as one parameter beats masking the JWT and leaving a
+     * dangling parameter name, and ``Bearer sk-…`` must collapse to a single mask
+     * rather than two.
      */
     private function applySecretShapePatterns(string $content, bool &$failed): string
     {
-        // Credential query parameters and connection-string userinfo.
-        $redacted = $this->sanitizeErrorMessage($content);
+        $redacted = $content;
 
-        foreach (self::secretShapePatterns() as [$pattern, $replacement]) {
-            $result = preg_replace($pattern, $replacement, (string)$redacted);
+        foreach (SecretPatternLibrary::all() as $pattern) {
+            if ($pattern->inlinePattern === null) {
+                continue;
+            }
 
-            if (is_string($result)) {
+            $result = preg_replace($pattern->inlinePattern, $pattern->inlineReplacement, $redacted);
+
+            if (\is_string($result)) {
                 $redacted = $result;
 
                 continue;
@@ -101,43 +103,5 @@ trait SecretShapeRedactorTrait
         }
 
         return $redacted;
-    }
-
-    /**
-     * Secret shapes that survive the URL sanitiser, as [pattern, replacement].
-     *
-     * All patterns are bounded character classes separated by literals — no
-     * nested quantifiers, so none is vulnerable to catastrophic backtracking.
-     *
-     * @return list<array{string, string}>
-     */
-    private static function secretShapePatterns(): array
-    {
-        return [
-            // Bearer credentials FIRST: a 'Bearer <token>' match subsumes whatever
-            // the token is, so running it before the prefix-specific shapes makes
-            // 'Bearer sk-…' collapse to a single mask. The other way round, the
-            // OpenAI rule rewrote the key to 'sk-***' and the Bearer rule then
-            // matched the leftover 'Bearer sk-', yielding 'Bearer ******'.
-            // The class covers base64-standard characters (+ / =) so a token's
-            // tail is not left behind after the mask.
-            ['/\b(Bearer\s+)[A-Za-z0-9._~+\/\-]+=*/i', '$1' . self::SECRET_SHAPE_MASK],
-            // OpenAI. The class allows '-' and '_' so modern project keys
-            // (sk-proj-…) match; the mask keeps the prefix.
-            ['/\bsk-[A-Za-z0-9_\-]{16,}/', 'sk-' . self::SECRET_SHAPE_MASK],
-            // A JWT is the canonical bearer secret even without a 'Bearer '
-            // prefix. Only the header segment must start with 'eyJ'.
-            ['/\beyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+/', self::SECRET_SHAPE_MASK],
-            // GitHub: classic tokens, then fine-grained PATs.
-            ['/\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}/', self::SECRET_SHAPE_MASK],
-            ['/\bgithub_pat_[A-Za-z0-9_]{22,}/', self::SECRET_SHAPE_MASK],
-            ['/\bAKIA[0-9A-Z]{16,}/', self::SECRET_SHAPE_MASK],
-            ['/\bAIza[0-9A-Za-z_\-]{35,}/', self::SECRET_SHAPE_MASK],
-            ['/\bxox[baprs]-[A-Za-z0-9\-]{10,}/', self::SECRET_SHAPE_MASK],
-            // Stripe secret and publishable keys. Note the underscore: these do
-            // not collide with the hyphenated OpenAI shape above.
-            ['/\b[sp]k_(?:live|test)_[A-Za-z0-9]{24,}/', self::SECRET_SHAPE_MASK],
-            ['/\bSG\.[A-Za-z0-9_\-]{22}\.[A-Za-z0-9_\-]{43}/', self::SECRET_SHAPE_MASK],
-        ];
     }
 }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -473,3 +473,13 @@ services:
         description: 'Run a golden question set against a retriever and report hit rates and regression.'
         schedulable: false
 
+
+  # ========================================
+  # nr-vault integration
+  # ========================================
+  # Re-wraps the encrypted agent-state columns during a master-key rotation
+  # (ADR-114, nr-vault ADR-033). The tag is what makes nr-vault call it INSIDE
+  # its rotation transaction; without it, every encrypted queued or suspended
+  # run silently becomes unreadable the first time an operator rotates.
+  Netresearch\NrLlm\Service\Tool\AgentStateEnvelopeRotator:
+    tags: ['nrvault.foreign_envelope_rotator']

--- a/Documentation/Adr/Adr114EncryptAgentStateAtRest.rst
+++ b/Documentation/Adr/Adr114EncryptAgentStateAtRest.rst
@@ -87,36 +87,45 @@ Consequences
 
 .. _adr-114-rotation:
 
-Key rotation: not yet covered
-=============================
+Key rotation
+============
 
-.. warning::
+Covered, but only because this extension registers for it.
 
-   An earlier revision of this ADR stated that "key rotation is the vault's …
-   rotating the master key re-wraps the DEKs without touching the row
-   ciphertext", citing nr-vault's rotate command and its
-   :php:`MasterKeyRotatedEvent`. **That was wrong on both counts**, and the
-   correction is recorded here rather than quietly edited away.
+An earlier revision of this ADR claimed rotation was handled: "key rotation is
+the vault's … rotating the master key re-wraps the DEKs without touching the row
+ciphertext", citing nr-vault's rotate command and its
+:php:`MasterKeyRotatedEvent`. **That was wrong on both counts, and it shipped in
+0.24.0.** nr-vault's ``vault:rotate-master-key`` re-wrapped the data keys it found
+by walking its own ``tx_nrvault_secret``; the data key of an agent-state envelope
+lives in ``tx_nrllm_agentrun``, where that walk never reached it. And the event,
+though declared and documented upstream, was never dispatched from anywhere — so
+this extension could not have subscribed to learn a rotation had happened either.
+Encrypting these columns was therefore a delayed data-loss bug: the first master
+key rotation made every encrypted queued and suspended run permanently
+unreadable, silently, because the rotation succeeded at everything it knew about.
 
-   nr-vault's ``vault:rotate-master-key`` re-wraps the DEKs it finds by iterating
-   its own ``tx_nrvault_secret`` table. The DEK of an agent-state envelope lives
-   in ``tx_nrllm_agentrun``, where that iteration never reaches it. And
-   :php:`MasterKeyRotatedEvent`, though declared and documented upstream, was
-   never dispatched from anywhere — so this extension could not have subscribed
-   to learn a rotation had happened either.
+The correction is recorded rather than edited away, because a wrong claim about
+where data survives is worth remembering.
 
-   **Consequence today:** if an operator rotates the nr-vault master key, every
-   encrypted QUEUED or suspended agent-run row becomes permanently undecryptable.
-   The fail-soft read path treats such a run as unreadable, so nothing crashes —
-   in-flight runs are lost, not the installation. Rows written before ADR-114
-   landed (plaintext JSON, no ``v2:`` marker) are unaffected, and no other
-   nr-llm data is encrypted this way.
+nr-vault now exposes :php:`ForeignEnvelopeRotatorInterface` (nr-vault ADR-033),
+and :php:`AgentStateEnvelopeRotator` implements it. Registering it is what makes
+rotation cover these rows:
 
-   **Fix in progress:** nr-vault gained a
-   :php:`ForeignEnvelopeRotatorInterface` (nr-vault ADR-033) that re-wraps a
-   consumer's envelopes inside the rotation's own transaction. This extension
-   registers a rotator for ``tx_nrllm_agentrun`` as soon as a released nr-vault
-   version contains it; this section is replaced when that lands.
+.. code-block:: yaml
+   :caption: Configuration/Services.yaml
 
-   **Until then:** treat a master-key rotation as draining the agent queue. Let
-   queued and suspended runs finish first, or accept losing them.
+   Netresearch\NrLlm\Service\Tool\AgentStateEnvelopeRotator:
+     tags: ['nrvault.foreign_envelope_rotator']
+
+The rotator re-wraps both columns inside the vault's own rotation transaction, so
+a failure rolls the whole rotation back rather than leaving half the installation
+under a key the operator is about to destroy. It re-wraps the DEK layer only —
+the payload is never decrypted — and it covers BOTH the current ``nrv1:`` marker
+and the legacy ``v2:`` one written by 0.24.0-0.25.x, since both are sealed under
+the same master key. Default query restrictions are removed so no row is hidden
+from the pass, and the walk pages by ``uid`` rather than ``OFFSET`` because it is
+rewriting the rows as it goes.
+
+Requires nr-vault ^0.13.0. On an older nr-vault the interface does not exist, so
+the constraint is a hard one rather than a suggestion.

--- a/Documentation/Adr/Adr123OneSecretShapeCatalogue.rst
+++ b/Documentation/Adr/Adr123OneSecretShapeCatalogue.rst
@@ -113,17 +113,36 @@ Consequences
 
 .. _adr-123-upstream:
 
-Relationship to nr-vault
-========================
+The catalogue lives in nr-vault
+===============================
 
-nr-vault carries the same knowledge for its plaintext scanner, and it had drifted
+nr-vault carried the same knowledge for its plaintext scanner, and it had drifted
 the other way — it knew Stripe, SendGrid, Twilio, Mailchimp and PayPal but not
 OpenAI project keys or fine-grained PATs. The merged superset now lives upstream
-in :php:`Netresearch\\NrVault\\Secret\\SecretPatternLibrary` (nr-vault ADR-031),
+in :php:`Netresearch\NrVault\Secret\SecretPatternLibrary` (nr-vault ADR-031),
 which is the right long-term home: one catalogue for every Netresearch extension
 rather than one per extension.
 
-This trait is deliberately shaped so that adopting the upstream library is a
-change to :php:`applySecretShapePatterns()` alone, with the two failure-mode
-entry points and every call site unchanged. That swap waits on a released
-nr-vault version that contains the library.
+This extension reads it. :php:`SecretShapeRedactorTrait` iterates
+:php:`SecretPatternLibrary::all()` and :php:`ErrorMessageSanitizerTrait` iterates
+:php:`SecretPatternLibrary::urlCredentials()`, so no secret regex is defined in
+nr-llm any more. Both gained shapes in the process — Slack legacy tokens,
+Mailchimp and SendGrid keys, Stripe publishable keys — without any change here.
+
+Read through the library's STATIC methods, not the injectable
+:php:`SecretRedactorInterface`. These traits are used from objects the container
+never builds: a provider exception, and
+:php:`Controller\Backend\Response\ErrorResponse`, which callers construct with
+``new``. A trait that reached into the DI container to mask a string would be a
+worse dependency than a static call to a pure pattern list.
+
+Requires nr-vault ^0.13.0.
+
+Why the sanitiser stays a narrower subset
+-----------------------------------------
+
+:php:`ErrorMessageSanitizerTrait` deliberately applies only the two URL shapes,
+not the whole catalogue. It runs on error messages, where the job is to strip the
+credential a client library put into a request URL — not to scan arbitrary prose
+for every vendor token shape. Callers that want the full catalogue use
+:php:`SecretShapeRedactorTrait`, and the guardrails do.

--- a/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
+++ b/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
@@ -22,6 +22,7 @@ use Netresearch\NrLlm\Service\Tool\AgentRunRepository;
 use Netresearch\NrLlm\Service\Tool\AgentStateCodec;
 use Netresearch\NrLlm\Tests\Fixture\FixedPrivacyPolicy;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use Netresearch\NrVault\Crypto\EnvelopeCodecInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\NullLogger;
@@ -164,7 +165,7 @@ final class AgentRunPersisterTest extends AbstractFunctionalTestCase
         self::assertNotNull($handle);
 
         $stored = $this->rawColumn($handle->uuid, 'queued_request');
-        self::assertStringStartsWith('v2:', $stored, 'stored at rest as ciphertext');
+        self::assertStringStartsWith(EnvelopeCodecInterface::MARKER, $stored, 'stored at rest as ciphertext');
         self::assertStringNotContainsString('private prompt', $stored);
 
         $run = $this->repository->findByUuid($handle->uuid);

--- a/Tests/Functional/Service/Tool/AgentStateCodecTest.php
+++ b/Tests/Functional/Service/Tool/AgentStateCodecTest.php
@@ -12,6 +12,8 @@ namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
 use Netresearch\NrLlm\Service\Tool\AgentStateCodec;
 use Netresearch\NrLlm\Service\Tool\Exception\AgentStateDecryptionException;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use Netresearch\NrVault\Crypto\EncryptionServiceInterface;
+use Netresearch\NrVault\Crypto\EnvelopeCodecInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -41,7 +43,7 @@ final class AgentStateCodecTest extends AbstractFunctionalTestCase
 
         $encoded = $this->codec->encode($plaintext, AgentStateCodec::PURPOSE_QUEUED_REQUEST);
 
-        self::assertStringStartsWith('v2:', $encoded);
+        self::assertStringStartsWith(EnvelopeCodecInterface::MARKER, $encoded);
         self::assertStringNotContainsString('private prompt', $encoded);
         self::assertSame($plaintext, $this->codec->decode($encoded, AgentStateCodec::PURPOSE_QUEUED_REQUEST));
     }
@@ -99,6 +101,68 @@ final class AgentStateCodecTest extends AbstractFunctionalTestCase
     public function aMalformedEnvelopeIsRejected(): void
     {
         $this->expectException(AgentStateDecryptionException::class);
-        $this->codec->decode('v2:@@@not-base64@@@', AgentStateCodec::PURPOSE_QUEUED_REQUEST);
+        $this->codec->decode(
+            EnvelopeCodecInterface::MARKER . '@@@not-base64@@@',
+            AgentStateCodec::PURPOSE_QUEUED_REQUEST,
+        );
+    }
+
+    /**
+     * The load-bearing upgrade test: a row written by nr-llm 0.24.0-0.25.x carries
+     * the old ``v2:`` marker. Those rows exist in production, so moving the
+     * envelope to nr-vault's codec must not need a data migration.
+     *
+     * The legacy value is built the way the OLD codec built it — straight from
+     * EncryptionService, base64 of the JSON EncryptedData array, with a ``v2:``
+     * prefix — rather than by rewriting a new envelope's marker. That is what makes
+     * this a proof of format compatibility instead of a restatement of the shim.
+     */
+    #[Test]
+    public function aRowWrittenByTheLegacyCodecStillDecodes(): void
+    {
+        $plaintext = '{"messages":[{"role":"user","content":"written by 0.24.0"}]}';
+
+        $encryptionService = $this->get(EncryptionServiceInterface::class);
+        self::assertInstanceOf(EncryptionServiceInterface::class, $encryptionService);
+
+        $encrypted = $encryptionService->encrypt($plaintext, AgentStateCodec::PURPOSE_QUEUED_REQUEST);
+        $legacyValue = 'v2:' . base64_encode(json_encode($encrypted->toArray(), JSON_THROW_ON_ERROR));
+
+        self::assertSame(
+            $plaintext,
+            $this->codec->decode($legacyValue, AgentStateCodec::PURPOSE_QUEUED_REQUEST),
+        );
+    }
+
+    /**
+     * The legacy marker is still bound to its column: re-marking must not weaken
+     * the AAD check.
+     */
+    #[Test]
+    public function aLegacyRowIsStillBoundToItsColumn(): void
+    {
+        $encryptionService = $this->get(EncryptionServiceInterface::class);
+        self::assertInstanceOf(EncryptionServiceInterface::class, $encryptionService);
+
+        $encrypted = $encryptionService->encrypt('{"x":1}', AgentStateCodec::PURPOSE_QUEUED_REQUEST);
+        $legacyValue = 'v2:' . base64_encode(json_encode($encrypted->toArray(), JSON_THROW_ON_ERROR));
+
+        $this->expectException(AgentStateDecryptionException::class);
+        $this->codec->decode($legacyValue, AgentStateCodec::PURPOSE_SUSPENDED_STATE);
+    }
+
+    /**
+     * A value carrying neither marker is pre-encryption cleartext even if it
+     * happens to start with something marker-ish.
+     */
+    #[Test]
+    public function anUnmarkedValueIsNeverTreatedAsAnEnvelope(): void
+    {
+        foreach (['{"v2":"not a marker"}', 'v3:something-else', 'nrv2:wrong-version'] as $value) {
+            self::assertSame(
+                $value,
+                $this->codec->decode($value, AgentStateCodec::PURPOSE_QUEUED_REQUEST),
+            );
+        }
     }
 }

--- a/Tests/Functional/Service/Tool/AgentStateCodecTest.php
+++ b/Tests/Functional/Service/Tool/AgentStateCodecTest.php
@@ -26,6 +26,9 @@ use PHPUnit\Framework\Attributes\Test;
 #[CoversClass(AgentStateCodec::class)]
 final class AgentStateCodecTest extends AbstractFunctionalTestCase
 {
+    /** Minimal payload for the tests that only care about the envelope, not its contents. */
+    private const SMALL_PAYLOAD = '{"x":1}';
+
     private AgentStateCodec $codec;
 
     protected function setUp(): void
@@ -81,7 +84,7 @@ final class AgentStateCodecTest extends AbstractFunctionalTestCase
     {
         // The per-column identifier is AAD: a queued-request envelope decrypted
         // as a suspended-state payload fails authentication rather than leaking.
-        $encoded = $this->codec->encode('{"x":1}', AgentStateCodec::PURPOSE_QUEUED_REQUEST);
+        $encoded = $this->codec->encode(self::SMALL_PAYLOAD, AgentStateCodec::PURPOSE_QUEUED_REQUEST);
 
         $this->expectException(AgentStateDecryptionException::class);
         $this->codec->decode($encoded, AgentStateCodec::PURPOSE_SUSPENDED_STATE);
@@ -90,7 +93,7 @@ final class AgentStateCodecTest extends AbstractFunctionalTestCase
     #[Test]
     public function aTamperedEnvelopeFailsAuthentication(): void
     {
-        $encoded  = $this->codec->encode('{"x":1}', AgentStateCodec::PURPOSE_QUEUED_REQUEST);
+        $encoded  = $this->codec->encode(self::SMALL_PAYLOAD, AgentStateCodec::PURPOSE_QUEUED_REQUEST);
         $tampered = substr($encoded, 0, -2) . ($encoded[-2] === 'A' ? 'B' : 'A') . $encoded[-1];
 
         $this->expectException(AgentStateDecryptionException::class);
@@ -144,7 +147,7 @@ final class AgentStateCodecTest extends AbstractFunctionalTestCase
         $encryptionService = $this->get(EncryptionServiceInterface::class);
         self::assertInstanceOf(EncryptionServiceInterface::class, $encryptionService);
 
-        $encrypted = $encryptionService->encrypt('{"x":1}', AgentStateCodec::PURPOSE_QUEUED_REQUEST);
+        $encrypted = $encryptionService->encrypt(self::SMALL_PAYLOAD, AgentStateCodec::PURPOSE_QUEUED_REQUEST);
         $legacyValue = 'v2:' . base64_encode(json_encode($encrypted->toArray(), JSON_THROW_ON_ERROR));
 
         $this->expectException(AgentStateDecryptionException::class);

--- a/Tests/Functional/Service/Tool/AgentStateEnvelopeRotatorTest.php
+++ b/Tests/Functional/Service/Tool/AgentStateEnvelopeRotatorTest.php
@@ -1,0 +1,275 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\AgentStateCodec;
+use Netresearch\NrLlm\Service\Tool\AgentStateEnvelopeRotator;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Crypto\EncryptionService;
+use Netresearch\NrVault\Crypto\EncryptionServiceInterface;
+use Netresearch\NrVault\Crypto\EnvelopeCodec;
+use Netresearch\NrVault\Crypto\EnvelopeCodecInterface;
+use Netresearch\NrVault\Crypto\EnvelopeRotationContext;
+use Netresearch\NrVault\Crypto\MasterKeyProviderInterface;
+use Netresearch\NrVault\Exception\EncryptionException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * The end-to-end proof that encrypting the agent-state columns is not a delayed
+ * data-loss bug: after a master-key rotation, the rows must still open.
+ *
+ * Before this rotator existed, `vault:rotate-master-key` walked
+ * `tx_nrvault_secret` only, so these envelopes stayed wrapped under a key the
+ * operator was told to destroy — and nothing reported it.
+ */
+#[CoversClass(AgentStateEnvelopeRotator::class)]
+final class AgentStateEnvelopeRotatorTest extends AbstractFunctionalTestCase
+{
+    private const TABLE = 'tx_nrllm_agentrun';
+
+    private AgentStateEnvelopeRotator $rotator;
+
+    private ConnectionPool $connectionPool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $rotator = $this->get(AgentStateEnvelopeRotator::class);
+        self::assertInstanceOf(AgentStateEnvelopeRotator::class, $rotator);
+        $this->rotator = $rotator;
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $this->connectionPool = $connectionPool;
+    }
+
+    #[Test]
+    public function itDeclaresTheTableItWrites(): void
+    {
+        self::assertSame([self::TABLE], $this->rotator->getTables());
+        self::assertStringContainsString('nr-llm', $this->rotator->getIdentifier());
+    }
+
+    #[Test]
+    public function countsOnlySealedColumns(): void
+    {
+        self::assertSame(0, $this->rotator->countEnvelopes());
+
+        $codec = $this->get(EnvelopeCodecInterface::class);
+        self::assertInstanceOf(EnvelopeCodecInterface::class, $codec);
+
+        // One row with both columns sealed => two envelopes.
+        $this->insertRun(
+            $codec->seal('{"request":1}', AgentStateCodec::PURPOSE_QUEUED_REQUEST),
+            $codec->seal('{"state":1}', AgentStateCodec::PURPOSE_SUSPENDED_STATE),
+        );
+        // One row of pre-encryption cleartext => not an envelope.
+        $this->insertRun('{"plain":"json"}', '');
+
+        self::assertSame(2, $this->rotator->countEnvelopes());
+    }
+
+    /**
+     * Rows written by nr-llm 0.24.0-0.25.x carry the legacy `v2:` marker and are
+     * sealed under the same master key. Missing them would be exactly the silent
+     * loss this class prevents, so they must be counted and re-wrapped too.
+     */
+    #[Test]
+    public function legacyMarkedRowsAreCountedAndRewrapped(): void
+    {
+        $plaintext = '{"messages":[{"role":"user","content":"from 0.24.0"}]}';
+        $legacy = $this->legacyEnvelope($plaintext, AgentStateCodec::PURPOSE_QUEUED_REQUEST);
+
+        $uid = $this->insertRun($legacy, '');
+
+        self::assertSame(1, $this->rotator->countEnvelopes());
+
+        $newKey = random_bytes(SODIUM_CRYPTO_AEAD_AES256GCM_KEYBYTES);
+        $rewrapped = $this->rotator->rewrapAll($this->contextTo($newKey));
+
+        self::assertSame(1, $rewrapped);
+
+        // The stored value changed, still opens under the NEW key, and no longer
+        // opens under the old one.
+        $stored = $this->storedValue($uid, 'queued_request');
+        self::assertNotSame($legacy, $stored);
+        self::assertSame($plaintext, $this->codecFor($newKey)->open($stored, AgentStateCodec::PURPOSE_QUEUED_REQUEST));
+    }
+
+    #[Test]
+    public function rewrappingMovesBothColumnsToTheNewKey(): void
+    {
+        $codec = $this->get(EnvelopeCodecInterface::class);
+        self::assertInstanceOf(EnvelopeCodecInterface::class, $codec);
+
+        $request = '{"request":"payload"}';
+        $state = '{"state":"payload"}';
+        $uid = $this->insertRun(
+            $codec->seal($request, AgentStateCodec::PURPOSE_QUEUED_REQUEST),
+            $codec->seal($state, AgentStateCodec::PURPOSE_SUSPENDED_STATE),
+        );
+
+        $newKey = random_bytes(SODIUM_CRYPTO_AEAD_AES256GCM_KEYBYTES);
+
+        self::assertSame(2, $this->rotator->rewrapAll($this->contextTo($newKey)));
+
+        $newCodec = $this->codecFor($newKey);
+        self::assertSame(
+            $request,
+            $newCodec->open($this->storedValue($uid, 'queued_request'), AgentStateCodec::PURPOSE_QUEUED_REQUEST),
+        );
+        self::assertSame(
+            $state,
+            $newCodec->open($this->storedValue($uid, 'suspended_state'), AgentStateCodec::PURPOSE_SUSPENDED_STATE),
+        );
+    }
+
+    /**
+     * The regression this whole seam exists for: without re-wrapping, a rotated
+     * installation cannot read its own queued runs.
+     */
+    #[Test]
+    public function withoutRewrappingTheRowWouldNotOpenUnderTheNewKey(): void
+    {
+        $codec = $this->get(EnvelopeCodecInterface::class);
+        self::assertInstanceOf(EnvelopeCodecInterface::class, $codec);
+
+        $sealed = $codec->seal('{"request":"payload"}', AgentStateCodec::PURPOSE_QUEUED_REQUEST);
+        $newKey = random_bytes(SODIUM_CRYPTO_AEAD_AES256GCM_KEYBYTES);
+
+        $this->expectException(EncryptionException::class);
+        $this->codecFor($newKey)->open($sealed, AgentStateCodec::PURPOSE_QUEUED_REQUEST);
+    }
+
+    #[Test]
+    public function cleartextRowsAreLeftUntouched(): void
+    {
+        $plain = '{"plain":"json"}';
+        $uid = $this->insertRun($plain, '');
+
+        self::assertSame(0, $this->rotator->rewrapAll(
+            $this->contextTo(random_bytes(SODIUM_CRYPTO_AEAD_AES256GCM_KEYBYTES)),
+        ));
+        self::assertSame($plain, $this->storedValue($uid, 'queued_request'));
+    }
+
+    #[Test]
+    public function rewrappingIsSafeAcrossMoreRowsThanOneBatch(): void
+    {
+        $codec = $this->get(EnvelopeCodecInterface::class);
+        self::assertInstanceOf(EnvelopeCodecInterface::class, $codec);
+
+        // BATCH_SIZE is 200; go past it to prove the uid cursor advances rather
+        // than re-reading the first page forever.
+        $expected = 205;
+        for ($i = 0; $i < $expected; ++$i) {
+            $this->insertRun($codec->seal('{"i":' . $i . '}', AgentStateCodec::PURPOSE_QUEUED_REQUEST), '');
+        }
+
+        self::assertSame($expected, $this->rotator->countEnvelopes());
+        self::assertSame($expected, $this->rotator->rewrapAll(
+            $this->contextTo(random_bytes(SODIUM_CRYPTO_AEAD_AES256GCM_KEYBYTES)),
+        ));
+    }
+
+    /**
+     * Build a value in the format nr-llm 0.24.0-0.25.x wrote, straight from the
+     * encryption service, so the test proves format compatibility rather than
+     * restating the codec's marker shim.
+     */
+    private function legacyEnvelope(string $plaintext, string $identifier): string
+    {
+        $encryptionService = $this->get(EncryptionServiceInterface::class);
+        self::assertInstanceOf(EncryptionServiceInterface::class, $encryptionService);
+
+        $encrypted = $encryptionService->encrypt($plaintext, $identifier);
+
+        return 'v2:' . base64_encode(json_encode($encrypted->toArray(), JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * A rotation context moving envelopes from the instance's current master key
+     * to $newKey.
+     */
+    private function contextTo(string $newKey): EnvelopeRotationContext
+    {
+        $codec = $this->get(EnvelopeCodecInterface::class);
+        self::assertInstanceOf(EnvelopeCodecInterface::class, $codec);
+
+        return new EnvelopeRotationContext($codec, $this->currentMasterKey(), $newKey);
+    }
+
+    /**
+     * A codec bound to an arbitrary master key, for asserting which key an
+     * envelope opens under.
+     */
+    private function codecFor(string $masterKey): EnvelopeCodec
+    {
+        // A mock rather than an anonymous class: MasterKeyProviderInterface also
+        // declares key generation, storage and cache clearing, none of which this
+        // test needs, and a hand-rolled stub would silently rot when the interface
+        // grows another method.
+        $provider = $this->createMock(MasterKeyProviderInterface::class);
+        $provider->method('getMasterKey')->willReturn($masterKey);
+        $provider->method('isAvailable')->willReturn(true);
+
+        $encryptionService = GeneralUtility::makeInstance(
+            EncryptionService::class,
+            $provider,
+            $this->get(ExtensionConfigurationInterface::class),
+        );
+
+        return new EnvelopeCodec($encryptionService);
+    }
+
+    private function currentMasterKey(): string
+    {
+        $provider = $this->get(MasterKeyProviderInterface::class);
+        self::assertInstanceOf(MasterKeyProviderInterface::class, $provider);
+
+        return $provider->getMasterKey();
+    }
+
+    private function insertRun(string $queuedRequest, string $suspendedState): int
+    {
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
+        $connection->insert(self::TABLE, [
+            'pid' => 0,
+            'uuid' => bin2hex(random_bytes(8)),
+            'queued_request' => $queuedRequest,
+            'suspended_state' => $suspendedState,
+        ]);
+
+        return (int)$connection->lastInsertId();
+    }
+
+    private function storedValue(int $uid, string $column): string
+    {
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
+        $queryBuilder = $connection->createQueryBuilder();
+        $queryBuilder->getRestrictions()->removeAll();
+
+        $value = $queryBuilder
+            ->select($column)
+            ->from(self::TABLE)
+            ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid)))
+            ->executeQuery()
+            ->fetchOne();
+
+        self::assertIsString($value);
+
+        return $value;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "netresearch/nr-llm",
-    "description": "Shared AI/LLM foundation for TYPO3 — centralized provider management, encrypted API keys, and ready-to-use services for chat, translation, vision, and embeddings",
+    "description": "Shared AI/LLM foundation for TYPO3 \u2014 centralized provider management, encrypted API keys, and ready-to-use services for chat, translation, vision, and embeddings",
     "license": "GPL-2.0-or-later",
     "type": "typo3-cms-extension",
     "keywords": [
@@ -32,7 +32,7 @@
     },
     "require": {
         "php": "^8.2",
-        "netresearch/nr-vault": "^0.10.1 || ^0.11.0 || ^0.12.0",
+        "netresearch/nr-vault": "^0.13.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/log": "^2.0 || ^3.0",
@@ -51,7 +51,7 @@
     },
     "suggest": {
         "apache-solr-for-typo3/solr": "Site-search RAG tools retrieve evidence from the Solr index when installed",
-        "poppler-utils": "System package (not a Composer package) providing pdftoppm/pdfimages — enables DocumentAnalysisService's rasterization fallback for providers without native PDF ingestion",
+        "poppler-utils": "System package (not a Composer package) providing pdftoppm/pdfimages \u2014 enables DocumentAnalysisService's rasterization fallback for providers without native PDF ingestion",
         "tpwd/ke_search": "Site-search RAG tools retrieve evidence from the ke_search index when installed",
         "typo3/cms-dashboard": "Adds AI usage / cost widgets to the TYPO3 dashboard",
         "typo3/cms-indexed-search": "Site-search RAG tools retrieve evidence from the indexed_search index when installed"


### PR DESCRIPTION
nr-vault **0.13.0 is released**
([tag](https://github.com/netresearch/t3x-nr-vault/releases/tag/v0.13.0),
Packagist indexed), so `^0.13.0` resolves and this is no longer blocked.


Completes the move upstream that #557 started, and makes ADR-114's rotation claim
true for the first time.

## Rotation was the real problem

ADR-114 claimed nr-vault's master-key rotation covered the encrypted agent-state
columns. It did not, and **the claim shipped in 0.24.0**. `vault:rotate-master-key`
re-wrapped the data keys in `tx_nrvault_secret`; the data key of an agent-state
envelope lives in `tx_nrllm_agentrun`, where that walk never reached it. So
encrypting those columns was a *delayed data-loss bug*: the first rotation made
every encrypted queued and suspended run permanently unreadable — silently,
because the rotation succeeded at everything it knew about.

`AgentStateEnvelopeRotator` implements nr-vault's new
`ForeignEnvelopeRotatorInterface`. The `nrvault.foreign_envelope_rotator` tag is
what brings these rows into the rotation's own transaction, so a failure rolls the
whole rotation back rather than leaving half the installation under a key the
operator is about to destroy. It re-wraps the DEK layer only — the payload is
never decrypted.

## A bug the tests caught

The rotator originally found legacy rows with its SQL predicate and then **skipped
every one of them**, because the vault's `isSealed()` only recognises its own
`nrv1:` marker and those rows carry nr-llm's older `v2:`. They would have been
left wrapped under the retired key — precisely the failure the rotator exists to
prevent. `AgentStateEnvelopeRotatorTest::legacyMarkedRowsAreCountedAndRewrapped`
caught it and now pins it.

The fix put the marker knowledge in **one** class, `AgentStateEnvelopeMarker`,
because the read path and the rotation path both need it and must agree — which
is exactly what they failed to do.

## No data migration

Rows written by 0.24.0–0.25.x carry `v2:`; the body after the marker is
byte-identical to what the vault writes, so the marker is swapped rather than the
data migrated. `AgentStateCodecTest::aRowWrittenByTheLegacyCodecStillDecodes`
builds a legacy value **straight from `EncryptionService`, the way the old codec
did** — so it proves format compatibility rather than restating the shim. Writing
back the normalised form means a rotation also migrates the marker, so the legacy
branch empties over time.

## Other details

- `AgentStateCodec` keeps only the storage boundary. ~100 of its 154 lines were
  framing and field validation, none of it specific to agent state.
- The rotator removes default query restrictions so no row is hidden from the
  pass, and pages by `uid` rather than `OFFSET` because it rewrites rows as it
  walks.
- **No secret regex is defined in this extension any more.**
  `SecretShapeRedactorTrait` and `ErrorMessageSanitizerTrait` read
  `SecretPatternLibrary`, and both gained shapes they never had (Slack legacy
  tokens, Mailchimp and SendGrid keys, Stripe publishable keys).
- They read the library's **static** methods, not the injectable
  `SecretRedactorInterface`, because these traits are used from objects the
  container never builds — a provider exception, and `ErrorResponse`, which
  callers construct with `new`. A trait reaching into the DI container to mask a
  string would be a worse dependency than a static call to a pure pattern list.
- The sanitiser stays a narrower subset (the two URL shapes only): it runs on
  error messages, where the job is to strip the credential a client library put
  into a request URL, not to scan prose for every vendor token shape.

## Verification

Re-run against the **released** `netresearch/nr-vault v0.13.0` from Packagist —
the path repository was removed and the package reinstalled first. PHP 8.4:

| Suite | Result |
|---|---|
| cgl | clean |
| PHPStan level 10 | clean |
| unit | **5749** tests, 15989 assertions |
| functional (sqlite) | **1308** tests, 14310 assertions |
| rector | clean |
| fuzzy | 79 tests, 15057 assertions |

`composer.json` carries only the real constraint; no path repository.

## Before merging

Nothing outstanding — nr-vault 0.13.0 is merged (`859bea99`) and released
(`4b8510e6` / `v0.13.0`), and ADR-114 already describes the fixed state.


---

Rebased after #557 was rebased onto `main` (ADR renumbered 122 → 123 because
#556 took 122).
