### PR TITLE
ci: add an enforceable DCO check

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,27 @@
+name: DCO
+
+# Enforced sign-off gate.
+#
+# This repository requires signed-off commits, but had no enforcing check: the
+# probot DCO app reacts to pull_request events only and therefore cannot report
+# on a merge_group. Because a merge queue treats a required check that has not
+# reported by check_response_timeout_minutes as failed and ejects the entry, the
+# app could never be a required context here — which is why DCO was absent from
+# the required set while every other gate was present.
+#
+# The shared reusable reads the merge group's base_sha..head_sha range on that
+# event, so it can gate a queued branch.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  merge_group:
+
+permissions: {}
+
+jobs:
+  dco:
+    uses: netresearch/.github/.github/workflows/dco.yml@main # NOSONAR — own-org reusable deliberately tracks main
+    permissions:
+      contents: read
+      pull-requests: read


### PR DESCRIPTION
This repository requires signed-off commits — `AGENTS.md` says so, and every commit carries the trailer — but nothing enforces it. DCO is absent from the 22 required contexts on `main`, all of which are GitHub Actions checks.

That was not an oversight. It was the only configuration available:

- The **probot DCO app** reacts to `pull_request` events only and cannot report on a `merge_group`.
- This branch runs a **merge queue**, which treats a required check that has not reported by `check_response_timeout_minutes` as **failed** and ejects the entry.

So making the app a required context would have made the queue unusable. The choice was queue-or-DCO, and the queue won.

[netresearch/.github#318](https://github.com/netresearch/.github/pull/318) removed the trade-off: the shared reusable now reads the merge groups `base_sha..head_sha` range on that event — exactly the commits about to land — so it can gate a queued branch. This adds the caller.

## What it checks

Unchanged from the reusable: every non-merge commit needs a `Signed-off-by:` trailer whose email matches the commits author or committer. Merge commits are skipped, and `dependabot[bot]` / `renovate[bot]` / `github-actions[bot]` are exempt by default — without that exemption a DCO gate blocks every dependency PR, including the ones meant to auto-merge.

## Next

Once this is on `main` and the check has reported, `dco / DCO` is added to the rulesets required contexts. Doing it in that order matters: a required context whose workflow does not yet exist on the default branch blocks every PR.

The same pair has just been applied to [`typo3-demo`](https://github.com/netresearch/typo3-demo/pull/104), where the queue was being introduced for the first time.