### PR TITLE
test: apply the PHPUnit rules Rector 2.6.1 auto-activates

### DIFF
--- a/Tests/Functional/Service/LlmConfigurationServiceTest.php
+++ b/Tests/Functional/Service/LlmConfigurationServiceTest.php
@@ -78,7 +78,7 @@ class LlmConfigurationServiceTest extends AbstractFunctionalTestCase
         $this->setUpAdminUser();
 
         $this->expectException(ConfigurationNotFoundException::class);
-        $this->expectExceptionMessage('LLM configuration "non-existent" not found');
+        $this->expectExceptionMessageIsOrContains('LLM configuration "non-existent" not found');
 
         $this->subject->getConfiguration('non-existent');
     }
@@ -89,7 +89,7 @@ class LlmConfigurationServiceTest extends AbstractFunctionalTestCase
         $this->setUpAdminUser();
 
         $this->expectException(ConfigurationNotFoundException::class);
-        $this->expectExceptionMessage('LLM configuration "inactive-config" is not active');
+        $this->expectExceptionMessageIsOrContains('LLM configuration "inactive-config" is not active');
 
         $this->subject->getConfiguration('inactive-config');
     }

--- a/Tests/Integration/Provider/OpenAiProviderIntegrationTest.php
+++ b/Tests/Integration/Provider/OpenAiProviderIntegrationTest.php
@@ -194,7 +194,7 @@ class OpenAiProviderIntegrationTest extends AbstractIntegrationTestCase
         ]);
 
         $this->expectException(ProviderResponseException::class);
-        $this->expectExceptionMessage('Incorrect API key');
+        $this->expectExceptionMessageIsOrContains('Incorrect API key');
 
         $provider->chatCompletion([
             ['role' => 'user', 'content' => 'Hello'],
@@ -218,7 +218,7 @@ class OpenAiProviderIntegrationTest extends AbstractIntegrationTestCase
         ]);
 
         $this->expectException(ProviderResponseException::class);
-        $this->expectExceptionMessage('Rate limit');
+        $this->expectExceptionMessageIsOrContains('Rate limit');
 
         $provider->chatCompletion([
             ['role' => 'user', 'content' => 'Hello'],

--- a/Tests/Integration/Service/LlmServiceManagerIntegrationTest.php
+++ b/Tests/Integration/Service/LlmServiceManagerIntegrationTest.php
@@ -222,7 +222,7 @@ class LlmServiceManagerIntegrationTest extends AbstractIntegrationTestCase
     public function throwsExceptionForUnknownProvider(): void
     {
         $this->expectException(ProviderException::class);
-        $this->expectExceptionMessage('Provider "unknown" not found');
+        $this->expectExceptionMessageIsOrContains('Provider "unknown" not found');
 
         $this->subject->getProvider('unknown');
     }
@@ -239,7 +239,7 @@ class LlmServiceManagerIntegrationTest extends AbstractIntegrationTestCase
         $manager = $this->createLlmServiceManager($configMock, new NullLogger(), $this->adapterRegistryStub, new MiddlewarePipeline([]), self::createStub(CacheManagerInterface::class));
 
         $this->expectException(ProviderException::class);
-        $this->expectExceptionMessage('No provider specified and no default provider configured');
+        $this->expectExceptionMessageIsOrContains('No provider specified and no default provider configured');
 
         $manager->getProvider();
     }

--- a/Tests/Unit/Controller/Backend/FormEngineUrlBuilderTest.php
+++ b/Tests/Unit/Controller/Backend/FormEngineUrlBuilderTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Controller\Backend;
 
 use Netresearch\NrLlm\Controller\Backend\FormEngineUrlBuilder;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -20,6 +21,7 @@ use TYPO3\CMS\Core\Http\Uri;
  * Unit tests for FormEngineUrlBuilder.
  */
 #[CoversClass(FormEngineUrlBuilder::class)]
+#[AllowMockObjectsWithoutExpectations]
 final class FormEngineUrlBuilderTest extends TestCase
 {
     /**

--- a/Tests/Unit/Domain/Model/EmbeddingResponseTest.php
+++ b/Tests/Unit/Domain/Model/EmbeddingResponseTest.php
@@ -226,7 +226,7 @@ class EmbeddingResponseTest extends AbstractUnitTestCase
         $vectorB = [0.1, 0.2];
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Vectors must have the same dimensions');
+        $this->expectExceptionMessageIsOrContains('Vectors must have the same dimensions');
 
         EmbeddingResponse::cosineSimilarity($vectorA, $vectorB);
     }

--- a/Tests/Unit/Domain/Model/ProviderTest.php
+++ b/Tests/Unit/Domain/Model/ProviderTest.php
@@ -258,7 +258,7 @@ final class ProviderTest extends AbstractUnitTestCase
     public function setApiKeyThrowsForRawApiKey(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('API key must be a vault identifier');
+        $this->expectExceptionMessageIsOrContains('API key must be a vault identifier');
 
         // Raw API key, not a UUID v7
         $this->subject->setApiKey('sk-abc123xyz');
@@ -301,7 +301,7 @@ final class ProviderTest extends AbstractUnitTestCase
     public function setApiKeyThrowsForKnownPlaintextKeyPrefixes(string $plaintextKey): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('API key must be a vault identifier');
+        $this->expectExceptionMessageIsOrContains('API key must be a vault identifier');
 
         $this->subject->setApiKey($plaintextKey);
     }

--- a/Tests/Unit/Domain/ValueObject/ChatMessageTest.php
+++ b/Tests/Unit/Domain/ValueObject/ChatMessageTest.php
@@ -71,7 +71,7 @@ class ChatMessageTest extends AbstractUnitTestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionCode(1736502001);
-        $this->expectExceptionMessage(sprintf('Invalid role "%s"', $invalidRole));
+        $this->expectExceptionMessageIsOrContains(sprintf('Invalid role "%s"', $invalidRole));
 
         self::assertInstanceOf(ChatMessage::class, new ChatMessage($invalidRole, 'content'));
     }

--- a/Tests/Unit/Provider/AbstractProviderMutationTest.php
+++ b/Tests/Unit/Provider/AbstractProviderMutationTest.php
@@ -20,6 +20,7 @@ use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\GeminiProvider;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -37,6 +38,7 @@ use Throwable;
  * extractErrorMessage(), and related methods.
  */
 #[CoversClass(AbstractProvider::class)]
+#[AllowMockObjectsWithoutExpectations]
 class AbstractProviderMutationTest extends AbstractUnitTestCase
 {
     // ===== Tests for supportsFeature() =====
@@ -481,7 +483,7 @@ class AbstractProviderMutationTest extends AbstractUnitTestCase
         ]);
 
         $this->expectException(ProviderConfigurationException::class);
-        $this->expectExceptionMessage('API key identifier is required');
+        $this->expectExceptionMessageIsOrContains('API key identifier is required');
 
         $reflection = new ReflectionClass($provider);
         $method = $reflection->getMethod('validateConfiguration');

--- a/Tests/Unit/Provider/ClaudeProviderMutationTest.php
+++ b/Tests/Unit/Provider/ClaudeProviderMutationTest.php
@@ -234,7 +234,7 @@ class ClaudeProviderMutationTest extends AbstractUnitTestCase
         $provider->configure(['apiKeyIdentifier' => $this->randomApiKey()]);
 
         $this->expectException(UnsupportedFeatureException::class);
-        $this->expectExceptionMessage('Anthropic Claude does not support embeddings');
+        $this->expectExceptionMessageIsOrContains('Anthropic Claude does not support embeddings');
 
         $provider->embeddings('test input');
     }

--- a/Tests/Unit/Provider/ClaudeProviderTest.php
+++ b/Tests/Unit/Provider/ClaudeProviderTest.php
@@ -20,6 +20,7 @@ use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -33,6 +34,7 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 
 #[CoversClass(ClaudeProvider::class)]
+#[AllowMockObjectsWithoutExpectations]
 class ClaudeProviderTest extends AbstractUnitTestCase
 {
     private ClaudeProvider $subject;
@@ -541,7 +543,7 @@ class ClaudeProviderTest extends AbstractUnitTestCase
     public function embeddingsThrowsUnsupportedFeatureException(): void
     {
         $this->expectException(UnsupportedFeatureException::class);
-        $this->expectExceptionMessage('Anthropic Claude does not support embeddings');
+        $this->expectExceptionMessageIsOrContains('Anthropic Claude does not support embeddings');
 
         $this->subject->embeddings('test text');
     }

--- a/Tests/Unit/Provider/GroqProviderMutationTest.php
+++ b/Tests/Unit/Provider/GroqProviderMutationTest.php
@@ -203,7 +203,7 @@ class GroqProviderMutationTest extends AbstractUnitTestCase
         $provider->configure(['apiKeyIdentifier' => $this->randomApiKey()]);
 
         $this->expectException(UnsupportedFeatureException::class);
-        $this->expectExceptionMessage('Groq does not support embeddings');
+        $this->expectExceptionMessageIsOrContains('Groq does not support embeddings');
 
         $provider->embeddings('test input');
     }

