### PR TITLE
ci: state the Rector PHP version instead of implying it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,14 +35,19 @@ jobs:
       # to 4. The required-status-checks ruleset is reduced to match (only the
       # 8.4 cells stay required); the other cells remain visible on the PR.
       #
-      # 8.2 must stay FIRST in both lists: the reusable runs the tool jobs
-      # (lint, cgl, phpstan, rector) on fromJSON(php-versions)[0], and Rector
-      # 2.6's PHPUnit rules resolve against the phpunit version composer
-      # installs — 8.2 resolves phpunit ^11, 8.4 resolves ^13, and the 13-only
-      # migrations (e.g. expectExceptionMessageIsOrContains) would break the
-      # 8.2 unit legs if applied. A queue that evaluated Rector on 8.4 while
-      # the PR evaluated it on 8.2 dequeued every entry with findings the PR
-      # run could not see (observed on #573, 2026-08-03).
+      # Rector must judge every event by the same rule set. Rector 2.6's
+      # PHPUnit rules resolve against the phpunit version composer installs —
+      # 8.2 resolves phpunit ^11, 8.4 resolves ^13, and the 13-only migrations
+      # (e.g. expectExceptionMessageIsOrContains) would break the 8.2 unit legs
+      # if applied. A queue that evaluated Rector on 8.4 while the PR evaluated
+      # it on 8.2 dequeued every entry with findings the PR run could not see
+      # (observed on #573, 2026-08-03).
+      #
+      # rector-php-version states the version outright instead of leaving it to
+      # fromJSON(php-versions)[0], so reordering either array below cannot move
+      # it again. The remaining single-version tool jobs (lint, cgl, fractor)
+      # still take [0].
+      rector-php-version: '8.2'
       php-versions: ${{ github.event_name == 'merge_group' && '["8.2","8.4"]' || '["8.2","8.3","8.4","8.5"]' }}
       typo3-versions: '["^13.4","^14.3"]'
       # Keeps the unit job's Codecov upload on every PR — that job is ~1min, so


### PR DESCRIPTION
Follow-up to [#573](https://github.com/netresearch/t3x-nr-llm/pull/573)/[#572](https://github.com/netresearch/t3x-nr-llm/pull/572). The Rector PHP version is now stated outright instead of being a property of list order.

## What it replaces

`main` holds Rector at 8.2 by keeping `8.2` first in both branches of the `php-versions` expression, with a comment asking future editors to preserve that: *"8.2 must stay FIRST in both lists"*. The invariant is real, but nothing enforces it. Widening the PR matrix, narrowing the queue matrix, or sorting the array descending would each silently move Rector to phpunit 13 and revive the failure that dequeued #573 — green pull request, red merge group, and **no failing check on the PR to explain the dequeue**. That invisibility is what makes this worth removing rather than documenting.

[netresearch/typo3-ci-workflows#152](https://github.com/netresearch/typo3-ci-workflows/pull/152) added `rector-php-version` for this case. Setting it decouples the Rector job from array order:

```yaml
rector-php-version: '8.2'
php-versions: ${{ github.event_name == 'merge_group' && '["8.2","8.4"]' || '["8.2","8.3","8.4","8.5"]' }}
```

## Why 8.2 and not 8.4

Unchanged from the reasoning already in the file: Rector 2.6 resolves its PHPUnit rules from the installed phpunit, 8.2 gives phpunit ^11 and 8.4 gives ^13, and the 13-only migrations (`expectExceptionMessageIsOrContains` and friends) would emit code the 8.2 unit legs cannot run. For an extension spanning PHP 8.2–8.5 the lowest supported version is the one the output has to satisfy.

## Scope

No change to which versions run. `lint`, `cgl` and `fractor` still take `php-versions[0]`; `phpstan` and the test suites still run the full matrix. `ci.yml` is an intentional-drift path in `.github/template.yaml`, so `Template drift` is unaffected.

Possible follow-up, deliberately not in this PR: with Rector no longer inherited from `[0]`, the merge-queue matrix could go back to `'["8.4"]'` and drop from 4 cells to 2. That is a coverage decision about the queue, not a correctness fix, so it belongs to whoever owns that trade-off.

## Verification

`actionlint .github/workflows/ci.yml` exits 0; the parsed workflow carries `jobs.ci.with.rector-php-version == '8.2'`. The input exists on `netresearch/typo3-ci-workflows@main`, which is the ref this caller uses.
