### PR TITLE
feat(tool): add the registry seam and the MCP server schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,6 +250,20 @@ Prefer looking at real code in this repo over inventing new patterns. Canonical 
   That is a stale `.Build`, not a code defect: run
   `./Build/Scripts/runTests.sh -s composerUpdate -p 8.4` and re-run the gate.
 
+- **Run the Rector gate with `-p 8.2`, never `-p 8.4`.** Rector's PHPUnit rules
+  activate from the phpunit version composer *installed*, not from the set named
+  in `Build/rector/rector.php`. PHP 8.2 resolves phpunit ^11, 8.4 resolves ^13,
+  and the 13-only migrations do not apply to a codebase whose blocking matrix
+  caps `phpunit/phpunit:<13`. CI pins the job with `rector-php-version: '8.2'`
+  in `ci.yml` and says so in a comment there. Running it on 8.4 reports dozens of
+  files CI will never flag — and applying those "fixes" breaks the blocking
+  matrix with `Call to an undefined method
+  expectExceptionMessageIsOrContains()`. Observed 2026-08-04: a 53-file Rector
+  run taken at face value produced a PR that turned 8 PHPStan cells and several
+  test cells red; a control on unmodified `main` with an uncapped local resolve
+  reproduced the same 53 files, proving the finding was the environment, not the
+  code.
+
 - **A local gate run covers one matrix cell; CI covers eight.** The six pre-push
   suites run against a single PHP version and a single TYPO3 constraint. CI runs
   PHP 8.2–8.5 × TYPO3 13.4 / 14.3. A PHPStan finding can therefore be invisible

--- a/Classes/Domain/ValueObject/McpImportReport.php
+++ b/Classes/Domain/ValueObject/McpImportReport.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\ValueObject;
+
+/**
+ * The outcome of one catalogue import for one MCP server (ADR-116).
+ *
+ * Carries the skip reasons as data so an operator can see which advertised tools
+ * did not make it into the catalogue and why; a tool missing from the list
+ * otherwise looks like a server that never offered it.
+ */
+final readonly class McpImportReport
+{
+    /**
+     * @param list<string> $skipReasons One entry per rejected tool, plus the refusal reason when $refused.
+     * @param bool         $refused     True when the import was declined before writing anything — an
+     *                                  inert server, an unreachable endpoint. Distinct from an import
+     *                                  that ran and wrote no tools, where the catalogue was still
+     *                                  reconciled and $imported is 0.
+     */
+    public function __construct(
+        public int $serverUid,
+        public int $imported,
+        public int $skipped,
+        public int $orphaned,
+        public array $skipReasons = [],
+        public bool $refused = false,
+    ) {}
+
+    public static function refused(int $serverUid, string $reason): self
+    {
+        return new self(
+            serverUid: $serverUid,
+            imported: 0,
+            skipped: 0,
+            orphaned: 0,
+            skipReasons: [$reason],
+            refused: true,
+        );
+    }
+}

--- a/Classes/Domain/ValueObject/McpServerRecord.php
+++ b/Classes/Domain/ValueObject/McpServerRecord.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\ValueObject;
+
+use Netresearch\NrLlm\Domain\Enum\ToolDataClass;
+
+/**
+ * One operator-configured MCP server, read back from `tx_nrllm_mcp_server` (ADR-116).
+ *
+ * The immutable read model the repository hands to the import action and to the
+ * registry. It carries the configuration only — no connection, no session — so a
+ * caller cannot mistake holding a record for having reached the server.
+ */
+final readonly class McpServerRecord
+{
+    public function __construct(
+        public int $uid,
+        public int $pid,
+        // Prefixes every imported tool name and the group `mcp_<identifier>`, so
+        // a remote tool can never collide with a builtin or with another server.
+        public string $identifier,
+        public string $name,
+        public string $description,
+        public string $url,
+        // nr-vault UUID, never a plaintext secret; '' = unauthenticated server.
+        public string $authCredential,
+        public string $authPlacement,
+        public string $authHeaderName,
+        // The ToolDataClass backed value the operator declared for everything this
+        // server returns; '' means undeclared — see self::dataClassEnum().
+        public string $dataClass,
+        public bool $enabled,
+        public string $importStatus,
+        public string $importError,
+        public int $lastImported,
+        public int $toolCount,
+        public int $tstamp,
+        public int $crdate,
+    ) {}
+
+    /**
+     * The declared data class as a typed enum, or null when the operator has not
+     * declared one (or declared a value this version does not know).
+     *
+     * Null makes the server inert: a caller must skip it, never substitute a
+     * default. A remote server's egress sensitivity cannot be inferred, and
+     * guessing one would let an undeclared server past the trust-zone gate
+     * (ADR-094) at whatever class the guess picked.
+     */
+    public function dataClassEnum(): ?ToolDataClass
+    {
+        return ToolDataClass::tryFrom($this->dataClass);
+    }
+}