--- a/Tests/Unit/Provider/GroqProviderTest.php
+++ b/Tests/Unit/Provider/GroqProviderTest.php
@@ -332,7 +332,7 @@ class GroqProviderTest extends AbstractUnitTestCase
     public function embeddingsThrowsUnsupportedFeatureException(): void
     {
         $this->expectException(UnsupportedFeatureException::class);
-        $this->expectExceptionMessage('Groq does not support embeddings');
+        $this->expectExceptionMessageIsOrContains('Groq does not support embeddings');
         // Pin the exception code against Increment/DecrementInteger mutants.
         $this->expectExceptionCode(4840547720);
 

--- a/Tests/Unit/Provider/Middleware/CacheMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/CacheMiddlewareTest.php
@@ -16,12 +16,14 @@ use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 
 #[CoversClass(CacheMiddleware::class)]
+#[AllowMockObjectsWithoutExpectations]
 final class CacheMiddlewareTest extends AbstractUnitTestCase
 {
     private CacheManagerInterface&MockObject $cache;

--- a/Tests/Unit/Provider/Middleware/GuardrailMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/GuardrailMiddlewareTest.php
@@ -97,7 +97,7 @@ final class GuardrailMiddlewareTest extends TestCase
         $middleware = new GuardrailMiddleware([$this->guardrail(GuardrailResult::deny('blocked'))]);
 
         $this->expectException(GuardrailViolationException::class);
-        $this->expectExceptionMessage('blocked');
+        $this->expectExceptionMessageIsOrContains('blocked');
         $this->screen($middleware, fn(): CompletionResponse => $this->response('bad'));
     }
 

--- a/Tests/Unit/Provider/Middleware/UsageMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/UsageMiddlewareTest.php
@@ -297,7 +297,7 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
         $this->tracker->expects(self::never())->method('trackUsage');
 
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('boom');
+        $this->expectExceptionMessageIsOrContains('boom');
 
         $this->pipeline()->run(
             context: ProviderCallContext::forConfiguration(ProviderOperation::Chat, $this->configuration()),

--- a/Tests/Unit/Provider/OpenAiProviderTest.php
+++ b/Tests/Unit/Provider/OpenAiProviderTest.php
@@ -23,6 +23,7 @@ use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\OpenAiProvider;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -36,6 +37,7 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 
 #[CoversClass(OpenAiProvider::class)]
+#[AllowMockObjectsWithoutExpectations]
 class OpenAiProviderTest extends AbstractUnitTestCase
 {
     private OpenAiProvider $subject;
@@ -302,7 +304,7 @@ class OpenAiProviderTest extends AbstractUnitTestCase
             ->willReturn($this->createErrorResponseMock(401, 'Invalid API key'));
 
         $this->expectException(ProviderResponseException::class);
-        $this->expectExceptionMessage('Invalid API key');
+        $this->expectExceptionMessageIsOrContains('Invalid API key');
 
         $this->subject->chatCompletion([['role' => 'user', 'content' => 'test']]);
     }
@@ -955,7 +957,7 @@ class OpenAiProviderTest extends AbstractUnitTestCase
             ->willReturn($this->createErrorResponseMock(400, 'Invalid request format'));
 
         $this->expectException(ProviderResponseException::class);
-        $this->expectExceptionMessage('Invalid request format');
+        $this->expectExceptionMessageIsOrContains('Invalid request format');
 
         $this->subject->chatCompletion([['role' => 'user', 'content' => 'test']]);
     }
@@ -990,7 +992,7 @@ class OpenAiProviderTest extends AbstractUnitTestCase
             ->willReturn($response);
 
         $this->expectException(ProviderResponseException::class);
-        $this->expectExceptionMessage('Model not found');
+        $this->expectExceptionMessageIsOrContains('Model not found');
 
         $this->subject->chatCompletion([['role' => 'user', 'content' => 'test']]);
     }
@@ -1013,7 +1015,7 @@ class OpenAiProviderTest extends AbstractUnitTestCase
             ->willReturn($response);
 
         $this->expectException(ProviderResponseException::class);
-        $this->expectExceptionMessage('Rate limit exceeded');
+        $this->expectExceptionMessageIsOrContains('Rate limit exceeded');
 
         $this->subject->chatCompletion([['role' => 'user', 'content' => 'test']]);
     }
@@ -1036,7 +1038,7 @@ class OpenAiProviderTest extends AbstractUnitTestCase
             ->willReturn($response);
 
         $this->expectException(ProviderResponseException::class);
-        $this->expectExceptionMessage('Unknown provider error');
+        $this->expectExceptionMessageIsOrContains('Unknown provider error');
 
         $this->subject->chatCompletion([['role' => 'user', 'content' => 'test']]);
     }
@@ -1983,7 +1985,7 @@ class OpenAiProviderTest extends AbstractUnitTestCase
             ->willReturn($response);
 
         $this->expectException(ProviderResponseException::class);
