### PR TITLE
feat(provider): store a provider API key from the command line

### DIFF
--- a/Classes/Command/SetProviderApiKeyCommand.php
+++ b/Classes/Command/SetProviderApiKeyCommand.php
@@ -102,7 +102,10 @@ final class SetProviderApiKeyCommand extends Command
 
         $stream = $this->resolveInputStream($input);
         if ($stream === null) {
-            $io->error('Refusing to read the key from a terminal. Pipe it in, for example: printf \'%s\' "$KEY" | vendor/bin/typo3 nrllm:provider:set-key ' . $providerIdentifier);
+            // The example carries a fixed placeholder rather than the argument
+            // just read: echoing it back into a copy-pasteable shell line would
+            // hand whitespace or metacharacters straight to the next shell.
+            $io->error('Refusing to read the key from a terminal. Pipe it in, for example: printf \'%s\' "$KEY" | vendor/bin/typo3 nrllm:provider:set-key <provider>');
 
             return Command::INVALID;
         }
@@ -187,8 +190,10 @@ final class SetProviderApiKeyCommand extends Command
         $raw = stream_get_contents($stream);
 
         // A key piped with `echo` carries a trailing newline; one piped with
-        // `printf '%s'` does not. Everything else is kept verbatim — trimming
-        // further would silently mangle a key rather than reject it.
+        // `printf '%s'` does not. Trailing CR/LF are dropped — all of them, a
+        // key never ends in one. Everything else is kept verbatim, including
+        // surrounding spaces: trimming those would silently mangle a key
+        // rather than reject it.
         return $raw === false ? '' : rtrim($raw, "\r\n");
     }
 }

--- a/Classes/Command/SetProviderApiKeyCommand.php
+++ b/Classes/Command/SetProviderApiKeyCommand.php
@@ -102,10 +102,11 @@ final class SetProviderApiKeyCommand extends Command
 
         $stream = $this->resolveInputStream($input);
         if ($stream === null) {
-            // The example carries a fixed placeholder rather than the argument
-            // just read: echoing it back into a copy-pasteable shell line would
-            // hand whitespace or metacharacters straight to the next shell.
-            $io->error('Refusing to read the key from a terminal. Pipe it in, for example: printf \'%s\' "$KEY" | vendor/bin/typo3 nrllm:provider:set-key <provider>');
+            // No shell line here on purpose. Echoing the argument back would
+            // hand whitespace or metacharacters to whoever pastes it, and a
+            // placeholder in angle brackets is formatter syntax to Symfony
+            // Console. The worked example lives in --help, once.
+            $io->error('Refusing to read the key from a terminal. Pipe the key in on STDIN; run this command with --help for a worked example.');
 
             return Command::INVALID;
         }

