### PR TITLE
ci: adopt the template's labeler split into its own workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,10 +73,3 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-
-  labeler:
-    if: github.event_name == 'pull_request'
-    uses: netresearch/.github/.github/workflows/labeler.yml@main
-    permissions:
-      contents: read
-      pull-requests: write

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: Labeler
+
+# pull_request_target is required: labeling fork PRs needs a write-scoped
+# token, which pull_request does not provide. The called reusable workflow
+# only runs actions/labeler (no checkout or execution of untrusted PR code),
+# so the usual pull_request_target risk does not apply here.
+on: # zizmor: ignore[dangerous-triggers]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  labeler:
+    uses: netresearch/.github/.github/workflows/labeler.yml@main
+    permissions:
+      contents: read
+      pull-requests: write


### PR DESCRIPTION
`drift / Template drift` is red on `main` and on every PR opened since this morning. This adopts the template change that caused it.

## What changed upstream

[netresearch/.github@8cb2463f](https://github.com/netresearch/.github/commit/8cb2463f) (2026-08-03 10:17 UTC) moved the labeler job out of `checks.yml` into a standalone `labeler.yml` triggered by `pull_request_target`, because labelling a **fork** PR needs a write-scoped token that `pull_request` does not hand out. The called reusable runs `actions/labeler` and nothing else — no checkout, no execution of PR code — so the usual `pull_request_target` exposure does not apply; the file carries the `zizmor: ignore[dangerous-triggers]` exemption and the reasoning as a comment.

This repo still had the old inline job, so it drifted the moment the template landed.

## Not caused by the PR that surfaced it

`main`'s last drift run was 2026-08-02 19:32 UTC, before the template change, so `main` is red too and simply has not been re-run. Verified with the template's own comparison script against the base commit `ca67a4fa`:

```
Missing files (template has them, consumer does not):
  - .github/workflows/labeler.yml
Differing files:
  - .github/workflows/checks.yml
```

Identical output for `ca67a4fa` and for [#575](https://github.com/netresearch/t3x-nr-llm/pull/575), which touches neither file. After this change: `notice: No drift detected.`

## Follow-up

[#575](https://github.com/netresearch/t3x-nr-llm/pull/575) is blocked on the same red check and needs a rebase once this lands.