-        $this->expectExceptionMessage('bad stream request');
+        $this->expectExceptionMessageIsOrContains('bad stream request');
 
         foreach ($this->subject->streamChatCompletion([['role' => 'user', 'content' => 'hi']]) as $ignored) {
             unset($ignored);

--- a/Tests/Unit/Provider/OpenRouterProviderTest.php
+++ b/Tests/Unit/Provider/OpenRouterProviderTest.php
@@ -22,6 +22,7 @@ use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\ProviderRateLimitException;
 use Netresearch\NrLlm\Provider\OpenRouterProvider;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -34,6 +35,7 @@ use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
 #[CoversClass(OpenRouterProvider::class)]
+#[AllowMockObjectsWithoutExpectations]
 class OpenRouterProviderTest extends AbstractUnitTestCase
 {
     private OpenRouterProvider $subject;
@@ -2350,7 +2352,7 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
             ->willReturn($this->createSseResponse([], 500));
 
         $this->expectException(ProviderConnectionException::class);
-        $this->expectExceptionMessage('Server returned status 500');
+        $this->expectExceptionMessageIsOrContains('Server returned status 500');
 
         $provider->streamChatCompletion(
             [['role' => 'user', 'content' => 'Hi']],
@@ -2806,7 +2808,7 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
             ));
 
         $this->expectException(ProviderException::class);
-        $this->expectExceptionMessage('OpenRouter API error (500): upstream exploded');
+        $this->expectExceptionMessageIsOrContains('OpenRouter API error (500): upstream exploded');
 
         $this->subject->chatCompletion(
             [['role' => 'user', 'content' => 'Hi']],

--- a/Tests/Unit/Provider/ProviderAdapterRegistryTest.php
+++ b/Tests/Unit/Provider/ProviderAdapterRegistryTest.php
@@ -145,7 +145,7 @@ class ProviderAdapterRegistryTest extends AbstractUnitTestCase
     public function constructorThrowsForInvalidOverrideClass(): void
     {
         $this->expectException(ProviderConfigurationException::class);
-        $this->expectExceptionMessage('must extend');
+        $this->expectExceptionMessageIsOrContains('must extend');
 
         // stdClass is not a subclass of AbstractProvider
         self::assertInstanceOf(ProviderAdapterRegistry::class, new ProviderAdapterRegistry(
@@ -163,7 +163,7 @@ class ProviderAdapterRegistryTest extends AbstractUnitTestCase
     public function constructorThrowsForNumericOverrideKey(): void
     {
         $this->expectException(ProviderConfigurationException::class);
-        $this->expectExceptionMessage('Adapter override key');
+        $this->expectExceptionMessageIsOrContains('Adapter override key');
 
         // Numeric (int) keys would be re-indexed by array_merge,
         // breaking the adapter-type lookup. Reject at the boundary.
@@ -182,7 +182,7 @@ class ProviderAdapterRegistryTest extends AbstractUnitTestCase
     public function constructorThrowsForEmptyStringOverrideKey(): void
     {
         $this->expectException(ProviderConfigurationException::class);
-        $this->expectExceptionMessage('Adapter override key');
+        $this->expectExceptionMessageIsOrContains('Adapter override key');
 
         self::assertInstanceOf(ProviderAdapterRegistry::class, new ProviderAdapterRegistry(
             $this->createRequestFactoryMock(),
@@ -198,7 +198,7 @@ class ProviderAdapterRegistryTest extends AbstractUnitTestCase
     public function constructorThrowsForNonStringOverrideValue(): void
     {
         $this->expectException(ProviderConfigurationException::class);
-        $this->expectExceptionMessage('must be a class-string');
+        $this->expectExceptionMessageIsOrContains('must be a class-string');
 
         // A non-string value would have caused TypeError inside
         // is_subclass_of(); the explicit guard surfaces it as a
@@ -359,7 +359,7 @@ class ProviderAdapterRegistryTest extends AbstractUnitTestCase
         $model->method('getIdentifier')->willReturn('orphan-model');
 
         $this->expectException(ProviderConfigurationException::class);
-        $this->expectExceptionMessage('has no associated provider');
+        $this->expectExceptionMessageIsOrContains('has no associated provider');
 
         $this->subject->createAdapterFromModel($model);
     }

--- a/Tests/Unit/Provider/ResponseParserTraitMutationTest.php
+++ b/Tests/Unit/Provider/ResponseParserTraitMutationTest.php
@@ -578,7 +578,7 @@ class ResponseParserTraitMutationTest extends AbstractUnitTestCase
     public function decodeJsonResponseThrowsOnNonObjectJson(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected JSON object');
+        $this->expectExceptionMessageIsOrContains('Expected JSON object');
         $this->invokeTraitMethod('decodeJsonResponse', ['"string"']);
     }
 

--- a/Tests/Unit/Service/Feature/CompletionServiceMutationTest.php
+++ b/Tests/Unit/Service/Feature/CompletionServiceMutationTest.php
@@ -432,7 +432,7 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
         $service = new CompletionService($llmManagerMock);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Failed to decode JSON response');
+        $this->expectExceptionMessageIsOrContains('Failed to decode JSON response');
 
         $service->completeJson('Generate JSON');
     }
@@ -526,7 +526,7 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
         $service = new CompletionService($llmManagerStub);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('max_tokens');
+        $this->expectExceptionMessageIsOrContains('max_tokens');
 
         $options = new ChatOptions(maxTokens: 0);
         $service->complete('Test', $options);

--- a/Tests/Unit/Service/Feature/CompletionServiceTest.php
+++ b/Tests/Unit/Service/Feature/CompletionServiceTest.php
@@ -147,7 +147,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
             ->willReturn($mockResponse);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Failed to decode JSON response');
+        $this->expectExceptionMessageIsOrContains('Failed to decode JSON response');
 
         $subject->completeJson('Generate JSON');
     }
@@ -213,7 +213,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
     public function validateOptionsThrowsOnInvalidTemperature(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('temperature must be between 0 and 2');
+        $this->expectExceptionMessageIsOrContains('temperature must be between 0 and 2');
 
         $this->subject->complete('Test', new ChatOptions(temperature: 3.0));
     }
@@ -222,7 +222,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
     public function validateOptionsThrowsOnInvalidMaxTokens(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('max_tokens must be a positive integer');
+        $this->expectExceptionMessageIsOrContains('max_tokens must be a positive integer');
 
         $this->subject->complete('Test', new ChatOptions(maxTokens: -1));
     }
@@ -231,7 +231,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
     public function validateOptionsThrowsOnInvalidResponseFormat(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('response_format must be');
+        $this->expectExceptionMessageIsOrContains('response_format must be');
 
         $this->subject->complete('Test', new ChatOptions(responseFormat: 'invalid'));
     }
@@ -258,7 +258,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
     public function validateOptionsThrowsOnInvalidTopP(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('top_p must be between 0 and 1');
+        $this->expectExceptionMessageIsOrContains('top_p must be between 0 and 1');
 
         $this->subject->complete('Test', new ChatOptions(topP: 1.5));
     }
@@ -276,7 +276,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
             ->willReturn($mockResponse);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('JSON response must be an object');
+        $this->expectExceptionMessageIsOrContains('JSON response must be an object');
 
         $subject->completeJson('Test');
     }
@@ -539,7 +539,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
             ->willReturn($mockResponse);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Failed to decode JSON response');
+        $this->expectExceptionMessageIsOrContains('Failed to decode JSON response');
 
         $subject->completeJson('Test');
     }
@@ -578,7 +578,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
             ->willReturn($mockResponse);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('JSON response must be an object');
+        $this->expectExceptionMessageIsOrContains('JSON response must be an object');
 
         $subject->completeJson('Test');
     }
@@ -587,7 +587,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
     public function validateOptionsThrowsOnNegativeTemperature(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('temperature must be between 0 and 2');
+        $this->expectExceptionMessageIsOrContains('temperature must be between 0 and 2');
 
         $this->subject->complete('Test', new ChatOptions(temperature: -0.1));
     }
@@ -596,7 +596,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
     public function validateOptionsThrowsOnZeroMaxTokens(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('max_tokens must be a positive integer');
+        $this->expectExceptionMessageIsOrContains('max_tokens must be a positive integer');
 
         $this->subject->complete('Test', new ChatOptions(maxTokens: 0));
     }
@@ -605,7 +605,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
     public function validateOptionsThrowsOnNegativeTopP(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('top_p must be between 0 and 1');
+        $this->expectExceptionMessageIsOrContains('top_p must be between 0 and 1');
 
         $this->subject->complete('Test', new ChatOptions(topP: -0.1));
     }
@@ -873,7 +873,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
         $configuration = self::createStub(LlmConfiguration::class);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('temperature must be between 0 and 2');
+        $this->expectExceptionMessageIsOrContains('temperature must be between 0 and 2');
 
         $this->subject->completeForConfiguration('Test', $configuration, new ChatOptions(temperature: 3.0));
     }
@@ -914,7 +914,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
             ->willReturn($this->createMockResponse('not json'));
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Failed to decode JSON response');
+        $this->expectExceptionMessageIsOrContains('Failed to decode JSON response');
 
         $subject->completeJsonForConfiguration('Prompt', $configuration);
     }

--- a/Tests/Unit/Service/Feature/EmbeddingServiceMutationTest.php
+++ b/Tests/Unit/Service/Feature/EmbeddingServiceMutationTest.php
@@ -202,7 +202,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
         $service = new EmbeddingService($llmManagerStub);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Text cannot be empty');
+        $this->expectExceptionMessageIsOrContains('Text cannot be empty');
 
         $service->embedFull('');
     }

--- a/Tests/Unit/Service/Feature/EmbeddingServiceTest.php
+++ b/Tests/Unit/Service/Feature/EmbeddingServiceTest.php
@@ -146,7 +146,7 @@ class EmbeddingServiceTest extends AbstractUnitTestCase
     public function embedThrowsOnEmptyText(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Text cannot be empty');
+        $this->expectExceptionMessageIsOrContains('Text cannot be empty');
 
         $this->subject->embed('');
     }
@@ -220,7 +220,7 @@ class EmbeddingServiceTest extends AbstractUnitTestCase
         $subject = new EmbeddingService($llmManagerMock);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Text cannot be empty');
+        $this->expectExceptionMessageIsOrContains('Text cannot be empty');
 
         $subject->embedForConfiguration('', $config);
     }

--- a/Tests/Unit/Service/Feature/VisionServiceMutationTest.php
+++ b/Tests/Unit/Service/Feature/VisionServiceMutationTest.php
@@ -366,7 +366,7 @@ class VisionServiceMutationTest extends AbstractUnitTestCase
         $service = new VisionService($llmManagerStub);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid image URL or base64 data URI');
+        $this->expectExceptionMessageIsOrContains('Invalid image URL or base64 data URI');
 
         $service->analyzeImageFull('not-a-valid-url', 'Analyze this');
     }

--- a/Tests/Unit/Service/Feature/VisionServiceTest.php
+++ b/Tests/Unit/Service/Feature/VisionServiceTest.php
@@ -183,7 +183,7 @@ class VisionServiceTest extends AbstractUnitTestCase
         $invalidUrl = 'not-a-valid-url';
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid image URL');
+        $this->expectExceptionMessageIsOrContains('Invalid image URL');
 
         $this->subject->generateAltText($invalidUrl);
     }

--- a/Tests/Unit/Service/Guardrail/InputGuardrailScreenerTest.php
+++ b/Tests/Unit/Service/Guardrail/InputGuardrailScreenerTest.php
@@ -102,7 +102,7 @@ final class InputGuardrailScreenerTest extends TestCase
         $screener = new InputGuardrailScreener([$this->denying('policy says no')]);
 
         $this->expectException(GuardrailViolationException::class);
-        $this->expectExceptionMessage('policy says no');
+        $this->expectExceptionMessageIsOrContains('policy says no');
         $screener->screen([ChatMessage::user('anything')]);
     }
 
@@ -112,7 +112,7 @@ final class InputGuardrailScreenerTest extends TestCase
         $screener = new InputGuardrailScreener([$this->requireApproval('needs review')]);
 
         $this->expectException(GuardrailApprovalRequiredException::class);
-        $this->expectExceptionMessage('needs review');
+        $this->expectExceptionMessageIsOrContains('needs review');
         $screener->screen([ChatMessage::user('anything')]);
     }
 
@@ -159,7 +159,7 @@ final class InputGuardrailScreenerTest extends TestCase
         $screener = new InputGuardrailScreener([$this->denying('policy says no')]);
 
         $this->expectException(GuardrailViolationException::class);
