### PR TITLE
feat(mcp): consume tools from operator-configured MCP servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Tools from an external MCP server can be used in an agent run. An
+  administrator configures a server, imports the catalogue it advertises and
+  enables individual tools; import is the only network call outside a run and
+  happens on an explicit action, never because a page rendered. Each server
+  declares what class of data its tools may see, and a server without that
+  declaration supplies nothing rather than falling back to a default nobody
+  chose. A remote tool always requires an administrator, counts as a write that
+  is not replayed on a retry, and is never waved through the trust-zone gate in
+  observe mode. The number of remote calls one run may make is bounded, because
+  a remote call crosses the network while a backend user waits and nothing else
+  limits how many a model asks for at once.
+
 - Translation and image generation can be tried from the backend. The test page
   gained two cards: translate a snippet with a chosen translator, or generate a
   single image with the OpenAI or the FAL service. Until now nothing in the

--- a/Classes/Controller/Backend/McpServerController.php
+++ b/Classes/Controller/Backend/McpServerController.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Controller\Backend;
+
+use Netresearch\NrLlm\Domain\ValueObject\McpServerRecord;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpImportService;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpServerRepository;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpToolRepository;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Backend\Attribute\AsController;
+use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
+use TYPO3\CMS\Core\Http\JsonResponse;
+use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+
+/**
+ * The MCP server module: what is configured, what was imported, import now (ADR-116).
+ *
+ * The import is an explicit administrator action and lives only here. It talks
+ * to a third party over the network, so it must never happen because a page
+ * rendered or because a run needed a tool — {@see McpImportService} is called
+ * from this one place and from nothing else.
+ *
+ * Both actions are admin-gated. The module registration already restricts the
+ * list; the AJAX route needs its own check because a backend route bypasses the
+ * module's `access` setting (ADR-037), and the import is exactly the kind of
+ * outbound action that must not be reachable without it.
+ */
+#[AsController]
+final class McpServerController extends ActionController
+{
+    use DefensiveLocalizationTrait;
+    use RequiresBackendAdminTrait;
+
+    public function __construct(
+        private readonly ModuleTemplateFactory $moduleTemplateFactory,
+        private readonly McpServerRepository $servers,
+        private readonly McpToolRepository $catalogue,
+        private readonly McpImportService $importer,
+        private readonly PageRenderer $pageRenderer,
+    ) {}
+
+    public function listAction(): ResponseInterface
+    {
+        $this->pageRenderer->loadJavaScriptModule('@netresearch/nr-llm/Backend/McpImport.js');
+        $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
+        $moduleTemplate->makeDocHeaderModuleMenu();
+
+        $servers = [];
+        foreach ($this->servers->findAll() as $server) {
+            $servers[] = [
+                'record' => $server,
+                // An undeclared data class is the one configuration mistake that
+                // silently costs a server all of its tools, so the view is told
+                // about it rather than leaving the operator to infer it from an
+                // empty list.
+                'usable' => $server->dataClassEnum() !== null,
+                'tools'  => $this->catalogue->findAllByServer($server->uid),
+            ];
+        }
+
+        $moduleTemplate->assign('servers', $servers);
+
+        return $moduleTemplate->renderResponse('Backend/McpServer/List');
+    }
+
+    /**
+     * Import one server's advertised catalogue (AJAX, admin-gated).
+     *
+     * Returns the report rather than a bare success flag: a refusal, an import
+     * that wrote nothing and an import that skipped half the catalogue are three
+     * different outcomes, and an operator who sees only "done" cannot tell them
+     * apart.
+     */
+    public function importAction(ServerRequestInterface $request): ResponseInterface
+    {
+        if (($deny = $this->denyNonAdmin()) !== null) {
+            return $deny;
+        }
+
+        $uid    = $this->intFromBody($request->getParsedBody(), 'server');
+        $server = $uid > 0 ? $this->servers->findByUid($uid) : null;
+
+        if (!$server instanceof McpServerRecord) {
+            return new JsonResponse([
+                'success' => false,
+                'error'   => $this->localize(
+                    'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.mcp.unknownServer',
+                    'Unknown MCP server',
+                ),
+            ], 404);
+        }
+
+        $report = $this->importer->import($server);
+
+        // A refusal answers 200 with `success: false`, like every other action
+        // in this backend: the shared front-end helper reads that shape and
+        // shows the reason, while a non-2xx would land in its generic transport
+        // error path and lose the message the operator needs. 404 above is the
+        // exception because there the request itself was wrong.
+        return new JsonResponse([
+            'success'     => !$report->refused,
+            'error'       => $report->refused ? ($report->skipReasons[0] ?? '') : '',
+            'imported'    => $report->imported,
+            'skipped'     => $report->skipped,
+            'orphaned'    => $report->orphaned,
+            'skipReasons' => $report->skipReasons,
+        ]);
+    }
+
+    private function intFromBody(mixed $body, string $key): int
+    {
+        if (!is_array($body)) {
+            return 0;
+        }
+
+        $value = $body[$key] ?? null;
+
+        return is_numeric($value) ? (int)$value : 0;
+    }
+}

--- a/Classes/Controller/Backend/McpServerController.php
+++ b/Classes/Controller/Backend/McpServerController.php
@@ -82,7 +82,7 @@ final class McpServerController extends ActionController
      */
     public function importAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
 

--- a/Classes/Controller/Backend/McpServerController.php
+++ b/Classes/Controller/Backend/McpServerController.php
@@ -116,6 +116,15 @@ final class McpServerController extends ActionController
         ]);
     }
 
+    /**
+     * A uid, or 0 for anything that is not one.
+     *
+     * Validated rather than cast. `is_numeric()` accepts "1.9" and "1e3", and
+     * casting either yields a uid the caller never named — the import would
+     * then reach an external server chosen by a rounding rule. A form-encoded
+     * body always carries strings, so the string case is the normal one; a JSON
+     * body can carry a real integer.
+     */
     private function intFromBody(mixed $body, string $key): int
     {
         if (!is_array($body)) {
@@ -124,6 +133,16 @@ final class McpServerController extends ActionController
 
         $value = $body[$key] ?? null;
 
-        return is_numeric($value) ? (int)$value : 0;
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (!is_string($value)) {
+            return 0;
+        }
+
+        $uid = filter_var($value, FILTER_VALIDATE_INT);
+
+        return $uid === false ? 0 : $uid;
     }
 }

--- a/Classes/Service/Tool/Mcp/Exception/McpTransportException.php
+++ b/Classes/Service/Tool/Mcp/Exception/McpTransportException.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Mcp\Exception;
+
+use RuntimeException;
+
+/**
+ * A call to an MCP server did not produce a usable result (ADR-116).
+ *
+ * One type for every way the conversation can fail — refused host, transport
+ * error, non-2xx status, unparseable body, JSON-RPC error object — because
+ * every caller does the same thing with it: record it against the server and
+ * stop. The distinction that matters to an operator is the message, which names
+ * the server, and that survives into `import_error`.
+ *
+ * The message is built here rather than at the call site so a server's own
+ * response text can never be pasted into it unbounded: a remote party writes
+ * that text, and it ends up in a backend view and a log line.
+ */
+final class McpTransportException extends RuntimeException
+{
+    /**
+     * How much of a remote party's text is worth keeping. Enough to identify
+     * the fault, short enough that a hostile server cannot flood the log.
+     */
+    private const REMOTE_TEXT_LIMIT = 200;
+
+    public static function forRefusedHost(string $identifier, string $host): self
+    {
+        return new self(
+            sprintf('MCP server "%s" points at host "%s", which outbound requests are not allowed to reach.', $identifier, $host),
+            1799990210,
+        );
+    }
+
+    public static function forTransportFailure(string $identifier, string $reason): self
+    {
+        return new self(
+            sprintf('MCP server "%s" could not be reached: %s', $identifier, self::clip($reason)),
+            1799990211,
+        );
+    }
+
+    public static function forStatus(string $identifier, int $status): self
+    {
+        return new self(
+            sprintf('MCP server "%s" answered with HTTP status %d.', $identifier, $status),
+            1799990212,
+        );
+    }
+
+    public static function forMalformedResponse(string $identifier, string $detail): self
+    {
+        return new self(
+            sprintf('MCP server "%s" sent a response that is not a JSON-RPC result: %s', $identifier, self::clip($detail)),
+            1799990213,
+        );
+    }
+
+    public static function forRpcError(string $identifier, int $code, string $message): self
+    {
+        return new self(
+            sprintf('MCP server "%s" refused the call with JSON-RPC error %d: %s', $identifier, $code, self::clip($message)),
+            1799990214,
+        );
+    }
+
+    public static function forUnsupportedContentType(string $identifier, string $contentType): self
+    {
+        return new self(
+            sprintf(
+                'MCP server "%s" answered with content type "%s"; this client reads JSON responses only and does not consume an event stream.',
+                $identifier,
+                self::clip($contentType),
+            ),
+            1799990215,
+        );
+    }
+
+    public static function forMissingCredential(string $identifier): self
+    {
+        return new self(
+            sprintf('MCP server "%s" declares a credential that the vault could not resolve.', $identifier),
+            1799990216,
+        );
+    }
+
+    /**
+     * Bound text that a remote party controls, and strip the control
+     * characters that would otherwise forge line breaks in a log record.
+     */
+    private static function clip(string $text): string
+    {
+        $clean = preg_replace('/[[:cntrl:]]+/u', ' ', $text) ?? '';
+        $clean = trim($clean);
+
+        if (mb_strlen($clean) <= self::REMOTE_TEXT_LIMIT) {
+            return $clean;
+        }
+
+        return mb_substr($clean, 0, self::REMOTE_TEXT_LIMIT) . '…';
+    }
+}

