### PR TITLE
ci: track netresearch/typo3-ci-workflows on @main again

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -175,3 +175,11 @@ jobs:
 - Use `act` for local testing: https://github.com/nektos/act
 - Check existing workflows in this repo for patterns
 <!-- AGENTS-GENERATED:END help -->
+
+## Org-owned reusables track `@main`
+
+The "pin to a full SHA, not a tag" rule above covers **third-party** actions only. Every `uses: netresearch/…` reference stays on `@main` — not a tag, not a SHA.
+
+Netresearch reusables are deliberately mutable so an upstream fix reaches all consumers at once. A pin freezes this repo on an old copy and turns each upstream fix into a Renovate bump PR — `republish.yml` was pinned in April 2026 and had already collected one such PR the following day.
+
+The `githubactions:S7637` hotspot this leaves in SonarCloud is accepted. If a quality gate blocks on it, mark the hotspot Safe — do not resolve it by pinning.

--- a/.github/workflows/republish.yml
+++ b/.github/workflows/republish.yml
@@ -22,7 +22,7 @@ permissions: {}
 
 jobs:
   republish:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/republish.yml@v1.3.2
+    uses: netresearch/typo3-ci-workflows/.github/workflows/republish.yml@main
     permissions:
       contents: read
     with:


### PR DESCRIPTION
`republish.yml` was the last caller in this repo still pinned to a tag (`@v1.3.2`). It now tracks `@main` like every other `netresearch/typo3-ci-workflows` reference here.

## Why

Org-owned reusables are referenced by `@main` so an upstream fix reaches every consumer at once — that propagation is the whole point of keeping them in one repo. A pin freezes this consumer on an old copy and converts each upstream fix into a Renovate bump PR instead. That already happened: the pin landed on 2026-04-24 and [#154](https://github.com/netresearch/t3x-nr-llm/pull/154) bumped it `v1.3.1 → v1.3.2` the next day.

SHA- and tag-pinning is for **third-party** actions. It does not apply to `netresearch/*`.

## How it got there

A Copilot review thread on [#140](https://github.com/netresearch/t3x-nr-llm/pull/140) asked for pin immutability; it was applied in [#153](https://github.com/netresearch/t3x-nr-llm/pull/153) ([cdabfebe](https://github.com/netresearch/t3x-nr-llm/commit/cdabfebe066d48b754ad4034f1c1b9b166a61e4d)), which pinned both `release.yml` and `republish.yml`. `release.yml` lost its pin again as a side effect of the template adoption in [0f1114cf](https://github.com/netresearch/t3x-nr-llm/commit/0f1114cf) on 2026-06-16. `republish.yml` is not part of that template, so its pin survived.

`.github/workflows/AGENTS.md` carried the "pin actions to a full SHA, not mutable tags" rule with no org-owned carve-out next to it. This PR adds that carve-out, outside the `AGENTS-GENERATED` blocks so the generator does not drop it.

## Scope check

A sweep over all 191 non-archived `netresearch` repos with a default branch found 1178 `uses: netresearch/…` references across 126 repos, of which 4 were pinned. This is one of them; the other three are fixed in [retro-skill#51](https://github.com/netresearch/retro-skill/pull/51) and [timetracker#665](https://github.com/netresearch/timetracker/pull/665).