-        $this->expectExceptionMessage('policy says no');
+        $this->expectExceptionMessageIsOrContains('policy says no');
         $screener->screenText('anything');
     }
 
@@ -169,7 +169,7 @@ final class InputGuardrailScreenerTest extends TestCase
         $screener = new InputGuardrailScreener([$this->requireApproval('needs review')]);
 
         $this->expectException(GuardrailApprovalRequiredException::class);
-        $this->expectExceptionMessage('needs review');
+        $this->expectExceptionMessageIsOrContains('needs review');
         $screener->screenText('anything');
     }
 

--- a/Tests/Unit/Service/KeyedProviderRegistryTest.php
+++ b/Tests/Unit/Service/KeyedProviderRegistryTest.php
@@ -71,7 +71,7 @@ class KeyedProviderRegistryTest extends AbstractUnitTestCase
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionCode(6273324883);
-        $this->expectExceptionMessage('Provider "nope" not found');
+        $this->expectExceptionMessageIsOrContains('Provider "nope" not found');
 
         $registry->getProvider('nope');
     }
@@ -83,7 +83,7 @@ class KeyedProviderRegistryTest extends AbstractUnitTestCase
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionCode(4867297358);
-        $this->expectExceptionMessage('No provider specified and no default provider configured');
+        $this->expectExceptionMessageIsOrContains('No provider specified and no default provider configured');
 
         $registry->getProvider();
     }
@@ -194,7 +194,7 @@ class KeyedProviderRegistryTest extends AbstractUnitTestCase
 
         $this->expectException(ProviderException::class);
         $this->expectExceptionCode(5332497319);
-        $this->expectExceptionMessage('Provider "unknown" not found');
+        $this->expectExceptionMessageIsOrContains('Provider "unknown" not found');
 
         $registry->configureProvider('unknown', []);
     }

--- a/Tests/Unit/Service/LlmServiceManagerMutationTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerMutationTest.php
@@ -69,7 +69,7 @@ class LlmServiceManagerMutationTest extends AbstractUnitTestCase
         $manager = $this->createManager();
 
         $this->expectException(ProviderException::class);
-        $this->expectExceptionMessage('No provider specified and no default provider configured');
+        $this->expectExceptionMessageIsOrContains('No provider specified and no default provider configured');
 
         $manager->getProvider();
     }
@@ -80,7 +80,7 @@ class LlmServiceManagerMutationTest extends AbstractUnitTestCase
         $manager = $this->createManager();
 
         $this->expectException(ProviderException::class);
-        $this->expectExceptionMessage('Provider "nonexistent" not found');
+        $this->expectExceptionMessageIsOrContains('Provider "nonexistent" not found');
 
         $manager->getProvider('nonexistent');
     }
@@ -177,7 +177,7 @@ class LlmServiceManagerMutationTest extends AbstractUnitTestCase
         $manager = $this->createManager();
 
         $this->expectException(ProviderException::class);
-        $this->expectExceptionMessage('Provider "unknown" not found');
+        $this->expectExceptionMessageIsOrContains('Provider "unknown" not found');
 
         $manager->configureProvider('unknown', ['apiKeyIdentifier' => 'test']);
     }

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -125,7 +125,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
     public function getProviderThrowsWhenProviderNotFound(): void
     {
         $this->expectException(ProviderException::class);
-        $this->expectExceptionMessage('Provider "nonexistent" not found');
+        $this->expectExceptionMessageIsOrContains('Provider "nonexistent" not found');
 
         $this->subject->getProvider('nonexistent');
     }
@@ -142,7 +142,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $manager = $this->createLlmServiceManager($extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         $this->expectException(ProviderException::class);
-        $this->expectExceptionMessage('No provider specified and no default provider configured');
+        $this->expectExceptionMessageIsOrContains('No provider specified and no default provider configured');
 
         $manager->getProvider();
     }
@@ -317,7 +317,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
     public function configureProviderThrowsForNonexistent(): void
     {
         $this->expectException(ProviderException::class);
-        $this->expectExceptionMessage('Provider "nonexistent" not found');
+        $this->expectExceptionMessageIsOrContains('Provider "nonexistent" not found');
 
         $this->subject->configureProvider('nonexistent', ['key' => 'value']);
     }
@@ -375,7 +375,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
     {
         // Pin the registered provider (openai), which doesn't implement VisionCapableInterface
         $this->expectException(UnsupportedFeatureException::class);
-        $this->expectExceptionMessage('does not support vision');
+        $this->expectExceptionMessageIsOrContains('does not support vision');
 
         $this->subject->vision([['type' => 'text', 'text' => 'test']], new VisionOptions(provider: 'openai'));
     }
@@ -400,7 +400,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
     public function streamChatThrowsWhenProviderDoesNotSupportStreaming(): void
     {
         $this->expectException(UnsupportedFeatureException::class);
-        $this->expectExceptionMessage('does not support streaming');
+        $this->expectExceptionMessageIsOrContains('does not support streaming');
 
         iterator_to_array($this->subject->streamChat([['role' => 'user', 'content' => 'test']], new ChatOptions(provider: 'openai')));
     }
@@ -474,7 +474,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
     public function chatWithToolsThrowsWhenProviderDoesNotSupportTools(): void
     {
         $this->expectException(UnsupportedFeatureException::class);
-        $this->expectExceptionMessage('does not support tool calling');
+        $this->expectExceptionMessageIsOrContains('does not support tool calling');
 
         $messages = [['role' => 'user', 'content' => 'test']];
         $tools = [ToolSpec::fromArray(['type' => 'function', 'function' => ['name' => 'test', 'description' => 'test', 'parameters' => []]])];
@@ -510,7 +510,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
     public function embedThrowsWhenProviderDoesNotSupportEmbeddings(): void
     {
         $this->expectException(UnsupportedFeatureException::class);
-        $this->expectExceptionMessage('does not support embeddings');
+        $this->expectExceptionMessageIsOrContains('does not support embeddings');
 
         $limitedProvider = new TestableNoEmbeddingsProvider();
         $this->subject->registerProvider($limitedProvider);
@@ -594,7 +594,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $config->method('getIdentifier')->willReturn('orphan-config');
 
         $this->expectException(ProviderException::class);
-        $this->expectExceptionMessage('has no model assigned');
+        $this->expectExceptionMessageIsOrContains('has no model assigned');
 
         $this->subject->getAdapterFromConfiguration($config);
     }
@@ -642,7 +642,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $this->adapterRegistryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class), null, null, $selection);
 
         $this->expectException(ProviderException::class);
-        $this->expectExceptionMessage('has no model assigned');
+        $this->expectExceptionMessageIsOrContains('has no model assigned');
 
         $manager->getAdapterFromConfiguration($config);
     }
@@ -1657,7 +1657,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         $this->expectException(UnsupportedFeatureException::class);
-        $this->expectExceptionMessage('Provider "chat-only" does not support embeddings');
+        $this->expectExceptionMessageIsOrContains('Provider "chat-only" does not support embeddings');
 
         $manager->embedForConfiguration('text', $config);
     }
@@ -1945,7 +1945,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         // extension-config default-provider fallback removed, the generic path
         // must throw rather than silently pick a provider.
         $this->expectException(ProviderException::class);
-        $this->expectExceptionMessage('No provider specified and no default provider configured');
+        $this->expectExceptionMessageIsOrContains('No provider specified and no default provider configured');
 
         $manager->chat([['role' => 'user', 'content' => 'Hello']]);
     }
@@ -1974,7 +1974,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         // returns null, so with no pinned provider the generic path throws the
         // no-provider error — asserting that distinguishes the gate from a misroute.
         $this->expectException(ProviderException::class);
-        $this->expectExceptionMessage('No provider specified and no default provider configured');
+        $this->expectExceptionMessageIsOrContains('No provider specified and no default provider configured');
 
         $manager->chat([['role' => 'user', 'content' => 'Hello']]);
     }
@@ -2004,7 +2004,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         // context to enforce membership: resolveDefaultConfiguration() returns
         // null, so with no pinned provider the generic path throws.
         $this->expectException(ProviderException::class);
-        $this->expectExceptionMessage('No provider specified and no default provider configured');
+        $this->expectExceptionMessageIsOrContains('No provider specified and no default provider configured');
 
         $manager->chat([['role' => 'user', 'content' => 'Hello']]);
     }
@@ -2101,7 +2101,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
 
         // Mirror of the chat() no-fallback contract for the complete() entry point.
         $this->expectException(ProviderException::class);
-        $this->expectExceptionMessage('No provider specified and no default provider configured');
+        $this->expectExceptionMessageIsOrContains('No provider specified and no default provider configured');
 
         $manager->complete('Prompt');
     }