--- a/Classes/Service/Tool/Mcp/McpClient.php
+++ b/Classes/Service/Tool/Mcp/McpClient.php
@@ -1,0 +1,219 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Mcp;
+
+use Netresearch\NrLlm\Domain\ValueObject\McpServerRecord;
+use Netresearch\NrLlm\Domain\ValueObject\McpToolsPage;
+use Netresearch\NrLlm\Service\Tool\Mcp\Exception\McpTransportException;
+use stdClass;
+
+/**
+ * The MCP conversation: handshake, catalogue listing, tool invocation (ADR-116).
+ *
+ * Owns the protocol; {@see McpHttpTransport} owns the wire. The split exists so
+ * the handshake and the pagination loop can be asserted against a fake
+ * transport, without a PSR-18 double and without a live server.
+ *
+ * A session is per OPERATION, not per instance. Each public method opens one,
+ * uses it and drops it. That costs two extra round trips per import and per
+ * tool call — the handshake and its confirmation — and buys the property that
+ * matters: this class is a DI singleton on a long-lived queue worker, so a
+ * retained session id would be handed to whatever server came next, and a
+ * session belonging to server A is meaningless, at best, when presented to
+ * server B. The price is paid per call and is bounded by the transport
+ * timeout; the alternative is a cache whose invalidation nobody owns.
+ */
+final readonly class McpClient
+{
+    /**
+     * The revision this client speaks. Sent in the handshake; a server that
+     * cannot serve it answers with its own and we proceed, because the two
+     * calls this client makes have been stable across revisions.
+     */
+    private const PROTOCOL_VERSION = '2025-06-18';
+
+    /**
+     * Pages a catalogue listing will walk before giving up.
+     *
+     * A cursor that never resolves to null is a server bug or a hostile server;
+     * either way the loop has to end. At the page sizes MCP servers use this is
+     * far more tools than a catalogue an operator would want.
+     */
+    private const MAX_PAGES = 50;
+
+    public function __construct(
+        private McpHttpTransport $transport,
+    ) {}
+
+    /**
+     * Every tool the server advertises, across all pages.
+     *
+     *
+     * @throws McpTransportException
+     *
+     * @return list<array<string, mixed>> the advertised tool objects, verbatim
+     */
+    public function listTools(McpServerRecord $server): array
+    {
+        $session = $this->openSession($server);
+
+        $tools  = [];
+        $cursor = null;
+
+        for ($page = 0; $page < self::MAX_PAGES; ++$page) {
+            $result = $this->transport->call(
+                $server,
+                'tools/list',
+                $cursor === null ? [] : ['cursor' => $cursor],
+                $session,
+            );
+
+            $parsed = $this->parseToolsPage($server, $result['result']);
+            foreach ($parsed->tools as $tool) {
+                $tools[] = $tool;
+            }
+
+            $cursor = $parsed->nextCursor;
+            if ($cursor === null) {
+                return $tools;
+            }
+        }
+
+        throw McpTransportException::forMalformedResponse(
+            $server->identifier,
+            sprintf('the tool listing did not end within %d pages', self::MAX_PAGES),
+        );
+    }
+
+    /**
+     * Invoke one remote tool and return its result as text.
+     *
+     * MCP lets a server answer with a list of typed content blocks. Only text
+     * blocks are read: an image or an embedded resource has no representation
+     * in a tool result here, and silently dropping one is better than inventing
+     * a rendering the caller never asked for. A server that returns nothing
+     * readable yields an explicit note rather than an empty string, so the
+     * model is told the call produced no text instead of inferring failure.
+     *
+     * @param array<string, mixed> $arguments
+     *
+     * @throws McpTransportException
+     */
+    public function callTool(McpServerRecord $server, string $remoteName, array $arguments): string
+    {
+        $session = $this->openSession($server);
+
+        $result = $this->transport->call($server, 'tools/call', [
+            'name'      => $remoteName,
+            'arguments' => $arguments === [] ? new stdClass() : $arguments,
+        ], $session)['result'];
+
+        $text = $this->textFromContent($result['content'] ?? null);
+
+        // `isError` is the protocol's way of reporting a tool-level failure
+        // inside a successful JSON-RPC response. It is a result, not a
+        // transport fault: the model should see what went wrong and may
+        // reasonably try something else, so it is returned rather than thrown.
+        if (($result['isError'] ?? false) === true) {
+            return 'The remote tool reported an error: ' . ($text === '' ? 'no detail given.' : $text);
+        }
+
+        return $text === '' ? 'The remote tool returned no textual content.' : $text;
+    }
+
+    /**
+     * Perform the initialize handshake and return the session id, if the server
+     * issued one.
+     *
+     * A server that runs statelessly issues none; null then simply means no
+     * session header on the following request, which is valid.
+     *
+     * @throws McpTransportException
+     */
+    private function openSession(McpServerRecord $server): ?string
+    {
+        $session = $this->transport->call($server, 'initialize', [
+            'protocolVersion' => self::PROTOCOL_VERSION,
+            // No capabilities are declared because none are offered: this
+            // client does not accept sampling requests, does not expose roots
+            // and does not subscribe to notifications. Declaring a capability
+            // we do not implement invites the server to use it.
+            'capabilities'    => new stdClass(),
+            'clientInfo'      => [
+                'name'    => 'nr_llm',
+                'version' => '1',
+            ],
+        ])['sessionId'];
+
+        // The protocol requires the client to confirm it is ready before it
+        // issues requests. A server may reject everything until it arrives.
+        $this->transport->notify($server, 'notifications/initialized', [], $session);
+
+        return $session;
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     *
+     * @throws McpTransportException
+     */
+    private function parseToolsPage(McpServerRecord $server, array $result): McpToolsPage
+    {
+        $tools = $result['tools'] ?? null;
+        if (!\is_array($tools)) {
+            throw McpTransportException::forMalformedResponse($server->identifier, 'the tool listing carries no "tools" array');
+        }
+
+        $objects = [];
+        foreach ($tools as $tool) {
+            // A non-object entry is dropped here rather than rejected: one
+            // malformed entry must not cost the operator the whole catalogue.
+            // The import counts what it could not name, so nothing vanishes
+            // silently.
+            if (\is_array($tool)) {
+                /** @var array<string, mixed> $tool */
+                $objects[] = $tool;
+            }
+        }
+
+        $cursor = $result['nextCursor'] ?? null;
+
+        return new McpToolsPage(
+            $objects,
+            \is_string($cursor) && $cursor !== '' ? $cursor : null,
+        );
+    }
+
+    /**
+     * Flatten the protocol's content blocks into plain text.
+     */
+    private function textFromContent(mixed $content): string
+    {
+        if (!\is_array($content)) {
+            return '';
+        }
+
+        $parts = [];
+        foreach ($content as $block) {
+            if (!\is_array($block)) {
+                continue;
+            }
+            if (($block['type'] ?? null) !== 'text') {
+                continue;
+            }
+            $text = $block['text'] ?? null;
+            if (\is_string($text) && $text !== '') {
+                $parts[] = $text;
+            }
+        }
+
+        return implode("\n", $parts);
+    }
+}

--- a/Classes/Service/Tool/Mcp/McpClient.php
+++ b/Classes/Service/Tool/Mcp/McpClient.php
@@ -205,9 +205,11 @@ final readonly class McpClient
             if (!\is_array($block)) {
                 continue;
             }
+
             if (($block['type'] ?? null) !== 'text') {
                 continue;
             }
+
             $text = $block['text'] ?? null;
             if (\is_string($text) && $text !== '') {
                 $parts[] = $text;

--- a/Classes/Service/Tool/Mcp/McpHttpTransport.php
+++ b/Classes/Service/Tool/Mcp/McpHttpTransport.php
@@ -1,0 +1,302 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Mcp;
+
+use JsonException;
+use Netresearch\NrLlm\Domain\ValueObject\McpServerRecord;
+use Netresearch\NrLlm\Service\Tool\Mcp\Exception\McpTransportException;
+use Netresearch\NrVault\Http\SecretPlacement;
+use Netresearch\NrVault\Http\SecureHttpClientFactory;
+use Netresearch\NrVault\Service\VaultServiceInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use stdClass;
+use Throwable;
+
+/**
+ * One JSON-RPC round trip to one MCP server over HTTP (ADR-116).
+ *
+ * Deliberately stateless and dumb: it builds a request, sends it through the
+ * SSRF-guarded vault client and hands back the `result` object. Sessions, the
+ * initialize handshake and pagination live in {@see McpClient}, so this class
+ * stays assertable against a fake PSR-18 client.
+ *
+ * Two properties are load-bearing and neither is an accident:
+ *
+ * - **The client is built per server, per call.** It is never memoised on the
+ *   instance. This class is a DI singleton, so a cached authenticated client
+ *   would send the first server's token to the second — a credential leak
+ *   between two operator-configured third parties, which is exactly the kind
+ *   of mistake that never shows up in a test that uses one server.
+ * - **The host is gated before the credential goes on.** A disallowed or
+ *   private-range target is rejected while the request is still anonymous, so a
+ *   misconfigured URL cannot be used to post a token at an internal address.
+ *   The vault client re-checks the host as defence in depth; this mirrors
+ *   {@see \Netresearch\NrLlm\Service\SetupWizard\SecureHttpDispatchTrait},
+ *   which cannot be reused here because it can neither authenticate per server
+ *   nor set a timeout.
+ */
+final class McpHttpTransport
+{
+    /**
+     * Total request duration. An agent run waits on this synchronously while a
+     * backend user watches, so an unreachable server has to fail while the
+     * answer is still worth having.
+     */
+    private const TIMEOUT_SECONDS = 15;
+
+    /**
+     * Bounds what a hostile or broken server can push into memory before we
+     * decide the body is not a JSON-RPC response.
+     */
+    private const MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
+
+    /**
+     * Test seam: when set, requests bypass the vault client entirely. Never set
+     * in production — the vault path is what audits the call and injects the
+     * credential.
+     */
+    private ?ClientInterface $configuredHttpClient = null;
+
+    public function __construct(
+        private readonly VaultServiceInterface $vault,
+        private readonly SecureHttpClientFactory $httpClientFactory,
+        private readonly RequestFactoryInterface $requestFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+    ) {}
+
+    /**
+     * @internal test seam only
+     */
+    public function setHttpClient(ClientInterface $client): void
+    {
+        $this->configuredHttpClient = $client;
+    }
+
+    /**
+     * Send one JSON-RPC request and return its `result` object.
+     *
+     * @param array<string, mixed> $params
+     *
+     * @throws McpTransportException on any outcome that is not a JSON-RPC result
+     *
+     * @return array{result: array<string, mixed>, sessionId: string|null}
+     */
+    public function call(McpServerRecord $server, string $method, array $params, ?string $sessionId = null): array
+    {
+        $response = $this->send($server, $this->encode($server, [
+            'jsonrpc' => '2.0',
+            // A single request per connection, so the id only has to be
+            // present and echoable, not unique across calls.
+            'id'      => 1,
+            'method'  => $method,
+            'params'  => $params === [] ? new stdClass() : $params,
+        ]), $sessionId);
+
+        return [
+            'result'    => $this->decodeResult($server, $response['body'], $response['status'], $response['contentType']),
+            'sessionId' => $response['sessionId'],
+        ];
+    }
+
+    /**
+     * Send one JSON-RPC notification, which by definition has no reply.
+     *
+     * A notification carries no `id`; a server answers it with 202 and an empty
+     * body. Anything it does send back is discarded rather than parsed — there
+     * is no result to take from it.
+     *
+     * @param array<string, mixed> $params
+     *
+     * @throws McpTransportException when the server could not be reached
+     */
+    public function notify(McpServerRecord $server, string $method, array $params, ?string $sessionId = null): void
+    {
+        $this->send($server, $this->encode($server, [
+            'jsonrpc' => '2.0',
+            'method'  => $method,
+            'params'  => $params === [] ? new stdClass() : $params,
+        ]), $sessionId);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @throws McpTransportException when the payload cannot be encoded
+     */
+    private function encode(McpServerRecord $server, array $payload): string
+    {
+        try {
+            return json_encode($payload, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        } catch (JsonException $e) {
+            throw McpTransportException::forMalformedResponse($server->identifier, 'the request could not be encoded: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * @throws McpTransportException
+     *
+     * @return array{status: int, body: string, contentType: string, sessionId: string|null}
+     */
+    private function send(McpServerRecord $server, string $body, ?string $sessionId): array
+    {
+        $request = $this->requestFactory
+            ->createRequest('POST', $server->url)
+            ->withHeader('Content-Type', 'application/json')
+            // JSON only, stated honestly: this client does not consume an event
+            // stream, so it does not claim to accept one. A server that can
+            // only answer with a stream rejects the request, which is a clearer
+            // failure than a body we would refuse after the fact.
+            ->withHeader('Accept', 'application/json')
+            ->withBody($this->streamFactory->createStream($body));
+
+        if ($sessionId !== null && $sessionId !== '') {
+            $request = $request->withHeader('Mcp-Session-Id', $sessionId);
+        }
+
+        $host = $request->getUri()->getHost();
+
+        try {
+            if ($this->configuredHttpClient !== null) {
+                $response = $this->configuredHttpClient->sendRequest($request);
+            } else {
+                // Anonymous host gate first — see the class docblock.
+                if (!$this->httpClientFactory->isHostAllowed($host)) {
+                    throw McpTransportException::forRefusedHost($server->identifier, $host);
+                }
+
+                $response = $this->clientFor($server)->sendRequest($request);
+            }
+        } catch (McpTransportException $e) {
+            throw $e;
+        } catch (Throwable $e) {
+            throw McpTransportException::forTransportFailure($server->identifier, $e->getMessage());
+        }
+
+        $status = $response->getStatusCode();
+        // 3xx counts as a failure rather than a redirect to follow: following
+        // one would take the credential to a host the gate above never saw.
+        if ($status >= 300) {
+            throw McpTransportException::forStatus($server->identifier, $status);
+        }
+
+        $returnedSession = $response->getHeaderLine('Mcp-Session-Id');
+
+        return [
+            'status'      => $status,
+            'body'        => $this->readBounded($response->getBody()),
+            'contentType' => $response->getHeaderLine('Content-Type'),
+            'sessionId'   => $returnedSession === '' ? null : $returnedSession,
+        ];
+    }
+
+    /**
+     * Read at most {@see self::MAX_RESPONSE_BYTES}, in chunks.
+     *
+     * A single `read()` may return fewer bytes than asked for even when more
+     * are available, so one call is not a body; and `getContents()` would let a
+     * server decide how much memory we spend.
+     */
+    private function readBounded(StreamInterface $stream): string
+    {
+        $body = '';
+
+        while (!$stream->eof() && strlen($body) < self::MAX_RESPONSE_BYTES) {
+            $chunk = $stream->read(min(8192, self::MAX_RESPONSE_BYTES - strlen($body)));
+            if ($chunk === '') {
+                break;
+            }
+            $body .= $chunk;
+        }
+
+        return $body;
+    }
+
+    /**
+     * A client bound to this one server's credential, built fresh every call.
+     *
+     * @throws McpTransportException when a declared credential does not resolve
+     */
+    private function clientFor(McpServerRecord $server): ClientInterface
+    {
+        $client = $this->vault->http()
+            ->withReason(sprintf('nr-llm MCP call to "%s"', $server->identifier))
+            ->withTimeout(self::TIMEOUT_SECONDS);
+
+        if ($server->authCredential === '') {
+            return $client;
+        }
+
+        // Fail closed. An MCP server that was configured with a credential is
+        // not one to try anonymously: the anonymous call would either be
+        // refused, which hides the real fault behind a 401, or succeed with
+        // less authority than the operator intended.
+        if (!$this->vault->exists($server->authCredential)) {
+            throw McpTransportException::forMissingCredential($server->identifier);
+        }
+
+        $placement = SecretPlacement::tryFrom($server->authPlacement) ?? SecretPlacement::Bearer;
+        $options   = [];
+        if ($placement === SecretPlacement::Header) {
+            if ($server->authHeaderName === '') {
+                throw McpTransportException::forMissingCredential($server->identifier);
+            }
+            $options['headerName'] = $server->authHeaderName;
+        }
+
+        // The plaintext never enters this process: the vault client injects it
+        // as it writes the request.
+        return $client->withAuthentication($server->authCredential, $placement, $options);
+    }
+
+    /**
+     * @throws McpTransportException
+     *
+     * @return array<string, mixed>
+     */
+    private function decodeResult(McpServerRecord $server, string $body, int $status, string $contentType): array
+    {
+        $mediaType = strtolower(trim(explode(';', $contentType, 2)[0]));
+        if ($mediaType !== '' && $mediaType !== 'application/json') {
+            throw McpTransportException::forUnsupportedContentType($server->identifier, $mediaType);
+        }
+
+        if (trim($body) === '') {
+            throw McpTransportException::forMalformedResponse($server->identifier, sprintf('empty body with status %d', $status));
+        }
+
+        try {
+            $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw McpTransportException::forMalformedResponse($server->identifier, $e->getMessage());
+        }
+
+        if (!\is_array($decoded)) {
+            throw McpTransportException::forMalformedResponse($server->identifier, 'the body is not a JSON object');
+        }
+
+        if (isset($decoded['error']) && \is_array($decoded['error'])) {
+            $code    = \is_int($decoded['error']['code'] ?? null) ? $decoded['error']['code'] : 0;
+            $message = \is_string($decoded['error']['message'] ?? null) ? $decoded['error']['message'] : 'no message';
+
+            throw McpTransportException::forRpcError($server->identifier, $code, $message);
+        }
+
+        $result = $decoded['result'] ?? null;
+        if (!\is_array($result)) {
+            throw McpTransportException::forMalformedResponse($server->identifier, 'the response carries neither a result nor an error');
+        }
+
+        /** @var array<string, mixed> $result */
+        return $result;
+    }
+}

--- a/Classes/Service/Tool/Mcp/McpHttpTransport.php
+++ b/Classes/Service/Tool/Mcp/McpHttpTransport.php
@@ -166,7 +166,7 @@ final class McpHttpTransport
         $host = $request->getUri()->getHost();
 
         try {
-            if ($this->configuredHttpClient !== null) {
+            if ($this->configuredHttpClient instanceof ClientInterface) {
                 $response = $this->configuredHttpClient->sendRequest($request);
             } else {
                 // Anonymous host gate first — see the class docblock.
@@ -215,6 +215,7 @@ final class McpHttpTransport
             if ($chunk === '') {
                 break;
             }
+
             $body .= $chunk;
         }
 
@@ -250,6 +251,7 @@ final class McpHttpTransport
             if ($server->authHeaderName === '') {
                 throw McpTransportException::forMissingCredential($server->identifier);
             }
+
             $options['headerName'] = $server->authHeaderName;
         }
 

--- a/Classes/Service/Tool/Mcp/McpImportService.php
+++ b/Classes/Service/Tool/Mcp/McpImportService.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service\Tool\Mcp;
 
 use JsonException;
+use Netresearch\NrLlm\Domain\Enum\ToolDataClass;
 use Netresearch\NrLlm\Domain\ValueObject\McpImportReport;
 use Netresearch\NrLlm\Domain\ValueObject\McpServerRecord;
 use Netresearch\NrLlm\Service\Tool\Mcp\Exception\McpTransportException;
@@ -57,7 +58,7 @@ final readonly class McpImportService
     {
         $now = $this->now();
 
-        if ($server->dataClassEnum() === null) {
+        if (!$server->dataClassEnum() instanceof ToolDataClass) {
             return $this->refuse($server, $now, 'The server has no declared data class, so its tools cannot be classified.');
         }
 
@@ -121,7 +122,7 @@ final readonly class McpImportService
         $this->servers->recordImportOutcome(
             $server->uid,
             $skipReasons === [] ? 'ok' : 'partial',
-            $skipReasons === [] ? '' : implode("\n", $skipReasons),
+            implode("\n", $skipReasons),
             count($accepted),
             $now,
         );

--- a/Classes/Service/Tool/Mcp/McpImportService.php
+++ b/Classes/Service/Tool/Mcp/McpImportService.php
@@ -1,0 +1,244 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Mcp;
+
+use JsonException;
+use Netresearch\NrLlm\Domain\ValueObject\McpImportReport;
+use Netresearch\NrLlm\Domain\ValueObject\McpServerRecord;
+use Netresearch\NrLlm\Service\Tool\Mcp\Exception\McpTransportException;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Psr\Log\LoggerInterface;
+use TYPO3\CMS\Core\Context\Context;
+
+/**
+ * Imports one MCP server's advertised catalogue into `tx_nrllm_mcp_tool` (ADR-116).
+ *
+ * The only writer of that table, and the only place a remote catalogue is
+ * validated. It runs on an explicit administrator action, never on a request
+ * path and never on a run: discovery talks to a third party over the network,
+ * and that must be something an operator chose to do.
+ *
+ * Everything a server sends is treated as a proposal. A tool is imported only
+ * when it can be named locally, its schema can be normalised, and its name
+ * collides with nothing already registered. Rejections are counted and reported
+ * with a reason, because a tool that is simply absent from the catalogue looks
+ * exactly like a tool the server never offered.
+ */
+final readonly class McpImportService
+{
+    /**
+     * A catalogue larger than this is refused rather than truncated.
+     *
+     * Every imported tool costs context in every run that offers its group, so
+     * a server advertising thousands of tools is either misconfigured or
+     * hostile. Truncating would import an arbitrary subset and report success.
+     */
+    private const MAX_TOOLS = 500;
+
+    public function __construct(
+        private McpClient $client,
+        private McpServerRepository $servers,
+        private McpToolRepository $catalogue,
+        private McpToolNameMapper $names,
+        private McpSchemaNormalizer $schemas,
+        private ToolRegistry $registry,
+        private LoggerInterface $logger,
+        private Context $context,
+    ) {}
+
+    public function import(McpServerRecord $server): McpImportReport
+    {
+        $now = $this->now();
+
+        if ($server->dataClassEnum() === null) {
+            return $this->refuse($server, $now, 'The server has no declared data class, so its tools cannot be classified.');
+        }
+
+        if ($server->url === '') {
+            return $this->refuse($server, $now, 'The server has no URL.');
+        }
+
+        // Two enabled servers sharing an identifier would generate the same
+        // local tool names, and the catalogue's unique index would reject the
+        // second one's rows halfway through. Refused up front so the operator
+        // is told which setting is wrong, rather than shown a database error.
+        // Not a database constraint: the table soft-deletes, so a unique index
+        // would keep a discarded server's identifier reserved for ever.
+        $twin = $this->identifierTwin($server);
+        if ($twin !== null) {
+            return $this->refuse($server, $now, sprintf(
+                'The identifier "%s" is also used by server "%s"; identifiers must be unique because they name the imported tools.',
+                $server->identifier,
+                $twin,
+            ));
+        }
+
+        try {
+            $advertised = $this->client->listTools($server);
+        } catch (McpTransportException $e) {
+            $this->logger->warning('An MCP catalogue import failed', [
+                'server'    => $server->identifier,
+                'exception' => $e,
+            ]);
+
+            return $this->refuse($server, $now, $e->getMessage());
+        }
+
+        if (count($advertised) > self::MAX_TOOLS) {
+            return $this->refuse($server, $now, sprintf(
+                'The server advertises %d tools, more than the %d this extension will import.',
+                count($advertised),
+                self::MAX_TOOLS,
+            ));
+        }
+
+        $accepted    = [];
+        $skipReasons = [];
+        $localNames  = [];
+
+        foreach ($advertised as $tool) {
+            $outcome = $this->accept($server, $tool, $localNames);
+
+            if (is_string($outcome)) {
+                $skipReasons[] = $outcome;
+
+                continue;
+            }
+
+            $localNames[$outcome['toolName']] = true;
+            $accepted[]                       = $outcome;
+        }
+
+        $orphaned = $this->catalogue->reconcile($server->uid, $server->pid, $accepted, $now);
+
+        $this->servers->recordImportOutcome(
+            $server->uid,
+            $skipReasons === [] ? 'ok' : 'partial',
+            $skipReasons === [] ? '' : implode("\n", $skipReasons),
+            count($accepted),
+            $now,
+        );
+
+        return new McpImportReport(
+            serverUid: $server->uid,
+            imported: count($accepted),
+            skipped: count($skipReasons),
+            orphaned: $orphaned,
+            skipReasons: $skipReasons,
+        );
+    }
+
+    /**
+     * Validate one advertised tool.
+     *
+     * @param array<string, mixed> $tool
+     * @param array<string, true>  $localNames names already accepted in this run
+     *
+     * @return array{toolName: string, remoteName: string, description: string, inputSchema: string, remoteAnnotations: string}|string
+     *                                                                                                                                 the catalogue row, or the reason it was rejected
+     */
+    private function accept(McpServerRecord $server, array $tool, array $localNames): array|string
+    {
+        $remoteName = $tool['name'] ?? null;
+        if (!is_string($remoteName) || $remoteName === '') {
+            return 'An advertised tool has no name and was skipped.';
+        }
+
+        $localName = $this->names->localName($server->identifier, $remoteName);
+        if ($localName === null) {
+            return sprintf('"%s" cannot be given a valid local tool name and was skipped.', $remoteName);
+        }
+
+        if (isset($localNames[$localName])) {
+            return sprintf('"%s" maps to a name this server already used and was skipped.', $remoteName);
+        }
+
+        // Against the compile-time builtins only. A name already held by
+        // another server's imported tool is caught by the catalogue's unique
+        // index and, before that, by the identifier check in import(); using
+        // the full registry here would consult the providers and make the
+        // import depend on the very catalogue it is writing.
+        if (in_array($localName, $this->registry->builtinNames(), true)) {
+            return sprintf('"%s" would collide with a builtin tool of the same name and was skipped.', $remoteName);
+        }
+
+        $schema = $this->schemas->normalise($tool['inputSchema'] ?? null);
+        if ($schema === null) {
+            return sprintf('"%s" has no usable parameter schema and was skipped.', $remoteName);
+        }
+
+        $encodedSchema = $this->encode($schema);
+        if ($encodedSchema === null) {
+            return sprintf('"%s" has a parameter schema that could not be stored and was skipped.', $remoteName);
+        }
+
+        $description = $tool['description'] ?? '';
+        $annotations = $tool['annotations'] ?? null;
+
+        return [
+            'toolName'          => $localName,
+            'remoteName'        => $remoteName,
+            'description'       => is_string($description) ? $description : '',
+            'inputSchema'       => $encodedSchema,
+            // Kept verbatim for display. Nothing reads it to make a decision:
+            // a remote server must not be able to influence authorisation by
+            // what it writes here.
+            'remoteAnnotations' => is_array($annotations) ? ($this->encode($annotations) ?? '') : '',
+        ];
+    }
+
+    /**
+     * The name of another enabled server claiming the same identifier, if any.
+     */
+    private function identifierTwin(McpServerRecord $server): ?string
+    {
+        foreach ($this->servers->findEnabled() as $other) {
+            if ($other->uid !== $server->uid && $other->identifier === $server->identifier) {
+                return $other->name;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<array-key, mixed> $value
+     */
+    private function encode(array $value): ?string
+    {
+        try {
+            return json_encode($value, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        } catch (JsonException) {
+            return null;
+        }
+    }
+
+    private function refuse(McpServerRecord $server, int $now, string $reason): McpImportReport
+    {
+        // The catalogue is left exactly as it was. A server we could not reach
+        // has not told us its tools are gone, and orphaning them on a network
+        // failure would disable an operator's working tools by accident.
+        $this->servers->recordImportOutcome($server->uid, 'error', $reason, $server->toolCount, $now);
+
+        return McpImportReport::refused($server->uid, $reason);
+    }
+
+    /**
+     * The request's pinned timestamp, so every row one import writes carries the
+     * same one. Falls back to wall time if the aspect is unavailable, which is
+     * the only case where two rows of one import could disagree by a second.
+     */
+    private function now(): int
+    {
+        $timestamp = $this->context->getPropertyFromAspect('date', 'timestamp');
+
+        return is_int($timestamp) && $timestamp > 0 ? $timestamp : time();
+    }
+}

--- a/Classes/Service/Tool/Mcp/McpServerRepository.php
+++ b/Classes/Service/Tool/Mcp/McpServerRepository.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service\Tool\Mcp;
 
 use Doctrine\DBAL\ParameterType;
+use Netresearch\NrLlm\Domain\Enum\ToolDataClass;
 use Netresearch\NrLlm\Domain\ValueObject\McpServerRecord;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -67,7 +68,7 @@ final readonly class McpServerRepository
     {
         return array_values(array_filter(
             $this->findEnabled(),
-            static fn(McpServerRecord $server): bool => $server->dataClassEnum() !== null,
+            static fn(McpServerRecord $server): bool => $server->dataClassEnum() instanceof ToolDataClass,
         ));
     }
 

--- a/Classes/Service/Tool/Mcp/McpServerRepository.php
+++ b/Classes/Service/Tool/Mcp/McpServerRepository.php
@@ -1,0 +1,161 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Mcp;
+
+use Doctrine\DBAL\ParameterType;
+use Netresearch\NrLlm\Domain\ValueObject\McpServerRecord;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+
+/**
+ * Reads and updates `tx_nrllm_mcp_server` (ADR-116).
+ *
+ * The table is operator-managed and carries `deleted`/`hidden`, unlike the
+ * catalogue table beside it. The deleted restriction is kept: a discarded
+ * server must disappear from the tool surface. The hidden restriction is
+ * dropped deliberately — `enabled` is this table's own switch and the one an
+ * operator reasons about, so honouring `hidden` as well would give the same
+ * decision two controls that can disagree.
+ */
+final readonly class McpServerRepository
+{
+    use SafeCastTrait;
+
+    private const TABLE = 'tx_nrllm_mcp_server';
+
+    public function __construct(private ConnectionPool $connectionPool) {}
+
+    /**
+     * Every configured server, enabled or not — the backend list needs both.
+     *
+     * @return list<McpServerRecord>
+     */
+    public function findAll(): array
+    {
+        $queryBuilder = $this->queryBuilder();
+
+        $rows = $queryBuilder
+            ->select('*')
+            ->from(self::TABLE)
+            ->orderBy('identifier', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    /**
+     * The servers whose tools may be offered at all.
+     *
+     * Two conditions, both necessary: the operator switched the server on, and
+     * the operator declared what class of data it may see. An undeclared server
+     * is not a server with a default — it is one nobody has classified, and
+     * {@see McpServerRecord::dataClassEnum()} says why that must stay inert.
+     *
+     * @return list<McpServerRecord>
+     */
+    public function findUsable(): array
+    {
+        return array_values(array_filter(
+            $this->findEnabled(),
+            static fn(McpServerRecord $server): bool => $server->dataClassEnum() !== null,
+        ));
+    }
+
+    /**
+     * @return list<McpServerRecord>
+     */
+    public function findEnabled(): array
+    {
+        $queryBuilder = $this->queryBuilder();
+
+        $rows = $queryBuilder
+            ->select('*')
+            ->from(self::TABLE)
+            ->where($queryBuilder->expr()->eq('enabled', $queryBuilder->createNamedParameter(1, ParameterType::INTEGER)))
+            ->orderBy('identifier', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    public function findByUid(int $uid): ?McpServerRecord
+    {
+        $queryBuilder = $this->queryBuilder();
+
+        $row = $queryBuilder
+            ->select('*')
+            ->from(self::TABLE)
+            ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, ParameterType::INTEGER)))
+            ->setMaxResults(1)
+            ->executeQuery()
+            ->fetchAssociative();
+
+        return $row === false ? null : $this->hydrate($row);
+    }
+
+    /**
+     * Record how the last import went.
+     *
+     * The error text is stored even when empty, so a server that recovers stops
+     * showing the fault that has been fixed.
+     */
+    public function recordImportOutcome(int $uid, string $status, string $error, int $toolCount, int $timestamp): void
+    {
+        $this->connectionPool->getConnectionForTable(self::TABLE)->update(
+            self::TABLE,
+            [
+                'import_status' => $status,
+                'import_error'  => $error,
+                'tool_count'    => $toolCount,
+                'last_imported' => $timestamp,
+                'tstamp'        => $timestamp,
+            ],
+            ['uid' => $uid],
+        );
+    }
+
+    private function queryBuilder(): QueryBuilder
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder->getRestrictions()->removeAll()->add(new DeletedRestriction());
+
+        return $queryBuilder;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrate(array $row): McpServerRecord
+    {
+        return new McpServerRecord(
+            uid: self::toInt($row['uid'] ?? 0),
+            pid: self::toInt($row['pid'] ?? 0),
+            identifier: self::toStr($row['identifier'] ?? ''),
+            name: self::toStr($row['name'] ?? ''),
+            description: self::toStr($row['description'] ?? ''),
+            url: self::toStr($row['url'] ?? ''),
+            authCredential: self::toStr($row['auth_credential'] ?? ''),
+            authPlacement: self::toStr($row['auth_placement'] ?? ''),
+            authHeaderName: self::toStr($row['auth_header_name'] ?? ''),
+            dataClass: self::toStr($row['data_class'] ?? ''),
+            enabled: self::toInt($row['enabled'] ?? 0) === 1,
+            importStatus: self::toStr($row['import_status'] ?? ''),
+            importError: self::toStr($row['import_error'] ?? ''),
+            lastImported: self::toInt($row['last_imported'] ?? 0),
+            toolCount: self::toInt($row['tool_count'] ?? 0),
+            tstamp: self::toInt($row['tstamp'] ?? 0),
+            crdate: self::toInt($row['crdate'] ?? 0),
+        );
+    }
+}

--- a/Classes/Service/Tool/Mcp/McpTool.php
+++ b/Classes/Service/Tool/Mcp/McpTool.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Mcp;
+
+use Netresearch\NrLlm\Domain\Enum\ToolDataClass;
+use Netresearch\NrLlm\Domain\Enum\ToolEffect;
+use Netresearch\NrLlm\Domain\ValueObject\McpServerRecord;
+use Netresearch\NrLlm\Domain\ValueObject\McpToolRecord;
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\Mcp\Exception\McpTransportException;
+use Netresearch\NrLlm\Service\Tool\RemoteToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolDataClassInterface;
+use Netresearch\NrLlm\Service\Tool\ToolEffectInterface;
+use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+
+/**
+ * One tool imported from one MCP server (ADR-116).
+ *
+ * Constructed per catalogue row by {@see McpToolProvider}, never by the
+ * container: its arguments are a database row. It is therefore excluded from
+ * autowiring in `Configuration/Services.yaml` — without that entry the
+ * `nr_llm.tool` autoconfigure tag on {@see ToolInterface} would have the
+ * container try to build it, and compilation fails on the scalar arguments.
+ *
+ * It declares both classifications explicitly, which is what makes
+ * {@see RemoteToolInterface}'s rules effective without touching the resolvers:
+ * each resolver already prefers an explicit declaration over its default, so
+ * the operator's choice simply wins.
+ *
+ * - The DATA CLASS is the one the operator declared on the server. There is no
+ *   code here to derive it from, and the group-default path would have landed
+ *   on the fail-closed `SECRET_ADJACENT` for every `mcp_*` group, which reads
+ *   like a decision but is only an absence.
+ * - The EFFECT is a non-idempotent write unless the catalogue says otherwise.
+ *   The builtin default is the opposite because every builtin reads; a remote
+ *   tool's body is not ours to inspect, so the assumption has to be that it
+ *   changed something and must not be replayed on a retry (ADR-111/112).
+ * - `requiresAdmin()` is hard-wired true. It is not derived from anything the
+ *   server sends, because the server is the party the guard exists against.
+ */
+final readonly class McpTool implements ToolInterface, RemoteToolInterface, ToolDataClassInterface, ToolEffectInterface
+{
+    /**
+     * @param array<string, mixed> $inputSchema the normalised parameter schema
+     */
+    public function __construct(
+        private McpServerRecord $server,
+        private McpToolRecord $record,
+        private array $inputSchema,
+        private ToolDataClass $dataClass,
+        private McpClient $client,
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            $this->record->toolName,
+            $this->description(),
+            $this->inputSchema,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $arguments
+     */
+    public function execute(array $arguments, ToolExecutionContext $context): ToolResult
+    {
+        try {
+            return ToolResult::text($this->client->callTool($this->server, $this->record->remoteName, $arguments));
+        } catch (McpTransportException $e) {
+            // Returned rather than thrown: a server that is down is a fact
+            // about this call, not a fault in the run. The loop can carry on
+            // and the model is told plainly what failed. The message is already
+            // bounded and control-stripped by the exception itself.
+            return ToolResult::text($e->getMessage());
+        }
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        // An imported tool is inert until an operator enables it. Import is an
+        // act of configuration; it should not also be an act of granting.
+        return false;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        return true;
+    }
+
+    public function getGroup(): string
+    {
+        return 'mcp_' . $this->server->identifier;
+    }
+
+    public function getDataClass(): ToolDataClass
+    {
+        return $this->dataClass;
+    }
+
+    public function getEffect(): ToolEffect
+    {
+        return ToolEffect::NON_IDEMPOTENT_WRITE;
+    }
+
+    /**
+     * The description the model sees, with the origin stated first.
+     *
+     * The remote text is written by a third party and is read by a model that
+     * treats it as instruction. Naming the server ahead of it does not make the
+     * text safe, but it does mean the model is never told the sentence came
+     * from this installation.
+     */
+    private function description(): string
+    {
+        $remote = trim($this->record->description);
+
+        $origin = sprintf('[via the external MCP server "%s"]', $this->server->name);
+
+        return $remote === '' ? $origin : $origin . ' ' . $remote;
+    }
+}

--- a/Classes/Service/Tool/Mcp/McpToolProvider.php
+++ b/Classes/Service/Tool/Mcp/McpToolProvider.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Mcp;
+
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolProviderInterface;
+
+/**
+ * Turns the imported catalogue into registered tools (ADR-116).
+ *
+ * The one place {@see McpTool} instances are made. Reads two tables and builds
+ * objects; it performs no network I/O, which the provider contract requires —
+ * this runs whenever the registry is first used, including on backend pages
+ * that have nothing to do with an agent run.
+ *
+ * Two silent-drop rules, both fail-closed:
+ *
+ * - A server whose data class the operator has not declared supplies nothing.
+ *   {@see McpServerRepository::findUsable()} filters it out, so an undeclared
+ *   server is inert rather than defaulted.
+ * - A catalogue row whose stored schema no longer decodes to a JSON object
+ *   supplies nothing. A tool without a parameter schema cannot be offered to a
+ *   provider, and inventing an empty one would advertise a signature the remote
+ *   tool does not have.
+ */
+final readonly class McpToolProvider implements ToolProviderInterface
+{
+    public function __construct(
+        private McpServerRepository $servers,
+        private McpToolRepository $tools,
+        private McpClient $client,
+    ) {}
+
+    /**
+     * @return iterable<ToolInterface>
+     */
+    public function tools(): iterable
+    {
+        foreach ($this->servers->findUsable() as $server) {
+            $dataClass = $server->dataClassEnum();
+            if ($dataClass === null) {
+                // findUsable() already excluded these; re-checked because the
+                // null is what makes the McpTool construction below type-safe,
+                // and a filter three calls away is a poor place to rely on it.
+                continue;
+            }
+
+            foreach ($this->tools->findLiveByServer($server->uid) as $record) {
+                $schema = $record->inputSchemaArray();
+                if ($schema === null) {
+                    continue;
+                }
+
+                yield new McpTool($server, $record, $schema, $dataClass, $this->client);
+            }
+        }
+    }
+}

--- a/Classes/Service/Tool/Mcp/McpToolRepository.php
+++ b/Classes/Service/Tool/Mcp/McpToolRepository.php
@@ -131,6 +131,7 @@ final readonly class McpToolRepository
             if (isset($seen[$toolName])) {
                 continue;
             }
+
             ++$orphaned;
 
             // Already marked from an earlier import: counted, not rewritten,

--- a/Classes/Service/Tool/Mcp/McpToolRepository.php
+++ b/Classes/Service/Tool/Mcp/McpToolRepository.php
@@ -1,0 +1,175 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Mcp;
+
+use Doctrine\DBAL\ParameterType;
+use Netresearch\NrLlm\Domain\ValueObject\McpToolRecord;
+use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+
+/**
+ * Reads and reconciles `tx_nrllm_mcp_tool` (ADR-116).
+ *
+ * A machine-managed catalogue: every row is written by an import and by nothing
+ * else. The table carries no `deleted`, no `hidden` and no TCA, so all
+ * restrictions are removed on every query — there is no enable field to honour
+ * and leaving the default restrictions on would silently return nothing.
+ *
+ * Reconciliation marks rather than deletes. A tool that vanished from a server
+ * keeps its row with `orphaned` set, because an operator who enabled it needs
+ * to see that it went away; deleting it would present the same situation as a
+ * tool that had never existed.
+ */
+final readonly class McpToolRepository
+{
+    use SafeCastTrait;
+
+    private const TABLE = 'tx_nrllm_mcp_tool';
+
+    public function __construct(private ConnectionPool $connectionPool) {}
+
+    /**
+     * Every non-orphaned tool of one server.
+     *
+     * @return list<McpToolRecord>
+     */
+    public function findLiveByServer(int $serverUid): array
+    {
+        $queryBuilder = $this->queryBuilder();
+
+        $rows = $queryBuilder
+            ->select('*')
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->eq('server', $queryBuilder->createNamedParameter($serverUid, ParameterType::INTEGER)),
+                $queryBuilder->expr()->eq('orphaned', $queryBuilder->createNamedParameter(0, ParameterType::INTEGER)),
+            )
+            ->orderBy('tool_name', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    /**
+     * Every tool of one server, orphans included — the backend list shows both.
+     *
+     * @return list<McpToolRecord>
+     */
+    public function findAllByServer(int $serverUid): array
+    {
+        $queryBuilder = $this->queryBuilder();
+
+        $rows = $queryBuilder
+            ->select('*')
+            ->from(self::TABLE)
+            ->where($queryBuilder->expr()->eq('server', $queryBuilder->createNamedParameter($serverUid, ParameterType::INTEGER)))
+            ->orderBy('orphaned', 'ASC')
+            ->addOrderBy('tool_name', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    /**
+     * Replace one server's catalogue with the tools an import just accepted.
+     *
+     * Written as an upsert plus an orphan sweep rather than delete-then-insert:
+     * a row's uid is what the operator's per-tool state would hang off, and
+     * recreating rows on every import would discard it. A tool that comes back
+     * after disappearing is un-orphaned rather than duplicated.
+     *
+     * @param list<array{toolName: string, remoteName: string, description: string, inputSchema: string, remoteAnnotations: string}> $tools
+     *
+     * @return int the number of rows marked orphaned by this reconciliation
+     */
+    public function reconcile(int $serverUid, int $pid, array $tools, int $timestamp): int
+    {
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
+        $existing   = [];
+
+        foreach ($this->findAllByServer($serverUid) as $record) {
+            $existing[$record->toolName] = $record;
+        }
+
+        $seen = [];
+        foreach ($tools as $tool) {
+            $seen[$tool['toolName']] = true;
+
+            $values = [
+                'server'             => $serverUid,
+                'pid'                => $pid,
+                'tool_name'          => $tool['toolName'],
+                'remote_name'        => $tool['remoteName'],
+                'description'        => $tool['description'],
+                'input_schema'       => $tool['inputSchema'],
+                'remote_annotations' => $tool['remoteAnnotations'],
+                'orphaned'           => 0,
+                'tstamp'             => $timestamp,
+            ];
+
+            if (isset($existing[$tool['toolName']])) {
+                $connection->update(self::TABLE, $values, ['uid' => $existing[$tool['toolName']]->uid]);
+
+                continue;
+            }
+
+            $connection->insert(self::TABLE, $values + ['crdate' => $timestamp]);
+        }
+
+        $orphaned = 0;
+        foreach ($existing as $toolName => $record) {
+            if (isset($seen[$toolName])) {
+                continue;
+            }
+            ++$orphaned;
+
+            // Already marked from an earlier import: counted, not rewritten,
+            // so tstamp keeps saying when the tool actually disappeared.
+            if ($record->orphaned) {
+                continue;
+            }
+
+            $connection->update(self::TABLE, ['orphaned' => 1, 'tstamp' => $timestamp], ['uid' => $record->uid]);
+        }
+
+        return $orphaned;
+    }
+
+    private function queryBuilder(): QueryBuilder
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+
+        return $queryBuilder;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrate(array $row): McpToolRecord
+    {
+        return new McpToolRecord(
+            uid: self::toInt($row['uid'] ?? 0),
+            pid: self::toInt($row['pid'] ?? 0),
+            server: self::toInt($row['server'] ?? 0),
+            toolName: self::toStr($row['tool_name'] ?? ''),
+            remoteName: self::toStr($row['remote_name'] ?? ''),
+            description: self::toStr($row['description'] ?? ''),
+            inputSchema: self::toStr($row['input_schema'] ?? ''),
+            remoteAnnotations: self::toStr($row['remote_annotations'] ?? ''),
+            orphaned: self::toInt($row['orphaned'] ?? 0) === 1,
+            tstamp: self::toInt($row['tstamp'] ?? 0),
+            crdate: self::toInt($row['crdate'] ?? 0),
+        );
+    }
+}

--- a/Classes/Service/Tool/RemoteCallBudget.php
+++ b/Classes/Service/Tool/RemoteCallBudget.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+/**
+ * How many calls to a {@see RemoteToolInterface} tool one run segment may make.
+ *
+ * A builtin call is local and returns in milliseconds; the loop's iteration cap
+ * is a sufficient bound on it. A remote call is neither. It crosses the network
+ * three times — handshake, confirmation, invocation — and each leg may sit at
+ * the transport timeout, while a backend user waits synchronously. Nothing else
+ * bounds how many tool calls a model may emit in a single round, so without
+ * this a model that loops on one MCP tool can hold a request open far longer
+ * than the iteration cap suggests.
+ *
+ * MUTABLE AND SHORT-LIVED, DELIBERATELY. It is created inside a run method and
+ * passed down, never injected. That is the whole point: the services around it
+ * are container singletons, and on the queue path the worker process outlives
+ * many runs, so any counter held on a service would bound the PROCESS and let
+ * the second run inherit the first one's exhaustion.
+ *
+ * The bound is per run SEGMENT, not per run: a resumed run starts a fresh
+ * budget. That is intentional — a resume only happens after a human approved
+ * the pause, so the loop cannot spin through segments on its own.
+ */
+final class RemoteCallBudget
+{
+    /**
+     * Generous enough that no plausible task hits it, small enough that a loop
+     * on a slow server ends in minutes rather than at the request timeout.
+     */
+    public const DEFAULT_LIMIT = 20;
+
+    private int $spent = 0;
+
+    public function __construct(
+        private readonly int $limit = self::DEFAULT_LIMIT,
+    ) {}
+
+    /**
+     * Claim one call, or report that the budget is exhausted.
+     */
+    public function tryConsume(): bool
+    {
+        if ($this->spent >= $this->limit) {
+            return false;
+        }
+
+        ++$this->spent;
+
+        return true;
+    }
+
+    public function limit(): int
+    {
+        return $this->limit;
+    }
+
+    public function spent(): int
+    {
+        return $this->spent;
+    }
+}

--- a/Classes/Service/Tool/ToolCallPolicy.php
+++ b/Classes/Service/Tool/ToolCallPolicy.php
@@ -75,7 +75,12 @@ final readonly class ToolCallPolicy implements ToolCallPolicyInterface
         }
 
         if (!$zone->permits($dataClass)) {
-            $enforcing = $this->enforcing();
+            // A remote tool never benefits from observe mode. Observe exists so
+            // an UPGRADE does not silently start dropping tools that already
+            // worked (ADR-115); no remote tool worked before, so there is
+            // nothing to preserve, and an upgraded install must not end up more
+            // permissive than a fresh one.
+            $enforcing = $this->enforcing() || $tool instanceof RemoteToolInterface;
 
             return new ToolPolicyDecision(
                 $toolName,

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -798,6 +798,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         if (!in_array($call->name, $allowedNames, true)) {
             return ToolResult::error(sprintf('Error: tool "%s" not permitted', $call->name));
         }
+
         // Charged after the permission checks and before execution, so a
         // refused call costs nothing and a granted one is counted exactly once.
         // The message says the budget is spent rather than that the tool is

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -145,6 +145,10 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         int $seedCompletionTokens = 0,
     ): ToolLoopResult {
         $max = $maxIterations ?? $this->defaultMaxIterations;
+        // Created HERE, per run, and passed down: this service is a container
+        // singleton and the queue worker outlives many runs, so a counter held
+        // anywhere but a local would bound the process instead (ADR-116).
+        $remoteCalls = new RemoteCallBudget();
 
         // Assemble the outgoing prompt once, before the loop: configuration
         // skills inject into the tool path here (the loop is the sole caller of
@@ -323,7 +327,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                     // runtime records the tool's effect and renews the lease so a
                     // reap mid non-idempotent-write can refuse to retry it.
                     $runTrace?->beforeToolExecution($call->name);
-                    $tr = $this->invoke($call, $allowedNames, $context);
+                    $tr = $this->invoke($call, $allowedNames, $context, $remoteCalls);
                     // WIRE: content ONLY — artifacts are run-scoped and never egress to the provider.
                     $messages[] = ChatMessage::toolResult($call->id, $tr->content);
                     $trace[]    = new ToolInvocation($call->name, $call->arguments, $tr->content, $tr->isError, $tr->artifacts);
@@ -490,7 +494,8 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         // Re-apply the gate NOW (a tool may have been disabled or restricted while
         // the run was suspended) rather than trusting the names captured at
         // suspend time.
-        $offered = $this->resolveOfferedNames($state->allowedToolNames, $configuration, $context);
+        $offered     = $this->resolveOfferedNames($state->allowedToolNames, $configuration, $context);
+        $remoteCalls = new RemoteCallBudget();
 
         foreach ($pendingCalls as $call) {
             if (!$approved) {
@@ -512,7 +517,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
             } else {
                 $tt0 = hrtime(true);
                 $runTrace?->beforeToolExecution($call->name);
-                $tr     = $this->invoke($call, $offered, $context);
+                $tr     = $this->invoke($call, $offered, $context, $remoteCalls);
                 $result = $tr->content;
                 $runTrace?->recordToolExecution($state->iterations, $this->elapsedMs($tt0), $call->name, $call->arguments, $tr->content, $tr->isError, $tr->artifacts);
             }
@@ -576,6 +581,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         $pendingCalls = $state->toolCalls();
         $options      = ToolOptions::fromArray($state->options, $beUserUid);
         $offered      = $this->resolveOfferedNames($state->allowedToolNames, $configuration, $context);
+        $remoteCalls  = new RemoteCallBudget();
 
         foreach ($pendingCalls as $call) {
             if (!in_array($call->name, $offered, true)) {
@@ -584,7 +590,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
             } elseif ($call->name === $state->inputToolName) {
                 $tt0 = hrtime(true);
                 $runTrace?->beforeToolExecution($call->name);
-                $tr = $this->invoke($this->withInput($call, $state->inputSchema, $inputData), $offered, $context);
+                $tr = $this->invoke($this->withInput($call, $state->inputSchema, $inputData), $offered, $context, $remoteCalls);
                 $result = $tr->content;
                 $runTrace?->recordToolExecution($state->iterations, $this->elapsedMs($tt0), $call->name, $call->arguments, $tr->content, $tr->isError, $tr->artifacts);
             } elseif ($this->registry->get($call->name) instanceof RequiresInputInterface) {
@@ -595,7 +601,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
             } else {
                 $tt0 = hrtime(true);
                 $runTrace?->beforeToolExecution($call->name);
-                $tr     = $this->invoke($call, $offered, $context);
+                $tr     = $this->invoke($call, $offered, $context, $remoteCalls);
                 $result = $tr->content;
                 $runTrace?->recordToolExecution($state->iterations, $this->elapsedMs($tt0), $call->name, $call->arguments, $tr->content, $tr->isError, $tr->artifacts);
             }
@@ -782,7 +788,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
      *
      * @param list<string> $allowedNames
      */
-    private function invoke(ToolCall $call, array $allowedNames, ToolExecutionContext $context): ToolResult
+    private function invoke(ToolCall $call, array $allowedNames, ToolExecutionContext $context, RemoteCallBudget $remoteCalls): ToolResult
     {
         $tool = $this->registry->get($call->name);
         if (!$tool instanceof ToolInterface) {
@@ -791,6 +797,17 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
 
         if (!in_array($call->name, $allowedNames, true)) {
             return ToolResult::error(sprintf('Error: tool "%s" not permitted', $call->name));
+        }
+        // Charged after the permission checks and before execution, so a
+        // refused call costs nothing and a granted one is counted exactly once.
+        // The message says the budget is spent rather than that the tool is
+        // broken, so the model stops calling it instead of retrying.
+        if ($tool instanceof RemoteToolInterface && !$remoteCalls->tryConsume()) {
+            return ToolResult::error(sprintf(
+                'Error: this run has used its budget of %d calls to external tools; "%s" was not called.',
+                $remoteCalls->limit(),
+                $call->name,
+            ));
         }
 
         try {

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 use Netresearch\NrLlm\Controller\Backend\ConfigurationController;
 use Netresearch\NrLlm\Controller\Backend\LlmModuleController;
+use Netresearch\NrLlm\Controller\Backend\McpServerController;
 use Netresearch\NrLlm\Controller\Backend\ModelController;
 use Netresearch\NrLlm\Controller\Backend\ModelDiscoveryController;
 use Netresearch\NrLlm\Controller\Backend\ModelTestController;
@@ -204,6 +205,12 @@ return [
     'nrllm_toolgroup_toggle' => [
         'path' => '/nrllm/toolgroup/toggle',
         'target' => ToolController::class . '::toggleToolGroupAction',
+    ],
+
+    // MCP catalogue import (admin-gated in the controller as well)
+    'nrllm_mcp_import' => [
+        'path' => '/nrllm/mcp/import',
+        'target' => McpServerController::class . '::importAction',
     ],
 
     // Setup Wizard routes

--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -11,6 +11,7 @@ use Netresearch\NrLlm\Controller\Backend\AgentRunController;
 use Netresearch\NrLlm\Controller\Backend\AnalyticsController;
 use Netresearch\NrLlm\Controller\Backend\ConfigurationController;
 use Netresearch\NrLlm\Controller\Backend\LlmModuleController;
+use Netresearch\NrLlm\Controller\Backend\McpServerController;
 use Netresearch\NrLlm\Controller\Backend\ModelController;
 use Netresearch\NrLlm\Controller\Backend\PromptSnippetController;
 use Netresearch\NrLlm\Controller\Backend\ProviderController;
@@ -216,6 +217,26 @@ return [
         'extensionName' => 'NrLlm',
         'controllerActions' => [
             ToolController::class => [
+                'list',
+            ],
+        ],
+    ],
+    // MCP servers - child of main module
+    // Admin-only: list the operator-configured MCP servers, what each one
+    // advertised at the last import, and trigger a fresh import. The import
+    // talks to a third party over the network, so it happens only on this
+    // explicit action; the AJAX route (nrllm_mcp_import) guards itself with
+    // RequiresBackendAdminTrait because a backend route bypasses this
+    // module's access setting (ADR-037).
+    'nrllm_mcp' => [
+        'parent' => 'nrllm',
+        'access' => 'admin',
+        'iconIdentifier' => 'module-nrllm-tool',
+        'path' => '/module/nrllm/mcp',
+        'labels' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_mcp.xlf',
+        'extensionName' => 'NrLlm',
+        'controllerActions' => [
+            McpServerController::class => [
                 'list',
             ],
         ],

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -28,6 +28,15 @@ services:
       - '../Classes/Service/Rerank/HttpReranker.php'
       - '../Classes/Service/SetupWizard/Exception/*'
       - '../Classes/Service/Skill/Exception/*'
+      - '../Classes/Service/Tool/Mcp/Exception/*'
+      # Built per catalogue row by McpToolProvider from a database row. Without
+      # this the `nr_llm.tool` autoconfigure tag on ToolInterface would have the
+      # container try to build it, and compilation fails on the scalar arguments.
+      - '../Classes/Service/Tool/Mcp/McpTool.php'
+      # Created inside a run method and passed down, never injected — the bound
+      # is per run, and a container-held instance would bound the process
+      # (ADR-116).
+      - '../Classes/Service/Tool/RemoteCallBudget.php'
       - '../Classes/Specialized/Exception/*'
       - '../Classes/Testing/*'
       - '../Classes/Widgets/*'

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -2312,6 +2312,10 @@
                 <source>Unknown tool group</source>
                 <target>Unbekannte Werkzeuggruppe</target>
             </trans-unit>
+            <trans-unit id="error.mcp.unknownServer">
+                <source>Unknown MCP server</source>
+                <target>Unbekannter MCP-Server</target>
+            </trans-unit>
             <trans-unit id="card.count.configurations">
                 <source>configuration(s) configured</source>
                 <target>Konfiguration(en) eingerichtet</target>

--- a/Resources/Private/Language/de.locallang_mod_mcp.xlf
+++ b/Resources/Private/Language/de.locallang_mod_mcp.xlf
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="de" datatype="plaintext" original="messages">
+        <body>
+            <trans-unit id="mlang_labels_tablabel">
+                <source>MCP Servers</source>
+                <target>MCP-Server</target>
+            </trans-unit>
+            <trans-unit id="mlang_tabs_tab">
+                <source>MCP Servers</source>
+                <target>MCP-Server</target>
+            </trans-unit>
+            <trans-unit id="mlang_labels_tabdescr">
+                <source>Manage external MCP servers and import the tools they advertise</source>
+                <target>Externe MCP-Server verwalten und die von ihnen angebotenen Tools importieren</target>
+            </trans-unit>
+            <trans-unit id="list.title">
+                <source>MCP Servers</source>
+                <target>MCP-Server</target>
+            </trans-unit>
+            <trans-unit id="list.intro">
+                <source>Tools imported from an external MCP server run on that server, not here. Importing a catalogue only records what a server offers; each tool stays off until you enable it, and every one requires an administrator. This module is admin-only.</source>
+                <target>Tools von einem externen MCP-Server laufen auf diesem Server, nicht hier. Ein Import hält nur fest, was ein Server anbietet. Jedes Tool bleibt aus, bis Sie es aktivieren, und jedes setzt Administratorrechte voraus. Dieses Modul ist nur für Administratoren.</target>
+            </trans-unit>
+            <trans-unit id="list.empty">
+                <source>No MCP server is configured. Add one as a record of type "MCP Server".</source>
+                <target>Es ist kein MCP-Server eingerichtet. Legen Sie einen als Datensatz vom Typ „MCP-Server“ an.</target>
+            </trans-unit>
+            <trans-unit id="server.url">
+                <source>Endpoint</source>
+                <target>Endpunkt</target>
+            </trans-unit>
+            <trans-unit id="server.dataClass">
+                <source>Data class</source>
+                <target>Datenklasse</target>
+            </trans-unit>
+            <trans-unit id="server.enabled">
+                <source>Enabled</source>
+                <target>Aktiv</target>
+            </trans-unit>
+            <trans-unit id="server.disabled">
+                <source>Disabled</source>
+                <target>Inaktiv</target>
+            </trans-unit>
+            <trans-unit id="server.undeclared">
+                <source>No data class declared — this server supplies no tools until you declare one.</source>
+                <target>Keine Datenklasse festgelegt — dieser Server liefert keine Tools, solange keine festgelegt ist.</target>
+            </trans-unit>
+            <trans-unit id="server.lastImport">
+                <source>Last import</source>
+                <target>Letzter Import</target>
+            </trans-unit>
+            <trans-unit id="server.never">
+                <source>Never imported</source>
+                <target>Nie importiert</target>
+            </trans-unit>
+            <trans-unit id="server.import">
+                <source>Import catalogue</source>
+                <target>Katalog importieren</target>
+            </trans-unit>
+            <trans-unit id="tools.title">
+                <source>Imported tools</source>
+                <target>Importierte Tools</target>
+            </trans-unit>
+            <trans-unit id="tools.none">
+                <source>No tools imported yet.</source>
+                <target>Noch keine Tools importiert.</target>
+            </trans-unit>
+            <trans-unit id="tools.localName">
+                <source>Local name</source>
+                <target>Lokaler Name</target>
+            </trans-unit>
+            <trans-unit id="tools.remoteName">
+                <source>Name on the server</source>
+                <target>Name auf dem Server</target>
+            </trans-unit>
+            <trans-unit id="tools.orphaned">
+                <source>Gone from the server</source>
+                <target>Auf dem Server verschwunden</target>
+            </trans-unit>
+            <trans-unit id="tools.orphanedHint">
+                <source>This tool was in an earlier import and the server no longer offers it. The row is kept so the change is visible; the tool is not available to a run.</source>
+                <target>Dieses Tool war in einem früheren Import enthalten, der Server bietet es nicht mehr an. Der Eintrag bleibt stehen, damit die Änderung sichtbar ist. Für einen Lauf steht das Tool nicht zur Verfügung.</target>
+            </trans-unit>
+            <trans-unit id="import.skipped">
+                <source>Skipped</source>
+                <target>Übersprungen</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1748,6 +1748,9 @@
             <trans-unit id="error.tool.unknownGroup">
                 <source>Unknown tool group</source>
             </trans-unit>
+            <trans-unit id="error.mcp.unknownServer">
+                <source>Unknown MCP server</source>
+            </trans-unit>
             <trans-unit id="card.count.configurations">
                 <source>configuration(s) configured</source>
             </trans-unit>

--- a/Resources/Private/Language/locallang_mod_mcp.xlf
+++ b/Resources/Private/Language/locallang_mod_mcp.xlf
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="messages">
+        <body>
+            <trans-unit id="mlang_labels_tablabel">
+                <source>MCP Servers</source>
+            </trans-unit>
+            <trans-unit id="mlang_tabs_tab">
+                <source>MCP Servers</source>
+            </trans-unit>
+            <trans-unit id="mlang_labels_tabdescr">
+                <source>Manage external MCP servers and import the tools they advertise</source>
+            </trans-unit>
+            <trans-unit id="list.title">
+                <source>MCP Servers</source>
+            </trans-unit>
+            <trans-unit id="list.intro">
+                <source>Tools imported from an external MCP server run on that server, not here. Importing a catalogue only records what a server offers; each tool stays off until you enable it, and every one requires an administrator. This module is admin-only.</source>
+            </trans-unit>
+            <trans-unit id="list.empty">
+                <source>No MCP server is configured. Add one as a record of type "MCP Server".</source>
+            </trans-unit>
+            <trans-unit id="server.url">
+                <source>Endpoint</source>
+            </trans-unit>
+            <trans-unit id="server.dataClass">
+                <source>Data class</source>
+            </trans-unit>
+            <trans-unit id="server.enabled">
+                <source>Enabled</source>
+            </trans-unit>
+            <trans-unit id="server.disabled">
+                <source>Disabled</source>
+            </trans-unit>
+            <trans-unit id="server.undeclared">
+                <source>No data class declared — this server supplies no tools until you declare one.</source>
+            </trans-unit>
+            <trans-unit id="server.lastImport">
+                <source>Last import</source>
+            </trans-unit>
+            <trans-unit id="server.never">
+                <source>Never imported</source>
+            </trans-unit>
+            <trans-unit id="server.import">
+                <source>Import catalogue</source>
+            </trans-unit>
+            <trans-unit id="tools.title">
+                <source>Imported tools</source>
+            </trans-unit>
+            <trans-unit id="tools.none">
+                <source>No tools imported yet.</source>
+            </trans-unit>
+            <trans-unit id="tools.localName">
+                <source>Local name</source>
+            </trans-unit>
+            <trans-unit id="tools.remoteName">
+                <source>Name on the server</source>
+            </trans-unit>
+            <trans-unit id="tools.orphaned">
+                <source>Gone from the server</source>
+            </trans-unit>
+            <trans-unit id="tools.orphanedHint">
+                <source>This tool was in an earlier import and the server no longer offers it. The row is kept so the change is visible; the tool is not available to a run.</source>
+            </trans-unit>
+            <trans-unit id="import.skipped">
+                <source>Skipped</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Templates/Backend/McpServer/List.html
+++ b/Resources/Private/Templates/Backend/McpServer/List.html
@@ -1,0 +1,123 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
+      xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+<!--
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+-->
+
+<f:layout name="Module" />
+
+<f:section name="Content">
+    <div id="nrllm-mcp-servers">
+        <h1>
+            <core:icon identifier="module-nrllm-tool" size="medium" />
+            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_mcp.xlf:list.title" default="MCP Servers" />
+        </h1>
+
+        <f:be.infobox state="-2">
+            <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_mcp.xlf:list.intro" default="Tools imported from an external MCP server run on that server, not here. Importing a catalogue only records what a server offers; each tool stays off until you enable it, and every one requires an administrator. This module is admin-only." /></p>
+        </f:be.infobox>
+
+        <div class="mb-3">
+            <strong><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:seeAlso.heading" default="See also" />:</strong>
+            <a href="{be:moduleLink(route: 'nrllm_tools')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:seeAlso.manageTools" default="Manage tools" /></a>
+            <a href="{be:moduleLink(route: 'nrllm_playground')}" class="badge text-bg-secondary text-decoration-none"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:seeAlso.playground" default="Tool Playground" /></a>
+        </div>
+
+        <f:if condition="{f:count(subject: servers)}">
+            <f:then>
+                <f:for each="{servers}" as="entry">
+                    <div class="card mb-4" data-mcp-server="{entry.record.uid}">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <div>
+                                <strong>{entry.record.name}</strong>
+                                <code class="ms-2">{entry.record.identifier}</code>
+                                <f:if condition="{entry.record.enabled}">
+                                    <f:then><span class="badge text-bg-success ms-2"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_mcp.xlf:server.enabled" default="Enabled" /></span></f:then>
+                                    <f:else><span class="badge text-bg-secondary ms-2"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_mcp.xlf:server.disabled" default="Disabled" /></span></f:else>
+                                </f:if>
+                            </div>
+                            <button type="button"
+                                    class="btn btn-sm btn-primary"
+                                    data-nrllm-mcp-import="{entry.record.uid}">
+                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_mcp.xlf:server.import" default="Import catalogue" />
+                            </button>
+                        </div>
+                        <div class="card-body">
+                            <dl class="row mb-2">
+                                <dt class="col-sm-3"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_mcp.xlf:server.url" default="Endpoint" /></dt>
+                                <dd class="col-sm-9"><code>{entry.record.url}</code></dd>
+
+                                <dt class="col-sm-3"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_mcp.xlf:server.dataClass" default="Data class" /></dt>
+                                <dd class="col-sm-9">
+                                    <f:if condition="{entry.usable}">
+                                        <f:then><code>{entry.record.dataClass}</code></f:then>
+                                        <f:else><span class="text-warning"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_mcp.xlf:server.undeclared" default="No data class declared — this server supplies no tools until you declare one." /></span></f:else>
+                                    </f:if>
+                                </dd>
+
+                                <dt class="col-sm-3"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_mcp.xlf:server.lastImport" default="Last import" /></dt>
+                                <dd class="col-sm-9">
+                                    <f:if condition="{entry.record.lastImported}">
+                                        <f:then><f:format.date format="Y-m-d H:i">@{entry.record.lastImported}</f:format.date> — {entry.record.importStatus}</f:then>
+                                        <f:else><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_mcp.xlf:server.never" default="Never imported" /></f:else>
+                                    </f:if>
+                                </dd>
+                            </dl>
+
+                            <f:if condition="{entry.record.importError}">
+                                <f:be.infobox state="2">
+                                    <pre class="mb-0">{entry.record.importError}</pre>
+                                </f:be.infobox>
+                            </f:if>
+
+                            <h3 class="h6"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_mcp.xlf:tools.title" default="Imported tools" /></h3>
+                            <f:if condition="{f:count(subject: entry.tools)}">
+                                <f:then>
+                                    <div class="table-responsive">
+                                        <table class="table table-sm">
+                                            <thead>
+                                                <tr>
+                                                    <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_mcp.xlf:tools.localName" default="Local name" /></th>
+                                                    <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_mcp.xlf:tools.remoteName" default="Name on the server" /></th>
+                                                    <th></th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <f:for each="{entry.tools}" as="tool">
+                                                    <tr>
+                                                        <td><code>{tool.toolName}</code></td>
+                                                        <td><code>{tool.remoteName}</code></td>
+                                                        <td>
+                                                            <f:if condition="{tool.orphaned}">
+                                                                <span class="badge text-bg-warning"
+                                                                      title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_mcp.xlf:tools.orphanedHint')}">
+                                                                    <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_mcp.xlf:tools.orphaned" default="Gone from the server" />
+                                                                </span>
+                                                            </f:if>
+                                                        </td>
+                                                    </tr>
+                                                </f:for>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </f:then>
+                                <f:else>
+                                    <p class="text-body-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_mcp.xlf:tools.none" default="No tools imported yet." /></p>
+                                </f:else>
+                            </f:if>
+                        </div>
+                    </div>
+                </f:for>
+            </f:then>
+            <f:else>
+                <f:be.infobox state="0">
+                    <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_mcp.xlf:list.empty" default="No MCP server is configured. Add one as a record of type &quot;MCP Server&quot;." /></p>
+                </f:be.infobox>
+            </f:else>
+        </f:if>
+    </div>
+</f:section>
+</html>

--- a/Resources/Public/JavaScript/Backend/McpImport.js
+++ b/Resources/Public/JavaScript/Backend/McpImport.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+/**
+ * Triggers an MCP catalogue import from the MCP server module (ES6 Module).
+ *
+ * Event delegation on the body, the POST/reload flow from the shared
+ * ModuleAction helper (AjaxRequest underneath, which injects TYPO3's CSRF
+ * token). The button is disabled while the request is in flight, which is how
+ * every other action in this backend reports that it is working.
+ *
+ * A partial import is reported rather than silently celebrated: an import that
+ * skipped half a catalogue is a success by status and a problem in fact, and
+ * the operator only finds out if the count is shown.
+ */
+import Notification from '@typo3/backend/notification.js';
+import { postAndReload, resolveAjaxUrl } from '@netresearch/nr-llm/Backend/ModuleAction.js';
+
+class McpImport {
+    constructor() {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', () => this.init());
+        } else {
+            this.init();
+        }
+    }
+
+    init() {
+        document.body.addEventListener('click', (e) => {
+            const btn = e.target.closest('[data-nrllm-mcp-import]');
+            if (!btn) {
+                return;
+            }
+            e.preventDefault();
+            e.stopPropagation();
+            this.handleImport(btn);
+        });
+    }
+
+    handleImport(btn) {
+        const url = resolveAjaxUrl('nrllm_mcp_import');
+        if (!url) {
+            return;
+        }
+
+        const formData = new FormData();
+        formData.append('server', btn.dataset.nrllmMcpImport);
+
+        postAndReload(url, formData, btn, (data) => {
+            const skipped = Number(data.skipped) || 0;
+            const message = skipped > 0
+                ? `${data.imported} imported, ${skipped} skipped`
+                : `${data.imported} imported`;
+            Notification.success('MCP import', message);
+        });
+    }
+}
+
+export default new McpImport();

--- a/Tests/Fixtures/Mcp/McpTestServer.php
+++ b/Tests/Fixtures/Mcp/McpTestServer.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Fixtures\Mcp;
+
+use Netresearch\NrLlm\Domain\ValueObject\McpServerRecord;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Core\Http\Response;
+use TYPO3\CMS\Core\Http\Stream;
+
+/**
+ * A scripted MCP server for the tests.
+ *
+ * Doubles the HTTP client, not the transport or the client: both of those are
+ * final, and giving either an interface purely so a test could replace it would
+ * add a seam nothing in production needs. Faking at the bottom also means the
+ * tests exercise the real JSON-RPC encoding, the real status handling and the
+ * real handshake ordering rather than a description of them.
+ */
+final class McpTestServer implements ClientInterface
+{
+    /** @var list<ResponseInterface> */
+    private array $queued = [];
+
+    /**
+     * The decoded body is convenient; the raw one is the only honest record of
+     * what went on the wire — decoding turns a JSON `{}` into a PHP `[]`, which
+     * re-encodes as `[]` and would hide the very distinction a strict server
+     * cares about.
+     *
+     * @var list<array{method: string|null, body: array<string, mixed>, raw: string, session: string}>
+     */
+    public array $received = [];
+
+    public function sendRequest(RequestInterface $request): ResponseInterface
+    {
+        $raw     = (string)$request->getBody();
+        $decoded = json_decode($raw, true);
+        $body    = is_array($decoded) ? $decoded : [];
+
+        /** @var array<string, mixed> $body */
+        $method = $body['method'] ?? null;
+
+        $this->received[] = [
+            'method'  => is_string($method) ? $method : null,
+            'body'    => $body,
+            'raw'     => $raw,
+            'session' => $request->getHeaderLine('Mcp-Session-Id'),
+        ];
+
+        // A notification carries no id and gets no reply, so it must not eat a
+        // queued response — otherwise every test would have to pad its queue
+        // with a placeholder for the handshake confirmation.
+        if (!isset($body['id']) || $this->queued === []) {
+            return (new Response())->withStatus(202);
+        }
+
+        return array_shift($this->queued);
+    }
+
+    /**
+     * Queue a JSON-RPC result object.
+     *
+     * @param array<string, mixed> $result
+     */
+    public function willReturn(array $result, ?string $sessionId = null): self
+    {
+        return $this->willReturnRaw((string)json_encode(['jsonrpc' => '2.0', 'id' => 1, 'result' => $result]), 200, 'application/json', $sessionId);
+    }
+
+    /**
+     * Queue a JSON-RPC error object.
+     */
+    public function willReturnRpcError(int $code, string $message): self
+    {
+        return $this->willReturnRaw(
+            (string)json_encode(['jsonrpc' => '2.0', 'id' => 1, 'error' => ['code' => $code, 'message' => $message]]),
+            200,
+            'application/json',
+        );
+    }
+
+    public function willReturnRaw(string $body, int $status = 200, string $contentType = 'application/json', ?string $sessionId = null): self
+    {
+        $stream = new Stream('php://temp', 'rw');
+        $stream->write($body);
+        $stream->rewind();
+
+        $response = (new Response())
+            ->withStatus($status)
+            ->withHeader('Content-Type', $contentType)
+            ->withBody($stream);
+
+        if ($sessionId !== null) {
+            $response = $response->withHeader('Mcp-Session-Id', $sessionId);
+        }
+
+        $this->queued[] = $response;
+
+        return $this;
+    }
+
+    /**
+     * Queue the handshake pair every operation opens with.
+     */
+    public function willHandshake(?string $sessionId = null): self
+    {
+        return $this->willReturn(['protocolVersion' => '2025-06-18', 'capabilities' => []], $sessionId);
+    }
+
+    /**
+     * The method names the server saw, in order.
+     *
+     * @return list<string|null>
+     */
+    public function methods(): array
+    {
+        return array_map(static fn(array $call): ?string => $call['method'], $this->received);
+    }
+
+    public static function server(string $identifier = 'srv', string $dataClass = 'publicContent'): McpServerRecord
+    {
+        return new McpServerRecord(
+            uid: 1,
+            pid: 0,
+            identifier: $identifier,
+            name: 'Test server',
+            description: '',
+            url: 'https://mcp.example.com/rpc',
+            authCredential: '',
+            authPlacement: 'bearer',
+            authHeaderName: '',
+            dataClass: $dataClass,
+            enabled: true,
+            importStatus: 'never_imported',
+            importError: '',
+            lastImported: 0,
+            toolCount: 0,
+            tstamp: 0,
+            crdate: 0,
+        );
+    }
+}

--- a/Tests/Functional/Controller/Backend/BackendAjaxAdminGuardTest.php
+++ b/Tests/Functional/Controller/Backend/BackendAjaxAdminGuardTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;
 use GuzzleHttp\Psr7\ServerRequest;
 use Netresearch\NrLlm\Controller\Backend\ConfigurationController;
 use Netresearch\NrLlm\Controller\Backend\LlmModuleController;
+use Netresearch\NrLlm\Controller\Backend\McpServerController;
 use Netresearch\NrLlm\Controller\Backend\ModelController;
 use Netresearch\NrLlm\Controller\Backend\ModelDiscoveryController;
 use Netresearch\NrLlm\Controller\Backend\ModelTestController;
@@ -52,6 +53,7 @@ use TYPO3\CMS\Core\Http\ServerRequest as Typo3ServerRequest;
 #[CoversClass(TaskExecutionController::class)]
 #[CoversClass(SetupWizardController::class)]
 #[CoversClass(LlmModuleController::class)]
+#[CoversClass(McpServerController::class)]
 final class BackendAjaxAdminGuardTest extends AbstractFunctionalTestCase
 {
     protected function setUp(): void
@@ -93,6 +95,23 @@ final class BackendAjaxAdminGuardTest extends AbstractFunctionalTestCase
         // falls back to the English source) rather than a bare "Forbidden".
         self::assertIsString($payload['error']);
         self::assertStringContainsStringIgnoringCase('administrator', $payload['error']);
+    }
+
+    /**
+     * The MCP import is the one action in this extension that reaches an
+     * external server on request, so the guard matters most here: the module is
+     * admin-only, but this route is dispatched outside it (ADR-037/116).
+     */
+    #[Test]
+    public function mcpImportDeniedForNonAdmin(): void
+    {
+        $controller = $this->get(McpServerController::class);
+        self::assertInstanceOf(McpServerController::class, $controller);
+
+        $request = (new ServerRequest('POST', '/ajax/nrllm/mcp/import'))
+            ->withParsedBody(['server' => 1]);
+
+        $this->assertForbidden($controller->importAction($request));
     }
 
     #[Test]

--- a/Tests/Functional/Controller/Backend/McpServerControllerTest.php
+++ b/Tests/Functional/Controller/Backend/McpServerControllerTest.php
@@ -13,8 +13,10 @@ use GuzzleHttp\Psr7\ServerRequest;
 use Netresearch\NrLlm\Controller\Backend\McpServerController;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\ServerRequest as Typo3ServerRequest;
 
 /**
@@ -41,6 +43,33 @@ final class McpServerControllerTest extends AbstractFunctionalTestCase
         // request.
         $GLOBALS['TYPO3_REQUEST'] = (new Typo3ServerRequest())
             ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE);
+
+        // A real server at uid 1, which is what the coercion cases below would
+        // land on if a malformed value were cast instead of validated. Without
+        // it those cases answer 404 for the wrong reason and prove nothing.
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $connectionPool->getConnectionForTable('tx_nrllm_mcp_server')->insert('tx_nrllm_mcp_server', [
+            'uid'              => 1,
+            'pid'              => 0,
+            'identifier'       => 'srv',
+            'name'             => 'A server',
+            'description'      => '',
+            'url'              => 'https://mcp.example.com/rpc',
+            'auth_credential'  => '',
+            'auth_placement'   => 'bearer',
+            'auth_header_name' => '',
+            'data_class'       => 'publicContent',
+            'enabled'          => 1,
+            'import_status'    => 'never_imported',
+            'import_error'     => '',
+            'last_imported'    => 0,
+            'tool_count'       => 0,
+            'tstamp'           => 0,
+            'crdate'           => 0,
+            'deleted'          => 0,
+            'hidden'           => 0,
+        ]);
     }
 
     protected function tearDown(): void
@@ -80,15 +109,35 @@ final class McpServerControllerTest extends AbstractFunctionalTestCase
     }
 
     /**
-     * A uid that is not a number must not coerce to 0 and then to "no server":
-     * it has to take the same explicit path, so a malformed request is never
-     * one integer cast away from naming a real row.
+     * @return array<string, array{mixed}>
      */
+    public static function unusableServerValues(): array
+    {
+        return [
+            'not a number'       => ['first'],
+            // The ones a cast would silently accept: is_numeric() says yes to
+            // both, and casting turns them into a uid nobody named — 1 and
+            // 1000 respectively. The import reaches an external server, so it
+            // must never be one rounding rule away from the wrong row.
+            'decimal'            => ['1.9'],
+            'exponent'           => ['1e3'],
+            'empty'              => [''],
+            'an array'           => [['1']],
+            // Deliberately absent: ' 1'. FILTER_VALIDATE_INT trims surrounding
+            // whitespace and answers 1, which is right — a padded integer means
+            // that integer, unlike '1.9', which means something else. Asserting
+            // it here would also send the test at a real endpoint, because a
+            // resolved server goes on to an actual import.
+
+        ];
+    }
+
     #[Test]
-    public function answersNotFoundForANonNumericServer(): void
+    #[DataProvider('unusableServerValues')]
+    public function answersNotFoundForAValueThatIsNotAUid(mixed $server): void
     {
         $response = $this->controller()->importAction(
-            (new ServerRequest('POST', '/ajax/nrllm/mcp/import'))->withParsedBody(['server' => 'first']),
+            (new ServerRequest('POST', '/ajax/nrllm/mcp/import'))->withParsedBody(['server' => $server]),
         );
 
         self::assertSame(404, $response->getStatusCode());

--- a/Tests/Functional/Controller/Backend/McpServerControllerTest.php
+++ b/Tests/Functional/Controller/Backend/McpServerControllerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;
+
+use GuzzleHttp\Psr7\ServerRequest;
+use Netresearch\NrLlm\Controller\Backend\McpServerController;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Http\ServerRequest as Typo3ServerRequest;
+
+/**
+ * What the MCP import route does for an administrator who names nothing usable.
+ *
+ * The non-admin denial lives in {@see BackendAjaxAdminGuardTest} with the other
+ * guarded routes. What is left here is the case above that gate: the import
+ * reaches an external party, so it must happen only for a server the caller
+ * actually named, and never for "whatever the first row is".
+ */
+#[CoversClass(McpServerController::class)]
+final class McpServerControllerTest extends AbstractFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importFixture('BeUsers.csv');
+        // uid 1 is an admin (admin=1) — past the guard, into the action itself.
+        $this->setUpBackendUser(1);
+
+        // Resolving an Extbase ActionController from the container triggers
+        // injectConfigurationManager(), which reads settings from the current
+        // request.
+        $GLOBALS['TYPO3_REQUEST'] = (new Typo3ServerRequest())
+            ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['BE_USER'], $GLOBALS['TYPO3_REQUEST']);
+
+        parent::tearDown();
+    }
+
+    private function controller(): McpServerController
+    {
+        $controller = $this->get(McpServerController::class);
+        self::assertInstanceOf(McpServerController::class, $controller);
+
+        return $controller;
+    }
+
+    #[Test]
+    public function answersNotFoundForAServerThatDoesNotExist(): void
+    {
+        $response = $this->controller()->importAction(
+            (new ServerRequest('POST', '/ajax/nrllm/mcp/import'))->withParsedBody(['server' => 4711]),
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+        self::assertStringContainsString('Unknown MCP server', (string)$response->getBody());
+    }
+
+    #[Test]
+    public function answersNotFoundWhenNoServerWasNamed(): void
+    {
+        $response = $this->controller()->importAction(
+            (new ServerRequest('POST', '/ajax/nrllm/mcp/import'))->withParsedBody([]),
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    /**
+     * A uid that is not a number must not coerce to 0 and then to "no server":
+     * it has to take the same explicit path, so a malformed request is never
+     * one integer cast away from naming a real row.
+     */
+    #[Test]
+    public function answersNotFoundForANonNumericServer(): void
+    {
+        $response = $this->controller()->importAction(
+            (new ServerRequest('POST', '/ajax/nrllm/mcp/import'))->withParsedBody(['server' => 'first']),
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+}

--- a/Tests/Functional/Service/Tool/Mcp/McpCatalogueTest.php
+++ b/Tests/Functional/Service/Tool/Mcp/McpCatalogueTest.php
@@ -1,0 +1,298 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool\Mcp;
+
+use Netresearch\NrLlm\Domain\ValueObject\McpServerRecord;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpServerRepository;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpToolRepository;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * The two MCP tables against a real database (ADR-116).
+ *
+ * The reconciliation rules are the reason this is functional rather than a
+ * unit test: they are statements about rows surviving an import, about uids
+ * staying stable, and about the deleted flag — none of which a double can
+ * demonstrate.
+ */
+#[CoversClass(McpServerRepository::class)]
+#[CoversClass(McpToolRepository::class)]
+final class McpCatalogueTest extends AbstractFunctionalTestCase
+{
+    private McpServerRepository $servers;
+
+    private McpToolRepository $tools;
+
+    private ConnectionPool $connectionPool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+
+        $this->connectionPool = $connectionPool;
+        $this->servers        = new McpServerRepository($connectionPool);
+        $this->tools          = new McpToolRepository($connectionPool);
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     */
+    private function insertServer(array $overrides = []): int
+    {
+        $connection = $this->connectionPool->getConnectionForTable('tx_nrllm_mcp_server');
+        $connection->insert('tx_nrllm_mcp_server', $overrides + [
+            'pid'              => 0,
+            'identifier'       => 'srv',
+            'name'             => 'A server',
+            'description'      => '',
+            'url'              => 'https://mcp.example.com/rpc',
+            'auth_credential'  => '',
+            'auth_placement'   => 'bearer',
+            'auth_header_name' => '',
+            'data_class'       => 'publicContent',
+            'enabled'          => 1,
+            'import_status'    => 'never_imported',
+            'import_error'     => '',
+            'last_imported'    => 0,
+            'tool_count'       => 0,
+            'tstamp'           => 0,
+            'crdate'           => 0,
+            'deleted'          => 0,
+            'hidden'           => 0,
+        ]);
+
+        return (int)$connection->lastInsertId();
+    }
+
+    /**
+     * @return list<array{toolName: string, remoteName: string, description: string, inputSchema: string, remoteAnnotations: string}>
+     */
+    private function catalogue(string ...$names): array
+    {
+        return array_values(array_map(static fn(string $name): array => [
+            'toolName'          => 'mcp_srv_' . $name,
+            'remoteName'        => $name,
+            'description'       => 'does ' . $name,
+            'inputSchema'       => '{"type":"object","properties":{}}',
+            'remoteAnnotations' => '',
+        ], $names));
+    }
+
+    #[Test]
+    public function readsAServerBackAsATypedRecord(): void
+    {
+        $uid = $this->insertServer(['identifier' => 'files', 'name' => 'File server']);
+
+        $server = $this->servers->findByUid($uid);
+
+        self::assertInstanceOf(McpServerRecord::class, $server);
+        self::assertSame('files', $server->identifier);
+        self::assertSame('File server', $server->name);
+        self::assertTrue($server->enabled);
+    }
+
+    /**
+     * A discarded server must disappear from the tool surface entirely.
+     */
+    #[Test]
+    public function aDeletedServerIsInvisible(): void
+    {
+        $this->insertServer(['deleted' => 1]);
+
+        self::assertSame([], $this->servers->findAll());
+    }
+
+    /**
+     * `enabled` is this table's own switch and the one an operator reasons
+     * about; honouring `hidden` as well would give one decision two controls
+     * that can disagree.
+     */
+    #[Test]
+    public function aHiddenServerStaysVisibleBecauseEnabledIsTheSwitch(): void
+    {
+        $this->insertServer(['hidden' => 1]);
+
+        self::assertCount(1, $this->servers->findAll());
+        self::assertCount(1, $this->servers->findEnabled());
+    }
+
+    /**
+     * An undeclared data class makes a server inert rather than defaulted:
+     * a remote server's egress sensitivity cannot be inferred.
+     */
+    #[Test]
+    public function aServerWithoutADeclaredDataClassIsNotUsable(): void
+    {
+        $this->insertServer(['identifier' => 'declared', 'data_class' => 'publicContent']);
+        $this->insertServer(['identifier' => 'undeclared', 'data_class' => '']);
+
+        $usable = $this->servers->findUsable();
+
+        self::assertSame(['declared'], array_map(static fn(McpServerRecord $s): string => $s->identifier, $usable));
+        self::assertCount(2, $this->servers->findEnabled(), 'both are still enabled — only classification differs');
+    }
+
+    #[Test]
+    public function anImportWritesTheCatalogue(): void
+    {
+        $uid = $this->insertServer();
+
+        $orphaned = $this->tools->reconcile($uid, 0, $this->catalogue('read', 'write'), 1000);
+
+        self::assertSame(0, $orphaned);
+        self::assertSame(
+            ['mcp_srv_read', 'mcp_srv_write'],
+            array_map(static fn(object $t): string => $t->toolName, $this->tools->findLiveByServer($uid)),
+        );
+    }
+
+    /**
+     * A row's uid is what per-tool state would hang off, so a second import
+     * must update in place rather than recreate.
+     */
+    #[Test]
+    public function aSecondImportKeepsTheExistingRowIdentity(): void
+    {
+        $uid = $this->insertServer();
+        $this->tools->reconcile($uid, 0, $this->catalogue('read'), 1000);
+        $liveBefore = $this->tools->findLiveByServer($uid);
+        self::assertCount(1, $liveBefore);
+        $first = $liveBefore[0];
+
+        $this->tools->reconcile($uid, 0, $this->catalogue('read'), 2000);
+        $live = $this->tools->findLiveByServer($uid);
+        self::assertCount(1, $live);
+        $second = $live[0];
+
+        self::assertSame($first->uid, $second->uid);
+        self::assertSame(2000, $second->tstamp);
+        self::assertCount(1, $this->tools->findAllByServer($uid));
+    }
+
+    /**
+     * Marked, not deleted: an operator who enabled a tool needs to see that it
+     * went away, and a deleted row looks like a tool that never existed.
+     */
+    #[Test]
+    public function aToolThatVanishedIsMarkedRatherThanRemoved(): void
+    {
+        $uid = $this->insertServer();
+        $this->tools->reconcile($uid, 0, $this->catalogue('read', 'write'), 1000);
+
+        $orphaned = $this->tools->reconcile($uid, 0, $this->catalogue('read'), 2000);
+
+        self::assertSame(1, $orphaned);
+        self::assertCount(1, $this->tools->findLiveByServer($uid));
+        self::assertCount(2, $this->tools->findAllByServer($uid));
+
+        $all  = $this->tools->findAllByServer($uid);
+        $gone = array_values(array_filter($all, static fn(object $t): bool => $t->orphaned));
+        self::assertCount(1, $gone);
+        self::assertSame('mcp_srv_write', $gone[0]->toolName);
+    }
+
+    #[Test]
+    public function aToolThatComesBackIsRevivedNotDuplicated(): void
+    {
+        $uid = $this->insertServer();
+        $this->tools->reconcile($uid, 0, $this->catalogue('read', 'write'), 1000);
+        $this->tools->reconcile($uid, 0, $this->catalogue('read'), 2000);
+
+        $this->tools->reconcile($uid, 0, $this->catalogue('read', 'write'), 3000);
+
+        self::assertCount(2, $this->tools->findLiveByServer($uid));
+        self::assertCount(2, $this->tools->findAllByServer($uid));
+    }
+
+    /**
+     * A row already marked keeps the timestamp that says when the tool actually
+     * disappeared, rather than being rewritten on every later import.
+     */
+    #[Test]
+    public function anAlreadyOrphanedRowKeepsTheTimestampOfItsDisappearance(): void
+    {
+        $uid = $this->insertServer();
+        $this->tools->reconcile($uid, 0, $this->catalogue('read', 'write'), 1000);
+        $this->tools->reconcile($uid, 0, $this->catalogue('read'), 2000);
+
+        $orphaned = $this->tools->reconcile($uid, 0, $this->catalogue('read'), 3000);
+
+        $gone = array_values(array_filter(
+            $this->tools->findAllByServer($uid),
+            static fn(object $t): bool => $t->orphaned,
+        ));
+
+        self::assertSame(1, $orphaned, 'it is still counted as missing');
+        self::assertCount(1, $gone);
+        self::assertSame(2000, $gone[0]->tstamp, 'but not re-stamped');
+    }
+
+    #[Test]
+    public function oneServersCatalogueDoesNotDisturbAnothers(): void
+    {
+        $first  = $this->insertServer(['identifier' => 'one']);
+        $second = $this->insertServer(['identifier' => 'two']);
+
+        $this->tools->reconcile($first, 0, [[
+            'toolName'          => 'mcp_one_read',
+            'remoteName'        => 'read',
+            'description'       => '',
+            'inputSchema'       => '{}',
+            'remoteAnnotations' => '',
+        ]], 1000);
+        $this->tools->reconcile($second, 0, [[
+            'toolName'          => 'mcp_two_read',
+            'remoteName'        => 'read',
+            'description'       => '',
+            'inputSchema'       => '{}',
+            'remoteAnnotations' => '',
+        ]], 1000);
+
+        self::assertCount(1, $this->tools->findLiveByServer($first));
+        self::assertCount(1, $this->tools->findLiveByServer($second));
+    }
+
+    #[Test]
+    public function recordsHowTheLastImportWent(): void
+    {
+        $uid = $this->insertServer();
+
+        $this->servers->recordImportOutcome($uid, 'error', 'the host refused', 0, 4242);
+
+        $server = $this->servers->findByUid($uid);
+        self::assertInstanceOf(McpServerRecord::class, $server);
+        self::assertSame('error', $server->importStatus);
+        self::assertSame('the host refused', $server->importError);
+        self::assertSame(4242, $server->lastImported);
+    }
+
+    /**
+     * A server that recovers must stop showing the fault that has been fixed.
+     */
+    #[Test]
+    public function aRecoveredServerClearsItsRecordedError(): void
+    {
+        $uid = $this->insertServer();
+        $this->servers->recordImportOutcome($uid, 'error', 'the host refused', 0, 1000);
+
+        $this->servers->recordImportOutcome($uid, 'ok', '', 3, 2000);
+
+        $server = $this->servers->findByUid($uid);
+        self::assertInstanceOf(McpServerRecord::class, $server);
+        self::assertSame('', $server->importError);
+        self::assertSame(3, $server->toolCount);
+    }
+}

--- a/Tests/Functional/Service/Tool/Mcp/McpImportServiceTest.php
+++ b/Tests/Functional/Service/Tool/Mcp/McpImportServiceTest.php
@@ -1,0 +1,354 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool\Mcp;
+
+use Netresearch\NrLlm\Domain\ValueObject\McpImportReport;
+use Netresearch\NrLlm\Domain\ValueObject\McpServerRecord;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpClient;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpHttpTransport;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpImportService;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpSchemaNormalizer;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpServerRepository;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpToolNameMapper;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpToolProvider;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpToolRepository;
+use Netresearch\NrLlm\Service\Tool\RemoteToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Fixtures\Mcp\McpTestServer;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
+use Netresearch\NrVault\Http\SecureHttpClientFactory;
+use Netresearch\NrVault\Service\VaultServiceInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Http\Client\GuzzleClientFactory;
+use TYPO3\CMS\Core\Http\RequestFactory;
+use TYPO3\CMS\Core\Http\StreamFactory;
+
+/**
+ * The import, end to end: a scripted server, a real database, real rows (ADR-116).
+ *
+ * Functional rather than unit because the repositories are `final readonly` and
+ * the interesting behaviour is what ends up in the table. Only the HTTP client
+ * is faked, so the JSON-RPC encoding, the handshake and the reconciliation are
+ * all the production ones.
+ */
+#[CoversClass(McpImportService::class)]
+#[CoversClass(McpToolProvider::class)]
+final class McpImportServiceTest extends AbstractFunctionalTestCase
+{
+    private ConnectionPool $connectionPool;
+
+    private McpServerRepository $servers;
+
+    private McpToolRepository $catalogue;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+
+        $this->connectionPool = $connectionPool;
+        $this->servers        = new McpServerRepository($connectionPool);
+        $this->catalogue      = new McpToolRepository($connectionPool);
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     */
+    private function insertServer(array $overrides = []): McpServerRecord
+    {
+        $connection = $this->connectionPool->getConnectionForTable('tx_nrllm_mcp_server');
+        $connection->insert('tx_nrllm_mcp_server', $overrides + [
+            'pid'              => 0,
+            'identifier'       => 'srv',
+            'name'             => 'A server',
+            'description'      => '',
+            'url'              => 'https://mcp.example.com/rpc',
+            'auth_credential'  => '',
+            'auth_placement'   => 'bearer',
+            'auth_header_name' => '',
+            'data_class'       => 'publicContent',
+            'enabled'          => 1,
+            'import_status'    => 'never_imported',
+            'import_error'     => '',
+            'last_imported'    => 0,
+            'tool_count'       => 0,
+            'tstamp'           => 0,
+            'crdate'           => 0,
+            'deleted'          => 0,
+            'hidden'           => 0,
+        ]);
+
+        $server = $this->servers->findByUid((int)$connection->lastInsertId());
+        self::assertInstanceOf(McpServerRecord::class, $server);
+
+        return $server;
+    }
+
+    private function importer(McpTestServer $fake, ToolRegistry $registry = new ToolRegistry()): McpImportService
+    {
+        $transport = new McpHttpTransport(
+            self::createStub(VaultServiceInterface::class),
+            new SecureHttpClientFactory(),
+            new RequestFactory(new GuzzleClientFactory()),
+            new StreamFactory(),
+        );
+        $transport->setHttpClient($fake);
+
+        return new McpImportService(
+            new McpClient($transport),
+            $this->servers,
+            $this->catalogue,
+            new McpToolNameMapper(),
+            new McpSchemaNormalizer(),
+            $registry,
+            new NullLogger(),
+            new Context(),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> ...$tools
+     */
+    private function advertising(array ...$tools): McpTestServer
+    {
+        return (new McpTestServer())->willHandshake()->willReturn(['tools' => array_values($tools)]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function tool(string $name, string $description = 'does a thing'): array
+    {
+        return [
+            'name'        => $name,
+            'description' => $description,
+            'inputSchema' => ['type' => 'object', 'properties' => ['id' => ['type' => 'integer']]],
+        ];
+    }
+
+    #[Test]
+    public function writesTheAdvertisedToolsIntoTheCatalogue(): void
+    {
+        $server = $this->insertServer();
+
+        $report = $this->importer($this->advertising($this->tool('read'), $this->tool('write')))->import($server);
+
+        self::assertFalse($report->refused);
+        self::assertSame(2, $report->imported);
+        self::assertSame(0, $report->skipped);
+        self::assertSame(
+            ['mcp_srv_read', 'mcp_srv_write'],
+            array_map(static fn(object $t): string => $t->toolName, $this->catalogue->findLiveByServer($server->uid)),
+        );
+    }
+
+    #[Test]
+    public function recordsTheOutcomeOnTheServerRow(): void
+    {
+        $server = $this->insertServer();
+
+        $this->importer($this->advertising($this->tool('read')))->import($server);
+
+        $after = $this->servers->findByUid($server->uid);
+        self::assertInstanceOf(McpServerRecord::class, $after);
+        self::assertSame('ok', $after->importStatus);
+        self::assertSame('', $after->importError);
+        self::assertSame(1, $after->toolCount);
+        self::assertGreaterThan(0, $after->lastImported);
+    }
+
+    /**
+     * An unclassified server cannot be classified by guessing, so it supplies
+     * nothing and says why.
+     */
+    #[Test]
+    public function refusesAServerWithoutADeclaredDataClass(): void
+    {
+        $server = $this->insertServer(['data_class' => '']);
+
+        $report = $this->importer($this->advertising($this->tool('read')))->import($server);
+
+        self::assertTrue($report->refused);
+        self::assertStringContainsString('data class', $report->skipReasons[0]);
+        self::assertSame([], $this->catalogue->findAllByServer($server->uid));
+    }
+
+    /**
+     * A server we could not reach has not told us its tools are gone. Orphaning
+     * them on a network failure would disable an operator's working tools by
+     * accident.
+     */
+    #[Test]
+    public function anUnreachableServerLeavesTheExistingCatalogueAlone(): void
+    {
+        $server = $this->insertServer();
+        $this->importer($this->advertising($this->tool('read')))->import($server);
+
+        $broken = (new McpTestServer())->willReturnRaw('gateway down', 502);
+        $report = $this->importer($broken)->import($server);
+
+        self::assertTrue($report->refused);
+        self::assertCount(1, $this->catalogue->findLiveByServer($server->uid), 'the working tool survives');
+
+        $after = $this->servers->findByUid($server->uid);
+        self::assertInstanceOf(McpServerRecord::class, $after);
+        self::assertSame('error', $after->importStatus);
+        self::assertStringContainsString('502', $after->importError);
+    }
+
+    /**
+     * A rejected tool must be reported, not merely absent: absence looks
+     * identical to a tool the server never offered.
+     */
+    #[Test]
+    public function reportsWhyEachRejectedToolWasSkipped(): void
+    {
+        $server = $this->insertServer();
+
+        $report = $this->importer($this->advertising(
+            $this->tool('good'),
+            $this->tool('has a space'),
+            ['description' => 'nameless'],
+        ))->import($server);
+
+        self::assertSame(1, $report->imported);
+        self::assertSame(2, $report->skipped);
+        self::assertCount(2, $report->skipReasons);
+        self::assertStringContainsString('has a space', implode(' ', $report->skipReasons));
+        self::assertStringContainsString('no name', implode(' ', $report->skipReasons));
+
+        $after = $this->servers->findByUid($server->uid);
+        self::assertInstanceOf(McpServerRecord::class, $after);
+        self::assertSame('partial', $after->importStatus);
+    }
+
+    /**
+     * A remote tool must never be able to take a builtin's name: the local name
+     * is what the gate, the tool state and the model all key on.
+     */
+    #[Test]
+    public function refusesARemoteToolThatWouldShadowABuiltin(): void
+    {
+        $server   = $this->insertServer(['identifier' => 'x']);
+        $registry = new ToolRegistry([new FakeTool('mcp_x_read')]);
+
+        $report = $this->importer($this->advertising($this->tool('read')), $registry)->import($server);
+
+        self::assertSame(0, $report->imported);
+        self::assertStringContainsString('collide with a builtin', $report->skipReasons[0]);
+    }
+
+    /**
+     * Two enabled servers sharing an identifier would generate the same local
+     * names and the second import would hit the catalogue's unique index
+     * halfway through. Refused up front, naming the setting that is wrong.
+     */
+    #[Test]
+    public function refusesTwoServersClaimingTheSameIdentifier(): void
+    {
+        $this->insertServer(['identifier' => 'twin', 'name' => 'The first one']);
+        $second = $this->insertServer(['identifier' => 'twin', 'name' => 'The second one']);
+
+        $report = $this->importer($this->advertising($this->tool('read')))->import($second);
+
+        self::assertTrue($report->refused);
+        self::assertStringContainsString('The first one', $report->skipReasons[0]);
+    }
+
+    #[Test]
+    public function aSecondImportRemovesWhatTheServerNoLongerOffers(): void
+    {
+        $server = $this->insertServer();
+        $this->importer($this->advertising($this->tool('read'), $this->tool('write')))->import($server);
+
+        $report = $this->importer($this->advertising($this->tool('read')))->import($server);
+
+        self::assertSame(1, $report->imported);
+        self::assertSame(1, $report->orphaned);
+        self::assertCount(1, $this->catalogue->findLiveByServer($server->uid));
+    }
+
+    /**
+     * The whole point of the import: the tools it wrote become registered tools
+     * on the next registry build, with the operator's classification on them.
+     */
+    #[Test]
+    public function theImportedToolsBecomeRegisteredRemoteTools(): void
+    {
+        $server = $this->insertServer();
+        $this->importer($this->advertising($this->tool('read')))->import($server);
+
+        $provider = new McpToolProvider($this->servers, $this->catalogue, $this->createClient());
+        $registry = new ToolRegistry([new FakeTool('a_builtin')], [$provider]);
+
+        self::assertSame(['a_builtin', 'mcp_srv_read'], $registry->names());
+        self::assertSame(['a_builtin'], $registry->builtinNames(), 'the coverage tests must not see a remote tool');
+
+        $tool = $registry->get('mcp_srv_read');
+        self::assertInstanceOf(RemoteToolInterface::class, $tool);
+        self::assertSame('mcp_srv', $tool->getGroup());
+        self::assertTrue($tool->requiresAdmin());
+        self::assertFalse($tool->isEnabledByDefault(), 'import configures, it does not grant');
+    }
+
+    /**
+     * An unclassified server is inert at run time too, not only at import: a
+     * classification removed after an import must take its tools out of the
+     * registry.
+     */
+    #[Test]
+    public function withdrawingTheClassificationWithdrawsTheTools(): void
+    {
+        $server = $this->insertServer();
+        $this->importer($this->advertising($this->tool('read')))->import($server);
+
+        $this->connectionPool->getConnectionForTable('tx_nrllm_mcp_server')
+            ->update('tx_nrllm_mcp_server', ['data_class' => ''], ['uid' => $server->uid]);
+
+        $provider = new McpToolProvider($this->servers, $this->catalogue, $this->createClient());
+
+        self::assertSame([], (new ToolRegistry([], [$provider]))->names());
+    }
+
+    private function createClient(): McpClient
+    {
+        $transport = new McpHttpTransport(
+            self::createStub(VaultServiceInterface::class),
+            new SecureHttpClientFactory(),
+            new RequestFactory(new GuzzleClientFactory()),
+            new StreamFactory(),
+        );
+
+        return new McpClient($transport);
+    }
+
+    /**
+     * A refusal is not an import that wrote nothing: the catalogue was never
+     * reconciled, and the report has to keep the two apart.
+     */
+    #[Test]
+    public function distinguishesARefusalFromAnEmptyCatalogue(): void
+    {
+        $server = $this->insertServer();
+
+        $empty = $this->importer($this->advertising())->import($server);
+
+        self::assertInstanceOf(McpImportReport::class, $empty);
+        self::assertFalse($empty->refused);
+        self::assertSame(0, $empty->imported);
+    }
+}

--- a/Tests/Functional/Service/Tool/ToolDataClassCoverageTest.php
+++ b/Tests/Functional/Service/Tool/ToolDataClassCoverageTest.php
@@ -33,12 +33,12 @@ final class ToolDataClassCoverageTest extends AbstractFunctionalTestCase
     {
         $registry = $this->get(ToolRegistry::class);
         self::assertInstanceOf(ToolRegistry::class, $registry);
-        self::assertNotSame([], $registry->names(), 'The registry must not be empty, or this test proves nothing.');
+        self::assertNotSame([], $registry->builtinNames(), 'The builtin set must not be empty, or this test proves nothing.');
 
         $resolver   = new ToolDataClassResolver($registry);
         $unclassed  = [];
 
-        foreach ($registry->names() as $name) {
+        foreach ($registry->builtinNames() as $name) {
             $tool = $registry->get($name);
             self::assertNotNull($tool);
 

--- a/Tests/Functional/Service/Tool/ToolEffectCoverageTest.php
+++ b/Tests/Functional/Service/Tool/ToolEffectCoverageTest.php
@@ -48,12 +48,12 @@ final class ToolEffectCoverageTest extends AbstractFunctionalTestCase
     {
         $registry = $this->get(ToolRegistry::class);
         self::assertInstanceOf(ToolRegistry::class, $registry);
-        self::assertNotSame([], $registry->names(), 'The registry must not be empty, or this test proves nothing.');
+        self::assertNotSame([], $registry->builtinNames(), 'The builtin set must not be empty, or this test proves nothing.');
 
         $resolver = new ToolEffectResolver($registry);
 
         $writers = [];
-        foreach ($registry->names() as $name) {
+        foreach ($registry->builtinNames() as $name) {
             if ($resolver->effectFor($name)->isWrite()) {
                 $writers[] = $name;
             }

--- a/Tests/Unit/Service/Tool/Mcp/McpClientTest.php
+++ b/Tests/Unit/Service/Tool/Mcp/McpClientTest.php
@@ -1,0 +1,210 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Mcp;
+
+use Netresearch\NrLlm\Service\Tool\Mcp\Exception\McpTransportException;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpClient;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpHttpTransport;
+use Netresearch\NrLlm\Tests\Fixtures\Mcp\McpTestServer;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrVault\Service\VaultServiceInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Http\Client\GuzzleClientFactory;
+use TYPO3\CMS\Core\Http\RequestFactory;
+use TYPO3\CMS\Core\Http\StreamFactory;
+
+#[CoversClass(McpClient::class)]
+final class McpClientTest extends AbstractUnitTestCase
+{
+    private function clientFor(McpTestServer $fake): McpClient
+    {
+        $transport = new McpHttpTransport(
+            self::createStub(VaultServiceInterface::class),
+            $this->createSecureHttpClientFactoryMock(),
+            new RequestFactory(new GuzzleClientFactory()),
+            new StreamFactory(),
+        );
+        $transport->setHttpClient($fake);
+
+        return new McpClient($transport);
+    }
+
+    #[Test]
+    public function handshakesBeforeItAsksForAnything(): void
+    {
+        $fake = (new McpTestServer())
+            ->willHandshake()
+            ->willReturn(['tools' => []]);
+
+        $this->clientFor($fake)->listTools(McpTestServer::server());
+
+        self::assertSame(['initialize', 'notifications/initialized', 'tools/list'], $fake->methods());
+    }
+
+    /**
+     * A stateful server issues a session id in the initialize reply and expects
+     * it back on every following request.
+     */
+    #[Test]
+    public function carriesTheIssuedSessionThroughTheWholeOperation(): void
+    {
+        $fake = (new McpTestServer())
+            ->willHandshake('sess-7')
+            ->willReturn(['tools' => []]);
+
+        $this->clientFor($fake)->listTools(McpTestServer::server());
+
+        self::assertSame('', $fake->received[0]['session'], 'the handshake itself has no session yet');
+        self::assertSame('sess-7', $fake->received[1]['session']);
+        self::assertSame('sess-7', $fake->received[2]['session']);
+    }
+
+    #[Test]
+    public function walksEveryPageOfTheCatalogue(): void
+    {
+        $fake = (new McpTestServer())
+            ->willHandshake()
+            ->willReturn(['tools' => [['name' => 'a']], 'nextCursor' => 'p2'])
+            ->willReturn(['tools' => [['name' => 'b']], 'nextCursor' => 'p3'])
+            ->willReturn(['tools' => [['name' => 'c']]]);
+
+        $tools = $this->clientFor($fake)->listTools(McpTestServer::server());
+
+        self::assertSame(['a', 'b', 'c'], array_column($tools, 'name'));
+        // 0 = initialize, 1 = the confirmation notification, 2 = the first
+        // page, which carries no cursor because there is nothing to resume from.
+        self::assertArrayNotHasKey('cursor', $fake->received[2]['body']['params']);
+        self::assertSame('p2', $fake->received[3]['body']['params']['cursor']);
+        self::assertSame('p3', $fake->received[4]['body']['params']['cursor']);
+    }
+
+    /**
+     * A cursor that never resolves has to end the walk. Left alone it is an
+     * unbounded loop driven by a third party.
+     */
+    #[Test]
+    public function givesUpOnACursorThatNeverEnds(): void
+    {
+        $fake = (new McpTestServer())->willHandshake();
+        for ($i = 0; $i < 60; ++$i) {
+            $fake->willReturn(['tools' => [], 'nextCursor' => 'forever']);
+        }
+
+        $this->expectException(McpTransportException::class);
+        $this->expectExceptionMessage('did not end within 50 pages');
+
+        $this->clientFor($fake)->listTools(McpTestServer::server());
+    }
+
+    #[Test]
+    public function dropsAMalformedEntryRatherThanTheWholeCatalogue(): void
+    {
+        $fake = (new McpTestServer())
+            ->willHandshake()
+            ->willReturn(['tools' => [['name' => 'good'], 'not an object', ['name' => 'also good']]]);
+
+        $tools = $this->clientFor($fake)->listTools(McpTestServer::server());
+
+        self::assertSame(['good', 'also good'], array_column($tools, 'name'));
+    }
+
+    #[Test]
+    public function refusesAListingWithoutAToolsArray(): void
+    {
+        $fake = (new McpTestServer())
+            ->willHandshake()
+            ->willReturn(['something else' => true]);
+
+        $this->expectException(McpTransportException::class);
+        $this->expectExceptionMessage('carries no "tools" array');
+
+        $this->clientFor($fake)->listTools(McpTestServer::server());
+    }
+
+    #[Test]
+    public function joinsTheTextBlocksOfAToolResult(): void
+    {
+        $fake = (new McpTestServer())
+            ->willHandshake()
+            ->willReturn(['content' => [
+                ['type' => 'text', 'text' => 'first'],
+                ['type' => 'image', 'data' => 'ignored'],
+                ['type' => 'text', 'text' => 'second'],
+            ]]);
+
+        $answer = $this->clientFor($fake)->callTool(McpTestServer::server(), 'do_it', ['a' => 1]);
+
+        self::assertSame("first\nsecond", $answer);
+        self::assertSame('do_it', $fake->received[2]['body']['params']['name']);
+        self::assertSame(['a' => 1], $fake->received[2]['body']['params']['arguments']);
+    }
+
+    /**
+     * A tool-level failure is a result, not a transport fault: the model should
+     * see what went wrong and may reasonably do something else.
+     */
+    #[Test]
+    public function reportsAToolLevelErrorAsTextInsteadOfThrowing(): void
+    {
+        $fake = (new McpTestServer())
+            ->willHandshake()
+            ->willReturn([
+                'isError' => true,
+                'content' => [['type' => 'text', 'text' => 'the file does not exist']],
+            ]);
+
+        $answer = $this->clientFor($fake)->callTool(McpTestServer::server(), 'read_file', []);
+
+        self::assertStringContainsString('reported an error', $answer);
+        self::assertStringContainsString('the file does not exist', $answer);
+    }
+
+    /**
+     * An empty string would read as an empty file rather than as no answer.
+     */
+    #[Test]
+    public function saysSoWhenAToolReturnsNothingReadable(): void
+    {
+        $fake = (new McpTestServer())
+            ->willHandshake()
+            ->willReturn(['content' => [['type' => 'image', 'data' => 'x']]]);
+
+        $answer = $this->clientFor($fake)->callTool(McpTestServer::server(), 'render', []);
+
+        self::assertSame('The remote tool returned no textual content.', $answer);
+    }
+
+    #[Test]
+    public function sendsEmptyArgumentsAsAnObject(): void
+    {
+        $fake = (new McpTestServer())
+            ->willHandshake()
+            ->willReturn(['content' => []]);
+
+        $this->clientFor($fake)->callTool(McpTestServer::server(), 'no_args', []);
+
+        self::assertStringContainsString('"arguments":{}', $fake->received[2]['raw']);
+    }
+
+    /**
+     * Declaring a capability invites the server to use it, and this client
+     * implements none of them.
+     */
+    #[Test]
+    public function declaresNoCapabilitiesInTheHandshake(): void
+    {
+        $fake = (new McpTestServer())->willHandshake()->willReturn(['tools' => []]);
+
+        $this->clientFor($fake)->listTools(McpTestServer::server());
+
+        self::assertStringContainsString('"capabilities":{}', $fake->received[0]['raw']);
+    }
+}

--- a/Tests/Unit/Service/Tool/Mcp/McpHttpTransportTest.php
+++ b/Tests/Unit/Service/Tool/Mcp/McpHttpTransportTest.php
@@ -1,0 +1,236 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Mcp;
+
+use Netresearch\NrLlm\Service\Tool\Mcp\Exception\McpTransportException;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpHttpTransport;
+use Netresearch\NrLlm\Tests\Fixtures\Mcp\McpTestServer;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrVault\Service\VaultServiceInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
+use TYPO3\CMS\Core\Http\Client\GuzzleClientFactory;
+use TYPO3\CMS\Core\Http\RequestFactory;
+use TYPO3\CMS\Core\Http\StreamFactory;
+
+#[CoversClass(McpHttpTransport::class)]
+final class McpHttpTransportTest extends AbstractUnitTestCase
+{
+    private function transportFor(McpTestServer $fake): McpHttpTransport
+    {
+        $transport = new McpHttpTransport(
+            self::createStub(VaultServiceInterface::class),
+            $this->createSecureHttpClientFactoryMock(),
+            new RequestFactory(new GuzzleClientFactory()),
+            new StreamFactory(),
+        );
+        $transport->setHttpClient($fake);
+
+        return $transport;
+    }
+
+    #[Test]
+    public function sendsJsonRpcAndReturnsTheResultObject(): void
+    {
+        $fake = (new McpTestServer())->willReturn(['tools' => []]);
+
+        $answer = $this->transportFor($fake)->call(McpTestServer::server(), 'tools/list', ['cursor' => 'abc']);
+
+        self::assertSame(['tools' => []], $answer['result']);
+        self::assertSame('tools/list', $fake->received[0]['method']);
+        self::assertSame('2.0', $fake->received[0]['body']['jsonrpc']);
+        self::assertSame(['cursor' => 'abc'], $fake->received[0]['body']['params']);
+    }
+
+    /**
+     * An empty parameter set has to go on the wire as a JSON object. Encoded
+     * from an empty PHP array it would become `[]`, which is a different type
+     * and which strict servers reject.
+     */
+    #[Test]
+    public function sendsEmptyParametersAsAnObject(): void
+    {
+        $fake = (new McpTestServer())->willReturn([]);
+
+        $this->transportFor($fake)->call(McpTestServer::server(), 'ping', []);
+
+        self::assertStringContainsString('"params":{}', $fake->received[0]['raw']);
+    }
+
+    #[Test]
+    public function carriesTheSessionHeaderWhenOneIsGiven(): void
+    {
+        $fake = (new McpTestServer())->willReturn([]);
+
+        $this->transportFor($fake)->call(McpTestServer::server(), 'ping', [], 'sess-1');
+
+        self::assertSame('sess-1', $fake->received[0]['session']);
+    }
+
+    #[Test]
+    public function returnsTheSessionIdTheServerIssued(): void
+    {
+        $fake = (new McpTestServer())->willReturn([], 'sess-9');
+
+        $answer = $this->transportFor($fake)->call(McpTestServer::server(), 'initialize', []);
+
+        self::assertSame('sess-9', $answer['sessionId']);
+    }
+
+    /**
+     * @return array<string, array{int}>
+     */
+    public static function failingStatuses(): array
+    {
+        return [
+            'redirect'     => [302],
+            'unauthorised' => [401],
+            'not found'    => [404],
+            'server error' => [500],
+        ];
+    }
+
+    /**
+     * 3xx is in the list on purpose: following a redirect would carry the
+     * credential to a host the SSRF gate never saw.
+     */
+    #[Test]
+    #[DataProvider('failingStatuses')]
+    public function rejectsAnyStatusFromThreeHundredUp(int $status): void
+    {
+        $fake = (new McpTestServer())->willReturnRaw('{}', $status);
+
+        $this->expectException(McpTransportException::class);
+        $this->expectExceptionCode(1799990212);
+
+        $this->transportFor($fake)->call(McpTestServer::server(), 'ping', []);
+    }
+
+    #[Test]
+    public function turnsAJsonRpcErrorIntoATypedException(): void
+    {
+        $fake = (new McpTestServer())->willReturnRpcError(-32601, 'Method not found');
+
+        $this->expectException(McpTransportException::class);
+        $this->expectExceptionCode(1799990214);
+        $this->expectExceptionMessage('Method not found');
+
+        $this->transportFor($fake)->call(McpTestServer::server(), 'nope', []);
+    }
+
+    #[Test]
+    public function refusesAnEventStreamRatherThanGuessingAtIt(): void
+    {
+        $fake = (new McpTestServer())->willReturnRaw("data: {}\n\n", 200, 'text/event-stream');
+
+        $this->expectException(McpTransportException::class);
+        $this->expectExceptionCode(1799990215);
+
+        $this->transportFor($fake)->call(McpTestServer::server(), 'ping', []);
+    }
+
+    #[Test]
+    public function rejectsABodyThatIsNotJson(): void
+    {
+        $fake = (new McpTestServer())->willReturnRaw('<html>maintenance</html>');
+
+        $this->expectException(McpTransportException::class);
+        $this->expectExceptionCode(1799990213);
+
+        $this->transportFor($fake)->call(McpTestServer::server(), 'ping', []);
+    }
+
+    #[Test]
+    public function rejectsAResponseWithNeitherResultNorError(): void
+    {
+        $fake = (new McpTestServer())->willReturnRaw('{"jsonrpc":"2.0","id":1}');
+
+        $this->expectException(McpTransportException::class);
+        $this->expectExceptionCode(1799990213);
+
+        $this->transportFor($fake)->call(McpTestServer::server(), 'ping', []);
+    }
+
+    /**
+     * A server's own text reaches a log line and a backend view, so it must not
+     * be able to carry a newline that forges a second record.
+     */
+    #[Test]
+    public function stripsControlCharactersOutOfRemoteText(): void
+    {
+        $fake = (new McpTestServer())->willReturnRpcError(-1, "first line\nsecond line");
+
+        try {
+            $this->transportFor($fake)->call(McpTestServer::server(), 'ping', []);
+            self::fail('expected the call to be refused');
+        } catch (McpTransportException $e) {
+            self::assertStringNotContainsString("\n", $e->getMessage());
+            self::assertStringContainsString('first line second line', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function boundsHowMuchRemoteTextItRepeats(): void
+    {
+        $fake = (new McpTestServer())->willReturnRpcError(-1, str_repeat('x', 5000));
+
+        try {
+            $this->transportFor($fake)->call(McpTestServer::server(), 'ping', []);
+            self::fail('expected the call to be refused');
+        } catch (McpTransportException $e) {
+            self::assertLessThan(500, mb_strlen($e->getMessage()));
+        }
+    }
+
+    #[Test]
+    public function reportsATransportFailureAgainstTheServerItBelongsTo(): void
+    {
+        $throwing = new class implements ClientInterface {
+            public function sendRequest(RequestInterface $request): ResponseInterface
+            {
+                throw new RuntimeException('connection refused', 1799990230);
+            }
+        };
+
+        $transport = new McpHttpTransport(
+            self::createStub(VaultServiceInterface::class),
+            $this->createSecureHttpClientFactoryMock(),
+            new RequestFactory(new GuzzleClientFactory()),
+            new StreamFactory(),
+        );
+        $transport->setHttpClient($throwing);
+
+        $this->expectException(McpTransportException::class);
+        $this->expectExceptionCode(1799990211);
+        $this->expectExceptionMessage('"srv"');
+
+        $transport->call(McpTestServer::server(), 'ping', []);
+    }
+
+    /**
+     * A notification has no id and its reply is not parsed — a 202 with an
+     * empty body is the normal answer and must not be read as a fault.
+     */
+    #[Test]
+    public function sendsANotificationWithoutAnIdAndIgnoresTheReply(): void
+    {
+        $fake = new McpTestServer();
+
+        $this->transportFor($fake)->notify(McpTestServer::server(), 'notifications/initialized', []);
+
+        self::assertSame('notifications/initialized', $fake->received[0]['method']);
+        self::assertArrayNotHasKey('id', $fake->received[0]['body']);
+    }
+}

--- a/Tests/Unit/Service/Tool/Mcp/McpToolTest.php
+++ b/Tests/Unit/Service/Tool/Mcp/McpToolTest.php
@@ -1,0 +1,158 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Mcp;
+
+use Netresearch\NrLlm\Domain\Enum\ToolDataClass;
+use Netresearch\NrLlm\Domain\Enum\ToolEffect;
+use Netresearch\NrLlm\Domain\ValueObject\McpToolRecord;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpClient;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpHttpTransport;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpTool;
+use Netresearch\NrLlm\Service\Tool\RemoteToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
+use Netresearch\NrLlm\Tests\Fixtures\Mcp\McpTestServer;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrVault\Service\VaultServiceInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Http\Client\GuzzleClientFactory;
+use TYPO3\CMS\Core\Http\RequestFactory;
+use TYPO3\CMS\Core\Http\StreamFactory;
+
+#[CoversClass(McpTool::class)]
+final class McpToolTest extends AbstractUnitTestCase
+{
+    private function record(string $description = 'Reads a page'): McpToolRecord
+    {
+        return new McpToolRecord(
+            uid: 5,
+            pid: 0,
+            server: 1,
+            toolName: 'mcp_srv_read_page',
+            remoteName: 'read_page',
+            description: $description,
+            inputSchema: '{"type":"object","properties":{}}',
+            remoteAnnotations: '',
+            orphaned: false,
+            tstamp: 0,
+            crdate: 0,
+        );
+    }
+
+    private function toolFor(McpTestServer $fake, ToolDataClass $dataClass = ToolDataClass::PUBLIC_CONTENT): McpTool
+    {
+        $transport = new McpHttpTransport(
+            self::createStub(VaultServiceInterface::class),
+            $this->createSecureHttpClientFactoryMock(),
+            new RequestFactory(new GuzzleClientFactory()),
+            new StreamFactory(),
+        );
+        $transport->setHttpClient($fake);
+
+        return new McpTool(
+            McpTestServer::server(),
+            $this->record(),
+            ['type' => 'object', 'properties' => ['id' => ['type' => 'integer']]],
+            $dataClass,
+            new McpClient($transport),
+        );
+    }
+
+    #[Test]
+    public function isMarkedAsRemote(): void
+    {
+        self::assertInstanceOf(RemoteToolInterface::class, $this->toolFor(new McpTestServer()));
+    }
+
+    #[Test]
+    public function takesItsDataClassFromTheOperatorDeclaration(): void
+    {
+        $tool = $this->toolFor(new McpTestServer(), ToolDataClass::INTERNAL_CONFIGURATION);
+
+        self::assertSame(ToolDataClass::INTERNAL_CONFIGURATION, $tool->getDataClass());
+    }
+
+    /**
+     * The inverse of the builtin default. A remote body is not ours to inspect,
+     * so the assumption has to be that the call changed something and must not
+     * be replayed.
+     */
+    #[Test]
+    public function countsAsANonIdempotentWrite(): void
+    {
+        self::assertSame(ToolEffect::NON_IDEMPOTENT_WRITE, $this->toolFor(new McpTestServer())->getEffect());
+    }
+
+    #[Test]
+    public function requiresAdminAndIsOffUntilEnabled(): void
+    {
+        $tool = $this->toolFor(new McpTestServer());
+
+        self::assertTrue($tool->requiresAdmin());
+        self::assertFalse($tool->isEnabledByDefault());
+    }
+
+    #[Test]
+    public function livesInItsOwnServerGroup(): void
+    {
+        self::assertSame('mcp_srv', $this->toolFor(new McpTestServer())->getGroup());
+    }
+
+    #[Test]
+    public function usesTheLocalNameAndTheStoredSchemaInItsSpec(): void
+    {
+        $spec = $this->toolFor(new McpTestServer())->getSpec();
+
+        self::assertSame('mcp_srv_read_page', $spec->name);
+        self::assertSame(['type' => 'object', 'properties' => ['id' => ['type' => 'integer']]], $spec->parameters);
+    }
+
+    /**
+     * The description is written by a third party and read by a model that
+     * treats it as instruction. Naming the origin first does not make it safe,
+     * but the model is never told the sentence came from this installation.
+     */
+    #[Test]
+    public function statesTheOriginAheadOfTheRemoteDescription(): void
+    {
+        $spec = $this->toolFor(new McpTestServer())->getSpec();
+
+        self::assertStringStartsWith('[via the external MCP server "Test server"]', $spec->description);
+        self::assertStringContainsString('Reads a page', $spec->description);
+    }
+
+    #[Test]
+    public function callsTheRemoteNameNotTheLocalOne(): void
+    {
+        $fake = (new McpTestServer())
+            ->willHandshake()
+            ->willReturn(['content' => [['type' => 'text', 'text' => 'done']]]);
+
+        $result = $this->toolFor($fake)->execute(['id' => 3], ToolExecutionContext::none());
+
+        self::assertSame('done', $result->content);
+        self::assertSame('read_page', $fake->received[2]['body']['params']['name']);
+    }
+
+    /**
+     * A server that is down is a fact about this call, not a fault in the run:
+     * the loop carries on and the model is told plainly what failed.
+     */
+    #[Test]
+    public function turnsAnUnreachableServerIntoAResultRatherThanAnException(): void
+    {
+        $fake = (new McpTestServer())->willReturnRaw('nope', 503);
+
+        $result = $this->toolFor($fake)->execute([], ToolExecutionContext::none());
+
+        self::assertStringContainsString('503', $result->content);
+        self::assertStringContainsString('"srv"', $result->content);
+    }
+}

--- a/Tests/Unit/Service/Tool/RemoteCallBudgetTest.php
+++ b/Tests/Unit/Service/Tool/RemoteCallBudgetTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\RemoteCallBudget;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RemoteCallBudget::class)]
+final class RemoteCallBudgetTest extends TestCase
+{
+    #[Test]
+    public function grantsExactlyItsLimit(): void
+    {
+        $budget = new RemoteCallBudget(3);
+
+        self::assertTrue($budget->tryConsume());
+        self::assertTrue($budget->tryConsume());
+        self::assertTrue($budget->tryConsume());
+        self::assertFalse($budget->tryConsume());
+        self::assertSame(3, $budget->spent());
+    }
+
+    /**
+     * A refused claim must not raise the count, or a long enough run would
+     * report having spent more than the limit it was never given.
+     */
+    #[Test]
+    public function aRefusedClaimCostsNothing(): void
+    {
+        $budget = new RemoteCallBudget(1);
+        $budget->tryConsume();
+
+        $budget->tryConsume();
+        $budget->tryConsume();
+
+        self::assertSame(1, $budget->spent());
+    }
+
+    #[Test]
+    public function aZeroLimitGrantsNothing(): void
+    {
+        self::assertFalse((new RemoteCallBudget(0))->tryConsume());
+    }
+
+    #[Test]
+    public function defaultsToTheDeclaredLimit(): void
+    {
+        self::assertSame(RemoteCallBudget::DEFAULT_LIMIT, (new RemoteCallBudget())->limit());
+    }
+}

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -1365,6 +1365,7 @@ final class ToolLoopServiceTest extends TestCase
         $service = $this->service($mgr, new ToolRegistry([$this->remoteTool()]));
 
         $service->runLoop([$this->userTurn('go')], $this->localConfiguration(), ToolExecutionContext::none(), null);
+
         $second = $service->runLoop([$this->userTurn('again')], $this->localConfiguration(), ToolExecutionContext::none(), null);
 
         $refused = array_filter(
@@ -1413,7 +1414,7 @@ final class ToolLoopServiceTest extends TestCase
         return new class implements ToolInterface, RemoteToolInterface {
             public function getSpec(): ToolSpec
             {
-                return ToolSpec::function('remote_thing', 'a tool on someone else\'s server', ['type' => 'object', 'properties' => []]);
+                return ToolSpec::function('remote_thing', "a tool on someone else's server", ['type' => 'object', 'properties' => []]);
             }
 
             /**

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -26,6 +26,7 @@ use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolArtifact;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Domain\ValueObject\ToolInvocation;
 use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
@@ -37,6 +38,8 @@ use Netresearch\NrLlm\Service\Skill\SkillComposer;
 use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
 use Netresearch\NrLlm\Service\Tool\Exception\ToolApprovalRequiredException;
 use Netresearch\NrLlm\Service\Tool\Exception\ToolInputRequiredException;
+use Netresearch\NrLlm\Service\Tool\RemoteCallBudget;
+use Netresearch\NrLlm\Service\Tool\RemoteToolInterface;
 use Netresearch\NrLlm\Service\Tool\RequiresApprovalInterface;
 use Netresearch\NrLlm\Service\Tool\RunAugmentation;
 use Netresearch\NrLlm\Service\Tool\RunTrace;
@@ -1299,6 +1302,145 @@ final class ToolLoopServiceTest extends TestCase
      * would assert the double's behaviour, which is precisely the substitution
      * the mandatory-collaborator work exists to remove.
      */
+    /**
+     * Nothing bounds how many tool calls a model may emit in a single round, and
+     * a remote call is not a local one: it crosses the network three times and
+     * each leg may sit at the transport timeout while a backend user waits. The
+     * budget is what keeps a model looping on one MCP tool from holding a
+     * request open far longer than the iteration cap suggests.
+     */
+    #[Test]
+    public function boundsHowManyRemoteToolsOneRunMayCall(): void
+    {
+        $overBudget = RemoteCallBudget::DEFAULT_LIMIT + 3;
+
+        $calls = [];
+        for ($i = 0; $i < $overBudget; ++$i) {
+            $calls[] = new ToolCall('call_' . $i, 'remote_thing', []);
+        }
+
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturnOnConsecutiveCalls(
+            $this->response('', $calls),
+            $this->response('done'),
+        );
+
+        $service = $this->service($mgr, new ToolRegistry([$this->remoteTool()]));
+        $result  = $service->runLoop([$this->userTurn('go')], $this->localConfiguration(), ToolExecutionContext::none(), null);
+
+        $refused = array_filter(
+            $result->trace,
+            static fn(ToolInvocation $t): bool => str_contains($t->result, 'budget'),
+        );
+
+        self::assertCount(3, $refused, 'every call past the budget is refused');
+        self::assertCount($overBudget, $result->trace, 'a refused call is still recorded');
+    }
+
+    /**
+     * The budget lives on the run, not on the service. The service is a
+     * container singleton and the queue worker outlives many runs, so a second
+     * run must start with a full budget.
+     */
+    #[Test]
+    public function aSecondRunStartsWithAFreshRemoteBudget(): void
+    {
+        $spend = static function (): array {
+            $calls = [];
+            for ($i = 0; $i < RemoteCallBudget::DEFAULT_LIMIT; ++$i) {
+                $calls[] = new ToolCall('call_' . $i, 'remote_thing', []);
+            }
+
+            return $calls;
+        };
+
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturnOnConsecutiveCalls(
+            $this->response('', $spend()),
+            $this->response('first done'),
+            $this->response('', $spend()),
+            $this->response('second done'),
+        );
+
+        $service = $this->service($mgr, new ToolRegistry([$this->remoteTool()]));
+
+        $service->runLoop([$this->userTurn('go')], $this->localConfiguration(), ToolExecutionContext::none(), null);
+        $second = $service->runLoop([$this->userTurn('again')], $this->localConfiguration(), ToolExecutionContext::none(), null);
+
+        $refused = array_filter(
+            $second->trace,
+            static fn(ToolInvocation $t): bool => str_contains($t->result, 'budget'),
+        );
+
+        self::assertSame([], $refused, 'the second run got its own budget');
+    }
+
+    /**
+     * A builtin is local and returns in milliseconds; the iteration cap already
+     * bounds it, so the remote budget must not touch it.
+     */
+    #[Test]
+    public function theRemoteBudgetDoesNotApplyToBuiltins(): void
+    {
+        $calls = [];
+        for ($i = 0; $i < RemoteCallBudget::DEFAULT_LIMIT + 5; ++$i) {
+            $calls[] = new ToolCall('call_' . $i, 'local_thing', []);
+        }
+
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturnOnConsecutiveCalls(
+            $this->response('', $calls),
+            $this->response('done'),
+        );
+
+        $service = $this->service($mgr, new ToolRegistry([new FakeTool('local_thing')]));
+        $result  = $service->runLoop([$this->userTurn('go')], $this->localConfiguration(), ToolExecutionContext::none(), null);
+
+        $refused = array_filter(
+            $result->trace,
+            static fn(ToolInvocation $t): bool => str_contains($t->result, 'budget'),
+        );
+
+        self::assertSame([], $refused);
+    }
+
+    /**
+     * A tool marked as living outside this codebase, which is the only thing
+     * the budget keys on.
+     */
+    private function remoteTool(): ToolInterface
+    {
+        return new class implements ToolInterface, RemoteToolInterface {
+            public function getSpec(): ToolSpec
+            {
+                return ToolSpec::function('remote_thing', 'a tool on someone else\'s server', ['type' => 'object', 'properties' => []]);
+            }
+
+            /**
+             * @param array<string, mixed> $arguments
+             */
+            public function execute(array $arguments, ToolExecutionContext $context): ToolResult
+            {
+                return ToolResult::text('remote ok');
+            }
+
+            public function isEnabledByDefault(): bool
+            {
+                return true;
+            }
+
+            public function requiresAdmin(): bool
+            {
+                return false;
+            }
+
+            public function getGroup(): string
+            {
+                return 'test';
+            }
+        };
+    }
+
     private function realPolicy(ToolRegistry $registry, FakeToolAvailability $availability): ToolCallPolicy
     {
         return new ToolCallPolicy(


### PR DESCRIPTION
An MCP server is a third party that offers tools over HTTP. This makes those tools usable from an agent run, without letting the remote party decide what it may see or do here. Reasoning in [ADR-116](Documentation/Adr/Adr116CentralToolingAuthority.rst); the registry seam and the schema landed in [#580](https://github.com/netresearch/t3x-nr-llm/pull/580).

## The path

An administrator configures a server, imports the catalogue it advertises, and enables individual tools. Import is the only network call outside a run, it happens on an explicit action, and it writes rows that a provider later turns into registered tools. Nothing is discovered on a request path — the registry is built by a FormEngine `itemsProcFunc` and by the Overview module, and neither should reach a third party.

## What is enforced, and where

**The credential is resolved per server, per call.** It is never memoised on the transport, which is a container singleton — a cached authenticated client would send the first server's token to the second. The host is gated while the request is still anonymous, so a misconfigured URL cannot be used to post a token at an internal address, and a 3xx is a failure rather than a redirect to follow: following one would take the credential to a host the gate never saw. The plaintext never enters the process; nr-vault injects it as it writes the request.

**The data class comes from the operator.** There is no code here to derive it from. A server without a declared class is inert — it supplies no tools rather than falling back to a default nobody chose, and the module says so rather than leaving an operator to infer it from an empty list. A remote tool also never benefits from observe mode at the trust-zone gate: observe exists so an upgrade does not silently drop tools that already worked, and no remote tool worked before.

**A remote call is a non-idempotent write unless stated otherwise** — the inverse of the builtin default, which is read-only because every builtin reads. A remote body is not ours to inspect.

## The per-run bound

Nothing limited how many tool calls a model may emit in one round, and a remote call crosses the network three times with a timeout on each leg while a backend user waits. The bound is created inside the run method and passed down, never injected: the loop service is a singleton and the queue worker outlives many runs, so a counter held anywhere else would bound the process and let the second run inherit the first one's exhaustion.

It is per run *segment*. A resume starts a fresh budget, which is deliberate — a resume only happens after a human approved the pause.

## Scope decisions

The two coverage tests that pin a data class and an effect for every tool now read the builtin set. A server's catalogue can neither satisfy nor break a guarantee that is about code in this repository.

Neither resolver changed. Both already prefer an explicit declaration over their default, and the imported tool carries one — so the operator's choice wins without touching the resolution rules.

No unique index on the server identifier, although two servers sharing one would collide on the catalogue's unique tool name. The table soft-deletes, so a unique index would keep a discarded server's identifier reserved for ever. The import refuses the second server and names the first one instead.

## Limitations

The client reads JSON responses and does not consume an event stream, and it says so in its `Accept` header rather than advertising a capability it does not have. A server that can only answer with a stream is refused with a message that states why.

## Tests

Transport and client are asserted against a scripted server that fakes only the HTTP client, so the JSON-RPC encoding, the status handling and the handshake ordering are the production ones. The import runs end to end against a real database. The MCP case for the AJAX admin guard went into `BackendAjaxAdminGuardTest`, where that rule already lives for every other route.

Locally on PHP 8.2, the version CI pins for Rector: cgl, PHPStan, Rector, fuzzy, unit (5854), functional sqlite (1338).