--- a/Classes/Command/SetProviderApiKeyCommand.php
+++ b/Classes/Command/SetProviderApiKeyCommand.php
@@ -1,0 +1,194 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Command;
+
+use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
+use Netresearch\NrVault\Service\VaultServiceInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\StreamableInputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
+
+/**
+ * Stores a provider API key from an unattended context (ADR-124).
+ *
+ * The setup wizard is the interactive way to hand nr-llm a key: it takes the
+ * plaintext, stores it and writes the resulting identifier onto the provider
+ * record. A Docker entrypoint, a DDEV install script or a CI provisioning step
+ * cannot operate a wizard, and without this command their only option was to
+ * call nr-vault directly and hand-write the identifier — pushing knowledge of
+ * where nr-llm keeps its secrets into every consuming extension.
+ *
+ * The secret is read from STDIN only. Passing it as an argument would put it in
+ * the process list and the shell history, which no option flag can undo.
+ */
+#[AsCommand(
+    name: 'nrllm:provider:set-key',
+    description: 'Store a provider API key read from STDIN and link it to the provider record.',
+)]
+final class SetProviderApiKeyCommand extends Command
+{
+    /**
+     * Recorded with the secret so an audit can tell a scripted install from a
+     * wizard run. Mirrors the metadata {@see SetupWizardController} writes.
+     *
+     * Note the nesting: nr-vault's `store()` reads provenance from the
+     * `metadata` option and ignores every unknown top-level key.
+     */
+    private const SECRET_OPTIONS = [
+        'metadata' => [
+            'table'  => 'tx_nrllm_provider',
+            'field'  => 'api_key',
+            'source' => 'console',
+        ],
+    ];
+
+    public function __construct(
+        private readonly ProviderRepository $providerRepository,
+        private readonly PersistenceManagerInterface $persistenceManager,
+        private readonly VaultServiceInterface $vault,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument(
+            'provider',
+            InputArgument::REQUIRED,
+            'Identifier of the provider record the key belongs to.',
+        );
+
+        $this->setHelp(
+            <<<'HELP'
+                Reads the API key from STDIN and links it to an existing provider record:
+
+                  printf '%s' "$OPENAI_API_KEY" | vendor/bin/typo3 nrllm:provider:set-key openai
+
+                Running it again for the same provider replaces the stored key while keeping
+                the identifier, so anything already referencing that identifier keeps working.
+                HELP
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $providerIdentifier = $input->getArgument('provider');
+        $providerIdentifier = is_string($providerIdentifier) ? $providerIdentifier : '';
+
+        $provider = $this->providerRepository->findOneByIdentifier($providerIdentifier);
+        if ($provider === null) {
+            $io->error(sprintf('No provider record has the identifier "%s".', $providerIdentifier));
+
+            return Command::FAILURE;
+        }
+
+        $stream = $this->resolveInputStream($input);
+        if ($stream === null) {
+            $io->error('Refusing to read the key from a terminal. Pipe it in, for example: printf \'%s\' "$KEY" | vendor/bin/typo3 nrllm:provider:set-key ' . $providerIdentifier);
+
+            return Command::INVALID;
+        }
+
+        $secret = $this->readSecret($stream);
+        if ($secret === '') {
+            $io->error('STDIN carried no key. Nothing was stored and the provider was left untouched.');
+
+            return Command::INVALID;
+        }
+
+        $identifier = $provider->getApiKey();
+        $isNewKey   = $identifier === '' || !$this->vault->exists($identifier);
+
+        try {
+            if ($isNewKey) {
+                if ($identifier === '') {
+                    $identifier = Uuid::v7()->toRfc4122();
+                }
+                $this->vault->store($identifier, $secret, self::SECRET_OPTIONS);
+            } else {
+                $this->vault->rotate($identifier, $secret, 'nrllm:provider:set-key');
+            }
+        } catch (Throwable $e) {
+            // The exception may carry the identifier or provider context, so it
+            // goes to the log rather than to the terminal.
+            $this->logger->error('nrllm:provider:set-key: failed to store the API key', [
+                'provider'  => $providerIdentifier,
+                'exception' => $e,
+            ]);
+            $io->error('Failed to store the API key. See the system log for details.');
+
+            return Command::FAILURE;
+        }
+
+        if ($provider->getApiKey() !== $identifier) {
+            $provider->setApiKey($identifier);
+            $this->providerRepository->update($provider);
+            $this->persistenceManager->persistAll();
+        }
+
+        $io->success(
+            $isNewKey
+                ? sprintf('Stored the API key for provider "%s" under identifier %s.', $providerIdentifier, $identifier)
+                : sprintf('Replaced the API key for provider "%s". Identifier %s is unchanged.', $providerIdentifier, $identifier),
+        );
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Returns the stream to read the secret from, or null when there is none.
+     *
+     * A terminal counts as "none": reading it would block on a prompt that a
+     * provisioning script can never answer, which looks like a hung install.
+     *
+     * @return resource|null
+     */
+    private function resolveInputStream(InputInterface $input)
+    {
+        $stream = $input instanceof StreamableInputInterface ? $input->getStream() : null;
+
+        if ($stream === null) {
+            if (!defined('STDIN')) {
+                return null;
+            }
+            $stream = STDIN;
+        }
+
+        if (!is_resource($stream)) {
+            return null;
+        }
+
+        return stream_isatty($stream) ? null : $stream;
+    }
+
+    /**
+     * @param resource $stream
+     */
+    private function readSecret($stream): string
+    {
+        $raw = stream_get_contents($stream);
+
+        // A key piped with `echo` carries a trailing newline; one piped with
+        // `printf '%s'` does not. Everything else is kept verbatim — trimming
+        // further would silently mangle a key rather than reject it.
+        return $raw === false ? '' : rtrim($raw, "\r\n");
+    }
+}

--- a/Classes/Controller/Backend/SetupWizardController.php
+++ b/Classes/Controller/Backend/SetupWizardController.php
@@ -334,10 +334,14 @@ final class SetupWizardController extends ActionController
         if ($providerApiKey !== '') {
             try {
                 $vaultIdentifier = $this->generateVaultIdentifier();
+                // nr-vault reads provenance from the `metadata` option and drops
+                // unknown top-level keys, so these have to be nested to survive.
                 $this->vaultService->store($vaultIdentifier, $providerApiKey, [
-                    'table' => 'tx_nrllm_provider',
-                    'field' => 'api_key',
-                    'source' => 'setup_wizard',
+                    'metadata' => [
+                        'table' => 'tx_nrllm_provider',
+                        'field' => 'api_key',
+                        'source' => 'setup_wizard',
+                    ],
                 ]);
             } catch (Throwable $e) {
                 $this->logger->error('Setup wizard: failed to store API key in vault', ['exception' => $e]);

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -473,6 +473,14 @@ services:
         description: 'Run a golden question set against a retriever and report hit rates and regression.'
         schedulable: false
 
+  # Reads the secret from STDIN, so it cannot run from the scheduler (ADR-124).
+  Netresearch\NrLlm\Command\SetProviderApiKeyCommand:
+    tags:
+      - name: 'console.command'
+        command: 'nrllm:provider:set-key'
+        description: 'Store a provider API key read from STDIN and link it to the provider record.'
+        schedulable: false
+
 
   # ========================================
   # nr-vault integration

--- a/Documentation/Administration/Providers.rst
+++ b/Documentation/Administration/Providers.rst
@@ -61,6 +61,37 @@ Adding a provider
    first-time setup — it auto-detects the provider
    type from your endpoint URL.
 
+.. _administration-providers-set-key:
+
+Setting the key from the command line
+=====================================
+
+An unattended install cannot operate the
+wizard. :bash:`nrllm:provider:set-key` does the
+same job for a provider record that already
+exists, reading the key from STDIN:
+
+.. code-block:: bash
+   :caption: Store a key for the "openai" provider
+
+   printf '%s' "$OPENAI_API_KEY" | \
+       vendor/bin/typo3 nrllm:provider:set-key openai
+
+The key is never accepted as an argument — that
+would put it in the process list and the shell
+history. A terminal is refused rather than read,
+so a provisioning script fails visibly instead of
+hanging on a prompt.
+
+Running it again for the same provider replaces
+the stored key and keeps the identifier, so
+anything already referring to that identifier —
+including
+``providers.openai.apiKeyIdentifier`` in the
+extension configuration, which the speech and
+image services read — keeps working. See
+:ref:`ADR-124 <adr-124>`.
+
 .. _administration-providers-test:
 
 Testing a connection

--- a/Documentation/Adr/Adr124ProviderKeyFromTheCommandLine.rst
+++ b/Documentation/Adr/Adr124ProviderKeyFromTheCommandLine.rst
@@ -1,0 +1,79 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-124:
+
+============================================================================
+ADR-124: A provider key can be set from the command line
+============================================================================
+
+:Status: Accepted
+:Date: 2026-08-04
+:Authors: Netresearch DTT GmbH
+
+.. _adr-124-context:
+
+Context
+=======
+
+nr-llm owns provider credentials. The setup wizard takes a plaintext key,
+generates the identifier, stores the secret and writes that identifier onto the
+provider record (:ref:`ADR-012 <adr-012>`). A consuming extension therefore
+never needs to know where the secret ends up — it configures a provider and
+refers to it.
+
+That encapsulation held only for someone sitting in the backend. No console
+command stored a key, so every unattended install — a container entrypoint, a
+DDEV ``install`` script, CI provisioning, a throwaway review instance — had to
+call nr-vault's :bash:`vault:store` itself and then hand-write the identifier
+into the provider record.
+
+Two things followed. Consuming extensions grew a dependency on nr-vault's CLI
+and on the knowledge that nr-llm keeps its keys there; nr_repurpose documented
+exactly that as part of its own setup. And the two paths produced different
+records: the wizard writes provenance metadata alongside the secret, a
+hand-rolled :bash:`vault:store` writes none, so what an audit sees depends on
+how the instance happened to be provisioned.
+
+.. _adr-124-decision:
+
+Decision
+========
+
+Add :bash:`nrllm:provider:set-key <provider>`, which does from a script exactly
+what the wizard does from the backend.
+
+1. **The secret arrives on STDIN, and only there.** An argument would be
+   visible in the process list and recorded in the shell history, and no option
+   flag can take that back afterwards. A terminal is refused rather than read:
+   prompting would hang a provisioning script in a way that looks like a freeze.
+
+2. **Re-running replaces, it does not re-issue.** When the provider already
+   references a stored credential, the secret is rotated under the existing
+   identifier. Anything already pointing at that identifier — most importantly
+   ``providers.openai.apiKeyIdentifier`` in the extension configuration, which
+   the specialized speech and image services read — keeps working. A provider
+   that references an identifier the vault no longer knows is re-stored under
+   that same identifier rather than given a new one.
+
+3. **Both paths write the same provenance.** The command records ``table``,
+   ``field`` and ``source`` with the secret, as the wizard intends to. The
+   wizard passed those keys at the top level of the options array, where
+   nr-vault's :php:`store()` ignores them — it reads provenance from the
+   ``metadata`` key. That is corrected here, so the audit trail no longer
+   depends on which path created the provider.
+
+.. _adr-124-consequences:
+
+Consequences
+============
+
+- A scripted install provisions a provider end to end without invoking any
+  ``vault:*`` command; nr-vault stays nr-llm's implementation detail rather
+  than a consumer's setup step.
+- The command is registered with ``schedulable: false``. It reads STDIN, which
+  the scheduler cannot supply.
+- Secrets stored by the wizard before this change carry no provenance metadata.
+  Nothing reads that metadata for behaviour, so no migration is needed; older
+  secrets simply stay unlabelled until they are next replaced.
+- The provider record still has to exist first. Creating providers from the
+  command line is a separate concern and is not addressed here.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -421,3 +421,4 @@ Tools
    Adr121ConversationContextWindow
    Adr122ToolEffectContractDeferred
    Adr123OneSecretShapeCatalogue
+   Adr124ProviderKeyFromTheCommandLine

--- a/Tests/Unit/Command/SetProviderApiKeyCommandTest.php
+++ b/Tests/Unit/Command/SetProviderApiKeyCommandTest.php
@@ -125,12 +125,12 @@ final class SetProviderApiKeyCommandTest extends TestCase
     }
 
     #[Test]
-    public function stripsOnlyTheTrailingNewlineAPipeAdds(): void
+    public function stripsTrailingLineBreaksButKeepsEveryOtherCharacter(): void
     {
         $provider = $this->provider('openai', apiKey: '');
         $vault    = new InMemoryVaultService();
 
-        $this->runCommand($this->command($provider, $vault), 'openai', "  sk-with-padding  \n");
+        $this->runCommand($this->command($provider, $vault), 'openai', "  sk-with-padding  \r\n\n");
 
         self::assertSame('  sk-with-padding  ', $vault->secrets[$provider->getApiKey()] ?? null);
     }
@@ -177,7 +177,11 @@ final class SetProviderApiKeyCommandTest extends TestCase
         $input = new ArrayInput(['provider' => $provider]);
         $input->setStream($stream);
 
-        return $command->run($input, $this->output);
+        try {
+            return $command->run($input, $this->output);
+        } finally {
+            fclose($stream);
+        }
     }
 
     private function command(?Provider $provider, InMemoryVaultService $vault): SetProviderApiKeyCommand

--- a/Tests/Unit/Command/SetProviderApiKeyCommandTest.php
+++ b/Tests/Unit/Command/SetProviderApiKeyCommandTest.php
@@ -1,0 +1,204 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Command;
+
+use Netresearch\NrLlm\Command\SetProviderApiKeyCommand;
+use Netresearch\NrLlm\Domain\Model\Provider;
+use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
+use Netresearch\NrLlm\Tests\Unit\Fixture\InMemoryVaultService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
+
+#[CoversClass(SetProviderApiKeyCommand::class)]
+final class SetProviderApiKeyCommandTest extends TestCase
+{
+    private const SECRET = 'sk-test-0123456789';
+
+    private BufferedOutput $output;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->output = new BufferedOutput();
+    }
+
+    #[Test]
+    public function storesTheKeyAndLinksItToTheProvider(): void
+    {
+        $provider = $this->provider('openai', apiKey: '');
+        $vault    = new InMemoryVaultService();
+
+        $exit = $this->runCommand($this->command($provider, $vault), 'openai', self::SECRET);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertNotSame('', $provider->getApiKey(), 'the provider must end up referencing an identifier');
+        self::assertSame(self::SECRET, $vault->secrets[$provider->getApiKey()] ?? null);
+        self::assertSame([$provider->getApiKey()], $vault->storeCalls);
+        self::assertSame([], $vault->rotateCalls);
+    }
+
+    #[Test]
+    public function recordsProvenanceUnderTheMetadataOption(): void
+    {
+        $provider = $this->provider('openai', apiKey: '');
+        $vault    = new InMemoryVaultService();
+
+        $this->runCommand($this->command($provider, $vault), 'openai', self::SECRET);
+
+        // nr-vault drops unknown top-level option keys — provenance only
+        // survives when it is nested under `metadata`.
+        self::assertSame(
+            ['table' => 'tx_nrllm_provider', 'field' => 'api_key', 'source' => 'console'],
+            $vault->storeOptions[$provider->getApiKey()]['metadata'] ?? null,
+        );
+    }
+
+    #[Test]
+    public function replacesAnExistingKeyWithoutChangingTheIdentifier(): void
+    {
+        $identifier                  = '0198c0de-dead-7000-8000-000000000001';
+        $provider                    = $this->provider('openai', apiKey: $identifier);
+        $vault                       = new InMemoryVaultService();
+        $vault->secrets[$identifier] = 'sk-the-old-one';
+
+        $exit = $this->runCommand($this->command($provider, $vault), 'openai', self::SECRET);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertSame($identifier, $provider->getApiKey(), 'the identifier must survive a replacement');
+        self::assertSame(self::SECRET, $vault->secrets[$identifier]);
+        self::assertSame([['identifier' => $identifier, 'reason' => 'nrllm:provider:set-key']], $vault->rotateCalls);
+        self::assertSame([], $vault->storeCalls, 'an existing secret is rotated, not stored again');
+    }
+
+    #[Test]
+    public function storesUnderTheReferencedIdentifierWhenTheSecretIsGone(): void
+    {
+        // The provider points at an identifier the vault no longer knows, e.g.
+        // after a restore that carried the tables but not the vault.
+        $identifier = '0198c0de-dead-7000-8000-000000000002';
+        $provider   = $this->provider('openai', apiKey: $identifier);
+        $vault      = new InMemoryVaultService();
+
+        $exit = $this->runCommand($this->command($provider, $vault), 'openai', self::SECRET);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertSame($identifier, $provider->getApiKey());
+        self::assertSame([$identifier], $vault->storeCalls);
+    }
+
+    #[Test]
+    public function failsOnAnUnknownProvider(): void
+    {
+        $vault = new InMemoryVaultService();
+
+        $exit = $this->runCommand($this->command(null, $vault), 'nope', self::SECRET);
+
+        self::assertSame(Command::FAILURE, $exit);
+        self::assertStringContainsString('"nope"', $this->output->fetch());
+        self::assertSame([], $vault->storeCalls);
+    }
+
+    #[Test]
+    public function rejectsEmptyStdin(): void
+    {
+        $provider = $this->provider('openai', apiKey: '');
+        $vault    = new InMemoryVaultService();
+
+        $exit = $this->runCommand($this->command($provider, $vault), 'openai', '');
+
+        self::assertSame(Command::INVALID, $exit);
+        self::assertSame('', $provider->getApiKey(), 'nothing may be written when no key arrived');
+        self::assertSame([], $vault->storeCalls);
+    }
+
+    #[Test]
+    public function stripsOnlyTheTrailingNewlineAPipeAdds(): void
+    {
+        $provider = $this->provider('openai', apiKey: '');
+        $vault    = new InMemoryVaultService();
+
+        $this->runCommand($this->command($provider, $vault), 'openai', "  sk-with-padding  \n");
+
+        self::assertSame('  sk-with-padding  ', $vault->secrets[$provider->getApiKey()] ?? null);
+    }
+
+    #[Test]
+    public function reportsAFailedWriteWithoutLeakingTheSecret(): void
+    {
+        $provider       = $this->provider('openai', apiKey: '');
+        $vault          = new InMemoryVaultService();
+        $vault->throwOn = 'store';
+
+        $exit = $this->runCommand($this->command($provider, $vault), 'openai', self::SECRET);
+
+        self::assertSame(Command::FAILURE, $exit);
+        self::assertStringNotContainsString(self::SECRET, $this->output->fetch());
+        self::assertSame('', $provider->getApiKey(), 'a failed write must not link an identifier');
+    }
+
+    #[Test]
+    public function neverEchoesTheSecretOnSuccess(): void
+    {
+        $provider = $this->provider('openai', apiKey: '');
+
+        $this->runCommand($this->command($provider, new InMemoryVaultService()), 'openai', self::SECRET);
+
+        self::assertStringNotContainsString(self::SECRET, $this->output->fetch());
+    }
+
+    /**
+     * Runs the command with $stdin piped in.
+     *
+     * The input is built here rather than through CommandTester::setInputs():
+     * the tester creates its input inside execute(), so a stream set before
+     * that call is discarded — and leaving the stream unset would fall through
+     * to the real STDIN of the test run.
+     */
+    private function runCommand(SetProviderApiKeyCommand $command, string $provider, string $stdin): int
+    {
+        $stream = fopen('php://memory', 'r+');
+        self::assertIsResource($stream);
+        fwrite($stream, $stdin);
+        rewind($stream);
+
+        $input = new ArrayInput(['provider' => $provider]);
+        $input->setStream($stream);
+
+        return $command->run($input, $this->output);
+    }
+
+    private function command(?Provider $provider, InMemoryVaultService $vault): SetProviderApiKeyCommand
+    {
+        $repository = $this->createMock(ProviderRepository::class);
+        $repository->method('findOneByIdentifier')->willReturn($provider);
+
+        return new SetProviderApiKeyCommand(
+            $repository,
+            self::createStub(PersistenceManagerInterface::class),
+            $vault,
+            new NullLogger(),
+        );
+    }
+
+    private function provider(string $identifier, string $apiKey): Provider
+    {
+        $provider = new Provider();
+        $provider->setIdentifier($identifier);
+        $provider->setApiKey($apiKey);
+
+        return $provider;
+    }
+}

--- a/Tests/Unit/Fixture/InMemoryVaultService.php
+++ b/Tests/Unit/Fixture/InMemoryVaultService.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Fixture;
+
+use Netresearch\NrVault\Domain\Dto\SecretDetails;
+use Netresearch\NrVault\Domain\Dto\SecretMetadata;
+use Netresearch\NrVault\Http\VaultHttpClientInterface;
+use Netresearch\NrVault\Service\VaultServiceInterface;
+use RuntimeException;
+use SensitiveParameter;
+
+/**
+ * Records what a command asked the vault to do, without any crypto or database.
+ *
+ * Keeps the stored secrets so a test can assert that a key really was written,
+ * and keeps `store` and `rotate` apart so a test can tell a first write from a
+ * replacement — the distinction the caller is expected to get right.
+ */
+final class InMemoryVaultService implements VaultServiceInterface
+{
+    /** @var array<string, string> */
+    public array $secrets = [];
+
+    /** @var array<string, array<string, mixed>> */
+    public array $storeOptions = [];
+
+    /** @var list<string> */
+    public array $storeCalls = [];
+
+    /** @var list<array{identifier: string, reason: string}> */
+    public array $rotateCalls = [];
+
+    public ?string $throwOn = null;
+
+    public function store(string $identifier, #[SensitiveParameter] string $secret, array $options = []): void
+    {
+        if ($this->throwOn === 'store') {
+            throw new RuntimeException('vault refused the write', 9990040379);
+        }
+
+        $this->secrets[$identifier]      = $secret;
+        $this->storeOptions[$identifier] = $options;
+        $this->storeCalls[]              = $identifier;
+    }
+
+    public function retrieve(string $identifier): ?string
+    {
+        return $this->secrets[$identifier] ?? null;
+    }
+
+    public function exists(string $identifier): bool
+    {
+        return isset($this->secrets[$identifier]);
+    }
+
+    public function delete(string $identifier, string $reason = ''): void
+    {
+        unset($this->secrets[$identifier], $this->storeOptions[$identifier]);
+    }
+
+    public function rotate(string $identifier, #[SensitiveParameter] string $newSecret, string $reason = ''): void
+    {
+        if ($this->throwOn === 'rotate') {
+            throw new RuntimeException('vault refused the rotation', 6956132853);
+        }
+
+        $this->secrets[$identifier] = $newSecret;
+        $this->rotateCalls[]        = ['identifier' => $identifier, 'reason' => $reason];
+    }
+
+    /**
+     * @return list<SecretMetadata>
+     */
+    public function list(?string $pattern = null): array
+    {
+        // The command never enumerates secrets; assert against $secrets instead.
+        return [];
+    }
+
+    public function getMetadata(string $identifier): SecretDetails
+    {
+        throw new RuntimeException('not needed by these tests', 9452800525);
+    }
+
+    public function clearCache(): void {}
+
+    public function http(): VaultHttpClientInterface
+    {
+        throw new RuntimeException('not needed by these tests', 2573807431);
+    }
+}


### PR DESCRIPTION
Closes #581

## What this adds

`nrllm:provider:set-key <provider>` stores a provider API key from a script, doing what the setup wizard does from the backend:

```bash
printf '%s' "$OPENAI_API_KEY" | vendor/bin/typo3 nrllm:provider:set-key openai
```

Three decisions worth stating, all recorded in [ADR-124](Documentation/Adr/Adr124ProviderKeyFromTheCommandLine.rst):

- **STDIN only.** An argument would be visible in the process list and recorded in the shell history, and no option flag takes that back afterwards. A terminal is refused rather than read — prompting would hang a provisioning script in a way that looks like a freeze, so it fails visibly instead.
- **Re-running replaces, it does not re-issue.** When the provider already references a stored credential, the secret is rotated under the existing identifier. That matters because `providers.openai.apiKeyIdentifier` in the extension configuration — which the specialized speech and image services read via `ExtensionConfiguration::get('nr_llm')` — refers to that identifier and would otherwise be left pointing at a stale secret. A provider whose identifier the vault no longer knows is re-stored under that same identifier rather than given a new one.
- **`schedulable: false`.** The scheduler cannot supply STDIN.

## The second commit: a bug found on the way

The wizard passes provenance to nr-vault like this:

```php
$this->vaultService->store($vaultIdentifier, $providerApiKey, [
    'table' => 'tx_nrllm_provider',
    'field' => 'api_key',
    'source' => 'setup_wizard',
]);
```

nr-vault's `VaultService::collectOptionalFields()` reads provenance from the `metadata` option and ignores every key it does not recognise. All three were therefore discarded on every wizard run — the provenance the code appears to record has never been stored. `40df12f1` nests them.

This is in scope rather than a follow-up because the issue names "wizard and script produce different shapes" as one of the two problems to solve; shipping the new command with correct metadata while leaving the wizard silently dropping its own would have kept exactly that split. Secrets stored before this change stay unlabelled — nothing reads the metadata for behaviour, so there is no migration.

## Tests

Nine unit tests in `Tests/Unit/Command/SetProviderApiKeyCommandTest.php`, one per acceptance criterion plus the edge cases: first write, replacement keeping the identifier, a dangling identifier being re-stored, unknown provider, empty STDIN, trailing-newline handling, a failed vault write leaving the provider untouched, and two asserting the secret never reaches the output.

The input stream is built in the test rather than through `CommandTester::setInputs()`: the tester creates its input inside `execute()`, so a stream set beforehand is discarded — and an unset stream would fall through to the real STDIN of the test run.

`Tests/Unit/Fixture/InMemoryVaultService.php` is a new fixture that keeps `store` and `rotate` apart so a test can tell a first write from a replacement.

## Verification

All six pre-push suites, run on **PHP 8.2** — the version `ci.yml` pins for Rector and the floor of the test matrix:

```
unit               SUCCESS  (5758 tests, 16023 assertions)
functional sqlite  SUCCESS
phpstan            SUCCESS  [OK] No errors        (level 10)
cgl                SUCCESS
rector -n          SUCCESS  [OK] Rector is done!
fuzzy              SUCCESS
architecture       SUCCESS  (PHPat, extra — the command injects a repository)
```

unit and phpstan additionally pass on PHP 8.4.

One note for whoever runs these next: `rector -n` on PHP 8.4 reports 55 files, on 8.2 it reports none. The PHPUnit-related rules resolve against the PHPUnit major that the PHP version pulls in, so a local run on the wrong version invents a 53-file backlog that CI does not see. `ci.yml` sets `rector-php-version: '8.2'` for that reason.