@@ -2247,7 +2247,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryMock, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class));
 
         $this->expectException(UnsupportedFeatureException::class);
-        $this->expectExceptionMessage('does not support streaming');
+        $this->expectExceptionMessageIsOrContains('does not support streaming');
 
         iterator_to_array($manager->streamChatWithConfiguration([['role' => 'user', 'content' => 'Hello']], $config));
     }
@@ -2325,7 +2325,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         );
 
         $this->expectException(UnsupportedFeatureException::class);
-        $this->expectExceptionMessage('does not support streaming');
+        $this->expectExceptionMessageIsOrContains('does not support streaming');
 
         // No iteration: the throw must come from the call itself, proving the
         // check is eager rather than deferred into the dispatcher generator.

--- a/Tests/Unit/Service/Option/ChatOptionsMutationTest.php
+++ b/Tests/Unit/Service/Option/ChatOptionsMutationTest.php
@@ -205,7 +205,7 @@ class ChatOptionsMutationTest extends AbstractUnitTestCase
     public function validateThrowsOnInvalidTemperature(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('temperature');
+        $this->expectExceptionMessageIsOrContains('temperature');
 
         self::assertInstanceOf(ChatOptions::class, new ChatOptions(temperature: 3.0)); // Above max of 2.0
     }
@@ -214,7 +214,7 @@ class ChatOptionsMutationTest extends AbstractUnitTestCase
     public function validateThrowsOnNegativeMaxTokens(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('max_tokens');
+        $this->expectExceptionMessageIsOrContains('max_tokens');
 
         self::assertInstanceOf(ChatOptions::class, new ChatOptions(maxTokens: -1));
     }
@@ -223,7 +223,7 @@ class ChatOptionsMutationTest extends AbstractUnitTestCase
     public function validateThrowsOnInvalidTopP(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('top_p');
+        $this->expectExceptionMessageIsOrContains('top_p');
 
         self::assertInstanceOf(ChatOptions::class, new ChatOptions(topP: 1.5)); // Above max of 1.0
     }
@@ -232,7 +232,7 @@ class ChatOptionsMutationTest extends AbstractUnitTestCase
     public function validateThrowsOnInvalidResponseFormat(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('response_format');
+        $this->expectExceptionMessageIsOrContains('response_format');
 
         self::assertInstanceOf(ChatOptions::class, new ChatOptions(responseFormat: 'invalid'));
     }

--- a/Tests/Unit/Service/Option/ChatOptionsTest.php
+++ b/Tests/Unit/Service/Option/ChatOptionsTest.php
@@ -52,7 +52,7 @@ class ChatOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForInvalidTemperature(float $temperature): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('temperature must be between 0 and 2');
+        $this->expectExceptionMessageIsOrContains('temperature must be between 0 and 2');
 
         self::assertInstanceOf(ChatOptions::class, new ChatOptions(temperature: $temperature));
     }
@@ -95,7 +95,7 @@ class ChatOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForNegativeMaxTokens(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('max_tokens must be a positive integer');
+        $this->expectExceptionMessageIsOrContains('max_tokens must be a positive integer');
 
         self::assertInstanceOf(ChatOptions::class, new ChatOptions(maxTokens: 0));
     }
@@ -105,7 +105,7 @@ class ChatOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForInvalidTopP(float $topP): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('top_p must be between 0 and 1');
+        $this->expectExceptionMessageIsOrContains('top_p must be between 0 and 1');
 
         self::assertInstanceOf(ChatOptions::class, new ChatOptions(topP: $topP));
     }
@@ -126,7 +126,7 @@ class ChatOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForInvalidFrequencyPenalty(float $penalty): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('frequency_penalty must be between -2 and 2');
+        $this->expectExceptionMessageIsOrContains('frequency_penalty must be between -2 and 2');
 
         self::assertInstanceOf(ChatOptions::class, new ChatOptions(frequencyPenalty: $penalty));
     }
@@ -136,7 +136,7 @@ class ChatOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForInvalidPresencePenalty(float $penalty): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('presence_penalty must be between -2 and 2');
+        $this->expectExceptionMessageIsOrContains('presence_penalty must be between -2 and 2');
 
         self::assertInstanceOf(ChatOptions::class, new ChatOptions(presencePenalty: $penalty));
     }
@@ -156,7 +156,7 @@ class ChatOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForInvalidResponseFormat(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('response_format must be one of: text, json, markdown');
+        $this->expectExceptionMessageIsOrContains('response_format must be one of: text, json, markdown');
 
         self::assertInstanceOf(ChatOptions::class, new ChatOptions(responseFormat: 'xml'));
     }
@@ -432,7 +432,7 @@ class ChatOptionsTest extends AbstractUnitTestCase
         // Per BudgetMiddleware contract: 0 = anonymous / skip, positive
         // = real BE user. Negative is always a caller bug.
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('be_user_uid must be >= 0');
+        $this->expectExceptionMessageIsOrContains('be_user_uid must be >= 0');
 
         self::assertInstanceOf(ChatOptions::class, new ChatOptions(beUserUid: -1));
     }
@@ -451,7 +451,7 @@ class ChatOptionsTest extends AbstractUnitTestCase
         // Negative cost would credit the per-day ceiling — i.e. a
         // budget bypass. Refuse it at construction time.
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('planned_cost must be >= 0.0');
+        $this->expectExceptionMessageIsOrContains('planned_cost must be >= 0.0');
 
         self::assertInstanceOf(ChatOptions::class, new ChatOptions(plannedCost: -0.01));
     }

--- a/Tests/Unit/Service/Option/EmbeddingOptionsTest.php
+++ b/Tests/Unit/Service/Option/EmbeddingOptionsTest.php
@@ -47,7 +47,7 @@ class EmbeddingOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForNegativeDimensions(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('dimensions must be a positive integer');
+        $this->expectExceptionMessageIsOrContains('dimensions must be a positive integer');
 
         self::assertInstanceOf(EmbeddingOptions::class, new EmbeddingOptions(dimensions: -1));
     }
@@ -56,7 +56,7 @@ class EmbeddingOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForZeroDimensions(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('dimensions must be a positive integer');
+        $this->expectExceptionMessageIsOrContains('dimensions must be a positive integer');
 
         self::assertInstanceOf(EmbeddingOptions::class, new EmbeddingOptions(dimensions: 0));
     }
@@ -65,7 +65,7 @@ class EmbeddingOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForNegativeCacheTtl(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('cache_ttl must be between');
+        $this->expectExceptionMessageIsOrContains('cache_ttl must be between');
 
         self::assertInstanceOf(EmbeddingOptions::class, new EmbeddingOptions(cacheTtl: -1));
     }
@@ -225,7 +225,7 @@ class EmbeddingOptionsTest extends AbstractUnitTestCase
     public function constructorRejectsNegativeBeUserUid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('be_user_uid must be >= 0');
+        $this->expectExceptionMessageIsOrContains('be_user_uid must be >= 0');
 
         self::assertInstanceOf(EmbeddingOptions::class, new EmbeddingOptions(beUserUid: -1));
     }
@@ -234,7 +234,7 @@ class EmbeddingOptionsTest extends AbstractUnitTestCase
     public function constructorRejectsNegativePlannedCost(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('planned_cost must be >= 0.0');
+        $this->expectExceptionMessageIsOrContains('planned_cost must be >= 0.0');
 
         self::assertInstanceOf(EmbeddingOptions::class, new EmbeddingOptions(plannedCost: -0.5));
     }

--- a/Tests/Unit/Service/Option/ToolOptionsTest.php
+++ b/Tests/Unit/Service/Option/ToolOptionsTest.php
@@ -63,7 +63,7 @@ class ToolOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForInvalidToolChoice(string $toolChoice): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('tool_choice must be one of: auto, none, required');
+        $this->expectExceptionMessageIsOrContains('tool_choice must be one of: auto, none, required');
 
         self::assertInstanceOf(ToolOptions::class, new ToolOptions(toolChoice: $toolChoice));
     }
@@ -158,7 +158,7 @@ class ToolOptionsTest extends AbstractUnitTestCase
     public function inheritsChatOptionsValidation(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('temperature must be between 0 and 2');
+        $this->expectExceptionMessageIsOrContains('temperature must be between 0 and 2');
 
         self::assertInstanceOf(ToolOptions::class, new ToolOptions(temperature: 3.0));
     }

--- a/Tests/Unit/Service/Option/TranslationOptionsTest.php
+++ b/Tests/Unit/Service/Option/TranslationOptionsTest.php
@@ -80,7 +80,7 @@ class TranslationOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForInvalidFormality(string $formality): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('formality must be one of: default, formal, informal');
+        $this->expectExceptionMessageIsOrContains('formality must be one of: default, formal, informal');
 
         self::assertInstanceOf(TranslationOptions::class, new TranslationOptions(formality: $formality));
     }