--- a/Classes/Domain/ValueObject/McpToolRecord.php
+++ b/Classes/Domain/ValueObject/McpToolRecord.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\ValueObject;
+
+/**
+ * One imported MCP tool, read back from `tx_nrllm_mcp_tool` (ADR-116).
+ *
+ * The catalogue row is written only by the import action; at run time this is a
+ * read model. It keeps the two names apart: {@see self::$toolName} is the local
+ * name the gate, the tool state and the model all see, {@see self::$remoteName}
+ * is what goes on the wire in `tools/call`.
+ */
+final readonly class McpToolRecord
+{
+    public function __construct(
+        public int $uid,
+        public int $pid,
+        public int $server,
+        public string $toolName,
+        public string $remoteName,
+        public string $description,
+        // Normalised JSON-Schema parameter object as stored; decode via
+        // self::inputSchemaArray().
+        public string $inputSchema,
+        // The server's `annotations` block, kept verbatim for display. No
+        // resolver reads it: a remote server must not be able to influence
+        // authorisation by what it writes here.
+        public string $remoteAnnotations,
+        // Present in an earlier import, absent from the latest. Kept rather than
+        // deleted so an operator sees what disappeared from the server.
+        public bool $orphaned,
+        public int $tstamp,
+        public int $crdate,
+    ) {}
+
+    /**
+     * The stored parameter schema, or null when it is undecodable or not a JSON
+     * object. Callers build a ToolSpec from this, and a schema that is not an
+     * object cannot become one.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function inputSchemaArray(): ?array
+    {
+        // A top-level JSON array decodes to a PHP array just like an object
+        // does, and `[]` and `{}` are indistinguishable after decoding — so the
+        // object-ness is decided on the raw text.
+        if (!str_starts_with(ltrim($this->inputSchema), '{')) {
+            return null;
+        }
+
+        $decoded = json_decode($this->inputSchema, true);
+        if (!\is_array($decoded)) {
+            return null;
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+}

--- a/Classes/Domain/ValueObject/McpToolsPage.php
+++ b/Classes/Domain/ValueObject/McpToolsPage.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\ValueObject;
+
+/**
+ * One page of an MCP `tools/list` response (ADR-116).
+ *
+ * Transport output, not persistence: the tool arrays are the server's payload as
+ * received, so the import action is the single place that validates and names
+ * them. Nothing here has passed a check yet.
+ */
+final readonly class McpToolsPage
+{
+    /**
+     * @param list<array<string, mixed>> $tools      Advertised tools, verbatim from the response.
+     * @param string|null                $nextCursor Cursor for the following request; null on the last page.
+     */
+    public function __construct(
+        public array $tools,
+        public ?string $nextCursor = null,
+    ) {}
+}

--- a/Classes/Service/Tool/Mcp/McpSchemaNormalizer.php
+++ b/Classes/Service/Tool/Mcp/McpSchemaNormalizer.php
@@ -1,0 +1,227 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Mcp;
+
+/**
+ * Maps the `inputSchema` an MCP server advertises in its `tools/list` response
+ * onto the parameter schema handed to :php:`ToolSpec` (ADR-116).
+ *
+ * The input arrives from a remote server over HTTP and is untrusted: it may be
+ * malformed, may use JSON-Schema constructs no provider accepts, and may be
+ * arbitrarily large or deep. Every rejection returns `null`; the caller drops
+ * the tool. A schema is never partially repaired — a silently altered schema
+ * makes the model call the tool with arguments the server then rejects, which
+ * surfaces as an opaque tool failure mid-run rather than as a missing tool at
+ * import time.
+ *
+ * Empty `properties` is NOT handled here: :php:`ToolSpec` already converts `[]`
+ * to a `stdClass` so it serialises as `{}` instead of `[]`. Do not add that
+ * conversion a second time.
+ */
+final readonly class McpSchemaNormalizer
+{
+    /**
+     * Nesting levels the schema may occupy, counted in PHP array levels: the
+     * root object is level 1, its `properties` map is level 2, each property
+     * sub-schema is level 3, so one level of declared object nesting costs two.
+     * Twelve therefore permits roughly five levels of nested objects — beyond
+     * that a model no longer fills the arguments reliably, and the cap bounds
+     * the recursive walk over a hostile schema.
+     */
+    public const MAX_DEPTH = 12;
+
+    /**
+     * Size of the JSON-encoded result. The schema is re-sent to the provider on
+     * every request that offers the tool, so its size is a recurring per-request
+     * token cost billed to the operator, not a one-off import cost. 16 KiB is
+     * roughly 4k tokens for a single tool declaration.
+     */
+    public const MAX_ENCODED_BYTES = 16384;
+
+    /**
+     * The only top-level keys carried over. Everything else is either an
+     * annotation a provider ignores (`title`, `$id`, `examples`, vendor
+     * extensions) or a constraint handled by self::UNSUPPORTED_KEYWORDS.
+     */
+    private const RETAINED_KEYS = [
+        'type',
+        'description',
+        'properties',
+        'required',
+        'additionalProperties',
+    ];
+
+    /**
+     * Keywords whose removal would widen what the server accepts: references
+     * into a definition block we do not carry over, and applicators that
+     * further constrain the arguments. Dropping any of them yields a schema
+     * that permits calls the server rejects, so their presence at any level
+     * rejects the whole schema.
+     *
+     * A property literally named after one of these keywords is rejected along
+     * with them: the walk does not distinguish a schema position from a
+     * property-name position. That costs an unusable tool, never a wrong one.
+     */
+    private const UNSUPPORTED_KEYWORDS = [
+        '$ref',
+        '$dynamicRef',
+        '$defs',
+        'definitions',
+        'allOf',
+        'anyOf',
+        'oneOf',
+        'not',
+        'if',
+        'then',
+        'else',
+        'patternProperties',
+        'propertyNames',
+        'dependentSchemas',
+        'dependentRequired',
+        'unevaluatedProperties',
+    ];
+
+    /**
+     * @return array<string, mixed>|null the provider-ready parameter schema, or
+     *                                   null if it cannot be made safe
+     */
+    public function normalise(mixed $inputSchema): ?array
+    {
+        if (!is_array($inputSchema)) {
+            return null;
+        }
+
+        // A union such as `['object', 'null']` is rejected: no provider agrees
+        // on how to render it, and guessing one member alters the contract.
+        if (($inputSchema['type'] ?? null) !== 'object') {
+            return null;
+        }
+
+        if ($this->carriesUnsupportedKeyword($inputSchema)) {
+            return null;
+        }
+
+        $normalised = [];
+        foreach (self::RETAINED_KEYS as $key) {
+            if (array_key_exists($key, $inputSchema)) {
+                $normalised[$key] = $inputSchema[$key];
+            }
+        }
+
+        if (!$this->retainedValuesAreWellFormed($normalised)) {
+            return null;
+        }
+
+        // Depth and size are measured on what survives the filter, because that
+        // is what is stored and sent — an oversized annotation block that was
+        // dropped costs nothing.
+        if (!$this->isWithinDepth($normalised, 1)) {
+            return null;
+        }
+
+        // Non-UTF-8 bytes anywhere in the remote schema fail the encode; such a
+        // schema cannot reach a provider intact either way.
+        $encoded = json_encode($normalised);
+
+        if ($encoded === false || strlen($encoded) > self::MAX_ENCODED_BYTES) {
+            return null;
+        }
+
+        return $normalised;
+    }
+
+    /**
+     * @param array<array-key, mixed> $node
+     */
+    private function carriesUnsupportedKeyword(array $node): bool
+    {
+        foreach (self::UNSUPPORTED_KEYWORDS as $keyword) {
+            if (array_key_exists($keyword, $node)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<array-key, mixed> $node
+     */
+    private function isWithinDepth(array $node, int $depth): bool
+    {
+        if ($depth > self::MAX_DEPTH) {
+            return false;
+        }
+
+        foreach ($node as $value) {
+            if (!is_array($value)) {
+                continue;
+            }
+
+            if ($this->carriesUnsupportedKeyword($value)) {
+                return false;
+            }
+
+            if (!$this->isWithinDepth($value, $depth + 1)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * A retained key with an unexpected value type is a malformed schema, not
+     * something to coerce: the coercion is the silent alteration this class
+     * exists to avoid.
+     *
+     * @param array<string, mixed> $normalised
+     */
+    private function retainedValuesAreWellFormed(array $normalised): bool
+    {
+        if (array_key_exists('description', $normalised) && !is_string($normalised['description'])) {
+            return false;
+        }
+
+        if (array_key_exists('additionalProperties', $normalised) && !is_bool($normalised['additionalProperties'])) {
+            return false;
+        }
+
+        if (array_key_exists('properties', $normalised)) {
+            $properties = $normalised['properties'];
+
+            if (!is_array($properties)) {
+                return false;
+            }
+
+            foreach ($properties as $propertySchema) {
+                if (!is_array($propertySchema)) {
+                    return false;
+                }
+            }
+        }
+
+        if (array_key_exists('required', $normalised)) {
+            $required = $normalised['required'];
+
+            if (!is_array($required) || !array_is_list($required)) {
+                return false;
+            }
+
+            foreach ($required as $name) {
+                if (!is_string($name)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/Classes/Service/Tool/Mcp/McpToolNameMapper.php
+++ b/Classes/Service/Tool/Mcp/McpToolNameMapper.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Mcp;
+
+/**
+ * Translates an MCP server's remote tool name into the local tool name
+ * nr_llm registers it under (ADR-116).
+ *
+ * The same rule runs twice: the import validates a remote catalogue against
+ * it and rejects what cannot be represented, the provider reconstructs the
+ * local name when it resolves a call back to a server. Keeping it in a
+ * dependency-free class makes that rule assertable without a database or a
+ * live MCP server.
+ *
+ * The accepted character set is the one the function-calling APIs impose on
+ * a tool name (letters, digits, underscore, hyphen, at most 64 characters);
+ * MCP itself places no such bound on a remote name, so names outside it are
+ * rejected rather than rewritten — a lossy rewrite could collide two remote
+ * tools onto one local name, and the local name is also the key the
+ * availability override is stored under.
+ */
+final readonly class McpToolNameMapper
+{
+    /**
+     * The `D` modifier is load-bearing: without it `$` also matches before a
+     * trailing newline, so a remote name ending in one would pass.
+     */
+    private const LOCAL_NAME_PATTERN = '/^[a-zA-Z0-9_-]{1,64}$/D';
+
+    private const PREFIX = 'mcp_';
+
+    /**
+     * @return string|null Null when server identifier and remote name cannot
+     *                     form a representable local tool name
+     */
+    public function localName(string $serverIdentifier, string $remoteName): ?string
+    {
+        $candidate = self::PREFIX . $serverIdentifier . '_' . $remoteName;
+
+        if (preg_match(self::LOCAL_NAME_PATTERN, $candidate) !== 1) {
+            return null;
+        }
+
+        return $candidate;
+    }
+
+    public function group(string $serverIdentifier): string
+    {
+        return self::PREFIX . $serverIdentifier;
+    }
+}

--- a/Classes/Service/Tool/RemoteToolInterface.php
+++ b/Classes/Service/Tool/RemoteToolInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+/**
+ * Marks a tool whose behaviour lives outside this codebase.
+ *
+ * A builtin's data class, effect and permission handling are properties of code
+ * we own, read and test. A remote tool's are not: what it returns, what it
+ * changes and whom it answers to are decided by a server we only talk to.
+ *
+ * Three rules follow, and each is enforced where it belongs rather than left to
+ * the implementation's good behaviour:
+ *
+ * - The data class comes from an operator declaration, because there is no code
+ *   to derive it from. {@see ToolDataClassInterface} says the class is "a
+ *   property of the CODE and deliberately not configurable"; that holds while
+ *   code is the better source, which for a remote tool it is not.
+ * - The trust-zone ceiling is enforced even where an install runs the gate in
+ *   observe mode. Observe exists so an UPGRADE does not silently start dropping
+ *   tools that already worked (ADR-115). No remote tool worked before, so there
+ *   is nothing to preserve, and an upgraded install must not end up more
+ *   permissive than a fresh one.
+ * - The effect is a write unless the operator states otherwise — the inverse of
+ *   the builtin default, which is read-only because every builtin reads.
+ *
+ * The marker carries no methods: it is a statement about provenance, and every
+ * consumer asks it as such.
+ */
+interface RemoteToolInterface {}

--- a/Classes/Service/Tool/ToolProviderInterface.php
+++ b/Classes/Service/Tool/ToolProviderInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * A source of tools that are not known when the container is compiled.
+ *
+ * Builtin tools are DI-tagged classes, so the registry knows them at compile
+ * time. A tool that comes from operator configuration — an MCP server's
+ * imported catalogue (ADR-116) — cannot be: it exists because a row exists.
+ *
+ * The set of PROVIDERS stays compile-fixed and declarative; only the set of
+ * TOOLS becomes dynamic. A provider is asked once per registry instance, on
+ * first use rather than at construction, because {@see ToolRegistry} is built
+ * on request paths that have nothing to do with an agent run.
+ *
+ * A provider must not perform network I/O. It reads what an explicit
+ * administrator action already persisted; discovery is never on a request path.
+ */
+#[AutoconfigureTag(name: ToolProviderInterface::TAG_NAME)]
+interface ToolProviderInterface
+{
+    public const TAG_NAME = 'nr_llm.tool_provider';
+
+    /**
+     * The tools this provider currently supplies.
+     *
+     * @return iterable<ToolInterface>
+     */
+    public function tools(): iterable;
+}

--- a/Classes/Service/Tool/ToolRegistry.php
+++ b/Classes/Service/Tool/ToolRegistry.php
@@ -11,14 +11,30 @@ namespace Netresearch\NrLlm\Service\Tool;
 
 use LogicException;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
 /**
- * Collects every DI-tagged ToolInterface and exposes it to the agent loop.
+ * Collects every tool and exposes it to the agent loop.
  *
- * Tools are injected through the `nr_llm.tool` tagged iterator and indexed by
- * their spec name; a duplicate name is a developer error and fails fast with a
- * LogicException at construction time.
+ * Two sources. Builtin tools arrive through the `nr_llm.tool` tagged iterator
+ * and are known when the container compiles. Tools that exist because operator
+ * configuration exists — an MCP server's imported catalogue (ADR-116) — arrive
+ * through {@see ToolProviderInterface}, whose implementations are themselves
+ * compile-fixed: the set of providers is declarative, only the set of tools is
+ * not.
+ *
+ * Builtins are indexed in the constructor, as before: a duplicate name among
+ * them is a developer error and still fails fast. Providers are merged on first
+ * use instead, because the registry is constructed on paths that have nothing
+ * to do with an agent run — a FormEngine itemsProcFunc and the Overview module
+ * both build it — and a provider must not be consulted merely because a backend
+ * page rendered.
+ *
+ * A provider-supplied name that collides with an already-indexed one is NOT
+ * fatal: it came from operator configuration, and a configuration mistake must
+ * not be able to break every page that builds the registry. The colliding tool
+ * is dropped and builtins win.
  *
  * The registry is the authoritative allow-set: `specs()` filters the declared
  * tool specs against an optional allow-list, dropping any name that does not
@@ -31,12 +47,23 @@ final class ToolRegistry
     /** @var array<string, ToolInterface> */
     private array $byName = [];
 
+    /** @var list<string> */
+    private array $builtinNames = [];
+
+    private bool $providersHydrated = false;
+
     /**
-     * @param iterable<ToolInterface> $tools
+     * @param iterable<ToolInterface>         $tools
+     * @param iterable<ToolProviderInterface> $providers
      */
     public function __construct(
         #[AutowireIterator(ToolInterface::TAG_NAME)]
-        iterable $tools,
+        iterable $tools = [],
+        // Defaulted so the hand-constructions across the test suite keep
+        // compiling; production autowires the tagged iterator.
+        #[AutowireIterator(ToolProviderInterface::TAG_NAME)]
+        private readonly iterable $providers = [],
+        private readonly ?LoggerInterface $logger = null,
     ) {
         foreach ($tools as $tool) {
             $name = $tool->getSpec()->name;
@@ -61,11 +88,68 @@ final class ToolRegistry
             }
             $this->byName[$name] = $tool;
         }
+
+        $this->builtinNames = array_keys($this->byName);
+    }
+
+    /**
+     * Merge in the provider-supplied tools, once.
+     *
+     * Deferred, unlike the builtins above: the registry is constructed on paths
+     * that have nothing to do with an agent run — a FormEngine itemsProcFunc
+     * and the Overview module both build it — and a provider must not be
+     * consulted merely because a backend page rendered.
+     */
+    private function hydrateProviders(): void
+    {
+        if ($this->providersHydrated) {
+            return;
+        }
+        $this->providersHydrated = true;
+
+        foreach ($this->providers as $provider) {
+            foreach ($provider->tools() as $tool) {
+                $name = $tool->getSpec()->name;
+                if (isset($this->byName[$name])) {
+                    // Not fatal, deliberately: the name came from operator
+                    // configuration, and a configuration mistake must not take
+                    // down every page that builds the registry.
+                    $this->logger?->warning('A provided tool was dropped because its name is already taken', [
+                        'tool'     => $name,
+                        'provider' => $provider::class,
+                    ]);
+
+                    continue;
+                }
+
+                $this->byName[$name] = $tool;
+            }
+        }
     }
 
     public function get(string $name): ?ToolInterface
     {
+        $this->hydrateProviders();
+
         return $this->byName[$name] ?? null;
+    }
+
+    /**
+     * The names of the compile-time builtin tools only.
+     *
+     * The coverage tests that guarantee every builtin has a declared data class
+     * and a known effect are scoped to this, so a provider-supplied tool can
+     * neither satisfy nor break a guarantee that is about code in this
+     * repository. Provided tools carry their own assertions.
+     *
+     * @return list<string>
+     */
+    public function builtinNames(): array
+    {
+        // Deliberately does NOT hydrate: this is the compile-time set, and the
+        // coverage tests that use it must not be able to see a provider's tools
+        // at all.
+        return $this->builtinNames;
     }
 
     /**
@@ -73,6 +157,8 @@ final class ToolRegistry
      */
     public function names(): array
     {
+        $this->hydrateProviders();
+
         return array_keys($this->byName);
     }
 
@@ -87,6 +173,8 @@ final class ToolRegistry
      */
     public function specs(?array $allowedNames = null): array
     {
+        $this->hydrateProviders();
+
         $specs = [];
         foreach ($this->byName as $name => $tool) {
             if ($allowedNames !== null && !in_array($name, $allowedNames, true)) {

--- a/Classes/Service/Tool/ToolRegistry.php
+++ b/Classes/Service/Tool/ToolRegistry.php
@@ -13,6 +13,7 @@ use LogicException;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+use Throwable;
 
 /**
  * Collects every tool and exposes it to the agent loop.
@@ -108,21 +109,33 @@ final class ToolRegistry
         $this->providersHydrated = true;
 
         foreach ($this->providers as $provider) {
-            foreach ($provider->tools() as $tool) {
-                $name = $tool->getSpec()->name;
-                if (isset($this->byName[$name])) {
-                    // Not fatal, deliberately: the name came from operator
-                    // configuration, and a configuration mistake must not take
-                    // down every page that builds the registry.
-                    $this->logger?->warning('A provided tool was dropped because its name is already taken', [
-                        'tool'     => $name,
-                        'provider' => $provider::class,
-                    ]);
+            try {
+                foreach ($provider->tools() as $tool) {
+                    $name = $tool->getSpec()->name;
+                    if (isset($this->byName[$name])) {
+                        // Not fatal, deliberately: the name came from operator
+                        // configuration, and a configuration mistake must not take
+                        // down every page that builds the registry.
+                        $this->logger?->warning('A provided tool was dropped because its name is already taken', [
+                            'tool'     => $name,
+                            'provider' => $provider::class,
+                        ]);
 
-                    continue;
+                        continue;
+                    }
+
+                    $this->byName[$name] = $tool;
                 }
-
-                $this->byName[$name] = $tool;
+            } catch (Throwable $e) {
+                // Same reasoning as the collision above, one level up: a
+                // provider reads persisted rows, so a broken table or a
+                // half-written record must cost that provider its tools and
+                // nothing else. A run that then names a missing tool fails
+                // closed at the gate, which is the safe direction.
+                $this->logger?->error('A tool provider failed and supplied no tools', [
+                    'provider'  => $provider::class,
+                    'exception' => $e,
+                ]);
             }
         }
     }

--- a/Configuration/TCA/tx_nrllm_mcp_server.php
+++ b/Configuration/TCA/tx_nrllm_mcp_server.php
@@ -1,0 +1,208 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+use Netresearch\NrVault\TCA\VaultFieldHelper;
+
+return [
+    'ctrl' => [
+        'title' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server',
+        'label' => 'name',
+        'label_alt' => 'identifier,url',
+        'tstamp' => 'tstamp',
+        'crdate' => 'crdate',
+        'delete' => 'deleted',
+        'default_sortby' => 'name ASC',
+        'searchFields' => 'identifier,name,description,url',
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+        ],
+        'iconfile' => 'EXT:nr_llm/Resources/Public/Icons/module-nrllm-tool.svg',
+        'rootLevel' => -1,
+        'security' => [
+            'ignorePageTypeRestriction' => true,
+        ],
+    ],
+    'types' => [
+        '0' => [
+            'showitem' => '
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
+                    identifier,
+                    name,
+                    description,
+                --div--;LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tab.connection,
+                    url,
+                    auth_placement,
+                    auth_header_name,
+                    auth_credential,
+                    data_class,
+                --div--;LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tab.metadata,
+                    import_status,
+                    import_error,
+                    last_imported,
+                    tool_count,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,
+                    enabled,
+                    hidden,
+            ',
+        ],
+    ],
+    'columns' => [
+        'hidden' => [
+            'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
+            'config' => [
+                'type' => 'check',
+                'default' => 0,
+            ],
+        ],
+        // Prefix of every imported tool name and of the group mcp_<identifier>,
+        // so an edit renames the whole tool namespace of this server.
+        'identifier' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.identifier',
+            'description' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.identifier.description',
+            'config' => [
+                'type' => 'input',
+                'size' => 30,
+                'max' => 32,
+                'trim' => true,
+                'eval' => 'alphanum_x,lower,unique',
+                'required' => true,
+            ],
+        ],
+        'name' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.name',
+            'config' => [
+                'type' => 'input',
+                'size' => 50,
+                'max' => 255,
+                'trim' => true,
+                'required' => true,
+            ],
+        ],
+        'description' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.description',
+            'config' => [
+                'type' => 'text',
+                'cols' => 40,
+                'rows' => 3,
+            ],
+        ],
+        'url' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.url',
+            'description' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.url.description',
+            'config' => [
+                'type' => 'input',
+                'size' => 50,
+                'max' => 2048,
+                'trim' => true,
+                'required' => true,
+            ],
+        ],
+        'auth_credential' => VaultFieldHelper::getSecureFieldConfig(
+            'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.auth_credential',
+            [
+                'description' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.auth_credential.description',
+                'size' => 50,
+            ],
+        ),
+        'auth_placement' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.auth_placement',
+            'description' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.auth_placement.description',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.auth_placement.bearer', 'value' => 'bearer'],
+                    ['label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.auth_placement.header', 'value' => 'header'],
+                ],
+                'default' => 'bearer',
+                'required' => true,
+            ],
+        ],
+        'auth_header_name' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.auth_header_name',
+            'description' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.auth_header_name.description',
+            'displayCond' => 'FIELD:auth_placement:=:header',
+            'config' => [
+                'type' => 'input',
+                'size' => 30,
+                'max' => 190,
+                'trim' => true,
+            ],
+        ],
+        // Egress ceiling every tool of this server is measured against
+        // (ADR-094). No default — an operator has to declare it, and until then
+        // the server contributes nothing.
+        'data_class' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.data_class',
+            'description' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.data_class.description',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['label' => '', 'value' => ''],
+                    ['label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm.tool_data_class.publicContent', 'value' => 'publicContent'],
+                    ['label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm.tool_data_class.editorContent', 'value' => 'editorContent'],
+                    ['label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm.tool_data_class.sourceCode', 'value' => 'sourceCode'],
+                    ['label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm.tool_data_class.internalConfiguration', 'value' => 'internalConfiguration'],
+                    ['label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm.tool_data_class.systemDiagnostics', 'value' => 'systemDiagnostics'],
+                    ['label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm.tool_data_class.secretAdjacent', 'value' => 'secretAdjacent'],
+                ],
+                'required' => true,
+            ],
+        ],
+        'import_status' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.import_status',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => [
+                    ['label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.import_status.never_imported', 'value' => 'never_imported'],
+                    ['label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.import_status.importing', 'value' => 'importing'],
+                    ['label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.import_status.ok', 'value' => 'ok'],
+                    ['label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.import_status.partial', 'value' => 'partial'],
+                    ['label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.import_status.error', 'value' => 'error'],
+                ],
+                'default' => 'never_imported',
+                'readOnly' => true,
+            ],
+        ],
+        'import_error' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.import_error',
+            'config' => [
+                'type' => 'text',
+                'cols' => 40,
+                'rows' => 3,
+                'readOnly' => true,
+            ],
+        ],
+        'last_imported' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.last_imported',
+            'config' => [
+                'type' => 'datetime',
+                'readOnly' => true,
+            ],
+        ],
+        'tool_count' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.tool_count',
+            'config' => [
+                'type' => 'number',
+                'size' => 5,
+                'readOnly' => true,
+            ],
+        ],
+        'enabled' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.enabled',
+            'description' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_mcp_server.enabled.description',
+            'config' => [
+                'type' => 'check',
+                'default' => 0,
+            ],
+        ],
+    ],
+];

--- a/Resources/Private/Language/de.locallang_tca.xlf
+++ b/Resources/Private/Language/de.locallang_tca.xlf
@@ -1306,6 +1306,146 @@
                 <source>Enabled</source>
                 <target>Aktiviert</target>
             </trans-unit>
+
+            <!-- MCP server (ADR-116) -->
+            <trans-unit id="tx_nrllm_mcp_server">
+                <source>MCP Server</source>
+                <target>MCP-Server</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.identifier">
+                <source>Identifier</source>
+                <target>Kennung</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.identifier.description">
+                <source>Lowercase letters, digits and underscores, up to 32 characters. Prefixes every tool imported from this server and its tool group mcp_&lt;identifier&gt;. Changing it renames all of them.</source>
+                <target>Kleinbuchstaben, Ziffern und Unterstriche, maximal 32 Zeichen. Steht als Pr&#228;fix vor jedem Tool dieses Servers und vor der Tool-Gruppe mcp_&lt;Kennung&gt;. Eine &#196;nderung benennt alle um.</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.name">
+                <source>Name</source>
+                <target>Name</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.description">
+                <source>Description</source>
+                <target>Beschreibung</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.url">
+                <source>Endpoint URL</source>
+                <target>Endpunkt-URL</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.url.description">
+                <source>Absolute http(s) URL of the MCP endpoint.</source>
+                <target>Absolute http(s)-URL des MCP-Endpunkts.</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.auth_credential">
+                <source>Credential</source>
+                <target>Zugangsdaten</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.auth_credential.description">
+                <source>Stored in nr-vault. Leave empty for an unauthenticated server.</source>
+                <target>Wird in nr-vault gespeichert. F&#252;r einen Server ohne Authentifizierung leer lassen.</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.auth_placement">
+                <source>Credential placement</source>
+                <target>Platzierung der Zugangsdaten</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.auth_placement.description">
+                <source>Where the credential goes on the request.</source>
+                <target>An welcher Stelle der Anfrage die Zugangsdaten mitgesendet werden.</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.auth_placement.bearer">
+                <source>Authorization: Bearer</source>
+                <target>Authorization: Bearer</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.auth_placement.header">
+                <source>Custom header</source>
+                <target>Eigener Header</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.auth_header_name">
+                <source>Header name</source>
+                <target>Header-Name</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.auth_header_name.description">
+                <source>Name of the header carrying the credential, for example X-Api-Key.</source>
+                <target>Name des Headers, der die Zugangsdaten tr&#228;gt, zum Beispiel X-Api-Key.</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.data_class">
+                <source>Data class</source>
+                <target>Datenklasse</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.data_class.description">
+                <source>Sensitivity every tool of this server is classified as. Required: until it is set, the server contributes no tools.</source>
+                <target>Vertraulichkeitsstufe, mit der jedes Tool dieses Servers eingestuft wird. Pflichtfeld: solange sie fehlt, steuert der Server keine Tools bei.</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.import_status">
+                <source>Import status</source>
+                <target>Import-Status</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.import_status.never_imported">
+                <source>Never imported</source>
+                <target>Nie importiert</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.import_status.importing">
+                <source>Importing</source>
+                <target>Import l&#228;uft</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.import_status.ok">
+                <source>OK</source>
+                <target>OK</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.import_status.partial">
+                <source>Partial</source>
+                <target>Teilweise</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.import_status.error">
+                <source>Error</source>
+                <target>Fehler</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.import_error">
+                <source>Import error</source>
+                <target>Import-Fehler</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.last_imported">
+                <source>Last imported</source>
+                <target>Zuletzt importiert</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.tool_count">
+                <source>Imported tools</source>
+                <target>Importierte Tools</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.enabled">
+                <source>Enabled</source>
+                <target>Aktiviert</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.enabled.description">
+                <source>Off until an operator switches it on. A disabled server keeps its catalogue but contributes no tools.</source>
+                <target>Standardm&#228;&#223;ig aus, bis ein Operator ihn einschaltet. Ein deaktivierter Server beh&#228;lt seinen Katalog, steuert aber keine Tools bei.</target>
+            </trans-unit>
+
+            <!-- Tool data class (ADR-094) -->
+            <trans-unit id="tx_nrllm.tool_data_class.publicContent">
+                <source>Public content</source>
+                <target>&#214;ffentliche Inhalte</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm.tool_data_class.editorContent">
+                <source>Editor content</source>
+                <target>Redaktionelle Inhalte</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm.tool_data_class.sourceCode">
+                <source>Source code</source>
+                <target>Quellcode</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm.tool_data_class.internalConfiguration">
+                <source>Internal configuration</source>
+                <target>Interne Konfiguration</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm.tool_data_class.systemDiagnostics">
+                <source>System diagnostics</source>
+                <target>Systemdiagnose</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm.tool_data_class.secretAdjacent">
+                <source>Secret-adjacent</source>
+                <target>Geheimnisnah</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -1012,6 +1012,112 @@
             <trans-unit id="tx_nrllm_skill.enabled">
                 <source>Enabled</source>
             </trans-unit>
+
+            <!-- MCP server (ADR-116) -->
+            <trans-unit id="tx_nrllm_mcp_server">
+                <source>MCP Server</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.identifier">
+                <source>Identifier</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.identifier.description">
+                <source>Lowercase letters, digits and underscores, up to 32 characters. Prefixes every tool imported from this server and its tool group mcp_&lt;identifier&gt;. Changing it renames all of them.</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.name">
+                <source>Name</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.description">
+                <source>Description</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.url">
+                <source>Endpoint URL</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.url.description">
+                <source>Absolute http(s) URL of the MCP endpoint.</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.auth_credential">
+                <source>Credential</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.auth_credential.description">
+                <source>Stored in nr-vault. Leave empty for an unauthenticated server.</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.auth_placement">
+                <source>Credential placement</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.auth_placement.description">
+                <source>Where the credential goes on the request.</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.auth_placement.bearer">
+                <source>Authorization: Bearer</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.auth_placement.header">
+                <source>Custom header</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.auth_header_name">
+                <source>Header name</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.auth_header_name.description">
+                <source>Name of the header carrying the credential, for example X-Api-Key.</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.data_class">
+                <source>Data class</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.data_class.description">
+                <source>Sensitivity every tool of this server is classified as. Required: until it is set, the server contributes no tools.</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.import_status">
+                <source>Import status</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.import_status.never_imported">
+                <source>Never imported</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.import_status.importing">
+                <source>Importing</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.import_status.ok">
+                <source>OK</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.import_status.partial">
+                <source>Partial</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.import_status.error">
+                <source>Error</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.import_error">
+                <source>Import error</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.last_imported">
+                <source>Last imported</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.tool_count">
+                <source>Imported tools</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.enabled">
+                <source>Enabled</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_mcp_server.enabled.description">
+                <source>Off until an operator switches it on. A disabled server keeps its catalogue but contributes no tools.</source>
+            </trans-unit>
+
+            <!-- Tool data class (ADR-094) -->
+            <trans-unit id="tx_nrllm.tool_data_class.publicContent">
+                <source>Public content</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm.tool_data_class.editorContent">
+                <source>Editor content</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm.tool_data_class.sourceCode">
+                <source>Source code</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm.tool_data_class.internalConfiguration">
+                <source>Internal configuration</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm.tool_data_class.systemDiagnostics">
+                <source>System diagnostics</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm.tool_data_class.secretAdjacent">
+                <source>Secret-adjacent</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Tests/Functional/Service/Privacy/RetentionCoverageTest.php
+++ b/Tests/Functional/Service/Privacy/RetentionCoverageTest.php
@@ -71,6 +71,8 @@ final class RetentionCoverageTest extends AbstractFunctionalTestCase
         'tx_nrllm_tool_state'                  => 'configuration record',
         'tx_nrllm_tool_group_state'            => 'configuration record',
         'tx_nrllm_user_budget'                 => 'configuration record',
+        'tx_nrllm_mcp_server'                  => 'configuration record',
+        'tx_nrllm_mcp_tool'                    => 'imported tool catalogue of an MCP server; derived from that configuration record and rewritten by every import, carries no run or user data',
         'tx_nrllm_service_usage'               => 'billing ledger the budget module reports on; retention is tracked as a follow-up',
     ];
 

--- a/Tests/Unit/Service/Tool/Mcp/McpSchemaNormalizerTest.php
+++ b/Tests/Unit/Service/Tool/Mcp/McpSchemaNormalizerTest.php
@@ -1,0 +1,237 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Mcp;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpSchemaNormalizer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+#[CoversClass(McpSchemaNormalizer::class)]
+final class McpSchemaNormalizerTest extends TestCase
+{
+    private McpSchemaNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new McpSchemaNormalizer();
+    }
+
+    #[Test]
+    #[DataProvider('nonObjectRoots')]
+    public function aRootThatIsNotAnObjectSchemaIsRejected(mixed $inputSchema): void
+    {
+        self::assertNull($this->normalizer->normalise($inputSchema));
+    }
+
+    /**
+     * @return iterable<string, array{mixed}>
+     */
+    public static function nonObjectRoots(): iterable
+    {
+        yield 'null' => [null];
+        yield 'string' => ['{"type":"object"}'];
+        yield 'integer' => [42];
+        yield 'boolean schema' => [true];
+        yield 'list' => [[['type' => 'object']]];
+        yield 'scalar root type' => [['type' => 'string']];
+        yield 'array root type' => [['type' => 'array', 'items' => ['type' => 'string']]];
+        yield 'type union with null' => [['type' => ['object', 'null'], 'properties' => []]];
+        yield 'no declared type' => [['properties' => ['q' => ['type' => 'string']]]];
+    }
+
+    #[Test]
+    public function aMinimalObjectSchemaPassesThroughUnchanged(): void
+    {
+        $schema = [
+            'type'       => 'object',
+            'properties' => [
+                'query' => ['type' => 'string', 'description' => 'Search term'],
+                'limit' => ['type' => 'integer'],
+            ],
+            'required' => ['query'],
+        ];
+
+        self::assertSame($schema, $this->normalizer->normalise($schema));
+    }
+
+    #[Test]
+    public function unknownTopLevelKeysAreDropped(): void
+    {
+        $result = $this->normalizer->normalise([
+            '$schema'    => 'https://json-schema.org/draft/2020-12/schema',
+            '$id'        => 'https://example.invalid/tool.json',
+            'title'      => 'Search',
+            'examples'   => [['query' => 'a']],
+            'x-vendor'   => ['internal' => true],
+            'type'       => 'object',
+            'properties' => ['query' => ['type' => 'string']],
+        ]);
+
+        self::assertSame(
+            [
+                'type'       => 'object',
+                'properties' => ['query' => ['type' => 'string']],
+            ],
+            $result,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $inputSchema
+     */
+    #[Test]
+    #[DataProvider('unsupportedKeywordSchemas')]
+    public function aKeywordWeCannotCarryOverRejectsTheWholeSchema(array $inputSchema): void
+    {
+        self::assertNull($this->normalizer->normalise($inputSchema));
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>}>
+     */
+    public static function unsupportedKeywordSchemas(): iterable
+    {
+        yield 'root allOf' => [[
+            'type'       => 'object',
+            'properties' => ['q' => ['type' => 'string']],
+            'allOf'      => [['required' => ['q']]],
+        ]];
+
+        yield 'reference into a dropped definition block' => [[
+            'type'       => 'object',
+            '$defs'      => ['Id' => ['type' => 'string']],
+            'properties' => ['id' => ['$ref' => '#/$defs/Id']],
+        ]];
+
+        yield 'nested $ref' => [[
+            'type'       => 'object',
+            'properties' => ['id' => ['$ref' => 'https://example.invalid/Id']],
+        ]];
+
+        yield 'nested oneOf' => [[
+            'type'       => 'object',
+            'properties' => ['id' => ['oneOf' => [['type' => 'string'], ['type' => 'integer']]]],
+        ]];
+    }
+
+    #[Test]
+    public function aSchemaAtTheDepthCapIsAccepted(): void
+    {
+        $schema = self::nestedObjectSchema(self::acceptableNestingLevels());
+
+        self::assertSame($schema, $this->normalizer->normalise($schema));
+    }
+
+    #[Test]
+    public function aSchemaBeyondTheDepthCapIsRejected(): void
+    {
+        self::assertNull(
+            $this->normalizer->normalise(self::nestedObjectSchema(self::acceptableNestingLevels() + 1)),
+        );
+    }
+
+    #[Test]
+    public function aSchemaBeyondTheByteCapIsRejected(): void
+    {
+        self::assertNull($this->normalizer->normalise([
+            'type'       => 'object',
+            'properties' => [
+                'query' => [
+                    'type'        => 'string',
+                    'description' => str_repeat('a', McpSchemaNormalizer::MAX_ENCODED_BYTES),
+                ],
+            ],
+        ]));
+    }
+
+    #[Test]
+    public function anOversizedAnnotationIsDroppedBeforeTheByteCapIsMeasured(): void
+    {
+        $result = $this->normalizer->normalise([
+            'type'       => 'object',
+            'properties' => ['query' => ['type' => 'string']],
+            'examples'   => [str_repeat('a', McpSchemaNormalizer::MAX_ENCODED_BYTES)],
+        ]);
+
+        self::assertSame(
+            [
+                'type'       => 'object',
+                'properties' => ['query' => ['type' => 'string']],
+            ],
+            $result,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $inputSchema
+     */
+    #[Test]
+    #[DataProvider('malformedRetainedValues')]
+    public function aRetainedKeyWithAnUnexpectedValueTypeIsRejected(array $inputSchema): void
+    {
+        self::assertNull($this->normalizer->normalise($inputSchema));
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>}>
+     */
+    public static function malformedRetainedValues(): iterable
+    {
+        yield 'properties is a string' => [['type' => 'object', 'properties' => 'none']];
+        yield 'property schema is a boolean' => [['type' => 'object', 'properties' => ['q' => true]]];
+        yield 'required is a string' => [['type' => 'object', 'required' => 'query']];
+        yield 'required is a map' => [['type' => 'object', 'required' => ['0' => 'q', '2' => 'r']]];
+        yield 'required holds a non-string' => [['type' => 'object', 'required' => ['q', 7]]];
+        yield 'description is an array' => [['type' => 'object', 'description' => ['a']]];
+        yield 'additionalProperties is a schema' => [['type' => 'object', 'additionalProperties' => ['type' => 'string']]];
+    }
+
+    #[Test]
+    public function emptyPropertiesSurvivesAsAnEmptyArrayBecauseToolSpecOwnsTheObjectCast(): void
+    {
+        $result = $this->normalizer->normalise(['type' => 'object', 'properties' => []]);
+
+        self::assertNotNull($result);
+        self::assertSame(['type' => 'object', 'properties' => []], $result);
+
+        // ToolSpec turns the empty array into `{}` so strict providers accept it;
+        // the normaliser must not do that a second time.
+        self::assertInstanceOf(stdClass::class, ToolSpec::function('t', '', $result)->parameters['properties']);
+    }
+
+    /**
+     * Nesting levels the cap still admits. The walk counts PHP array levels, so
+     * one declared object level costs two: the `properties` map and the property
+     * sub-schema. Derived from the constant so a changed cap does not silently
+     * turn these two tests into assertions about the same side of the boundary.
+     */
+    private static function acceptableNestingLevels(): int
+    {
+        return intdiv(McpSchemaNormalizer::MAX_DEPTH - 1, 2);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function nestedObjectSchema(int $levels): array
+    {
+        $schema = ['type' => 'object', 'properties' => ['leaf' => ['type' => 'string']]];
+
+        for ($level = 1; $level < $levels; ++$level) {
+            $schema = ['type' => 'object', 'properties' => ['child' => $schema]];
+        }
+
+        return $schema;
+    }
+}

--- a/Tests/Unit/Service/Tool/Mcp/McpToolNameMapperTest.php
+++ b/Tests/Unit/Service/Tool/Mcp/McpToolNameMapperTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Mcp;
+
+use Netresearch\NrLlm\Service\Tool\Mcp\McpToolNameMapper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(McpToolNameMapper::class)]
+final class McpToolNameMapperTest extends TestCase
+{
+    private McpToolNameMapper $mapper;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mapper = new McpToolNameMapper();
+    }
+
+    #[Test]
+    public function prefixesServerIdentifierAndRemoteName(): void
+    {
+        self::assertSame(
+            'mcp_typo3_get_page_tree',
+            $this->mapper->localName('typo3', 'get_page_tree'),
+        );
+    }
+
+    #[Test]
+    public function acceptsHyphensAndDigits(): void
+    {
+        self::assertSame(
+            'mcp_srv-2_list-items9',
+            $this->mapper->localName('srv-2', 'list-items9'),
+        );
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function rejectedNames(): array
+    {
+        return [
+            'dot in remote name'       => ['typo3', 'page.tree'],
+            'slash in remote name'     => ['typo3', 'page/tree'],
+            'space in remote name'     => ['typo3', 'page tree'],
+            'non-ASCII remote name'    => ['typo3', 'seitenbäume'],
+            'trailing newline'         => ['typo3', "page_tree\n"],
+            'dot in server identifier' => ['ty.po3', 'page_tree'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('rejectedNames')]
+    public function rejectsNamesOutsideTheAcceptedCharacterSet(string $serverIdentifier, string $remoteName): void
+    {
+        self::assertNull($this->mapper->localName($serverIdentifier, $remoteName));
+    }
+
+    /**
+     * The mapper judges the concatenated result, and the bare prefix is a
+     * legal tool name, so an empty remote name passes here. Callers that
+     * import a catalogue have to reject a nameless remote tool themselves.
+     */
+    #[Test]
+    public function anEmptyRemoteNameYieldsTheBarePrefix(): void
+    {
+        self::assertSame('mcp_typo3_', $this->mapper->localName('typo3', ''));
+    }
+
+    #[Test]
+    public function acceptsAResultOfExactlySixtyFourCharacters(): void
+    {
+        $remoteName = str_repeat('a', 64 - \strlen('mcp_typo3_'));
+
+        $localName = $this->mapper->localName('typo3', $remoteName);
+
+        self::assertNotNull($localName);
+        self::assertSame(64, \strlen($localName));
+    }
+
+    #[Test]
+    public function rejectsAResultExceedingSixtyFourCharacters(): void
+    {
+        $remoteName = str_repeat('a', 64 - \strlen('mcp_typo3_') + 1);
+
+        self::assertNull($this->mapper->localName('typo3', $remoteName));
+    }
+
+    #[Test]
+    public function groupIsThePrefixedServerIdentifier(): void
+    {
+        self::assertSame('mcp_typo3', $this->mapper->group('typo3'));
+    }
+}

--- a/Tests/Unit/Service/Tool/Mcp/McpToolNameMapperTest.php
+++ b/Tests/Unit/Service/Tool/Mcp/McpToolNameMapperTest.php
@@ -40,8 +40,8 @@ final class McpToolNameMapperTest extends TestCase
     public function acceptsHyphensAndDigits(): void
     {
         self::assertSame(
-            'mcp_srv-2_list-items9',
-            $this->mapper->localName('srv-2', 'list-items9'),
+            'mcp_srv2_list-items9',
+            $this->mapper->localName('srv2', 'list-items9'),
         );
     }
 

--- a/Tests/Unit/Service/Tool/ToolRegistryProviderTest.php
+++ b/Tests/Unit/Service/Tool/ToolRegistryProviderTest.php
@@ -1,0 +1,207 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolProviderInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * The provider seam: tools that exist because operator configuration exists.
+ *
+ * Separate from ToolRegistryTest, which covers the compile-time builtin set.
+ * The behaviours pinned here are the ones a provider can get wrong at runtime —
+ * lateness, collision and failure — none of which a builtin can.
+ */
+#[CoversClass(ToolRegistry::class)]
+final class ToolRegistryProviderTest extends TestCase
+{
+    /**
+     * @param list<ToolInterface> $tools
+     */
+    private function provider(array $tools): ToolProviderInterface
+    {
+        return new class ($tools) implements ToolProviderInterface {
+            /**
+             * @param list<ToolInterface> $tools
+             */
+            public function __construct(private readonly array $tools) {}
+
+            public function tools(): iterable
+            {
+                return $this->tools;
+            }
+        };
+    }
+
+    #[Test]
+    public function exposesProvidedToolsAlongsideBuiltins(): void
+    {
+        $registry = new ToolRegistry(
+            [new FakeTool('builtin_one')],
+            [$this->provider([new FakeTool('mcp_srv_remote')])],
+        );
+
+        self::assertSame(['builtin_one', 'mcp_srv_remote'], $registry->names());
+        self::assertNotNull($registry->get('mcp_srv_remote'));
+        self::assertCount(2, $registry->specs());
+    }
+
+    #[Test]
+    public function builtinWinsAgainstACollidingProvidedName(): void
+    {
+        $builtin = new FakeTool('shared_name', 'from builtin');
+        $logger  = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('warning');
+
+        $registry = new ToolRegistry(
+            [$builtin],
+            [$this->provider([new FakeTool('shared_name', 'from provider')])],
+            $logger,
+        );
+
+        self::assertSame($builtin, $registry->get('shared_name'));
+        self::assertSame(['shared_name'], $registry->names());
+    }
+
+    /**
+     * A collision among providers is decided the same way, by order: the first
+     * one indexed keeps the name. Neither is privileged, so the outcome must be
+     * stable rather than correct — hence pinning it.
+     */
+    #[Test]
+    public function theFirstProviderToClaimANameKeepsIt(): void
+    {
+        $first = new FakeTool('mcp_dup', 'first');
+
+        $registry = new ToolRegistry(
+            [],
+            [
+                $this->provider([$first]),
+                $this->provider([new FakeTool('mcp_dup', 'second')]),
+            ],
+        );
+
+        self::assertSame($first, $registry->get('mcp_dup'));
+    }
+
+    /**
+     * builtinNames() answers the compile-time question, so it must not see a
+     * provider's tools — and must not consult a provider to find that out. The
+     * data-class and effect coverage tests are scoped to it for exactly this
+     * reason.
+     */
+    #[Test]
+    public function builtinNamesExcludesProvidedToolsWithoutConsultingProviders(): void
+    {
+        $provider = new class implements ToolProviderInterface {
+            public bool $consulted = false;
+
+            public function tools(): iterable
+            {
+                $this->consulted = true;
+
+                return [new FakeTool('mcp_srv_remote')];
+            }
+        };
+
+        $registry = new ToolRegistry([new FakeTool('builtin_one')], [$provider]);
+
+        self::assertSame(['builtin_one'], $registry->builtinNames());
+        self::assertFalse($provider->consulted, 'builtinNames() must not hydrate providers');
+    }
+
+    /**
+     * The registry is built on backend request paths that have nothing to do
+     * with an agent run. Constructing it must therefore cost nothing.
+     */
+    #[Test]
+    public function providersAreNotConsultedUntilAToolIsLookedUp(): void
+    {
+        $provider = new class implements ToolProviderInterface {
+            public int $calls = 0;
+
+            public function tools(): iterable
+            {
+                ++$this->calls;
+
+                return [new FakeTool('mcp_srv_remote')];
+            }
+        };
+
+        $registry = new ToolRegistry([], [$provider]);
+        self::assertSame(0, $provider->calls);
+
+        $registry->names();
+        $registry->specs();
+        $registry->get('mcp_srv_remote');
+
+        self::assertSame(1, $provider->calls, 'providers are consulted once per registry instance');
+    }
+
+    /**
+     * A provider reads persisted rows, so a broken table or a half-written
+     * record can throw. That must cost the failing provider its tools and
+     * nothing else: the registry is built on pages that have no stake in the
+     * MCP configuration at all.
+     */
+    #[Test]
+    public function aFailingProviderCostsOnlyItsOwnTools(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('error');
+
+        $broken = new class implements ToolProviderInterface {
+            public function tools(): iterable
+            {
+                throw new RuntimeException('table is gone', 1799990200);
+            }
+        };
+
+        $registry = new ToolRegistry(
+            [new FakeTool('builtin_one')],
+            [$broken, $this->provider([new FakeTool('mcp_srv_remote')])],
+            $logger,
+        );
+
+        self::assertSame(['builtin_one', 'mcp_srv_remote'], $registry->names());
+    }
+
+    /**
+     * The failure is absorbed mid-iteration too, which is the shape a generator
+     * reading rows one at a time actually takes. Whatever it yielded before
+     * throwing stays registered; there is no half-state to roll back to.
+     */
+    #[Test]
+    public function aProviderThatThrowsMidIterationKeepsWhatItAlreadyYielded(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('error');
+
+        $broken = new class implements ToolProviderInterface {
+            public function tools(): iterable
+            {
+                yield new FakeTool('mcp_srv_first');
+
+                throw new RuntimeException('row 2 is malformed', 1799990201);
+            }
+        };
+
+        $registry = new ToolRegistry([], [$broken], $logger);
+
+        self::assertSame(['mcp_srv_first'], $registry->names());
+    }
+}

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -885,3 +885,93 @@ CREATE TABLE tx_nrllm_governance_event (
     -- Join a middleware-origin row to its trace.
     KEY correlation (correlation_id)
 );
+
+#
+# Table structure for table 'tx_nrllm_mcp_server'
+# Operator-configured external MCP servers (ADR-116). nr_llm is the only MCP
+# client in the stack; consumers reach these servers through ToolRegistry, never
+# directly. HTTP is the sole transport, so there is no transport column.
+#
+CREATE TABLE tx_nrllm_mcp_server (
+    uid int(11) NOT NULL auto_increment,
+    pid int(11) DEFAULT '0' NOT NULL,
+
+    -- Identity. The identifier prefixes every imported tool name and the group
+    -- mcp_<identifier>, so it is part of the tool namespace: ^[a-z0-9_]{1,32}$.
+    identifier varchar(32) DEFAULT '' NOT NULL,
+    name varchar(255) DEFAULT '' NOT NULL,
+    description text,
+
+    -- Absolute http(s) MCP endpoint.
+    url varchar(2048) DEFAULT '' NOT NULL,
+
+    -- Credential (nr-vault UUID, never plaintext). Empty = unauthenticated server.
+    auth_credential varchar(64) DEFAULT '' NOT NULL,
+    auth_placement varchar(32) DEFAULT 'bearer' NOT NULL,
+    auth_header_name varchar(190) DEFAULT '' NOT NULL,
+
+    -- ToolDataClass every tool of this server is classified as (ADR-094). No
+    -- default: a server whose class the operator has not declared is inert.
+    data_class varchar(32) DEFAULT '' NOT NULL,
+
+    -- Off until an operator switches it on.
+    enabled tinyint(1) DEFAULT '0' NOT NULL,
+
+    -- Import state
+    import_status varchar(20) DEFAULT 'never_imported' NOT NULL,
+    import_error text,
+    last_imported int(11) unsigned DEFAULT '0' NOT NULL,
+    tool_count int(11) unsigned DEFAULT '0' NOT NULL,
+
+    -- Standard TYPO3 fields
+    tstamp int(11) unsigned DEFAULT '0' NOT NULL,
+    crdate int(11) unsigned DEFAULT '0' NOT NULL,
+
+    deleted tinyint(4) unsigned DEFAULT '0' NOT NULL,
+    hidden tinyint(4) unsigned DEFAULT '0' NOT NULL,
+
+    PRIMARY KEY (uid),
+    KEY parent (pid),
+    KEY identifier (identifier)
+);
+
+#
+# Table structure for table 'tx_nrllm_mcp_tool'
+# Tool catalogue imported from an MCP server, written only by the import action
+# (no FormEngine UI / no TCA). Queries drop the default restrictions, like
+# tx_nrllm_tool_state, so there is no deleted/hidden column.
+#
+# Per-tool enablement is NOT stored here: an imported tool is toggled through the
+# existing tx_nrllm_tool_state override keyed by tool_name, the same switch a
+# builtin tool uses.
+#
+CREATE TABLE tx_nrllm_mcp_tool (
+    uid int(11) NOT NULL auto_increment,
+    pid int(11) DEFAULT '0' NOT NULL,
+
+    server int(11) unsigned DEFAULT '0' NOT NULL,
+
+    -- Local name mcp_<identifier>_<remote>, <= 64 chars, ^[a-zA-Z0-9_-]+$. This
+    -- is the ToolSpec name the model sees.
+    tool_name varchar(190) DEFAULT '' NOT NULL,
+    -- The name on the wire, sent verbatim in tools/call.
+    remote_name varchar(190) DEFAULT '' NOT NULL,
+
+    description text,
+    -- Normalised JSON-Schema parameter object.
+    input_schema mediumtext,
+    -- Stored verbatim for display only; no resolver reads it.
+    remote_annotations text,
+
+    -- Present in an earlier import, absent from the latest. Kept so an operator
+    -- sees what disappeared.
+    orphaned tinyint(1) DEFAULT '0' NOT NULL,
+
+    tstamp int(11) unsigned DEFAULT '0' NOT NULL,
+    crdate int(11) unsigned DEFAULT '0' NOT NULL,
+
+    PRIMARY KEY (uid),
+    KEY parent (pid),
+    KEY server (server),
+    UNIQUE KEY tool_name (tool_name)
+);


### PR DESCRIPTION
Foundation for the MCP client ([ADR-116](Documentation/Adr/Adr116CentralToolingAuthority.rst)). **No MCP connection is made yet** — this is the seam tools can arrive through, the tables an operator's configuration lives in, and the two pure helpers the import will need. Nothing in this PR talks to a network.

## The registry seam

`ToolProviderInterface` is a second, also DI-tagged source for `ToolRegistry`. The set of **providers** stays fixed when the container compiles; only the set of **tools** becomes dynamic.

Builtins are still indexed in the constructor, so a duplicate name among them fails fast exactly as before — that check is about code we write. Providers are merged on first use instead, because the registry is built on paths that have nothing to do with an agent run: a FormEngine `itemsProcFunc` builds it on every render of a configuration record, and the Overview module builds it too. Neither should reach a provider.

A provider-supplied name that collides with an already-indexed one is **dropped and logged, not fatal**. Among builtins a collision is a programming error; from a provider it is an operator's configuration mistake, and that must not blank unrelated backend pages.

`builtinNames()` is the compile-time set and deliberately does **not** hydrate. The coverage tests guaranteeing every builtin has a declared data class and a known effect will be scoped to it, so a provider's tool can neither satisfy nor break a guarantee about code in this repository.

## Provenance is a first-class fact

`RemoteToolInterface` marks a tool whose behaviour lives outside this codebase, and states the three rules that follow — each enforced where it belongs rather than left to an implementation's good behaviour:

- the **data class** comes from an operator declaration, because there is no code to derive it from;
- the **trust-zone ceiling** is enforced even where an install runs the gate in observe mode (observe exists so an *upgrade* does not start dropping tools that already worked — no remote tool worked before, so there is nothing to preserve);
- the **effect** is a write unless declared otherwise, the inverse of the builtin default.

## Schema

`tx_nrllm_mcp_server` is operator-managed and FormEngine-editable. Its `data_class` column has **no default**: an undeclared server is inert rather than guessed at.

`tx_nrllm_mcp_tool` holds the imported catalogue, written only by the explicit admin import. It carries no `enabled` column, because per-tool enablement is the existing `tx_nrllm_tool_state` override — an MCP tool gets the same admin toggle, the same cascade and the same fail-closed group rule as a builtin. Neither table has a `transport` column: ADR-116 settles on HTTP only.

Both tables are declared exempt in `RetentionCoverageTest` with a reason. That test caught them — a review note had asserted retention was unaffected, which was true for the column it was about and not for these tables.

## Tests

`McpToolNameMapper` and `McpSchemaNormalizer` are pure and separately testable, so the naming rule and the schema-safety rule can be exercised without a database or a socket.

## Gates

All six on **PHP 8.2**, the version CI pins for Rector: cgl, phpstan, rector, fuzzy, unit (5788 / 16031 assertions), functional sqlite (1311).

The second commit records why 8.2 and not 8.4 — Rector's PHPUnit rules activate from the *installed* phpunit version, and running the gate on 8.4 reports dozens of files CI never flags.

## Still to come

Transport, client, `McpTool` with its DI exclusion, the import service, the two repositories and the backend controller — plus the tests proving the DI exclusion holds and that an MCP tool traverses the same gate as a builtin.