@@ -125,7 +125,7 @@ class TranslationOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForInvalidDomain(string $domain): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('domain must be one of: general, technical, medical, legal, marketing');
+        $this->expectExceptionMessageIsOrContains('domain must be one of: general, technical, medical, legal, marketing');
 
         self::assertInstanceOf(TranslationOptions::class, new TranslationOptions(domain: $domain));
     }
@@ -146,7 +146,7 @@ class TranslationOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForInvalidTemperature(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('temperature must be between 0 and 2');
+        $this->expectExceptionMessageIsOrContains('temperature must be between 0 and 2');
 
         self::assertInstanceOf(TranslationOptions::class, new TranslationOptions(temperature: 2.5));
     }
@@ -155,7 +155,7 @@ class TranslationOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForNegativeMaxTokens(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('max_tokens must be a positive integer');
+        $this->expectExceptionMessageIsOrContains('max_tokens must be a positive integer');
 
         self::assertInstanceOf(TranslationOptions::class, new TranslationOptions(maxTokens: 0));
     }
@@ -451,7 +451,7 @@ class TranslationOptionsTest extends AbstractUnitTestCase
     public function constructorRejectsNegativeBeUserUid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('be_user_uid must be >= 0');
+        $this->expectExceptionMessageIsOrContains('be_user_uid must be >= 0');
 
         self::assertInstanceOf(TranslationOptions::class, new TranslationOptions(beUserUid: -1));
     }
@@ -460,7 +460,7 @@ class TranslationOptionsTest extends AbstractUnitTestCase
     public function constructorRejectsNegativePlannedCost(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('planned_cost must be >= 0.0');
+        $this->expectExceptionMessageIsOrContains('planned_cost must be >= 0.0');
 
         self::assertInstanceOf(TranslationOptions::class, new TranslationOptions(plannedCost: -1.5));
     }

--- a/Tests/Unit/Service/Option/VisionOptionsTest.php
+++ b/Tests/Unit/Service/Option/VisionOptionsTest.php
@@ -42,7 +42,7 @@ class VisionOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForInvalidDetailLevel(string $detailLevel): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('detail_level must be one of: auto, low, high');
+        $this->expectExceptionMessageIsOrContains('detail_level must be one of: auto, low, high');
 
         self::assertInstanceOf(VisionOptions::class, new VisionOptions(detailLevel: $detailLevel));
     }
@@ -84,7 +84,7 @@ class VisionOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForNegativeMaxTokens(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('max_tokens must be a positive integer');
+        $this->expectExceptionMessageIsOrContains('max_tokens must be a positive integer');
 
         self::assertInstanceOf(VisionOptions::class, new VisionOptions(maxTokens: 0));
     }
@@ -94,7 +94,7 @@ class VisionOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForInvalidTemperature(float $temperature): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('temperature must be between 0 and 2');
+        $this->expectExceptionMessageIsOrContains('temperature must be between 0 and 2');
 
         self::assertInstanceOf(VisionOptions::class, new VisionOptions(temperature: $temperature));
     }
@@ -290,7 +290,7 @@ class VisionOptionsTest extends AbstractUnitTestCase
     public function constructorRejectsNegativeBeUserUid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('be_user_uid must be >= 0');
+        $this->expectExceptionMessageIsOrContains('be_user_uid must be >= 0');
 
         self::assertInstanceOf(VisionOptions::class, new VisionOptions(beUserUid: -2));
     }
@@ -299,7 +299,7 @@ class VisionOptionsTest extends AbstractUnitTestCase
     public function constructorRejectsNegativePlannedCost(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('planned_cost must be >= 0.0');
+        $this->expectExceptionMessageIsOrContains('planned_cost must be >= 0.0');
 
         self::assertInstanceOf(VisionOptions::class, new VisionOptions(plannedCost: -0.5));
     }

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -1851,7 +1851,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         $this->setupSuccessfulRequest(['data' => []]);
 
         $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessage('Prompt cannot be empty');
+        $this->expectExceptionMessageIsOrContains('Prompt cannot be empty');
 
         $subject->generateMultiple('   ', 2, new ImageGenerationOptions(model: 'dall-e-2', size: '512x512'));
     }

--- a/Tests/Unit/Specialized/Image/FalImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/FalImageServiceTest.php
@@ -992,7 +992,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
         $this->expectException(ServiceUnavailableException::class);
         // FAL surfaces 422 with its own validation wording (see mapErrorStatus()):
         // the prefix and the decoded detail in that exact order.
-        $this->expectExceptionMessage('FAL API validation error: Invalid prompt');
+        $this->expectExceptionMessageIsOrContains('FAL API validation error: Invalid prompt');
 
         $subject->generate('A sunset');
     }
@@ -1189,7 +1189,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
         $this->setupQueueResponses(['IN_PROGRESS'], null);
 
         $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessage('FAL generation timed out');
+        $this->expectExceptionMessageIsOrContains('FAL generation timed out');
 
         $subject->generate('A sunset', 'sdxl');
     }
@@ -1253,7 +1253,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
             ->willReturn($queueSubmitResponse);
 
         $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessage('no request_id');
+        $this->expectExceptionMessageIsOrContains('no request_id');
 
         $subject->generate('A sunset', 'sdxl'); // sdxl uses queue
     }
@@ -1300,7 +1300,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
             ->willReturnOnConsecutiveCalls($queueSubmitResponse, $statusResponse);
 
         $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessage('FAL generation failed');
+        $this->expectExceptionMessageIsOrContains('FAL generation failed');
 
         $subject->generate('A sunset', 'sdxl');
     }
@@ -1350,7 +1350,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
         );
 
         $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessage('Failed to connect to FAL API');
+        $this->expectExceptionMessageIsOrContains('Failed to connect to FAL API');
 
         $subject->generate('A sunset');
     }
@@ -1387,7 +1387,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
             ->willReturn($responseStub);
 
         $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessage('Invalid model specified');
+        $this->expectExceptionMessageIsOrContains('Invalid model specified');
 
         $subject->generate('A sunset');
     }
@@ -1796,7 +1796,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
         $this->setupFailedRequest(500, 'Boom detail');
 
         $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessage('Boom detail');
+        $this->expectExceptionMessageIsOrContains('Boom detail');
 
         $subject->generate('A sunset');
     }
@@ -1810,7 +1810,7 @@ class FalImageServiceTest extends AbstractUnitTestCase
         $this->setupFailedRequestRaw(500, ['detail' => '', 'message' => '']);
 
         $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessage('Unknown FAL API error');
+        $this->expectExceptionMessageIsOrContains('Unknown FAL API error');
 
         $subject->generate('A sunset');
     }

--- a/Tests/Unit/Specialized/Option/DeepLOptionsMutationTest.php
+++ b/Tests/Unit/Specialized/Option/DeepLOptionsMutationTest.php
@@ -159,7 +159,7 @@ class DeepLOptionsMutationTest extends AbstractUnitTestCase
     public function validateRejectsInvalidFormality(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('formality');
+        $this->expectExceptionMessageIsOrContains('formality');
 
         self::assertInstanceOf(DeepLOptions::class, new DeepLOptions(formality: 'invalid'));
     }
@@ -179,7 +179,7 @@ class DeepLOptionsMutationTest extends AbstractUnitTestCase
     public function validateRejectsInvalidTagHandling(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('tagHandling');
+        $this->expectExceptionMessageIsOrContains('tagHandling');
 
         self::assertInstanceOf(DeepLOptions::class, new DeepLOptions(tagHandling: 'invalid'));
     }

--- a/Tests/Unit/Specialized/Option/DeepLOptionsTest.php
+++ b/Tests/Unit/Specialized/Option/DeepLOptionsTest.php
@@ -76,7 +76,7 @@ class DeepLOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForInvalidFormality(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('formality must be one of');
+        $this->expectExceptionMessageIsOrContains('formality must be one of');
 
         self::assertInstanceOf(DeepLOptions::class, new DeepLOptions(formality: 'invalid'));
     }
@@ -105,7 +105,7 @@ class DeepLOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForInvalidTagHandling(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('tagHandling must be one of');
+        $this->expectExceptionMessageIsOrContains('tagHandling must be one of');
 
         self::assertInstanceOf(DeepLOptions::class, new DeepLOptions(tagHandling: 'markdown'));
     }

--- a/Tests/Unit/Specialized/Option/ImageGenerationOptionsTest.php
+++ b/Tests/Unit/Specialized/Option/ImageGenerationOptionsTest.php
@@ -95,7 +95,7 @@ class ImageGenerationOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForInvalidSizeOnDalle3(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid size');
+        $this->expectExceptionMessageIsOrContains('Invalid size');
 
         self::assertInstanceOf(ImageGenerationOptions::class, new ImageGenerationOptions(model: 'dall-e-3', size: '256x256'));
     }
@@ -104,7 +104,7 @@ class ImageGenerationOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForInvalidSizeOnDalle2(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid size');
+        $this->expectExceptionMessageIsOrContains('Invalid size');
 
         self::assertInstanceOf(ImageGenerationOptions::class, new ImageGenerationOptions(model: 'dall-e-2', size: '1792x1024'));
     }
@@ -133,7 +133,7 @@ class ImageGenerationOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForInvalidQuality(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('quality must be one of');
+        $this->expectExceptionMessageIsOrContains('quality must be one of');
 
         self::assertInstanceOf(ImageGenerationOptions::class, new ImageGenerationOptions(quality: 'ultra'));
     }
@@ -162,7 +162,7 @@ class ImageGenerationOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForInvalidStyle(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('style must be one of');
+        $this->expectExceptionMessageIsOrContains('style must be one of');
 
         self::assertInstanceOf(ImageGenerationOptions::class, new ImageGenerationOptions(style: 'artistic'));
     }
@@ -191,7 +191,7 @@ class ImageGenerationOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForInvalidFormat(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('format must be one of');
+        $this->expectExceptionMessageIsOrContains('format must be one of');
 
         self::assertInstanceOf(ImageGenerationOptions::class, new ImageGenerationOptions(format: 'binary'));
     }
@@ -220,7 +220,7 @@ class ImageGenerationOptionsTest extends AbstractUnitTestCase
     public function constructorThrowsForInvalidModel(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('model must be one of');
+        $this->expectExceptionMessageIsOrContains('model must be one of');
 
         self::assertInstanceOf(ImageGenerationOptions::class, new ImageGenerationOptions(model: 'dall-e-4'));
     }
@@ -254,7 +254,7 @@ class ImageGenerationOptionsTest extends AbstractUnitTestCase
     {
         // The prefix is strict ("gpt-image-"), so near-misses without the dash are not the family.
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('model must be one of');
+        $this->expectExceptionMessageIsOrContains('model must be one of');
 
         $options = new ImageGenerationOptions(model: $model);
         self::fail('Expected the constructor to reject model: ' . $options->model);
@@ -603,7 +603,7 @@ class ImageGenerationOptionsTest extends AbstractUnitTestCase
     public function constructorRejectsNegativeBeUserUid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('be_user_uid must be >= 0');
+        $this->expectExceptionMessageIsOrContains('be_user_uid must be >= 0');
 
         self::assertInstanceOf(ImageGenerationOptions::class, new ImageGenerationOptions(beUserUid: -1));
     }
@@ -612,7 +612,7 @@ class ImageGenerationOptionsTest extends AbstractUnitTestCase
     public function constructorRejectsNegativePlannedCost(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('planned_cost must be >= 0.0');
+        $this->expectExceptionMessageIsOrContains('planned_cost must be >= 0.0');
 
         self::assertInstanceOf(ImageGenerationOptions::class, new ImageGenerationOptions(plannedCost: -0.01));
     }

--- a/Tests/Unit/Specialized/Option/SpeechSynthesisOptionsTest.php
+++ b/Tests/Unit/Specialized/Option/SpeechSynthesisOptionsTest.php
@@ -384,7 +384,7 @@ class SpeechSynthesisOptionsTest extends AbstractUnitTestCase
     public function constructorRejectsNegativeBeUserUid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('be_user_uid must be >= 0');
+        $this->expectExceptionMessageIsOrContains('be_user_uid must be >= 0');
 
         self::assertInstanceOf(SpeechSynthesisOptions::class, new SpeechSynthesisOptions(beUserUid: -1));
     }
@@ -393,7 +393,7 @@ class SpeechSynthesisOptionsTest extends AbstractUnitTestCase
     public function constructorRejectsNegativePlannedCost(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('planned_cost must be >= 0.0');
+        $this->expectExceptionMessageIsOrContains('planned_cost must be >= 0.0');
 
         self::assertInstanceOf(SpeechSynthesisOptions::class, new SpeechSynthesisOptions(plannedCost: -0.01));
     }

--- a/Tests/Unit/Specialized/Option/TranscriptionOptionsTest.php
+++ b/Tests/Unit/Specialized/Option/TranscriptionOptionsTest.php
@@ -323,7 +323,7 @@ class TranscriptionOptionsTest extends AbstractUnitTestCase
     public function constructorRejectsNegativeBeUserUid(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('be_user_uid must be >= 0');
+        $this->expectExceptionMessageIsOrContains('be_user_uid must be >= 0');
 
         self::assertInstanceOf(TranscriptionOptions::class, new TranscriptionOptions(beUserUid: -1));
     }
@@ -332,7 +332,7 @@ class TranscriptionOptionsTest extends AbstractUnitTestCase
     public function constructorRejectsNegativePlannedCost(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('planned_cost must be >= 0.0');
+        $this->expectExceptionMessageIsOrContains('planned_cost must be >= 0.0');
 
         self::assertInstanceOf(TranscriptionOptions::class, new TranscriptionOptions(plannedCost: -0.01));
     }

--- a/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
@@ -408,7 +408,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         // ensureAvailable() fires FIRST, before any request is built — the
         // not-configured message is distinct from the generic API-error
         // message the send path would otherwise raise.
-        $this->expectExceptionMessage('Tts service is not configured');
+        $this->expectExceptionMessageIsOrContains('Tts service is not configured');
 
         $subject->synthesize('Hello world');
     }
@@ -421,7 +421,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         $this->expectException(ServiceUnavailableException::class);
         // trim('   ') is empty, so validateInput() rejects it with this exact
         // message — pins both the trim() unwrap and the throw itself.
-        $this->expectExceptionMessage('Input text cannot be empty');
+        $this->expectExceptionMessageIsOrContains('Input text cannot be empty');
 
         $subject->synthesize('   ');
     }
@@ -435,7 +435,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         $this->expectException(ServiceUnavailableException::class);
         // Over-length input is rejected by validateInput() before any request
         // — pins the throw against the generic send-path error message.
-        $this->expectExceptionMessage('Input text exceeds maximum length');
+        $this->expectExceptionMessageIsOrContains('Input text exceeds maximum length');
 
         $subject->synthesize($longText);
     }
@@ -1138,7 +1138,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             ->willReturn($responseStub);
 
         $this->expectException(ServiceQuotaExceededException::class);
-        $this->expectExceptionMessage('Rate limit exceeded');
+        $this->expectExceptionMessageIsOrContains('Rate limit exceeded');
 
         $subject->synthesize('Test text');
     }
@@ -1172,7 +1172,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             ->willReturn($responseStub);
 
         $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessage('Server error');
+        $this->expectExceptionMessageIsOrContains('Server error');
 
         $subject->synthesize('Test text');
     }
@@ -1318,7 +1318,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
             ->willThrowException(new RuntimeException('Connection refused'));
 
         $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessage('Failed to connect to TTS API');
+        $this->expectExceptionMessageIsOrContains('Failed to connect to TTS API');
 
         $subject->synthesize('Test text');
     }
@@ -1927,7 +1927,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         // The success window is [200, 300): a 300 response is an error and
         // maps through the default branch of mapErrorStatus().
         $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessage('OpenAI TTS API error: Multiple choices');
+        $this->expectExceptionMessageIsOrContains('OpenAI TTS API error: Multiple choices');
 
         $subject->synthesize('Hello world');
     }
@@ -2021,7 +2021,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         // InvalidArgumentException from the options validation instead of
         // the not-configured error.
         $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessage('Tts service is not configured');
+        $this->expectExceptionMessageIsOrContains('Tts service is not configured');
 
         $subject->synthesizeLong('Hello world', ['voice' => 'not-a-real-voice']);
     }

--- a/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
@@ -597,7 +597,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         // The availability guard runs before any request work; without it the
         // path would later surface a generic connection failure instead.
         $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessage('Whisper service is not configured');
+        $this->expectExceptionMessageIsOrContains('Whisper service is not configured');
 
         $subject->transcribe($audioFile);
     }
@@ -783,7 +783,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
 
         $this->expectException(UnsupportedFormatException::class);
         // 25 * 1024 * 1024 / 1024 / 1024 = 25 MB in the limit message.
-        $this->expectExceptionMessage('Audio content exceeds maximum size of 25 MB');
+        $this->expectExceptionMessageIsOrContains('Audio content exceeds maximum size of 25 MB');
 
         $subject->transcribeFromContent($largeContent, 'test.mp3');
     }
@@ -1115,7 +1115,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         );
 
         $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessage('Failed to connect to Whisper API');
+        $this->expectExceptionMessageIsOrContains('Failed to connect to Whisper API');
 
         $subject->transcribe($audioFile);
     }
@@ -1151,7 +1151,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
             ->willReturn($responseStub);
 
         $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessage('Unknown Whisper API error');
+        $this->expectExceptionMessageIsOrContains('Unknown Whisper API error');
 
         $subject->transcribe($audioFile);
     }
@@ -1386,7 +1386,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         $subject = $this->createSubjectWithoutApiKey();
 
         $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessage('Whisper service is not configured');
+        $this->expectExceptionMessageIsOrContains('Whisper service is not configured');
 
         $subject->transcribeFromContent('fake audio content', 'test.mp3');
     }
@@ -1398,7 +1398,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         $audioFile = $this->createTestAudioFile();
 
         $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessage('Whisper service is not configured');
+        $this->expectExceptionMessageIsOrContains('Whisper service is not configured');
 
         $subject->translateToEnglish($audioFile);
     }
@@ -1426,7 +1426,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         $this->tempFile = $largeFile;
 
         $this->expectException(UnsupportedFormatException::class);
-        $this->expectExceptionMessage('Audio file exceeds maximum size of 25 MB');
+        $this->expectExceptionMessageIsOrContains('Audio file exceeds maximum size of 25 MB');
 
         $subject->transcribe($largeFile);
     }

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorMutationTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorMutationTest.php
@@ -606,7 +606,7 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
         $translator = $this->createTranslatorWithHttpClient($httpClientMock);
 
         $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessage('Internal error');
+        $this->expectExceptionMessageIsOrContains('Internal error');
 
         $translator->translate('Hello', 'de');
     }
@@ -622,7 +622,7 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
         $translator = $this->createTranslatorWithHttpClient($httpClientMock);
 
         $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessage('Unknown DeepL API error');
+        $this->expectExceptionMessageIsOrContains('Unknown DeepL API error');
 
         $translator->translate('Hello', 'de');
     }
@@ -767,7 +767,7 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
         $translator = $this->createTranslatorWithHttpClient($httpClientMock);
 
         $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessage('Connection failed');
+        $this->expectExceptionMessageIsOrContains('Connection failed');
 
         $translator->translate('Hello', 'de');
     }

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorOptionsTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorOptionsTest.php
@@ -20,6 +20,7 @@ use Netresearch\NrLlm\Specialized\Usage\DeepLUsageExtractor;
 use Netresearch\NrLlm\Tests\Fixture\AllowingBudgetService;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrVault\Service\VaultServiceInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -30,6 +31,7 @@ use ReflectionClass;
  * Additional tests for DeepLTranslator to kill escaped mutants.
  */
 #[CoversClass(DeepLTranslator::class)]
+#[AllowMockObjectsWithoutExpectations]
 class DeepLTranslatorOptionsTest extends AbstractUnitTestCase
 {
     /**

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
@@ -31,6 +31,7 @@ use Netresearch\NrLlm\Tests\Unit\Specialized\PipelineRoutingAssertionTrait;
 use Netresearch\NrVault\Http\SecretPlacement;
 use Netresearch\NrVault\Http\VaultHttpClientInterface;
 use Netresearch\NrVault\Service\VaultServiceInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -44,6 +45,7 @@ use Psr\Http\Message\UriInterface;
 use ReflectionClass;
 
 #[CoversClass(DeepLTranslator::class)]
+#[AllowMockObjectsWithoutExpectations]
 class DeepLTranslatorTest extends AbstractUnitTestCase
 {
     use PipelineRoutingAssertionTrait;
@@ -843,7 +845,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
         );
 
         $this->expectException(ServiceQuotaExceededException::class);
-        $this->expectExceptionMessage('Rate limit exceeded');
+        $this->expectExceptionMessageIsOrContains('Rate limit exceeded');
 
         $subject->translate('Hello', 'de');
     }
@@ -856,7 +858,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
         );
 
         $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessage('quota exceeded');
+        $this->expectExceptionMessageIsOrContains('quota exceeded');
 
         $subject->translate('Hello', 'de');
     }
@@ -869,7 +871,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
         $subject = $this->createSubjectWithResponse($this->createJsonResponseMock($apiResponse));
 
         $this->expectException(ServiceUnavailableException::class);
-        $this->expectExceptionMessage('empty translation');
+        $this->expectExceptionMessageIsOrContains('empty translation');
 
         $subject->translate('Hello', 'de');
     }

--- a/Tests/Unit/Testing/FakeBudgetServiceTest.php
+++ b/Tests/Unit/Testing/FakeBudgetServiceTest.php
@@ -67,7 +67,7 @@ final class FakeBudgetServiceTest extends TestCase
         $subject->throwable = new RuntimeException('boom');
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('boom');
+        $this->expectExceptionMessageIsOrContains('boom');
 
         $subject->check(1);
     }

--- a/Tests/Unit/Testing/FakeCompletionServiceTest.php
+++ b/Tests/Unit/Testing/FakeCompletionServiceTest.php
@@ -110,7 +110,7 @@ final class FakeCompletionServiceTest extends TestCase
         $subject->throwable = new RuntimeException('boom');
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('boom');
+        $this->expectExceptionMessageIsOrContains('boom');
 
         $subject->complete('a');
     }
@@ -139,7 +139,7 @@ final class FakeCompletionServiceTest extends TestCase
         $subject = new FakeCompletionService();
 
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('no response was queued');
+        $this->expectExceptionMessageIsOrContains('no response was queued');
 
         $subject->complete('a');
     }

--- a/Tests/Unit/Testing/FakeEmbeddingServiceTest.php
+++ b/Tests/Unit/Testing/FakeEmbeddingServiceTest.php
@@ -107,7 +107,7 @@ final class FakeEmbeddingServiceTest extends TestCase
         $subject->throwable = new RuntimeException('embed failed');
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('embed failed');
+        $this->expectExceptionMessageIsOrContains('embed failed');
 
         $subject->embed('text');
     }

--- a/Tests/Unit/Testing/FakeToolCallingServiceTest.php
+++ b/Tests/Unit/Testing/FakeToolCallingServiceTest.php
@@ -84,7 +84,7 @@ final class FakeToolCallingServiceTest extends TestCase
         $subject->throwable = new RuntimeException('boom');
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('boom');
+        $this->expectExceptionMessageIsOrContains('boom');
 
         $subject->chatWithTools([], []);
     }
@@ -115,7 +115,7 @@ final class FakeToolCallingServiceTest extends TestCase
         $subject = new FakeToolCallingService();
 
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('no response was queued');
+        $this->expectExceptionMessageIsOrContains('no response was queued');
 
         $subject->chatWithTools([], []);
     }

--- a/Tests/Unit/Testing/FakeVisionServiceTest.php
+++ b/Tests/Unit/Testing/FakeVisionServiceTest.php
@@ -100,7 +100,7 @@ final class FakeVisionServiceTest extends TestCase
         $subject->throwable = new RuntimeException('boom');
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('boom');
+        $this->expectExceptionMessageIsOrContains('boom');
 
         $subject->generateAltText('https://example.test/a.png');
     }

--- a/Tests/Unit/Widgets/DataProvider/MonthlyCostDataProviderTest.php
+++ b/Tests/Unit/Widgets/DataProvider/MonthlyCostDataProviderTest.php
@@ -12,11 +12,13 @@ namespace Netresearch\NrLlm\Tests\Unit\Widgets\DataProvider;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrLlm\Widgets\DataProvider\MonthlyCostDataProvider;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
 #[CoversClass(MonthlyCostDataProvider::class)]
+#[AllowMockObjectsWithoutExpectations]
 class MonthlyCostDataProviderTest extends AbstractUnitTestCase
 {
     #[Test]


### PR DESCRIPTION
Same shape as [#573](https://github.com/netresearch/t3x-nr-llm/pull/573), one Rector minor later. Mechanical, no behaviour change.

## Why now

Rector arrives transitively through `netresearch/typo3-ci-workflows` with no pin, and this repo deliberately does not commit a lock file. A fresh resolve therefore picks up whatever is current. `main` was green against **2.6.0**; **2.6.1** activates rules it did not, so the next run on `main` goes red without this.

Found while rebasing an unrelated branch: its Rector gate reported 53 files it had never touched. That branch was not the cause — it was the first place a fresh dependency resolve became visible.

## What changed

| rule | sites | |
|---|---|---|
| `RenameMethodRector` | 161 | `expectExceptionMessage()` → `expectExceptionMessageIsOrContains()` — same semantics, new name in current PHPUnit |
| `AllowMockObjectsWithoutExpectationsAttributeRector` / `AllowMockObjectsForDataProviderRector` | 9 classes | a class attribute that stops a stricter PHPUnit warning about mocks created without expectations |

**The attribute suppresses the warning, it does not resolve it.** Those nine classes really do create mocks without expectations; the attribute preserves what they do today. Removing the needless mocks instead is a judgement about each test, not a migration, and does not belong in a mechanical pass. Worth a separate look if anyone wants it.

## Gates

Locally on PHP 8.4: cgl, phpstan, `rector -n` (now clean), unit (5749), functional sqlite (1311).