### PR TITLE
fix(rector): adopt the shared org rector config

### DIFF
--- a/Build/rector/rector.php
+++ b/Build/rector/rector.php
@@ -8,42 +8,42 @@
 declare(strict_types=1);
 
 /**
- * Rector Configuration - TYPO3 LLM Extension
- * Based on TYPO3 Best Practices: https://github.com/TYPO3BestPractices/tea.
+ * Rector Configuration - TYPO3 LLM Extension.
  *
- * This configuration enables:
- * - Automated TYPO3 v13/v14 migrations
- * - PHP 8.2+ modernization
- * - PHPUnit 12 test modernization
- * - Code quality improvements
- * - ExtEmConf automatic maintenance
+ * The rule baseline (PHP/code-quality sets, common skips, importNames,
+ * phpVersion and the Rector-specific PHPStan config) comes from the shared
+ * org config in netresearch/typo3-ci-workflows. Only extension-specific
+ * additions live here.
  */
 
 use Rector\Config\RectorConfig;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
-use Rector\ValueObject\PhpVersion;
 use Ssch\TYPO3Rector\CodeQuality\General\AddErrorCodeToExceptionRector;
-use Ssch\TYPO3Rector\CodeQuality\General\ExtEmConfRector;
-use Ssch\TYPO3Rector\Configuration\Typo3Option;
 use Ssch\TYPO3Rector\Set\Typo3LevelSetList;
 use Ssch\TYPO3Rector\Set\Typo3SetList;
 
-return RectorConfig::configure()
-    ->withPaths([
-        __DIR__ . '/../../Classes/',
-        __DIR__ . '/../../Configuration/',
-        __DIR__ . '/../../Tests/',
-        __DIR__ . '/../../ext_emconf.php',
-        __DIR__ . '/../../ext_localconf.php',
-    ])
-    // PHP 8.2 - TYPO3 v13.4 minimum
-    ->withPhpVersion(PhpVersion::PHP_82)
-    // Enable PHP 8.2 migration sets
-    ->withPhpSets(php82: true)
-    ->withSets([
-        // PHPUnit 12 Sets - modernize tests
+$configure = require_once __DIR__ . '/../../.Build/vendor/netresearch/typo3-ci-workflows/config/rector/rector.php';
+
+return static function (RectorConfig $rectorConfig) use ($configure): void {
+    // Shared org base config: code-quality sets, rule skips, phpstan-rector.neon
+    $configure($rectorConfig, __DIR__ . '/../..');
+
+    // paths() replaces the shared list — re-declared to keep Tests/ in scope,
+    // which the shared $projectRoot default leaves out.
+    $rectorConfig->paths(array_merge(
+        [
+            __DIR__ . '/../../Classes',
+            __DIR__ . '/../../Configuration',
+            __DIR__ . '/../../Resources',
+            __DIR__ . '/../../Tests',
+        ],
+        glob(__DIR__ . '/../../ext_*.php') ?: [],
+    ));
+
+    $rectorConfig->sets([
+        // PHPUnit sets - modernize tests
         PHPUnitSetList::PHPUNIT_110,
 
         // TYPO3 Sets - CRITICAL for TYPO3 migrations
@@ -52,23 +52,14 @@ return RectorConfig::configure()
 
         // TYPO3 v13 migration (v14 set adds ComponentFactory/cache imports not yet needed)
         Typo3LevelSetList::UP_TO_TYPO3_13,
-    ])
-    // PHPStan integration for better analysis
-    ->withPHPStanConfigs([
-        Typo3Option::PHPSTAN_FOR_RECTOR_PATH,
-    ])
-    // Additional useful rules
-    ->withRules([
+    ]);
+
+    // Not part of the shared TYPE_DECLARATION set
+    $rectorConfig->rules([
         AddVoidReturnTypeWhereNoReturnRector::class,
-    ])
-    // ExtEmConfRector: Automatically maintains ext_emconf.php
-    ->withConfiguredRule(ExtEmConfRector::class, [
-        ExtEmConfRector::PHP_VERSION_CONSTRAINT => '8.2.0-8.99.99',
-        ExtEmConfRector::TYPO3_VERSION_CONSTRAINT => '13.4.0-14.99.99',
-        ExtEmConfRector::ADDITIONAL_VALUES_TO_BE_REMOVED => [],
-    ])
-    // Skip specific rules and files that cause issues
-    ->withSkip([
+    ]);
+
+    $rectorConfig->skip([
         // Skip readonly for test properties that are set in setUp() - causes PHPStan errors
         ReadOnlyPropertyRector::class => [
             __DIR__ . '/../../Tests/Integration/Provider/OpenAiProviderIntegrationTest.php',
@@ -85,6 +76,5 @@ return RectorConfig::configure()
         ],
         // Skip Fuzzy tests - Eris\Generator namespace functions conflict with auto-imports
         __DIR__ . '/../../Tests/Fuzzy/',
-    ])
-    // Disable function imports for Fuzzy tests - Eris\Generator uses namespace functions
-    ->withImportNames(true, true, false, false);
+    ]);
+};

--- a/Classes/Command/EvalRunCommand.php
+++ b/Classes/Command/EvalRunCommand.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Command;
 
 use Netresearch\NrLlm\Service\Evaluation\EvaluationResultRepositoryInterface;
 use Netresearch\NrLlm\Service\Evaluation\EvaluationService;
+use Netresearch\NrLlm\Service\Evaluation\GoldenPromptSet;
 use Netresearch\NrLlm\Service\Evaluation\GoldenPromptSetRegistry;
 use Netresearch\NrLlm\Service\Evaluation\Grader\DeterministicGrader;
 use Netresearch\NrLlm\Service\Evaluation\RegressionDetector;
@@ -68,7 +69,7 @@ final class EvalRunCommand extends Command
         $setArgument = $input->getArgument('set');
         $setIdentifier = is_string($setArgument) ? $setArgument : '';
         $set = $this->registry->findByIdentifier($setIdentifier);
-        if ($set === null) {
+        if (!$set instanceof GoldenPromptSet) {
             $io->error(sprintf('Unknown golden prompt set "%s".', $setIdentifier));
             $available = $this->registry->identifiers();
             if ($available !== []) {
@@ -130,6 +131,7 @@ final class EvalRunCommand extends Command
                 $evaluation->result->reason,
             ];
         }
+
         $io->table(['Prompt', 'Result', 'Score', 'Latency (ms)', 'Detail'], $rows);
 
         $io->writeln(sprintf('Model:      %s', $result->model !== '' ? $result->model : '(unknown)'));
@@ -150,8 +152,9 @@ final class EvalRunCommand extends Command
         if (is_string($model) && $model !== '') {
             $options = $options->withModel($model);
         }
+
         if (is_string($provider) && $provider !== '') {
-            $options = $options->withProvider($provider);
+            return $options->withProvider($provider);
         }
 
         return $options;

--- a/Classes/Command/PurgePrivacyDataCommand.php
+++ b/Classes/Command/PurgePrivacyDataCommand.php
@@ -65,7 +65,7 @@ final class PurgePrivacyDataCommand extends Command
             'd',
             InputOption::VALUE_REQUIRED,
             'Delete rows older than this many days, overriding every per-category window. '
-            . 'Defaults to each category\'s own configured retention window.',
+            . "Defaults to each category's own configured retention window.",
         );
     }
 

--- a/Classes/Command/ReapStaleAgentRunsCommand.php
+++ b/Classes/Command/ReapStaleAgentRunsCommand.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Command;
 use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
 use Netresearch\NrLlm\Service\Agent\AgentRuntime;
 use Netresearch\NrLlm\Service\Agent\Queue\AgentRunQueuedMessage;
+use Netresearch\NrLlm\Service\Tool\AgentRunHandle;
 use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -73,7 +74,7 @@ final class ReapStaleAgentRunsCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        if ($this->messageBus === null) {
+        if (!$this->messageBus instanceof MessageBusInterface) {
             $io->error('No message bus is available; queued runs cannot be reclaimed.');
 
             return Command::FAILURE;
@@ -140,9 +141,10 @@ final class ReapStaleAgentRunsCommand extends Command
                 ++$requeued;
             } catch (Throwable $exception) {
                 $handle = $this->persister->resumeHandle($run);
-                if ($handle !== null) {
+                if ($handle instanceof AgentRunHandle) {
                     $this->persister->settleFailed($handle, $exception);
                 }
+
                 $io->warning(sprintf('Run "%s" was reclaimed but its wake-up could not be dispatched; settled failed to avoid an orphan: %s', $run->uuid, $exception->getMessage()));
                 ++$deadLetter;
             }

--- a/Classes/Command/RetrievalEvalRunCommand.php
+++ b/Classes/Command/RetrievalEvalRunCommand.php
@@ -9,8 +9,10 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Command;
 
+use Netresearch\NrLlm\Service\Evaluation\EvaluatableRetrieverInterface;
 use Netresearch\NrLlm\Service\Evaluation\EvaluatableRetrieverRegistry;
 use Netresearch\NrLlm\Service\Evaluation\EvaluationResultRepositoryInterface;
+use Netresearch\NrLlm\Service\Evaluation\GoldenQuestionSet;
 use Netresearch\NrLlm\Service\Evaluation\GoldenQuestionSetRegistry;
 use Netresearch\NrLlm\Service\Evaluation\RegressionDetector;
 use Netresearch\NrLlm\Service\Evaluation\RegressionThresholds;
@@ -67,7 +69,7 @@ final class RetrievalEvalRunCommand extends Command
         $setArgument = $input->getArgument('set');
         $setIdentifier = is_string($setArgument) ? $setArgument : '';
         $set = $this->setRegistry->findByIdentifier($setIdentifier);
-        if ($set === null) {
+        if (!$set instanceof GoldenQuestionSet) {
             $io->error(sprintf('Unknown golden question set "%s".', $setIdentifier));
             $available = $this->setRegistry->identifiers();
             if ($available !== []) {
@@ -80,7 +82,7 @@ final class RetrievalEvalRunCommand extends Command
         $retrieverArgument = $input->getArgument('retriever');
         $retrieverIdentifier = is_string($retrieverArgument) ? $retrieverArgument : '';
         $retriever = $this->retrieverRegistry->findByIdentifier($retrieverIdentifier);
-        if ($retriever === null) {
+        if (!$retriever instanceof EvaluatableRetrieverInterface) {
             $io->error(sprintf('Unknown retriever "%s".', $retrieverIdentifier));
             $available = $this->retrieverRegistry->identifiers();
             if ($available !== []) {
@@ -134,6 +136,7 @@ final class RetrievalEvalRunCommand extends Command
                 (string)$evaluation->latencyMs,
             ];
         }
+
         $io->table(['Question', 'Form', 'Hard class', 'Top-1', 'Top-3', 'Latency (ms)'], $rows);
 
         $io->writeln(sprintf('Retriever:      %s', $result->retriever));
@@ -173,6 +176,7 @@ final class RetrievalEvalRunCommand extends Command
                 sprintf('%.1f%%', $rates['top3HitRate'] * 100),
             ];
         }
+
         $io->table(['Class', 'Questions', 'Top-1', 'Top-3'], $rows);
     }
 

--- a/Classes/Command/SetProviderApiKeyCommand.php
+++ b/Classes/Command/SetProviderApiKeyCommand.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Command;
 
+use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Psr\Log\LoggerInterface;
@@ -94,7 +95,7 @@ final class SetProviderApiKeyCommand extends Command
         $providerIdentifier = is_string($providerIdentifier) ? $providerIdentifier : '';
 
         $provider = $this->providerRepository->findOneByIdentifier($providerIdentifier);
-        if ($provider === null) {
+        if (!$provider instanceof Provider) {
             $io->error(sprintf('No provider record has the identifier "%s".', $providerIdentifier));
 
             return Command::FAILURE;
@@ -126,6 +127,7 @@ final class SetProviderApiKeyCommand extends Command
                 if ($identifier === '') {
                     $identifier = Uuid::v7()->toRfc4122();
                 }
+
                 $this->vault->store($identifier, $secret, self::SECRET_OPTIONS);
             } else {
                 $this->vault->rotate($identifier, $secret, 'nrllm:provider:set-key');
@@ -173,6 +175,7 @@ final class SetProviderApiKeyCommand extends Command
             if (!defined('STDIN')) {
                 return null;
             }
+
             $stream = STDIN;
         }
 

--- a/Classes/Controller/Backend/AgentRunController.php
+++ b/Classes/Controller/Backend/AgentRunController.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Controller\Backend;
 
 use Netresearch\NrLlm\Domain\Enum\AgentRunOutcome;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Service\Agent\AgentRunResult;
 use Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface;
 use Netresearch\NrLlm\Service\Agent\ApprovalDecision;
@@ -104,7 +105,7 @@ final class AgentRunController extends ActionController
         // Stale-review guard: reload the CURRENT state and refuse to approve a
         // turn the operator did not review (a stale tab or a second admin).
         $run = $this->persister->findRun($runUuid);
-        if ($run === null) {
+        if (!$run instanceof AgentRun) {
             $this->flash('runs.flash.error', ContextualFeedbackSeverity::ERROR);
 
             return $this->redirect('list');
@@ -116,6 +117,7 @@ final class AgentRunController extends ActionController
 
             return $this->redirect('list');
         }
+
         if ($currentDigest !== $turnDigest) {
             $this->flash('runs.error.staleReview', ContextualFeedbackSeverity::WARNING);
 
@@ -159,7 +161,7 @@ final class AgentRunController extends ActionController
         // Reload the CURRENT schema and coerce the all-strings POST against it,
         // so the no-JS path validates. Never coerce against a broken schema.
         $run = $this->persister->findRun($runUuid);
-        $schema = $run !== null ? $this->viewFactory->inputSchemaForRun($run) : null;
+        $schema = $run instanceof AgentRun ? $this->viewFactory->inputSchemaForRun($run) : null;
         if ($schema === null) {
             $this->flash('runs.unreadable', ContextualFeedbackSeverity::ERROR);
 

--- a/Classes/Controller/Backend/ConfigurationController.php
+++ b/Classes/Controller/Backend/ConfigurationController.php
@@ -17,6 +17,8 @@ use Netresearch\NrLlm\Controller\Backend\Response\SuccessResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\TestConfigurationResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\ToggleActiveResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
@@ -125,6 +127,7 @@ final class ConfigurationController extends ActionController
             if ($uid === null) {
                 continue;
             }
+
             $editUrls[$uid] = $this->buildEditUrl($uid);
         }
 
@@ -204,6 +207,7 @@ final class ConfigurationController extends ActionController
             );
             return $this->redirect('wizardForm');
         }
+
         if (mb_strlen($description) > 2000) {
             $description = mb_substr($description, 0, 2000);
         }
@@ -246,9 +250,10 @@ final class ConfigurationController extends ActionController
      */
     public function toggleActiveAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $body = $request->getParsedBody();
         $uid = $this->extractIntFromBody($body, 'uid');
 
@@ -279,9 +284,10 @@ final class ConfigurationController extends ActionController
      */
     public function setDefaultAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $body = $request->getParsedBody();
         $uid = $this->extractIntFromBody($body, 'uid');
 
@@ -309,9 +315,10 @@ final class ConfigurationController extends ActionController
      */
     public function getModelsAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $body = $request->getParsedBody();
         $providerKey = $this->extractStringFromBody($body, 'provider');
 
@@ -356,9 +363,10 @@ final class ConfigurationController extends ActionController
      */
     public function testConfigurationAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $body = $request->getParsedBody();
         $uid = $this->extractIntFromBody($body, 'uid');
 
@@ -375,7 +383,7 @@ final class ConfigurationController extends ActionController
             // records, is what the runtime does; testing only getLlmModel()
             // reported "has no model assigned" for a configuration that works.
             $model = $this->modelSelectionService->resolveModel($configuration);
-            if ($model === null || $model->getProvider() === null) {
+            if (!$model instanceof Model || !$model->getProvider() instanceof Provider) {
                 $response = new JsonResponse((new ErrorResponse($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.config.noModel', 'Configuration has no model assigned')))->jsonSerialize(), 400);
             } else {
                 $testPrompt = $this->testPromptResolver->resolve();
@@ -430,9 +438,10 @@ final class ConfigurationController extends ActionController
      */
     public function getModelConstraintsAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $body = $request->getParsedBody();
         $modelUid = $this->extractIntFromBody($body, 'modelUid');
 
@@ -484,6 +493,7 @@ final class ConfigurationController extends ActionController
         if (in_array($adapterType, ['openai', 'azure_openai', 'openrouter', 'groq', 'custom'], true)) {
             return (bool)preg_match('/^(o[1-9]|gpt-5)/', $modelId);
         }
+
         return false;
     }
 
@@ -651,6 +661,7 @@ final class ConfigurationController extends ActionController
                 $params['defVals[' . $table . '][' . $key . ']'] = is_string($value) || is_numeric($value) ? (string)$value : '';
             }
         }
+
         return (string)$this->backendUriBuilder->buildUriFromRoute('record_edit', $params);
     }
 

--- a/Classes/Controller/Backend/DTO/FetchRecordsRequest.php
+++ b/Classes/Controller/Backend/DTO/FetchRecordsRequest.php
@@ -19,6 +19,7 @@ use Psr\Http\Message\ServerRequestInterface;
 final readonly class FetchRecordsRequest
 {
     private const MAX_LIMIT = 200;
+
     private const DEFAULT_LIMIT = 50;
 
     public function __construct(

--- a/Classes/Controller/Backend/LlmModuleController.php
+++ b/Classes/Controller/Backend/LlmModuleController.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Controller\Backend;
 
 use DateTimeImmutable;
 use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
+use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Service\Analytics\AnalyticsPeriod;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
@@ -89,11 +90,13 @@ final class LlmModuleController extends ActionController
         foreach ($providerBreakdown as $row) {
             $maxProviderRequests = max($maxProviderRequests, $row['requests']);
         }
+
         foreach ($providerBreakdown as &$providerRow) {
             $providerRow['percentage'] = $maxProviderRequests > 0
                 ? (int)round($providerRow['requests'] * 100 / $maxProviderRequests)
                 : 0;
         }
+
         unset($providerRow);
 
         // 30-day daily request history for the sparkline. Bar heights are
@@ -104,6 +107,7 @@ final class LlmModuleController extends ActionController
         foreach ($dailyTrend as $day) {
             $maxDailyRequests = max($maxDailyRequests, $day['requests']);
         }
+
         $dailyBars = [];
         foreach ($dailyTrend as $day) {
             $dailyBars[] = [
@@ -158,7 +162,7 @@ final class LlmModuleController extends ActionController
      */
     public function reachabilityAction(): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
 
@@ -191,7 +195,7 @@ final class LlmModuleController extends ActionController
 
         $moduleTemplate->assignMultiple([
             'providers' => array_map(
-                fn($p) => ['identifier' => $p->getIdentifier(), 'name' => $p->getName()],
+                fn(ProviderInterface $p): array => ['identifier' => $p->getIdentifier(), 'name' => $p->getName()],
                 $providers,
             ),
         ]);
@@ -201,9 +205,10 @@ final class LlmModuleController extends ActionController
 
     public function executeTestAction(): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $body = $this->request->getParsedBody();
         $provider = $this->extractStringFromBody($body, 'provider');
         $prompt = $this->extractStringFromBody($body, 'prompt', $this->testPromptResolver->resolve());
@@ -272,6 +277,7 @@ final class LlmModuleController extends ActionController
         if ($activeTab === 'dashboard') {
             $dashboardItem->setActive(true);
         }
+
         $menu->addMenuItem($dashboardItem);
 
         $helpItem = $menu->makeMenuItem()
@@ -280,6 +286,7 @@ final class LlmModuleController extends ActionController
         if ($activeTab === 'help') {
             $helpItem->setActive(true);
         }
+
         $menu->addMenuItem($helpItem);
 
         $menuRegistry->addMenu($menu);

--- a/Classes/Controller/Backend/ModelController.php
+++ b/Classes/Controller/Backend/ModelController.php
@@ -16,7 +16,6 @@ use Netresearch\NrLlm\Controller\Backend\Response\ModelListResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\SuccessResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\ToggleActiveResponse;
 use Netresearch\NrLlm\Domain\Model\Model;
-use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
 use Netresearch\NrLlm\Service\Analytics\AnalyticsPeriod;
@@ -110,6 +109,7 @@ final class ModelController extends ActionController
             if ($uid === null) {
                 continue;
             }
+
             $editUrls[$uid] = $this->buildEditUrl($uid);
         }
 
@@ -125,7 +125,7 @@ final class ModelController extends ActionController
             'editUrls' => $editUrls,
             'newUrl' => $this->buildNewUrl(),
             'wizardUrl' => (string)$this->backendUriBuilder->buildUriFromRoute('nrllm_wizard'),
-            'hasDefaultModel' => $this->modelRepository->findDefault() !== null,
+            'hasDefaultModel' => $this->modelRepository->findDefault() instanceof Model,
             'costByModel' => $usage['cost'],
             'reqByModel' => $usage['requests'],
             'tokByModel' => $usage['tokens'],
@@ -155,9 +155,10 @@ final class ModelController extends ActionController
      */
     public function toggleActiveAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $body = $request->getParsedBody();
         $uid = $this->extractIntFromBody($body, 'uid');
 
@@ -190,9 +191,10 @@ final class ModelController extends ActionController
      */
     public function setDefaultAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $body = $request->getParsedBody();
         $uid = $this->extractIntFromBody($body, 'uid');
 
@@ -221,9 +223,10 @@ final class ModelController extends ActionController
      */
     public function getByProviderAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $body = $request->getParsedBody();
         $providerUid = $this->extractIntFromBody($body, 'providerUid');
 

--- a/Classes/Controller/Backend/ModelDiscoveryController.php
+++ b/Classes/Controller/Backend/ModelDiscoveryController.php
@@ -56,9 +56,10 @@ final class ModelDiscoveryController extends ActionController
      */
     public function fetchAvailableModelsAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $body = $request->getParsedBody();
         $providerUid = $this->extractIntFromBody($body, 'providerUid');
 
@@ -145,15 +146,16 @@ final class ModelDiscoveryController extends ActionController
      */
     public function detectLimitsAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $body = $request->getParsedBody();
         $providerUid = $this->extractIntFromBody($body, 'providerUid');
         $modelId = $this->extractStringFromBody($body, 'modelId');
 
         $validationError = $this->validateDetectLimitsInput($providerUid, $modelId);
-        if ($validationError !== null) {
+        if ($validationError instanceof ResponseInterface) {
             return $validationError;
         }
 

--- a/Classes/Controller/Backend/ModelTestController.php
+++ b/Classes/Controller/Backend/ModelTestController.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Controller\Backend\Response\ErrorResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\TestConnectionResponse;
 use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
@@ -91,9 +92,10 @@ final class ModelTestController extends ActionController
      */
     public function testModelAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $body = $request->getParsedBody();
         $uid = $this->extractIntFromBody($body, 'uid');
 
@@ -111,7 +113,7 @@ final class ModelTestController extends ActionController
     private function performModelTest(Model $model, int $uid): ResponseInterface
     {
         // Provider is lazy-loaded by Extbase
-        if ($model->getProvider() === null) {
+        if (!$model->getProvider() instanceof Provider) {
             return new JsonResponse((new ErrorResponse($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.model.noProviderConfigured', 'Model has no provider configured')))->jsonSerialize(), 400);
         }
 

--- a/Classes/Controller/Backend/PresetController.php
+++ b/Classes/Controller/Backend/PresetController.php
@@ -9,8 +9,10 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend;
 
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Exception\InvalidArgumentException;
+use Netresearch\NrLlm\Service\Preset\ConfigurationPreset;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPresetDiffService;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPresetImportService;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPresetRegistry;
@@ -64,9 +66,10 @@ final class PresetController extends ActionController
      */
     public function listPresetsAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $presets = [];
         foreach ($this->presetRegistry->pending() as $preset) {
             $preflight = $this->importService->preflight($preset);
@@ -80,6 +83,7 @@ final class PresetController extends ActionController
                 'matchedModelLabel' => $preflight->matchedModelLabel,
             ];
         }
+
         $drifted = [];
         foreach ($this->presetRegistry->drifted() as $drift) {
             $drifted[] = [
@@ -89,6 +93,7 @@ final class PresetController extends ActionController
                 'changedFields' => $this->diffService->diff($drift['preset'], $drift['configuration'])->changedFields(),
             ];
         }
+
         return new JsonResponse(['success' => true, 'presets' => $presets, 'drifted' => $drifted]);
     }
 
@@ -102,19 +107,22 @@ final class PresetController extends ActionController
      */
     public function importAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $identifier = $this->stringFromBody($request->getParsedBody(), 'identifier');
         $preset = $this->presetRegistry->findByIdentifier($identifier);
-        if ($preset === null) {
+        if (!$preset instanceof ConfigurationPreset) {
             return new JsonResponse(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.preset.unknown', 'Unknown preset')], 404);
         }
+
         try {
             $configuration = $this->importService->import($preset);
         } catch (InvalidArgumentException $e) {
             return new JsonResponse(['success' => false, 'error' => $e->getMessage()], 422);
         }
+
         return new JsonResponse([
             'success' => true,
             'identifier' => $configuration->getIdentifier(),
@@ -132,23 +140,27 @@ final class PresetController extends ActionController
      */
     public function diffAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $identifier = $this->stringFromBody($request->getQueryParams(), 'identifier');
         $preset = $this->presetRegistry->findByIdentifier($identifier);
-        if ($preset === null) {
+        if (!$preset instanceof ConfigurationPreset) {
             return $this->unknownPresetResponse();
         }
+
         $record = $this->configurationRepository->findOneByIdentifier($identifier);
-        if ($record === null) {
+        if (!$record instanceof LlmConfiguration) {
             return $this->notDriftedResponse();
         }
+
         try {
             $diff = $this->importService->previewUpdate($preset, $record);
         } catch (InvalidArgumentException $e) {
             return $this->refusalResponse($e);
         }
+
         return new JsonResponse([
             'success' => true,
             'identifier' => $diff->identifier,
@@ -166,23 +178,27 @@ final class PresetController extends ActionController
      */
     public function updateAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $identifier = $this->stringFromBody($request->getParsedBody(), 'identifier');
         $preset = $this->presetRegistry->findByIdentifier($identifier);
-        if ($preset === null) {
+        if (!$preset instanceof ConfigurationPreset) {
             return $this->unknownPresetResponse();
         }
+
         $record = $this->configurationRepository->findOneByIdentifier($identifier);
-        if ($record === null) {
+        if (!$record instanceof LlmConfiguration) {
             return $this->notDriftedResponse();
         }
+
         try {
             $diff = $this->importService->update($preset, $record);
         } catch (InvalidArgumentException $e) {
             return $this->refusalResponse($e);
         }
+
         return new JsonResponse([
             'success' => true,
             'identifier' => $diff->identifier,
@@ -235,6 +251,7 @@ final class PresetController extends ActionController
         if (!is_array($body)) {
             return '';
         }
+
         $value = $body[$key] ?? '';
         return is_scalar($value) ? (string)$value : '';
     }

--- a/Classes/Controller/Backend/PromptSnippetController.php
+++ b/Classes/Controller/Backend/PromptSnippetController.php
@@ -61,10 +61,12 @@ final class PromptSnippetController extends ActionController
             if (!$snippet instanceof PromptSnippet) { // @phpstan-ignore instanceof.alwaysTrue
                 continue;
             }
+
             $uid = $snippet->getUid();
             if ($uid === null) {
                 continue;
             }
+
             $editUrls[$uid] = $this->formEngineUrlBuilder
                 ->buildEditUrl(self::TABLE_NAME, $uid, self::MODULE_ROUTE);
         }

--- a/Classes/Controller/Backend/ProviderController.php
+++ b/Classes/Controller/Backend/ProviderController.php
@@ -99,6 +99,7 @@ final class ProviderController extends ActionController
             if ($uid === null) {
                 continue;
             }
+
             $editUrls[$uid] = $this->buildEditUrl($uid);
         }
 
@@ -142,9 +143,10 @@ final class ProviderController extends ActionController
      */
     public function toggleActiveAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $body = $request->getParsedBody();
         $uid = $this->extractIntFromBody($body, 'uid');
 
@@ -194,9 +196,10 @@ final class ProviderController extends ActionController
      */
     public function testConnectionAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $body = $request->getParsedBody();
         $uid = $this->extractIntFromBody($body, 'uid');
 

--- a/Classes/Controller/Backend/SetupWizardController.php
+++ b/Classes/Controller/Backend/SetupWizardController.php
@@ -139,9 +139,10 @@ final class SetupWizardController extends ActionController
      */
     public function detectAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $body = $request->getParsedBody();
         $endpoint = $this->extractStringFromBody($body, 'endpoint');
 
@@ -164,9 +165,10 @@ final class SetupWizardController extends ActionController
      */
     public function testAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $body = $request->getParsedBody();
         $endpoint = $this->extractStringFromBody($body, 'endpoint');
         $apiKey = $this->extractStringFromBody($body, 'apiKey');
@@ -197,9 +199,10 @@ final class SetupWizardController extends ActionController
      */
     public function discoverAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $body = $request->getParsedBody();
         $endpoint = $this->extractStringFromBody($body, 'endpoint');
         $apiKey = $this->extractStringFromBody($body, 'apiKey');
@@ -233,14 +236,16 @@ final class SetupWizardController extends ActionController
      */
     public function generateAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         try {
             $body = $this->parseRequestBody($request);
         } catch (InvalidArgumentException $e) {
             return new JsonResponse((new ErrorResponse($e->getMessage()))->jsonSerialize(), 400);
         }
+
         $endpoint = $this->extractStringFromBody($body, 'endpoint');
         $apiKey = $this->extractStringFromBody($body, 'apiKey');
         $adapterType = $this->extractStringFromBody($body, 'adapterType', 'openai');
@@ -278,14 +283,16 @@ final class SetupWizardController extends ActionController
      */
     public function saveAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         try {
             $body = $this->parseRequestBody($request);
         } catch (InvalidArgumentException $e) {
             return new JsonResponse((new ErrorResponse($e->getMessage()))->jsonSerialize(), 400);
         }
+
         $providerData = $this->extractArrayFromBody($body, 'provider');
         $modelsData = $this->extractArrayFromBody($body, 'models');
         $configurationsData = $this->extractArrayFromBody($body, 'configurations');
@@ -327,6 +334,7 @@ final class SetupWizardController extends ActionController
         if ($providerEndpoint !== '') {
             $providerEndpoint = $this->providerDetector->normalizeEndpointForAdapter($providerEndpoint, $providerAdapter);
         }
+
         $providerApiKey = is_string($providerData['apiKey'] ?? null) ? $providerData['apiKey'] : '';
 
         // Store the API key in the vault and use the vault identifier
@@ -400,6 +408,7 @@ final class SetupWizardController extends ActionController
             if (!is_array($modelData)) {
                 continue;
             }
+
             if (!($modelData['selected'] ?? false)) {
                 continue;
             }
@@ -472,6 +481,7 @@ final class SetupWizardController extends ActionController
             if (!is_array($configData)) {
                 continue;
             }
+
             if (!($configData['selected'] ?? false)) {
                 continue;
             }
@@ -479,7 +489,7 @@ final class SetupWizardController extends ActionController
             $recommendedModelId = is_string($configData['recommendedModelId'] ?? null) ? $configData['recommendedModelId'] : '';
             // Prefer the recommended model; otherwise fall back to the first
             // saved model, or null when none were saved.
-            $model = $savedModels[$recommendedModelId] ?? (empty($savedModels) ? null : reset($savedModels));
+            $model = $savedModels[$recommendedModelId] ?? ($savedModels === [] ? null : reset($savedModels));
 
             if ($model === null) {
                 continue;
@@ -544,6 +554,7 @@ final class SetupWizardController extends ActionController
             if (!is_array($modelData)) {
                 continue;
             }
+
             $models[] = new DiscoveredModel(
                 modelId: is_string($modelData['modelId'] ?? null) ? $modelData['modelId'] : '',
                 name: is_string($modelData['name'] ?? null) ? $modelData['name'] : '',
@@ -587,6 +598,7 @@ final class SetupWizardController extends ActionController
                 } catch (JsonException $e) {
                     throw new InvalidArgumentException('Invalid JSON request body: ' . $e->getMessage(), 1751280101, $e);
                 }
+
                 if (is_array($decoded)) {
                     /** @var array<string, mixed> $decoded */
                     return $decoded;
@@ -608,6 +620,7 @@ final class SetupWizardController extends ActionController
         if (!is_array($body)) {
             return $default;
         }
+
         $value = $body[$key] ?? $default;
         return is_scalar($value) ? trim((string)$value) : $default;
     }
@@ -622,6 +635,7 @@ final class SetupWizardController extends ActionController
         if (!is_array($body)) {
             return [];
         }
+
         $value = $body[$key] ?? [];
         return is_array($value) ? $value : [];
     }
@@ -634,6 +648,7 @@ final class SetupWizardController extends ActionController
         if (!is_array($body)) {
             return $default;
         }
+
         $value = $body[$key] ?? $default;
         return is_numeric($value) ? (int)$value : $default;
     }

--- a/Classes/Controller/Backend/SkillSourceController.php
+++ b/Classes/Controller/Backend/SkillSourceController.php
@@ -87,6 +87,7 @@ final class SkillSourceController extends ActionController
             if ($uid === null) {
                 continue;
             }
+
             $sourceEditUrls[$uid] = $this->formEngineUrlBuilder->buildEditUrl('tx_nrllm_skill_source', $uid, 'nrllm_skills');
         }
 
@@ -100,14 +101,16 @@ final class SkillSourceController extends ActionController
 
     public function syncAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $uid = $this->intFromBody($request->getParsedBody(), 'source');
         $source = $this->sourceRepository->findByUid($uid);
         if ($source === null) {
             return new JsonResponse(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.skill.unknownSource', 'Unknown source')], 404);
         }
+
         $result = $this->syncService->sync($source);
         return new JsonResponse([
             'success' => true,
@@ -123,14 +126,16 @@ final class SkillSourceController extends ActionController
 
     public function toggleSkillAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $body = $request->getParsedBody();
         [$skill, $error] = $this->resolveToggleableSkill($body);
-        if ($error !== null) {
+        if ($error instanceof ResponseInterface) {
             return $error;
         }
+
         assert($skill instanceof Skill);
         $skill->setEnabled($this->boolFromBody($body, 'enabled'));
         $this->skillRepository->update($skill);
@@ -155,22 +160,26 @@ final class SkillSourceController extends ActionController
         if ($skill === null) {
             return [null, new JsonResponse(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.skill.unknownSkill', 'Unknown skill')], 404)];
         }
+
         if ($skill->isOrphaned()) {
             return [null, new JsonResponse(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.skill.orphaned', 'Cannot enable an orphaned skill')], 422)];
         }
+
         return [$skill, null];
     }
 
     public function setTokenAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $body = $request->getParsedBody();
         $source = $this->sourceRepository->findByUid($this->intFromBody($body, 'source'));
         if ($source === null) {
             return new JsonResponse(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.skill.unknownSource', 'Unknown source')], 404);
         }
+
         $token = $this->stringFromBody($body, 'token');
         $uuid = $source->getGithubToken() !== '' ? $source->getGithubToken() : StringUtility::getUniqueId('ghtoken_');
         try {
@@ -194,6 +203,7 @@ final class SkillSourceController extends ActionController
         if (!is_array($body)) {
             return 0;
         }
+
         $value = $body[$key] ?? 0;
         return is_numeric($value) ? (int)$value : 0;
     }
@@ -203,6 +213,7 @@ final class SkillSourceController extends ActionController
         if (!is_array($body)) {
             return '';
         }
+
         $value = $body[$key] ?? '';
         return is_scalar($value) ? (string)$value : '';
     }
@@ -212,6 +223,7 @@ final class SkillSourceController extends ActionController
         if (!is_array($body)) {
             return false;
         }
+
         // filter_var (not a plain cast) so the string "false"/"0" from form bodies is correctly false.
         return filter_var($body[$key] ?? false, FILTER_VALIDATE_BOOLEAN);
     }

--- a/Classes/Controller/Backend/SpecializedTestController.php
+++ b/Classes/Controller/Backend/SpecializedTestController.php
@@ -64,7 +64,7 @@ final readonly class SpecializedTestController
      */
     public function translateAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
 
@@ -130,7 +130,7 @@ final readonly class SpecializedTestController
      */
     public function translatorsAction(): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
 
@@ -149,7 +149,7 @@ final readonly class SpecializedTestController
      */
     public function generateImageAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
 

--- a/Classes/Controller/Backend/TaskExecutionController.php
+++ b/Classes/Controller/Backend/TaskExecutionController.php
@@ -183,9 +183,10 @@ final class TaskExecutionController extends ActionController
      */
     public function executeAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $dto = ExecuteTaskRequest::fromRequest($request);
 
         $task = $this->taskRepository->findByUid($dto->uid);
@@ -257,9 +258,10 @@ final class TaskExecutionController extends ActionController
      */
     public function refreshInputAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $dto = RefreshInputRequest::fromRequest($request);
 
         $task = $this->taskRepository->findByUid($dto->uid);

--- a/Classes/Controller/Backend/TaskListController.php
+++ b/Classes/Controller/Backend/TaskListController.php
@@ -73,10 +73,12 @@ final class TaskListController extends ActionController
             if (!$task instanceof Task) { // @phpstan-ignore instanceof.alwaysTrue
                 continue;
             }
+
             $uid = $task->getUid();
             if ($uid === null) {
                 continue;
             }
+
             $editUrls[$uid] = $this->buildEditUrl($uid);
             $category = $task->getCategory();
             if (!isset($groupedTasks[$category])) {
@@ -85,10 +87,11 @@ final class TaskListController extends ActionController
                     'tasks' => [],
                 ];
             }
+
             $groupedTasks[$category]['tasks'][] = $task;
         }
 
-        $groupedTasks = array_filter($groupedTasks, fn($group) => !empty($group['tasks']));
+        $groupedTasks = array_filter($groupedTasks, fn(array $group): bool => !empty($group['tasks']));
 
         $period = AnalyticsPeriod::fromPreset('30d', new DateTimeImmutable());
         $usage = UsageAnalyticsService::formatUsageColumns(

--- a/Classes/Controller/Backend/TaskRecordsController.php
+++ b/Classes/Controller/Backend/TaskRecordsController.php
@@ -62,9 +62,10 @@ final class TaskRecordsController extends ActionController
      */
     public function listTablesAction(): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         try {
             return new JsonResponse((new TableListResponse(
                 tables: $this->recordTableReader->listAllowedTables(),
@@ -84,9 +85,10 @@ final class TaskRecordsController extends ActionController
      */
     public function fetchRecordsAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $dto = FetchRecordsRequest::fromRequest($request);
 
         if (!$dto->isValid()) {
@@ -151,9 +153,10 @@ final class TaskRecordsController extends ActionController
      */
     public function loadRecordDataAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
+
         $dto = LoadRecordDataRequest::fromRequest($request);
 
         if (!$dto->isValid()) {

--- a/Classes/Controller/Backend/TaskWizardController.php
+++ b/Classes/Controller/Backend/TaskWizardController.php
@@ -72,6 +72,7 @@ final class TaskWizardController extends ActionController
     {
         $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
         $moduleTemplate->makeDocHeaderModuleMenu();
+
         $this->pageRenderer->loadJavaScriptModule('@netresearch/nr-llm/Backend/WizardFormLoading.js');
 
         $availableConfigs = $this->configurationRepository->findActive();
@@ -97,11 +98,13 @@ final class TaskWizardController extends ActionController
     {
         $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
         $moduleTemplate->makeDocHeaderModuleMenu();
+
         $description = trim($description);
         if ($description === '') {
             $this->enqueueFlashMessage($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.missingDescription.body', 'Please describe what this task should do.'), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.missingDescription.title', 'Missing description'), ContextualFeedbackSeverity::WARNING);
             return new RedirectResponse($this->uriBuilder->reset()->uriFor('wizardForm'));
         }
+
         if (mb_strlen($description) > 2000) {
             $description = mb_substr($description, 0, 2000);
         }
@@ -121,6 +124,7 @@ final class TaskWizardController extends ActionController
                     $params['defVals[' . $table . '][' . $key . ']'] = is_string($value) || is_numeric($value) ? (string)$value : '';
                 }
             }
+
             $newUrl = (string)$this->backendUriBuilder->buildUriFromRoute('record_edit', $params);
 
             $moduleTemplate->assignMultiple([
@@ -142,6 +146,7 @@ final class TaskWizardController extends ActionController
                 $this->logger->error('Task wizard: single-task generation failed unexpectedly', ['exception' => $e]);
                 $this->enqueueFlashMessage($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.generationFailed.generic', 'Generation failed. See system log for details.'), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.error.title', 'Error'), ContextualFeedbackSeverity::ERROR);
             }
+
             return new RedirectResponse($this->uriBuilder->reset()->uriFor('wizardForm'));
         }
     }
@@ -150,11 +155,13 @@ final class TaskWizardController extends ActionController
     {
         $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
         $moduleTemplate->makeDocHeaderModuleMenu();
+
         $description = trim($description);
         if ($description === '') {
             $this->enqueueFlashMessage($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.missingDescription.body', 'Please describe what this task should do.'), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.missingDescription.title', 'Missing description'), ContextualFeedbackSeverity::WARNING);
             return new RedirectResponse($this->uriBuilder->reset()->uriFor('wizardForm'));
         }
+
         if (mb_strlen($description) > 2000) {
             $description = mb_substr($description, 0, 2000);
         }
@@ -188,6 +195,7 @@ final class TaskWizardController extends ActionController
                 $this->logger->error('Task wizard: chain generation failed unexpectedly', ['exception' => $e]);
                 $this->enqueueFlashMessage($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.generationFailed.generic', 'Generation failed. See system log for details.'), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.error.title', 'Error'), ContextualFeedbackSeverity::ERROR);
             }
+
             return new RedirectResponse($this->uriBuilder->reset()->uriFor('wizardForm'));
         }
     }
@@ -232,6 +240,7 @@ final class TaskWizardController extends ActionController
                 if ($model instanceof Model) {
                     $configuration->setLlmModel($model);
                 }
+
                 $this->configurationRepository->add($configuration);
                 $this->persistenceManager->persistAll();
             }
@@ -297,9 +306,11 @@ final class TaskWizardController extends ActionController
         if ($modelChoice === 'existing' && $existingModelUid > 0) {
             $model = $this->modelRepository->findByUid($existingModelUid);
         }
+
         if (!$model instanceof Model) {
             $model = $this->modelRepository->findDefault();
         }
+
         if (!$model instanceof Model) {
             $first = $this->modelRepository->findActive()->getFirst();
             if ($first instanceof Model) {

--- a/Classes/Controller/Backend/ToolController.php
+++ b/Classes/Controller/Backend/ToolController.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Controller\Backend;
 
 use Netresearch\NrLlm\Service\Tool\ToolAvailabilityServiceInterface;
 use Netresearch\NrLlm\Service\Tool\ToolGroupStateRepository;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 use Netresearch\NrLlm\Service\Tool\ToolStateRepository;
 use Psr\Http\Message\ResponseInterface;
@@ -69,13 +70,13 @@ final class ToolController extends ActionController
      */
     public function toggleToolAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
 
         $body     = $request->getParsedBody();
         $toolName = $this->stringFromBody($body, 'tool');
-        if ($toolName === '' || $this->toolRegistry->get($toolName) === null) {
+        if ($toolName === '' || !$this->toolRegistry->get($toolName) instanceof ToolInterface) {
             return new JsonResponse(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.unknownTool', 'Unknown tool')], 404);
         }
 
@@ -97,7 +98,7 @@ final class ToolController extends ActionController
      */
     public function toggleToolGroupAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
 
@@ -134,6 +135,7 @@ final class ToolController extends ActionController
         if (!is_array($body)) {
             return '';
         }
+
         $value = $body[$key] ?? '';
         return is_scalar($value) ? (string)$value : '';
     }
@@ -143,6 +145,7 @@ final class ToolController extends ActionController
         if (!is_array($body)) {
             return false;
         }
+
         // filter_var (not a plain cast) so the string "false"/"0" from form bodies is correctly false.
         return filter_var($body[$key] ?? false, FILTER_VALIDATE_BOOLEAN);
     }

--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -19,7 +19,9 @@ use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
 use Netresearch\NrLlm\Domain\Repository\SkillRepository;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
+use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Service\Agent\AgentRunRequest;
 use Netresearch\NrLlm\Service\Agent\AgentRunResult;
@@ -103,6 +105,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
     {
         $this->pageRenderer->loadJavaScriptModule('@netresearch/nr-llm/Backend/ToolPlayground.js');
         $this->pageRenderer->addCssFile('EXT:nr_llm/Resources/Public/Css/Backend/Playground.css');
+
         $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
         $moduleTemplate->makeDocHeaderModuleMenu();
         $moduleTemplate->assignMultiple([
@@ -132,7 +135,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
      */
     public function runAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
 
@@ -159,6 +162,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         if ($temperature !== null) {
             $temperature = max(0.0, min(2.0, $temperature));
         }
+
         // Tri-state reasoning toggle (#312): '1' forces thinking on, '0'
         // off, anything else keeps the provider/model default.
         $think = match ($this->stringFromBody($body, 'think')) {
@@ -171,8 +175,8 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
             maxTokens: $maxTokens > 0 ? $maxTokens : null,
             systemPrompt: $systemPrompt !== '' ? $systemPrompt : null,
             beUserUid: $this->currentBackendUserUid(),
-            captureRaw: $captureRaw,
             think: $think,
+            captureRaw: $captureRaw,
         );
 
         // The checked tool boxes restrict this run; absent any selection, fall
@@ -183,6 +187,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         $agentRequest = new AgentRunRequest(
             configuration: $config,
             messages: [ChatMessage::user($prompt)],
+            actor: $this->currentActor(),
             allowedToolNames: $selected,
             options: $options,
             maxIterations: $maxRounds > 0 ? $maxRounds : null,
@@ -192,7 +197,6 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
                 dryRun: $dryRun,
             ),
             captureRaw: $captureRaw,
-            actor: $this->currentActor(),
         );
 
         // Live path: stream each recorded step to the browser as it happens.
@@ -216,7 +220,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
      */
     public function resumeAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
 
@@ -254,7 +258,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
      */
     public function submitInputAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) !== null) {
+        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
             return $deny;
         }
 
@@ -340,7 +344,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         }
 
         $loop = $result->loopResult;
-        if ($loop === null) {
+        if (!$loop instanceof ToolLoopResult) {
             // Contract violation: a COMPLETED result always carries the loop
             // result. Surface it as a failure instead of fabricating a payload.
             $this->logger?->error('Completed agent run carried no loop result', ['run' => $result->runUuid]);
@@ -407,8 +411,8 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
             'status'       => 'awaiting_input',
             'runUuid'      => $result->runUuid,
             'inputRequest' => [
-                'tool'   => $state !== null ? ($state->inputToolName ?? '') : '',
-                'schema' => $state !== null ? $state->inputSchema : [],
+                'tool'   => $state instanceof SuspendedRunState ? ($state->inputToolName ?? '') : '',
+                'schema' => $state instanceof SuspendedRunState ? $state->inputSchema : [],
             ],
             'steps'        => array_map(static fn(RunStep $step): array => $step->toArray(), $result->steps),
         ];
@@ -471,6 +475,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         while (ob_get_level() > 0) {
             ob_end_flush();
         }
+
         if (!headers_sent()) {
             header('Content-Type: application/x-ndjson; charset=utf-8');
             header('Cache-Control: no-cache, no-transform');
@@ -530,8 +535,8 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
                     'success'      => true,
                     'runUuid'      => $result->runUuid,
                     'inputRequest' => [
-                        'tool'   => $inputState !== null ? ($inputState->inputToolName ?? '') : '',
-                        'schema' => $inputState !== null ? $inputState->inputSchema : [],
+                        'tool'   => $inputState instanceof SuspendedRunState ? ($inputState->inputToolName ?? '') : '',
+                        'schema' => $inputState instanceof SuspendedRunState ? $inputState->inputSchema : [],
                     ],
                 ]);
 
@@ -591,7 +596,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         }
 
         $loop = $result->loopResult;
-        if ($loop === null) {
+        if (!$loop instanceof ToolLoopResult) {
             // Contract violation: a COMPLETED result always carries the loop
             // result. Emit an error line instead of fabricating a done event.
             $this->logger?->error('Completed agent run carried no loop result', ['run' => $result->runUuid]);
@@ -664,6 +669,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         if (!is_array($body)) {
             return 0;
         }
+
         $value = $body[$key] ?? 0;
         return is_numeric($value) ? (int)$value : 0;
     }
@@ -686,6 +692,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         if (!is_array($body)) {
             return '';
         }
+
         $value = $body[$key] ?? '';
         return is_scalar($value) ? (string)$value : '';
     }
@@ -718,9 +725,10 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         if (!is_array($body)) {
             return false;
         }
+
         $value = $body[$key] ?? false;
 
-        return $value === true || $value === 1 || $value === '1' || $value === 'true';
+        return in_array($value, [true, 1, '1', 'true'], true);
     }
 
     /**
@@ -823,7 +831,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
      */
     private function diagnoseRunFailure(?Throwable $e): string
     {
-        if ($e === null) {
+        if (!$e instanceof Throwable) {
             return 'Unknown error';
         }
 
@@ -835,6 +843,7 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
             if ($e->httpStatus > 0) {
                 $detail .= sprintf(' (HTTP %d)', $e->httpStatus);
             }
+
             $body = trim($e->responseBody);
             if ($body !== '') {
                 $snippet = $this->sanitizeErrorMessage(mb_substr($body, 0, 500));

--- a/Classes/DependencyInjection/ProviderCompilerPass.php
+++ b/Classes/DependencyInjection/ProviderCompilerPass.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\DependencyInjection;
 
 use Netresearch\NrLlm\Attribute\AsLlmProvider;
 use Netresearch\NrLlm\Service\LlmServiceManager;
+use ReflectionClass;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -82,12 +83,20 @@ final class ProviderCompilerPass implements CompilerPassInterface
             }
 
             $class = $definition->getClass() ?? $serviceId;
-            if (!is_string($class) || $class === '' || !str_starts_with($class, self::SCAN_NAMESPACE_PREFIX)) {
+            if (!is_string($class)) {
+                continue;
+            }
+
+            if ($class === '') {
+                continue;
+            }
+
+            if (!str_starts_with($class, self::SCAN_NAMESPACE_PREFIX)) {
                 continue;
             }
 
             $reflection = $container->getReflectionClass($class, false);
-            if ($reflection === null) {
+            if (!$reflection instanceof ReflectionClass) {
                 continue;
             }
 

--- a/Classes/DependencyInjection/TranslatorCompilerPass.php
+++ b/Classes/DependencyInjection/TranslatorCompilerPass.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\DependencyInjection;
 
 use Netresearch\NrLlm\Attribute\AsTranslator;
+use ReflectionClass;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -54,12 +55,20 @@ final readonly class TranslatorCompilerPass implements CompilerPassInterface
             }
 
             $class = $definition->getClass() ?? $serviceId;
-            if (!is_string($class) || $class === '' || !str_starts_with($class, $this->scanNamespacePrefix)) {
+            if (!is_string($class)) {
+                continue;
+            }
+
+            if ($class === '') {
+                continue;
+            }
+
+            if (!str_starts_with($class, $this->scanNamespacePrefix)) {
                 continue;
             }
 
             $reflection = $container->getReflectionClass($class, false);
-            if ($reflection === null) {
+            if (!$reflection instanceof ReflectionClass) {
                 continue;
             }
 

--- a/Classes/Domain/DTO/BudgetCheckResult.php
+++ b/Classes/Domain/DTO/BudgetCheckResult.php
@@ -19,14 +19,23 @@ namespace Netresearch\NrLlm\Domain\DTO;
 final readonly class BudgetCheckResult
 {
     public const LIMIT_NONE = '';
+
     public const LIMIT_DAILY_REQUESTS = 'daily_requests';
+
     public const LIMIT_DAILY_TOKENS = 'daily_tokens';
+
     public const LIMIT_DAILY_COST = 'daily_cost';
+
     public const LIMIT_MONTHLY_REQUESTS = 'monthly_requests';
+
     public const LIMIT_MONTHLY_TOKENS = 'monthly_tokens';
+
     public const LIMIT_MONTHLY_COST = 'monthly_cost';
+
     public const LIMIT_CONFIGURATION_DAILY_REQUESTS = 'configuration_daily_requests';
+
     public const LIMIT_CONFIGURATION_DAILY_TOKENS = 'configuration_daily_tokens';
+
     public const LIMIT_CONFIGURATION_DAILY_COST = 'configuration_daily_cost';
 
     /**

--- a/Classes/Domain/DTO/CapabilitySet.php
+++ b/Classes/Domain/DTO/CapabilitySet.php
@@ -69,6 +69,7 @@ final readonly class CapabilitySet implements Countable, JsonSerializable
         if ($csv === '') {
             return new self();
         }
+
         return self::fromArray(explode(',', $csv));
     }
 
@@ -83,12 +84,18 @@ final readonly class CapabilitySet implements Countable, JsonSerializable
         $out  = [];
         foreach ($tokens as $token) {
             $enum = self::coerceToEnum($token);
-            if ($enum === null || isset($seen[$enum->value])) {
+            if (!$enum instanceof ModelCapability) {
                 continue;
             }
+
+            if (isset($seen[$enum->value])) {
+                continue;
+            }
+
             $seen[$enum->value] = true;
             $out[]              = $enum;
         }
+
         return new self($out);
     }
 
@@ -124,9 +131,10 @@ final readonly class CapabilitySet implements Countable, JsonSerializable
     public function has(ModelCapability|string $capability): bool
     {
         $needle = self::coerceToEnum($capability);
-        if ($needle === null) {
+        if (!$needle instanceof ModelCapability) {
             return false;
         }
+
         // PHP enums are singletons, so strict equality is enough — and
         // `in_array(..., true)` short-circuits on first match.
         return in_array($needle, $this->capabilities, true);
@@ -140,9 +148,10 @@ final readonly class CapabilitySet implements Countable, JsonSerializable
     public function with(ModelCapability|string $capability): self
     {
         $enum = self::coerceToEnum($capability);
-        if ($enum === null || $this->has($enum)) {
+        if (!$enum instanceof ModelCapability || $this->has($enum)) {
             return $this;
         }
+
         return new self([...$this->capabilities, $enum]);
     }
 
@@ -153,9 +162,10 @@ final readonly class CapabilitySet implements Countable, JsonSerializable
     public function without(ModelCapability|string $capability): self
     {
         $enum = self::coerceToEnum($capability);
-        if ($enum === null || !$this->has($enum)) {
+        if (!$enum instanceof ModelCapability || !$this->has($enum)) {
             return $this;
         }
+
         $filtered = array_values(array_filter(
             $this->capabilities,
             static fn(ModelCapability $cap): bool => $cap !== $enum,
@@ -188,9 +198,11 @@ final readonly class CapabilitySet implements Countable, JsonSerializable
         if ($token instanceof ModelCapability) {
             return $token;
         }
+
         if (!is_string($token)) {
             return null;
         }
+
         return ModelCapability::tryFrom(trim($token));
     }
 }

--- a/Classes/Domain/DTO/FallbackChain.php
+++ b/Classes/Domain/DTO/FallbackChain.php
@@ -45,6 +45,7 @@ final readonly class FallbackChain implements JsonSerializable
         if (!is_array($identifiers)) {
             return new self();
         }
+
         return new self(self::sanitize($identifiers));
     }
 
@@ -53,10 +54,12 @@ final readonly class FallbackChain implements JsonSerializable
         if ($json === '') {
             return new self();
         }
+
         $data = json_decode($json, true);
         if (!is_array($data)) {
             return new self();
         }
+
         /** @var array{configurationIdentifiers?: mixed} $data */
         return self::fromArray($data);
     }
@@ -109,6 +112,7 @@ final readonly class FallbackChain implements JsonSerializable
         if ($normalised === '' || $this->contains($normalised)) {
             return $this;
         }
+
         return new self([...$this->configurationIdentifiers, $normalised]);
     }
 
@@ -122,6 +126,7 @@ final readonly class FallbackChain implements JsonSerializable
         if ($normalised === '' || !$this->contains($normalised)) {
             return $this;
         }
+
         $filtered = array_values(array_filter(
             $this->configurationIdentifiers,
             static fn(string $link): bool => $link !== $normalised,
@@ -147,13 +152,20 @@ final readonly class FallbackChain implements JsonSerializable
             if (!is_string($identifier)) {
                 continue;
             }
+
             $normalised = self::normalise($identifier);
-            if ($normalised === '' || isset($seen[$normalised])) {
+            if ($normalised === '') {
                 continue;
             }
+
+            if (isset($seen[$normalised])) {
+                continue;
+            }
+
             $seen[$normalised] = true;
             $out[] = $normalised;
         }
+
         return $out;
     }
 

--- a/Classes/Domain/DTO/ModelSelectionCriteria.php
+++ b/Classes/Domain/DTO/ModelSelectionCriteria.php
@@ -59,10 +59,12 @@ final readonly class ModelSelectionCriteria implements JsonSerializable
         if ($json === '') {
             return new self();
         }
+
         $data = json_decode($json, true);
         if (!is_array($data)) {
             return new self();
         }
+
         /** @var array{capabilities?: list<string>, adapterTypes?: list<string>, minContextLength?: int, maxCostInput?: int, preferLowestCost?: bool} $data */
         return self::fromArray($data);
     }
@@ -127,6 +129,7 @@ final readonly class ModelSelectionCriteria implements JsonSerializable
         if ($this->adapterTypes === []) {
             return true; // No restriction means all are allowed
         }
+
         return in_array($adapterType, $this->adapterTypes, true);
     }
 
@@ -139,6 +142,7 @@ final readonly class ModelSelectionCriteria implements JsonSerializable
         if (in_array($capabilityValue, $this->capabilities, true)) {
             return $this;
         }
+
         return new self(
             capabilities: [...$this->capabilities, $capabilityValue],
             adapterTypes: $this->adapterTypes,
@@ -156,6 +160,7 @@ final readonly class ModelSelectionCriteria implements JsonSerializable
         if (in_array($adapterType, $this->adapterTypes, true)) {
             return $this;
         }
+
         return new self(
             capabilities: $this->capabilities,
             adapterTypes: [...$this->adapterTypes, $adapterType],

--- a/Classes/Domain/DTO/ProviderOptions.php
+++ b/Classes/Domain/DTO/ProviderOptions.php
@@ -133,10 +133,12 @@ final readonly class ProviderOptions implements JsonSerializable
         if ($json === '') {
             return new self();
         }
+
         $decoded = json_decode($json, true);
         if (!is_array($decoded)) {
             return new self();
         }
+
         /** @var array<string, mixed> $decoded */
         return self::fromArray($decoded);
     }
@@ -250,6 +252,7 @@ final readonly class ProviderOptions implements JsonSerializable
         if ($proxy === '') {
             $proxy = null;
         }
+
         return new self(
             proxy: $proxy,
             customHeaders: $this->customHeaders,
@@ -274,6 +277,7 @@ final readonly class ProviderOptions implements JsonSerializable
                 $sanitised[$name] = $value;
             }
         }
+
         return new self(
             proxy: $this->proxy,
             customHeaders: $sanitised,
@@ -295,6 +299,7 @@ final readonly class ProviderOptions implements JsonSerializable
         if ($key === 'proxy' || $key === 'customHeaders') {
             return $this;
         }
+
         $extra = $this->extra;
         $extra[$key] = $value;
         return new self(

--- a/Classes/Domain/Model/AdapterType.php
+++ b/Classes/Domain/Model/AdapterType.php
@@ -97,6 +97,7 @@ enum AdapterType: string
         foreach (self::cases() as $case) {
             $result[$case->value] = $case->label();
         }
+
         return $result;
     }
 }

--- a/Classes/Domain/Model/EmbeddingResponse.php
+++ b/Classes/Domain/Model/EmbeddingResponse.php
@@ -74,6 +74,7 @@ final readonly class EmbeddingResponse
         if (!\is_array($usageData)) {
             $usageData = [];
         }
+
         /** @var array<string, mixed> $usageData The serialized usage shape is a JSON object (string keys). */
 
         return new self(
@@ -105,13 +106,16 @@ final readonly class EmbeddingResponse
             if (!\is_array($vector)) {
                 return [];
             }
+
             $floats = [];
             foreach ($vector as $component) {
                 if (!\is_int($component) && !\is_float($component)) {
                     return [];
                 }
+
                 $floats[] = (float)$component;
             }
+
             $normalized[] = $floats;
         }
 
@@ -164,13 +168,13 @@ final readonly class EmbeddingResponse
      */
     public function normalizeVector(array $vector): array
     {
-        $magnitude = sqrt(array_sum(array_map(static fn($x) => $x * $x, $vector)));
+        $magnitude = sqrt(array_sum(array_map(static fn(float $x): float => $x * $x, $vector)));
 
         if ($magnitude === 0.0) {
             return $vector;
         }
 
-        return array_map(static fn($x) => $x / $magnitude, $vector);
+        return array_map(static fn(float $x): float => $x / $magnitude, $vector);
     }
 
     /**

--- a/Classes/Domain/Model/LlmConfiguration.php
+++ b/Classes/Domain/Model/LlmConfiguration.php
@@ -30,7 +30,9 @@ class LlmConfiguration extends AbstractEntity
     private const DEFAULT_TIMEOUT = 120;
 
     protected string $identifier = '';
+
     protected string $name = '';
+
     protected string $description = '';
 
     /** Reference to database Model entity. */
@@ -42,6 +44,7 @@ class LlmConfiguration extends AbstractEntity
      * @deprecated Use ModelSelectionMode enum instead
      */
     public const SELECTION_MODE_FIXED = 'fixed';
+
     /** @deprecated Use ModelSelectionMode enum instead */
     public const SELECTION_MODE_CRITERIA = 'criteria';
 
@@ -52,13 +55,21 @@ class LlmConfiguration extends AbstractEntity
     protected string $modelSelectionCriteria = '';
 
     protected string $translator = '';
+
     protected string $systemPrompt = '';
+
     protected float $temperature = 0.7;
+
     protected int $maxTokens = 1000;
+
     protected float $topP = 1.0;
+
     protected float $frequencyPenalty = 0.0;
+
     protected float $presencePenalty = 0.0;
+
     protected int $timeout = 0;
+
     protected string $options = '';
 
     /**
@@ -74,9 +85,13 @@ class LlmConfiguration extends AbstractEntity
      * See {@see getAllowedGuardrailsList()} and GuardrailPolicyResolver.
      */
     protected string $allowedGuardrails = '';
+
     protected int $maxRequestsPerDay = 0;
+
     protected int $maxTokensPerDay = 0;
+
     protected float $maxCostPerDay = 0.0;
+
     /**
      * JSON-encoded fallback chain (ordered list of LlmConfiguration identifiers).
      * Populated automatically from the `fallback_chain` column by Extbase.
@@ -91,9 +106,13 @@ class LlmConfiguration extends AbstractEntity
     protected string $presetChecksum = '';
 
     protected bool $isActive = true;
+
     protected bool $isDefault = false;
+
     protected int $tstamp = 0;
+
     protected int $crdate = 0;
+
     /**
      * Allowed backend groups (MM relation) — the single source of truth for the
      * per-group access restriction. Its TCA config lives on the `allowed_groups`
@@ -145,7 +164,7 @@ class LlmConfiguration extends AbstractEntity
      */
     public function hasLlmModel(): bool
     {
-        return $this->llmModel !== null;
+        return $this->llmModel instanceof Model;
     }
 
     public function getModelSelectionMode(): string
@@ -185,10 +204,12 @@ class LlmConfiguration extends AbstractEntity
         if ($this->modelSelectionCriteria === '') {
             return [];
         }
+
         $decoded = json_decode($this->modelSelectionCriteria, true);
         if (!is_array($decoded)) {
             return [];
         }
+
         /** @var array{capabilities?: string[], adapterTypes?: string[], minContextLength?: int, maxCostInput?: int, preferLowestCost?: bool} $decoded */
         return $decoded;
     }
@@ -214,12 +235,13 @@ class LlmConfiguration extends AbstractEntity
      */
     public function getProviderType(): string
     {
-        if ($this->llmModel !== null) {
+        if ($this->llmModel instanceof Model) {
             $provider = $this->llmModel->getProvider();
-            if ($provider !== null) {
+            if ($provider instanceof Provider) {
                 return $provider->getAdapterType();
             }
         }
+
         return '';
     }
 
@@ -228,9 +250,10 @@ class LlmConfiguration extends AbstractEntity
      */
     public function getModelId(): string
     {
-        if ($this->llmModel !== null) {
+        if ($this->llmModel instanceof Model) {
             return $this->llmModel->getModelId();
         }
+
         return '';
     }
 
@@ -285,9 +308,11 @@ class LlmConfiguration extends AbstractEntity
         if ($this->timeout > 0) {
             return $this->timeout;
         }
-        if ($this->llmModel !== null) {
+
+        if ($this->llmModel instanceof Model) {
             return $this->llmModel->getDefaultTimeout();
         }
+
         return self::DEFAULT_TIMEOUT;
     }
 
@@ -321,10 +346,12 @@ class LlmConfiguration extends AbstractEntity
         if ($this->options === '') {
             return [];
         }
+
         $decoded = json_decode($this->options, true);
         if (!is_array($decoded)) {
             return [];
         }
+
         /** @var array<string, mixed> $decoded */
         return $decoded;
     }
@@ -387,9 +414,10 @@ class LlmConfiguration extends AbstractEntity
     {
         // Extbase can reconstitute a relation-less entity without the constructor's
         // ObjectStorage init, leaving this property unset/null.
-        if (!isset($this->beGroups)) { // @phpstan-ignore isset.initializedProperty (Extbase reconstitution skips the constructor)
+        if (!$this->beGroups instanceof ObjectStorage) { // @phpstan-ignore isset.initializedProperty (Extbase reconstitution skips the constructor)
             $this->beGroups = new ObjectStorage();
         }
+
         return $this->beGroups;
     }
 
@@ -403,6 +431,7 @@ class LlmConfiguration extends AbstractEntity
         if (!isset($this->skills)) { // @phpstan-ignore isset.initializedProperty (Extbase reconstitution skips the constructor)
             $this->skills = new ObjectStorage();
         }
+
         return $this->skills;
     }
 
@@ -478,6 +507,7 @@ class LlmConfiguration extends AbstractEntity
         if (!ModelSelectionMode::isValid($modelSelectionMode)) {
             $modelSelectionMode = ModelSelectionMode::FIXED->value;
         }
+
         $this->modelSelectionMode = $modelSelectionMode;
     }
 
@@ -755,8 +785,8 @@ class LlmConfiguration extends AbstractEntity
 
         // Merge additional options
         $additionalOptions = $this->getOptionsArray();
-        if (!empty($additionalOptions)) {
-            $options = array_merge($options, $additionalOptions);
+        if ($additionalOptions !== []) {
+            return array_merge($options, $additionalOptions);
         }
 
         return $options;

--- a/Classes/Domain/Model/Model.php
+++ b/Classes/Domain/Model/Model.php
@@ -22,24 +22,40 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 class Model extends AbstractEntity
 {
     protected string $identifier = '';
+
     protected string $name = '';
+
     protected string $description = '';
+
     protected ?Provider $provider = null;
+
     protected string $modelId = '';
+
     protected int $contextLength = 0;
+
     protected int $maxOutputTokens = 0;
 
     /** Embedding vector dimensionality of the model (0 = unknown). */
     protected int $dimensions = 0;
+
     protected string $capabilities = '';
+
     protected int $defaultTimeout = 120;
+
     protected int $costInput = 0;
+
     protected int $costOutput = 0;
+
     protected bool $isActive = true;
+
     protected bool $isDefault = false;
+
     protected int $sorting = 0;
+
     protected int $tstamp = 0;
+
     protected int $crdate = 0;
+
     // ========================================
     // Getters
     // ========================================
@@ -119,6 +135,7 @@ class Model extends AbstractEntity
         if ($this->capabilities === '') {
             return [];
         }
+
         return array_map(trim(...), explode(',', $this->capabilities));
     }
 
@@ -153,6 +170,7 @@ class Model extends AbstractEntity
                 $enums[] = $enum;
             }
         }
+
         return $enums;
     }
 
@@ -487,9 +505,10 @@ class Model extends AbstractEntity
      */
     public function getDisplayName(): string
     {
-        if ($this->provider !== null) {
+        if ($this->provider instanceof Provider) {
             return sprintf('%s (%s)', $this->name, $this->provider->getName());
         }
+
         return $this->name;
     }
 

--- a/Classes/Domain/Model/PromptSnippet.php
+++ b/Classes/Domain/Model/PromptSnippet.php
@@ -26,7 +26,9 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 class PromptSnippet extends AbstractEntity
 {
     protected string $identifier = '';
+
     protected string $name = '';
+
     protected string $description = '';
 
     /** Comma-separated free-form tags, e.g. "audience,tone_of_voice". */
@@ -42,6 +44,7 @@ class PromptSnippet extends AbstractEntity
     protected string $metadata = '';
 
     protected bool $isActive = true;
+
     protected int $sorting = 0;
 
     // Getters

--- a/Classes/Domain/Model/Provider.php
+++ b/Classes/Domain/Model/Provider.php
@@ -39,8 +39,11 @@ class Provider extends AbstractEntity
     private const PLAINTEXT_API_KEY_PREFIXES = ['sk-', 'xai-', 'AIza', 'gsk_'];
 
     protected string $identifier = '';
+
     protected string $name = '';
+
     protected string $description = '';
+
     protected string $adapterType = '';
 
     /**
@@ -49,17 +52,29 @@ class Provider extends AbstractEntity
      * resolves that to the strictest zone.
      */
     protected string $trustZone = '';
+
     protected string $endpointUrl = '';
+
     protected string $apiKey = '';
+
     protected string $organizationId = '';
+
     protected int $apiTimeout = 120;
+
     protected int $maxRetries = 3;
+
     protected string $options = '';
+
     protected bool $isActive = true;
+
     protected int $priority = 50;
+
     protected int $sorting = 0;
+
     protected int $tstamp = 0;
+
     protected int $crdate = 0;
+
     /**
      * Models associated with this provider.
      *
@@ -136,7 +151,7 @@ class Provider extends AbstractEntity
         }
 
         // Detect legacy plaintext API keys that were stored before vault integration
-        if (!self::isVaultIdentifier($this->apiKey)) {
+        if (!$this->isVaultIdentifier($this->apiKey)) {
             trigger_error(
                 \sprintf(
                     'Provider %d has a plaintext API key instead of a vault identifier. '
@@ -228,10 +243,12 @@ class Provider extends AbstractEntity
         if ($this->options === '') {
             return [];
         }
+
         $decoded = json_decode($this->options, true);
         if (!is_array($decoded)) {
             return [];
         }
+
         /** @var array<string, mixed> $decoded */
         return $decoded;
     }
@@ -292,9 +309,10 @@ class Provider extends AbstractEntity
     {
         // Extbase can reconstitute a relation-less entity without the constructor's
         // ObjectStorage init, leaving this property unset/null.
-        if (!isset($this->models)) { // @phpstan-ignore isset.initializedProperty (Extbase reconstitution skips the constructor)
+        if (!$this->models instanceof ObjectStorage) { // @phpstan-ignore isset.initializedProperty (Extbase reconstitution skips the constructor)
             $this->models = new ObjectStorage();
         }
+
         return $this->models;
     }
 
@@ -375,7 +393,7 @@ class Provider extends AbstractEntity
     {
         // Allow empty string (no key / clearing)
         // Reject values that look like raw API keys (not vault identifiers)
-        if ($apiKey !== '' && !self::isVaultIdentifier($apiKey)) {
+        if ($apiKey !== '' && !$this->isVaultIdentifier($apiKey)) {
             throw new InvalidArgumentException(
                 'API key must be a vault identifier (UUID v7 or name-style identifier), not a raw secret. '
                 . 'Use VaultServiceInterface::store() first.',
@@ -395,7 +413,7 @@ class Provider extends AbstractEntity
      * prefix are conservatively treated as legacy plaintext secrets, since
      * some raw keys would otherwise match the name-style pattern.
      */
-    private static function isVaultIdentifier(string $value): bool
+    private function isVaultIdentifier(string $value): bool
     {
         foreach (self::PLAINTEXT_API_KEY_PREFIXES as $prefix) {
             if (str_starts_with($value, $prefix)) {
@@ -521,6 +539,7 @@ class Provider extends AbstractEntity
         if ($this->endpointUrl !== '') {
             return $this->endpointUrl;
         }
+
         return self::getDefaultEndpointForAdapter($this->adapterType);
     }
 
@@ -592,8 +611,8 @@ class Provider extends AbstractEntity
 
         // Merge additional options
         $additionalOptions = $this->getOptionsArray();
-        if (!empty($additionalOptions)) {
-            $config = array_merge($config, $additionalOptions);
+        if ($additionalOptions !== []) {
+            return array_merge($config, $additionalOptions);
         }
 
         return $config;

--- a/Classes/Domain/Model/RenderedPrompt.php
+++ b/Classes/Domain/Model/RenderedPrompt.php
@@ -97,7 +97,7 @@ final readonly class RenderedPrompt
     {
         $messages = [];
 
-        if (!empty($this->systemPrompt)) {
+        if ($this->systemPrompt !== '' && $this->systemPrompt !== '0') {
             $messages[] = [
                 'role' => 'system',
                 'content' => $this->systemPrompt,

--- a/Classes/Domain/Model/Skill.php
+++ b/Classes/Domain/Model/Skill.php
@@ -16,19 +16,33 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 class Skill extends AbstractEntity
 {
     protected int $source = 0;
+
     protected string $identifier = '';
+
     protected string $name = '';
+
     protected string $description = '';
+
     protected string $body = '';
+
     protected string $bodyChecksum = '';
+
     protected string $sourceSha = '';
+
     protected string $rawFrontmatter = '';
+
     protected string $supportStatus = SupportStatus::FULL->value;
+
     protected string $unsupportedNotes = '';
+
     protected string $allowedTools = '';
+
     protected string $trustLevel = SkillTrustLevel::UNTRUSTED->value;
+
     protected string $injectionScan = '';
+
     protected bool $orphaned = false;
+
     protected bool $enabled = false;
 
     public function getSource(): int
@@ -119,14 +133,17 @@ class Skill extends AbstractEntity
         if (trim($this->rawFrontmatter) === '') {
             return [];
         }
+
         $decoded = json_decode($this->rawFrontmatter, true);
         if (!is_array($decoded) || array_is_list($decoded)) {
             return [];
         }
+
         $out = [];
         foreach ($decoded as $k => $v) {
             $out[(string)$k] = $v;
         }
+
         return $out;
     }
 
@@ -184,6 +201,7 @@ class Skill extends AbstractEntity
         if ($this->allowedTools === '') {
             return null;
         }
+
         $decoded = json_decode($this->allowedTools, true);
         return is_array($decoded) ? array_values(array_filter($decoded, is_string(...))) : null;
     }
@@ -228,21 +246,26 @@ class Skill extends AbstractEntity
         if (trim($this->injectionScan) === '') {
             return [];
         }
+
         $decoded = json_decode($this->injectionScan, true);
         if (!is_array($decoded) || !array_is_list($decoded)) {
             return [];
         }
+
         $out = [];
         foreach ($decoded as $entry) {
             if (!is_array($entry)) {
                 continue;
             }
+
             $row = [];
             foreach ($entry as $key => $value) {
                 $row[(string)$key] = $value;
             }
+
             $out[] = $row;
         }
+
         return $out;
     }
 

--- a/Classes/Domain/Model/SkillSource.php
+++ b/Classes/Domain/Model/SkillSource.php
@@ -17,16 +17,27 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 class SkillSource extends AbstractEntity
 {
     protected string $title = '';
+
     protected string $type = SkillSourceType::SINGLE_FILE->value;
+
     protected string $url = '';
+
     protected string $ref = '';
+
     protected string $pinnedSha = '';
+
     protected string $githubToken = '';
+
     protected string $trustLevel = SkillTrustLevel::UNTRUSTED->value;
+
     protected string $expectedFingerprint = '';
+
     protected string $syncStatus = SyncStatus::NEVER_SYNCED->value;
+
     protected string $syncError = '';
+
     protected int $lastSynced = 0;
+
     protected bool $enabled = true;
 
     public function getTitle(): string

--- a/Classes/Domain/Model/Task.php
+++ b/Classes/Domain/Model/Task.php
@@ -34,12 +34,16 @@ class Task extends AbstractEntity
      * @deprecated Use TaskInputType enum instead
      */
     public const INPUT_MANUAL = 'manual';
+
     /** @deprecated Use TaskInputType enum instead */
     public const INPUT_SYSLOG = 'syslog';
+
     /** @deprecated Use TaskInputType enum instead */
     public const INPUT_DEPRECATION_LOG = 'deprecation_log';
+
     /** @deprecated Use TaskInputType enum instead */
     public const INPUT_TABLE = 'table';
+
     /** @deprecated Use TaskInputType enum instead */
     public const INPUT_FILE = 'file';
 
@@ -49,10 +53,13 @@ class Task extends AbstractEntity
      * @deprecated Use TaskOutputFormat enum instead
      */
     public const OUTPUT_MARKDOWN = 'markdown';
+
     /** @deprecated Use TaskOutputFormat enum instead */
     public const OUTPUT_JSON = 'json';
+
     /** @deprecated Use TaskOutputFormat enum instead */
     public const OUTPUT_PLAIN = 'plain';
+
     /** @deprecated Use TaskOutputFormat enum instead */
     public const OUTPUT_HTML = 'html';
 
@@ -62,28 +69,45 @@ class Task extends AbstractEntity
      * @deprecated Use TaskCategory enum instead
      */
     public const CATEGORY_LOG_ANALYSIS = 'log_analysis';
+
     /** @deprecated Use TaskCategory enum instead */
     public const CATEGORY_CONTENT = 'content';
+
     /** @deprecated Use TaskCategory enum instead */
     public const CATEGORY_SYSTEM = 'system';
+
     /** @deprecated Use TaskCategory enum instead */
     public const CATEGORY_DEVELOPER = 'developer';
+
     /** @deprecated Use TaskCategory enum instead */
     public const CATEGORY_GENERAL = 'general';
 
     protected string $identifier = '';
+
     protected string $name = '';
+
     protected string $description = '';
+
     protected string $category = TaskCategory::GENERAL->value;
+
     protected ?LlmConfiguration $configuration = null;
+
     protected string $promptTemplate = '';
+
     protected string $inputType = TaskInputType::MANUAL->value;
+
     protected string $inputSource = '';
+
     protected string $outputFormat = TaskOutputFormat::MARKDOWN->value;
+
     protected bool $isActive = true;
+
     protected bool $isSystem = false;
+
     protected int $sorting = 0;
+
     protected int $tstamp = 0;
+
     protected int $crdate = 0;
 
     /**
@@ -168,10 +192,12 @@ class Task extends AbstractEntity
         if ($this->inputSource === '') {
             return [];
         }
+
         $decoded = json_decode($this->inputSource, true);
         if (!is_array($decoded)) {
             return [];
         }
+
         /** @var array<string, mixed> $decoded */
         return $decoded;
     }
@@ -234,6 +260,7 @@ class Task extends AbstractEntity
         if (!isset($this->skills)) { // @phpstan-ignore isset.initializedProperty (Extbase reconstitution skips the constructor)
             $this->skills = new ObjectStorage();
         }
+
         return $this->skills;
     }
 

--- a/Classes/Domain/Model/TranslationResult.php
+++ b/Classes/Domain/Model/TranslationResult.php
@@ -59,6 +59,6 @@ final readonly class TranslationResult
      */
     public function hasAlternatives(): bool
     {
-        return !empty($this->alternatives);
+        return $this->alternatives !== null && $this->alternatives !== [];
     }
 }

--- a/Classes/Domain/Model/UserBudget.php
+++ b/Classes/Domain/Model/UserBudget.php
@@ -26,16 +26,21 @@ class UserBudget extends AbstractEntity
     protected int $beUser = 0;
 
     protected int $maxRequestsPerDay = 0;
+
     protected int $maxTokensPerDay = 0;
+
     protected float $maxCostPerDay = 0.0;
 
     protected int $maxRequestsPerMonth = 0;
+
     protected int $maxTokensPerMonth = 0;
+
     protected float $maxCostPerMonth = 0.0;
 
     protected bool $isActive = true;
 
     protected int $tstamp = 0;
+
     protected int $crdate = 0;
 
     public function getBeUser(): int

--- a/Classes/Domain/Model/VisionResponse.php
+++ b/Classes/Domain/Model/VisionResponse.php
@@ -41,7 +41,7 @@ final readonly class VisionResponse
      */
     public function getDescription(): string
     {
-        return $this->getText();
+        return $this->description;
     }
 
     /**

--- a/Classes/Domain/Repository/LlmConfigurationRepository.php
+++ b/Classes/Domain/Repository/LlmConfigurationRepository.php
@@ -173,6 +173,7 @@ class LlmConfigurationRepository extends Repository
             if (!$configuration instanceof LlmConfiguration) {
                 continue;
             }
+
             if ($configuration->isDefault()) {
                 $configuration->setIsDefault(false);
                 $this->update($configuration);

--- a/Classes/Domain/Repository/ModelRepository.php
+++ b/Classes/Domain/Repository/ModelRepository.php
@@ -244,6 +244,7 @@ class ModelRepository extends Repository
             if (!$model instanceof Model) {
                 continue;
             }
+
             if ($model->isDefault()) {
                 $model->setIsDefault(false);
                 $this->update($model);

--- a/Classes/Domain/Repository/ProviderRepository.php
+++ b/Classes/Domain/Repository/ProviderRepository.php
@@ -197,10 +197,12 @@ class ProviderRepository extends Repository
             if (!$provider instanceof Provider) {
                 continue;
             }
+
             $type = $provider->getAdapterType();
             if (!isset($counts[$type])) {
                 $counts[$type] = 0;
             }
+
             $counts[$type]++;
         }
 

--- a/Classes/Domain/Repository/UserBudgetRepository.php
+++ b/Classes/Domain/Repository/UserBudgetRepository.php
@@ -36,6 +36,7 @@ class UserBudgetRepository extends Repository
         if ($beUser <= 0) {
             return null;
         }
+
         $query = $this->createQuery();
         $query->matching($query->equals('beUser', $beUser));
         /** @var UserBudget|null $result */
@@ -70,6 +71,7 @@ class UserBudgetRepository extends Repository
             if (!$budget instanceof UserBudget) {
                 continue;
             }
+
             $uid = $budget->getBeUser();
             // First budget per user wins (matches findOneByBeUser()'s getFirst()).
             if (!isset($map[$uid])) {

--- a/Classes/Domain/ValueObject/AgentRun.php
+++ b/Classes/Domain/ValueObject/AgentRun.php
@@ -88,8 +88,6 @@ final readonly class AgentRun
             startedAt: $this->startedAt,
             finishedAt: $this->finishedAt,
             crdate: $this->crdate,
-            suspendedState: null,
-            queuedRequest: null,
             claimedBy: $this->claimedBy,
             leaseExpires: $this->leaseExpires,
             requeueCount: $this->requeueCount,

--- a/Classes/Domain/ValueObject/ChatMessage.php
+++ b/Classes/Domain/ValueObject/ChatMessage.php
@@ -76,6 +76,7 @@ final readonly class ChatMessage implements JsonSerializable
                 1736502001,
             );
         }
+
         $this->role = $resolved->value;
 
         if ($toolCalls !== null && $resolved !== MessageRole::ASSISTANT) {
@@ -84,6 +85,7 @@ final readonly class ChatMessage implements JsonSerializable
                 1752400001,
             );
         }
+
         if ($toolCalls === []) {
             throw new InvalidArgumentException(
                 'An assistant tool-call message requires at least one tool call.',
@@ -102,8 +104,10 @@ final readonly class ChatMessage implements JsonSerializable
                         1752400003,
                     );
                 }
+
                 $validated[] = $call;
             }
+
             $this->toolCalls = $validated;
         }
 
@@ -113,6 +117,7 @@ final readonly class ChatMessage implements JsonSerializable
                 1752400004,
             );
         }
+
         if ($this->toolCallId === '') {
             throw new InvalidArgumentException(
                 'A tool message requires a non-empty tool_call_id.',
@@ -234,12 +239,14 @@ final readonly class ChatMessage implements JsonSerializable
 
                     continue;
                 }
+
                 if (!is_array($call)) {
                     throw new InvalidArgumentException(
                         'Every "tool_calls" element must be an array or a ToolCall instance.',
                         1752400007,
                     );
                 }
+
                 /** @var array{id?: string, type?: string, function?: array{name?: string, arguments?: string|array<string, mixed>}} $call */
                 $toolCalls[] = ToolCall::fromArray($call);
             }
@@ -255,12 +262,13 @@ final readonly class ChatMessage implements JsonSerializable
 
         $content = $data['content'] ?? null;
         if (!is_string($content)) {
-            if (!($content === null && $toolCalls !== null)) {
+            if ($content !== null || $toolCalls === null) {
                 throw new InvalidArgumentException(
                     'ChatMessage::fromArray() requires a string "content" key.',
                     1736502003,
                 );
             }
+
             $content = '';
         }
 

--- a/Classes/Domain/ValueObject/SuspendedRunState.php
+++ b/Classes/Domain/ValueObject/SuspendedRunState.php
@@ -127,6 +127,7 @@ final readonly class SuspendedRunState
         if (!is_array($value)) {
             return [];
         }
+
         $out = [];
         foreach ($value as $item) {
             if (is_array($item)) {

--- a/Classes/Domain/ValueObject/ToolCall.php
+++ b/Classes/Domain/ValueObject/ToolCall.php
@@ -59,12 +59,14 @@ final readonly class ToolCall implements JsonSerializable
                 1745411001,
             );
         }
+
         if ($this->name === '') {
             throw new InvalidArgumentException(
                 'ToolCall name must not be empty.',
                 1745411002,
             );
         }
+
         if ($this->type === '') {
             throw new InvalidArgumentException(
                 'ToolCall type must not be empty.',
@@ -198,6 +200,7 @@ final readonly class ToolCall implements JsonSerializable
             /** @var array<string, mixed> $raw */
             return $raw;
         }
+
         if (\is_string($raw) && $raw !== '') {
             $decoded = \json_decode($raw, true);
             if (\is_array($decoded)) {

--- a/Classes/Domain/ValueObject/ToolSpec.php
+++ b/Classes/Domain/ValueObject/ToolSpec.php
@@ -67,6 +67,7 @@ final readonly class ToolSpec implements JsonSerializable
                 1745410001,
             );
         }
+
         if ($this->type === '') {
             throw new InvalidArgumentException(
                 'ToolSpec type must not be empty.',
@@ -74,7 +75,7 @@ final readonly class ToolSpec implements JsonSerializable
             );
         }
 
-        $this->parameters = self::normaliseParameters($parameters);
+        $this->parameters = $this->normaliseParameters($parameters);
     }
 
     /**
@@ -90,7 +91,7 @@ final readonly class ToolSpec implements JsonSerializable
      *
      * @return array<string, mixed>
      */
-    private static function normaliseParameters(array $parameters): array
+    private function normaliseParameters(array $parameters): array
     {
         if (($parameters['properties'] ?? null) === []) {
             $parameters['properties'] = new stdClass();
@@ -134,6 +135,7 @@ final readonly class ToolSpec implements JsonSerializable
                 1745410003,
             );
         }
+
         $function = $data['function'];
         if (!isset($function['name']) || !\is_string($function['name'])) {
             throw new InvalidArgumentException(

--- a/Classes/Domain/ValueObject/VisionContent.php
+++ b/Classes/Domain/ValueObject/VisionContent.php
@@ -32,10 +32,13 @@ use Netresearch\NrLlm\Exception\InvalidArgumentException;
 final readonly class VisionContent implements JsonSerializable
 {
     public const TYPE_TEXT      = 'text';
+
     public const TYPE_IMAGE_URL = 'image_url';
 
     public const DETAIL_LOW  = 'low';
+
     public const DETAIL_HIGH = 'high';
+
     public const DETAIL_AUTO = 'auto';
 
     /**
@@ -81,18 +84,21 @@ final readonly class VisionContent implements JsonSerializable
                 1745420001,
             );
         }
+
         if ($this->type === self::TYPE_TEXT && ($this->text === null || $this->text === '')) {
             throw new InvalidArgumentException(
                 'VisionContent of type "text" requires a non-empty text payload.',
                 1745420002,
             );
         }
+
         if ($this->type === self::TYPE_IMAGE_URL && ($this->imageUrl === null || $this->imageUrl === '')) {
             throw new InvalidArgumentException(
                 'VisionContent of type "image_url" requires a non-empty URL.',
                 1745420003,
             );
         }
+
         if ($this->detail !== null && !\in_array($this->detail, self::KNOWN_DETAILS, true)) {
             throw new InvalidArgumentException(
                 sprintf(
@@ -103,6 +109,7 @@ final readonly class VisionContent implements JsonSerializable
                 1745420004,
             );
         }
+
         if ($this->detail !== null && $this->type !== self::TYPE_IMAGE_URL) {
             throw new InvalidArgumentException(
                 'VisionContent detail can only be set on image_url items.',
@@ -165,6 +172,7 @@ final readonly class VisionContent implements JsonSerializable
                         1745420004,
                     );
                 }
+
                 $detail = $imageUrl['detail'];
             }
 
@@ -235,6 +243,7 @@ final readonly class VisionContent implements JsonSerializable
         if (\is_string($raw)) {
             return $raw;
         }
+
         if (\is_array($raw)) {
             $url = $raw['url'] ?? '';
 

--- a/Classes/Form/Element/ModelIdElement.php
+++ b/Classes/Form/Element/ModelIdElement.php
@@ -24,6 +24,7 @@ use TYPO3\CMS\Core\Utility\StringUtility;
 final class ModelIdElement extends AbstractFormElement
 {
     public function __construct(private readonly BackendUriBuilder $uriBuilder) {}
+
     /**
      * @return array<string, mixed>
      */

--- a/Classes/Form/FieldWizard/ModelConstraintsWizard.php
+++ b/Classes/Form/FieldWizard/ModelConstraintsWizard.php
@@ -22,6 +22,7 @@ use TYPO3\CMS\Core\Page\JavaScriptModuleInstruction;
 final class ModelConstraintsWizard extends AbstractNode
 {
     public function __construct(private readonly BackendUriBuilder $uriBuilder) {}
+
     /**
      * @return array<string, mixed>
      */

--- a/Classes/Form/Tca/GuardrailItems.php
+++ b/Classes/Form/Tca/GuardrailItems.php
@@ -50,6 +50,7 @@ final class GuardrailItems
         } else {
             $stored = (string)$stored;
         }
+
         foreach (GeneralUtility::trimExplode(',', $stored, true) as $known) {
             $ids[$known] ??= true;
         }

--- a/Classes/Form/Tca/ToolGroupItems.php
+++ b/Classes/Form/Tca/ToolGroupItems.php
@@ -38,6 +38,7 @@ final class ToolGroupItems
                 $groups[$tool->getGroup()] = true;
             }
         }
+
         ksort($groups);
 
         // Keep already-stored but currently unknown groups selectable.
@@ -53,6 +54,7 @@ final class ToolGroupItems
         } else {
             $stored = (string)$stored;
         }
+
         foreach (GeneralUtility::trimExplode(',', $stored, true) as $known) {
             $groups[$known] ??= true;
         }

--- a/Classes/Hook/ProviderEndpointNormalizationHook.php
+++ b/Classes/Hook/ProviderEndpointNormalizationHook.php
@@ -11,7 +11,6 @@ namespace Netresearch\NrLlm\Hook;
 
 use Netresearch\NrLlm\Service\SetupWizard\ProviderDetector;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
-use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 
@@ -39,7 +38,6 @@ final class ProviderEndpointNormalizationHook
         array &$fieldArray,
         string $table,
         int|string $id,
-        DataHandler $dataHandler,
     ): void {
         if ($table !== 'tx_nrllm_provider' || !array_key_exists('endpoint_url', $fieldArray)) {
             return;

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -46,22 +46,32 @@ abstract class AbstractProvider implements ProviderInterface
      * @deprecated Use ModelCapability enum instead
      */
     protected const FEATURE_CHAT = 'chat';
+
     /** @deprecated Use ModelCapability enum instead */
     protected const FEATURE_COMPLETION = 'completion';
+
     /** @deprecated Use ModelCapability enum instead */
     protected const FEATURE_EMBEDDINGS = 'embeddings';
+
     /** @deprecated Use ModelCapability enum instead */
     protected const FEATURE_VISION = 'vision';
+
     /** @deprecated Use ModelCapability enum instead */
     protected const FEATURE_STREAMING = 'streaming';
+
     /** @deprecated Use ModelCapability enum instead */
     protected const FEATURE_TOOLS = 'tools';
 
     protected string $apiKeyIdentifier = '';
+
     protected string $baseUrl = '';
+
     protected string $defaultModel = '';
+
     protected int $timeout = 120;
+
     protected int $maxRetries = 3;
+
     protected string $organizationId = '';
 
     /**
@@ -173,7 +183,7 @@ abstract class AbstractProvider implements ProviderInterface
      */
     protected function getHttpClient(?int $timeout = null): ClientInterface
     {
-        if ($this->configuredHttpClient !== null) {
+        if ($this->configuredHttpClient instanceof ClientInterface) {
             return $this->configuredHttpClient;
         }
 
@@ -323,6 +333,7 @@ abstract class AbstractProvider implements ProviderInterface
         if ($httpClient instanceof VaultHttpClientInterface) {
             $httpClient = $httpClient->withReason($this->buildAuditReason($endpoint, $payload));
         }
+
         $attempt = 0;
         $lastException = null;
         // maxRetries counts retries after the initial attempt; max_retries = 0
@@ -367,7 +378,7 @@ abstract class AbstractProvider implements ProviderInterface
                     // attempt >= 9 (100000 * 2**9 = 51.2s already exceeds the
                     // cap) so the 2 ** $attempt term cannot overflow the float→int
                     // cast into a negative value and make usleep() throw.
-                    $backoffMicros = $attempt >= 9 ? 30_000_000 : (int)(100000 * (2 ** $attempt));
+                    $backoffMicros = $attempt >= 9 ? 30_000_000 : 100000 * (2 ** $attempt);
                     usleep($backoffMicros);
                 }
             }
@@ -491,7 +502,15 @@ abstract class AbstractProvider implements ProviderInterface
                 continue;
             }
 
-            if (!is_string($value) || str_contains($value, "\r") || str_contains($value, "\n")) {
+            if (!is_string($value)) {
+                continue;
+            }
+
+            if (str_contains($value, "\r")) {
+                continue;
+            }
+
+            if (str_contains($value, "\n")) {
                 continue;
             }
 

--- a/Classes/Provider/CircuitBreaker/CircuitState.php
+++ b/Classes/Provider/CircuitBreaker/CircuitState.php
@@ -35,7 +35,7 @@ final readonly class CircuitState
      */
     public static function closed(): self
     {
-        return new self(0, null);
+        return new self(0);
     }
 
     /**

--- a/Classes/Provider/ClaudeProvider.php
+++ b/Classes/Provider/ClaudeProvider.php
@@ -46,6 +46,7 @@ final class ClaudeProvider extends AbstractProvider implements
     ];
 
     private const DEFAULT_MODEL = 'claude-sonnet-4-5-20250929';
+
     private const API_VERSION = '2023-06-01';
 
     public function getName(): string
@@ -703,6 +704,7 @@ final class ClaudeProvider extends AbstractProvider implements
             if (is_string($arguments)) {
                 $arguments = json_decode($arguments, true) ?? [];
             }
+
             if (!is_array($arguments)) {
                 $arguments = [];
             }

--- a/Classes/Provider/Exception/ProviderResponseException.php
+++ b/Classes/Provider/Exception/ProviderResponseException.php
@@ -50,6 +50,7 @@ use Throwable;
 class ProviderResponseException extends ProviderException
 {
     public readonly int $httpStatus;
+
     public readonly string $endpoint;
 
     public function __construct(
@@ -61,7 +62,7 @@ class ProviderResponseException extends ProviderException
     ) {
         parent::__construct($message, $httpStatus, $previous);
         $this->httpStatus = $httpStatus;
-        $this->endpoint   = self::sanitizeEndpoint($endpoint);
+        $this->endpoint   = $this->sanitizeEndpoint($endpoint);
     }
 
     /**
@@ -70,12 +71,13 @@ class ProviderResponseException extends ProviderException
      * endpoint field is meant for diagnostic purposes only and must
      * never leak credentials downstream.
      */
-    private static function sanitizeEndpoint(string $endpoint): string
+    private function sanitizeEndpoint(string $endpoint): string
     {
         $queryStart = strpos($endpoint, '?');
         if ($queryStart === false) {
             return $endpoint;
         }
+
         return substr($endpoint, 0, $queryStart);
     }
 }

--- a/Classes/Provider/GeminiProvider.php
+++ b/Classes/Provider/GeminiProvider.php
@@ -45,6 +45,7 @@ final class GeminiProvider extends AbstractProvider implements
     ];
 
     private const DEFAULT_MODEL = 'gemini-3-flash-preview';
+
     // text-embedding-004 was shut down 2026-01-14 and gemini-embedding-001
     // retires 2026-07-14; gemini-embedding-2 is the current GA default and
     // remains compatible with the text-only embedContent request below.
@@ -750,6 +751,7 @@ final class GeminiProvider extends AbstractProvider implements
             if (is_string($arguments)) {
                 $arguments = json_decode($arguments, true) ?? [];
             }
+
             if (!is_array($arguments)) {
                 $arguments = [];
             }

--- a/Classes/Provider/GroqProvider.php
+++ b/Classes/Provider/GroqProvider.php
@@ -233,7 +233,7 @@ final class GroqProvider extends AbstractProvider implements
                 // Untrusted provider output: skip a malformed tool call (missing
                 // id/name) instead of crashing the whole completion.
                 $call = ToolCall::tryFromArray($this->asArray($tc));
-                if ($call !== null) {
+                if ($call instanceof ToolCall) {
                     $toolCalls[] = $call;
                 }
             }

--- a/Classes/Provider/Middleware/BudgetMiddleware.php
+++ b/Classes/Provider/Middleware/BudgetMiddleware.php
@@ -74,6 +74,7 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 final readonly class BudgetMiddleware implements ProviderMiddlewareInterface
 {
     public const METADATA_BE_USER_UID  = 'beUserUid';
+
     public const METADATA_PLANNED_COST = 'plannedCost';
 
     public function __construct(

--- a/Classes/Provider/Middleware/CacheMiddleware.php
+++ b/Classes/Provider/Middleware/CacheMiddleware.php
@@ -75,7 +75,9 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 final readonly class CacheMiddleware implements ProviderMiddlewareInterface
 {
     public const METADATA_CACHE_KEY  = 'cacheKey';
+
     public const METADATA_CACHE_TTL  = 'cacheTtl';
+
     public const METADATA_CACHE_TAGS = 'cacheTags';
 
     private const DEFAULT_TTL_SECONDS = 3600;

--- a/Classes/Provider/Middleware/CircuitBreakerMiddleware.php
+++ b/Classes/Provider/Middleware/CircuitBreakerMiddleware.php
@@ -77,6 +77,7 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 final readonly class CircuitBreakerMiddleware implements ProviderMiddlewareInterface
 {
     private const DEFAULT_FAILURE_THRESHOLD = 5;
+
     private const DEFAULT_COOLDOWN_SECONDS  = 30;
 
     public function __construct(
@@ -114,6 +115,7 @@ final readonly class CircuitBreakerMiddleware implements ProviderMiddlewareInter
             // Fail fast so FallbackMiddleware can try the next provider.
             throw new CircuitOpenException($provider, $state->secondsUntilHalfOpen($now, $cooldown));
         }
+
         if ($halfOpenProbe) {
             // Cooldown elapsed. Reserve the single probe by refreshing the open
             // window up front, so any concurrent caller keeps failing fast while
@@ -246,6 +248,7 @@ final readonly class CircuitBreakerMiddleware implements ProviderMiddlewareInter
         if (\is_int($value) && $value > 0) {
             return $value;
         }
+
         if (\is_string($value) && ctype_digit($value) && (int)$value > 0) {
             return (int)$value;
         }

--- a/Classes/Provider/Middleware/FallbackMiddleware.php
+++ b/Classes/Provider/Middleware/FallbackMiddleware.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Middleware;
 
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Provider\Exception\FallbackChainExhaustedException;
 use Netresearch\NrLlm\Service\Health\ProviderHealthServiceInterface;
@@ -69,7 +70,7 @@ final readonly class FallbackMiddleware implements ProviderMiddlewareInterface
         // fallback chain — there is nothing to swap to, so pass it straight
         // through, exactly as an empty chain does.
         $configuration = $context->configuration;
-        if ($configuration === null || $configuration->getFallbackChainDTO()->isEmpty()) {
+        if (!$configuration instanceof LlmConfiguration || $configuration->getFallbackChainDTO()->isEmpty()) {
             return $next($context);
         }
 
@@ -82,6 +83,7 @@ final readonly class FallbackMiddleware implements ProviderMiddlewareInterface
             if (!$this->isRetryable($e)) {
                 throw $e;
             }
+
             $attempts[] = [
                 'configuration' => $configuration->getIdentifier(),
                 'error'         => $e,
@@ -123,7 +125,7 @@ final readonly class FallbackMiddleware implements ProviderMiddlewareInterface
 
         foreach ($chain->configurationIdentifiers as $identifier) {
             $fallback = $this->repository->findOneByIdentifier($identifier);
-            if ($fallback === null) {
+            if (!$fallback instanceof LlmConfiguration) {
                 $this->logger->warning(
                     'LLM fallback configuration not found, skipping',
                     [
@@ -134,6 +136,7 @@ final readonly class FallbackMiddleware implements ProviderMiddlewareInterface
                 );
                 continue;
             }
+
             if (!$fallback->isActive()) {
                 $this->logger->warning(
                     'LLM fallback configuration is inactive, skipping',
@@ -170,6 +173,7 @@ final readonly class FallbackMiddleware implements ProviderMiddlewareInterface
                 if (!$this->isRetryable($e)) {
                     throw $e;
                 }
+
                 $attempts[] = [
                     'configuration' => $identifier,
                     'error'         => $e,

--- a/Classes/Provider/Middleware/GuardrailMiddleware.php
+++ b/Classes/Provider/Middleware/GuardrailMiddleware.php
@@ -87,6 +87,7 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
         if ($result instanceof CompletionResponse) {
             return $this->screen($result, $context, $next, false, $guardrails);
         }
+
         if ($result instanceof VisionResponse) {
             return $this->screenVision($result, $context, $guardrails);
         }
@@ -117,6 +118,7 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
                     'A guardrail asked to retry, but retrying is not supported for vision responses.',
                 );
             }
+
             $screened = match ($verdict) {
                 GuardrailVerdict::ALLOW => $screened,
                 GuardrailVerdict::REDACT => $result->redactedContent ?? $screened,
@@ -198,6 +200,7 @@ final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
                 'A guardrail asked to retry, but the retried response also failed: ' . $result->reason,
             );
         }
+
         // $next is the behavioural stack BELOW this guardrail (Budget → Fallback →
         // Usage → CircuitBreaker → terminal) and INSIDE Idempotency/Cache, so a
         // retry genuinely re-runs the provider rather than replaying an

--- a/Classes/Provider/Middleware/ProviderMiddlewareInterface.php
+++ b/Classes/Provider/Middleware/ProviderMiddlewareInterface.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Middleware;
 
-use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 /**

--- a/Classes/Provider/Middleware/UsageMiddleware.php
+++ b/Classes/Provider/Middleware/UsageMiddleware.php
@@ -11,7 +11,7 @@ namespace Netresearch\NrLlm\Provider\Middleware;
 
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
-use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Provider\Middleware\Usage\UsageMetricsExtractorInterface;
@@ -139,7 +139,7 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
         mixed $result,
     ): void {
         [$usage, $provider, $responseModel] = $this->extractUsage($result);
-        if ($usage === null) {
+        if (!$usage instanceof UsageStatistics) {
             // Not a token-shaped response — a specialized operation (image /
             // speech / translation) records through its tagged extractor instead
             // (ADR-100).
@@ -169,7 +169,7 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
         // Cost: prefer a cost the provider already computed; otherwise derive
         // it from the model's pricing and the prompt/completion token split.
         $cost = $usage->estimatedCost;
-        if ($cost === null && $model !== null && $model->hasPricing()) {
+        if ($cost === null && $model instanceof Model && $model->hasPricing()) {
             $cost = $model->estimateCost($usage->promptTokens, $usage->completionTokens);
         }
 

--- a/Classes/Provider/MistralProvider.php
+++ b/Classes/Provider/MistralProvider.php
@@ -50,6 +50,7 @@ final class MistralProvider extends AbstractProvider implements
     private const ENDPOINT_CHAT_COMPLETIONS = 'chat/completions';
 
     private const DEFAULT_CHAT_MODEL = 'mistral-large-latest';
+
     private const DEFAULT_EMBEDDING_MODEL = 'mistral-embed';
 
     /** @var array<string, string> */
@@ -218,7 +219,7 @@ final class MistralProvider extends AbstractProvider implements
                 // Untrusted provider output: skip a malformed tool call (missing
                 // id/name) instead of crashing the whole completion.
                 $call = ToolCall::tryFromArray($this->asArray($tc));
-                if ($call !== null) {
+                if ($call instanceof ToolCall) {
                     $toolCalls[] = $call;
                 }
             }

--- a/Classes/Provider/OllamaProvider.php
+++ b/Classes/Provider/OllamaProvider.php
@@ -107,7 +107,7 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
             // in a misconfigured baseUrl don't leak into sys_log.
             $this->logger->warning('Ollama: getAvailableModels failed, returning hardcoded defaults', [
                 'exception' => $e,
-                'baseUrl'   => self::sanitizeUrlForLog($this->baseUrl),
+                'baseUrl'   => $this->sanitizeUrlForLog($this->baseUrl),
             ]);
 
             return [
@@ -129,7 +129,7 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
      * embedded credentials (`https://user:pass@host:11434`) does not leak
      * those credentials into sys_log.
      */
-    private static function sanitizeUrlForLog(string $url): string
+    private function sanitizeUrlForLog(string $url): string
     {
         $parts = parse_url($url);
         if (!is_array($parts)) {
@@ -291,9 +291,10 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
                 // Untrusted provider output: skip a malformed call (missing name)
                 // instead of crashing the whole completion.
                 $call = ToolCall::tryFromArray($callData);
-                if ($call !== null) {
+                if ($call instanceof ToolCall) {
                     $toolCalls[] = $call;
                 }
+
                 ++$index;
             }
         }
@@ -367,6 +368,7 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
                 foreach ($message['tool_calls'] as $call) {
                     $calls[] = $this->decodeToolCallArguments($call);
                 }
+
                 $message['tool_calls'] = $calls;
             }
 

--- a/Classes/Provider/OpenAiProvider.php
+++ b/Classes/Provider/OpenAiProvider.php
@@ -44,6 +44,7 @@ final class OpenAiProvider extends AbstractProvider implements
     private const ENDPOINT_CHAT_COMPLETIONS = 'chat/completions';
 
     private const DEFAULT_CHAT_MODEL = 'gpt-5.2';
+
     private const DEFAULT_EMBEDDING_MODEL = 'text-embedding-3-small';
 
     public function getName(): string
@@ -76,7 +77,7 @@ final class OpenAiProvider extends AbstractProvider implements
     protected function addProviderSpecificHeaders(RequestInterface $request): RequestInterface
     {
         if ($this->organizationId !== '') {
-            $request = $request->withHeader('OpenAI-Organization', $this->organizationId);
+            return $request->withHeader('OpenAI-Organization', $this->organizationId);
         }
 
         return $request;
@@ -214,7 +215,7 @@ final class OpenAiProvider extends AbstractProvider implements
                 // Untrusted provider output: skip a malformed tool call (missing
                 // id/name) instead of crashing the whole completion.
                 $call = ToolCall::tryFromArray($this->asArray($tc));
-                if ($call !== null) {
+                if ($call instanceof ToolCall) {
                     $toolCalls[] = $call;
                 }
             }

--- a/Classes/Provider/OpenRouterProvider.php
+++ b/Classes/Provider/OpenRouterProvider.php
@@ -65,6 +65,7 @@ final class OpenRouterProvider extends AbstractProvider implements
     private const ENDPOINT_CHAT_COMPLETIONS = 'chat/completions';
 
     private const DEFAULT_CHAT_MODEL = 'anthropic/claude-sonnet-4-5';
+
     private const DEFAULT_EMBEDDING_MODEL = 'openai/text-embedding-3-small';
 
     /** @var array<int, string> */
@@ -406,7 +407,7 @@ final class OpenRouterProvider extends AbstractProvider implements
                 // Untrusted provider output: skip a malformed tool call (missing
                 // id/name) instead of crashing the whole completion.
                 $call = ToolCall::tryFromArray($this->asArray($tc));
-                if ($call !== null) {
+                if ($call instanceof ToolCall) {
                     $toolCalls[] = $call;
                 }
             }
@@ -657,6 +658,7 @@ final class OpenRouterProvider extends AbstractProvider implements
         if ($this->siteUrl !== '') {
             $request = $request->withHeader('HTTP-Referer', $this->siteUrl);
         }
+
         if ($this->appName !== '') {
             $request = $request->withHeader('X-Title', $this->appName);
         }
@@ -754,7 +756,7 @@ final class OpenRouterProvider extends AbstractProvider implements
         if ($minContext > 0) {
             $filtered = array_filter(
                 $filtered,
-                static fn($model) => $model['context_length'] >= $minContext,
+                static fn(array $model): bool => $model['context_length'] >= $minContext,
             );
         }
 
@@ -762,15 +764,15 @@ final class OpenRouterProvider extends AbstractProvider implements
         if ($this->getBool($options, 'vision_required')) {
             $filtered = array_filter(
                 $filtered,
-                static fn($model) => $model['capabilities']['vision'] ?? false,
+                static fn(array $model) => $model['capabilities']['vision'] ?? false,
             );
         }
 
         // Function calling
         if ($this->getBool($options, 'function_calling')) {
-            $filtered = array_filter(
+            return array_filter(
                 $filtered,
-                static fn($model) => $model['capabilities']['function_calling'] ?? false,
+                static fn(array $model) => $model['capabilities']['function_calling'] ?? false,
             );
         }
 
@@ -900,6 +902,7 @@ final class OpenRouterProvider extends AbstractProvider implements
         if ($this->siteUrl !== '') {
             $request = $request->withHeader('HTTP-Referer', $this->siteUrl);
         }
+
         if ($this->appName !== '') {
             $request = $request->withHeader('X-Title', $this->appName);
         }

--- a/Classes/Provider/ProviderAdapterRegistry.php
+++ b/Classes/Provider/ProviderAdapterRegistry.php
@@ -120,6 +120,7 @@ final class ProviderAdapterRegistry implements ProviderAdapterRegistryInterface,
                     1735300002,
                 );
             }
+
             if (!is_string($adapterClass) || $adapterClass === '') {
                 throw new ProviderConfigurationException(
                     sprintf(
@@ -130,6 +131,7 @@ final class ProviderAdapterRegistry implements ProviderAdapterRegistryInterface,
                     1735300003,
                 );
             }
+
             if (!is_subclass_of($adapterClass, AbstractProvider::class)) {
                 throw new ProviderConfigurationException(
                     sprintf('Adapter class %s must extend %s', $adapterClass, AbstractProvider::class),
@@ -245,7 +247,7 @@ final class ProviderAdapterRegistry implements ProviderAdapterRegistryInterface,
     {
         $provider = $model->getProvider();
 
-        if ($provider === null) {
+        if (!$provider instanceof Provider) {
             throw new ProviderConfigurationException(
                 sprintf('Model "%s" has no associated provider', $model->getIdentifier()),
                 1735300002,
@@ -319,8 +321,8 @@ final class ProviderAdapterRegistry implements ProviderAdapterRegistryInterface,
 
         // Merge additional options from JSON field
         $additionalOptions = $provider->getOptionsArray();
-        if (!empty($additionalOptions)) {
-            $config = array_merge($config, $additionalOptions);
+        if ($additionalOptions !== []) {
+            return array_merge($config, $additionalOptions);
         }
 
         return $config;

--- a/Classes/Provider/ResponseParserTrait.php
+++ b/Classes/Provider/ResponseParserTrait.php
@@ -53,6 +53,7 @@ trait ResponseParserTrait
             );
         }
     }
+
     /**
      * Get a string value from array, with optional default.
      *
@@ -144,6 +145,7 @@ trait ResponseParserTrait
         if (!is_array($value)) {
             return $default;
         }
+
         /** @var array<string, mixed> $value */
         return $value;
     }
@@ -162,6 +164,7 @@ trait ResponseParserTrait
         if (!is_array($value)) {
             return [];
         }
+
         /** @var array<int, array<string, mixed>> $value */
         return $value;
     }
@@ -223,12 +226,14 @@ trait ResponseParserTrait
             if (!is_array($current) || !array_key_exists($key, $current)) {
                 return $default;
             }
+
             $current = $current[$key];
         }
 
         if (!is_array($current)) {
             return $default;
         }
+
         /** @var array<string, mixed> $current */
         return $current;
     }
@@ -247,6 +252,7 @@ trait ResponseParserTrait
             if (!is_array($current) || !array_key_exists($key, $current)) {
                 return $default;
             }
+
             $current = $current[$key];
         }
 
@@ -267,6 +273,7 @@ trait ResponseParserTrait
             if (!is_array($current) || !array_key_exists($key, $current)) {
                 return $default;
             }
+
             $current = $current[$key];
         }
 
@@ -287,6 +294,7 @@ trait ResponseParserTrait
         if (!is_array($value)) {
             return $default;
         }
+
         /** @var array<string, mixed> $value */
         return $value;
     }
@@ -303,6 +311,7 @@ trait ResponseParserTrait
         if (!is_array($value)) {
             return [];
         }
+
         /** @var array<int, array<string, mixed>> $value */
         return $value;
     }

--- a/Classes/Service/Agent/AgentRunExecutor.php
+++ b/Classes/Service/Agent/AgentRunExecutor.php
@@ -169,7 +169,7 @@ final readonly class AgentRunExecutor
      */
     private function trace(?AgentRunHandle $handle, ?Closure $onStep, bool $captureRaw, ?string $leaseOwner = null): RunTrace
     {
-        if ($handle === null && $onStep === null) {
+        if (!$handle instanceof AgentRunHandle && !$onStep instanceof Closure) {
             return new RunTrace(captureRaw: $captureRaw);
         }
 
@@ -179,10 +179,11 @@ final readonly class AgentRunExecutor
                 // The live observer sees the step FIRST (emit-before-persist),
                 // so a step is shown even when its persistence or the checks
                 // below abort the loop.
-                if ($onStep !== null) {
+                if ($onStep instanceof Closure) {
                     $onStep($step);
                 }
-                if ($handle === null) {
+
+                if (!$handle instanceof AgentRunHandle) {
                     return;
                 }
 
@@ -213,7 +214,7 @@ final readonly class AgentRunExecutor
 
                 $this->recordStepFailClosedForWrites($handle, $step);
             },
-            onBeforeTool: $leaseOwner === null || $handle === null ? null : function (string $toolName) use ($handle, $leaseOwner): void {
+            onBeforeTool: $leaseOwner === null || !$handle instanceof AgentRunHandle ? null : function (string $toolName) use ($handle, $leaseOwner): void {
                 // Fence a WRITE before it runs (ADR-111): stamp its effect and
                 // renew the lease so a reap mid non-idempotent-write dead-letters
                 // instead of retrying. Read-only tools need no fence — repeating
@@ -283,7 +284,7 @@ final readonly class AgentRunExecutor
      */
     private function stepEffect(RunStep $step): ToolEffect
     {
-        if ($step->kind !== RunStep::KIND_TOOL || $this->toolEffectResolver === null) {
+        if ($step->kind !== RunStep::KIND_TOOL || !$this->toolEffectResolver instanceof ToolEffectResolver) {
             return ToolEffect::READ_ONLY;
         }
 
@@ -311,13 +312,13 @@ final readonly class AgentRunExecutor
      */
     private function execute(?AgentRunHandle $handle, RunTrace $trace, Closure $loopCall, ?Closure $recover = null, ?string $ownerGuard = null): AgentRunResult
     {
-        $runUuid = $handle !== null ? $handle->uuid : '';
+        $runUuid = $handle instanceof AgentRunHandle ? $handle->uuid : '';
         $settled = false;
 
         try {
             $result = $loopCall();
 
-            if ($handle !== null) {
+            if ($handle instanceof AgentRunHandle) {
                 $settledOk = $this->persister->settleCompleted($handle, $result, $ownerGuard);
                 // Ownership-guarded on the queued path: if the run was reclaimed
                 // to another worker mid-loop, this completion must not overwrite
@@ -328,6 +329,7 @@ final readonly class AgentRunExecutor
                     return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $trace->getSteps());
                 }
             }
+
             $settled = true;
 
             return new AgentRunResult(
@@ -357,7 +359,7 @@ final readonly class AgentRunExecutor
             // finally-guard must not run either way.
             $settled = true;
 
-            if ($handle !== null && $this->persister->suspend($handle, $approval->state)) {
+            if ($handle instanceof AgentRunHandle && $this->persister->suspend($handle, $approval->state)) {
                 return new AgentRunResult(
                     outcome: AgentRunOutcome::AWAITING_APPROVAL,
                     runUuid: $runUuid,
@@ -374,11 +376,12 @@ final readonly class AgentRunExecutor
             // since ADR-101 (the old code silently ignored a failed
             // re-suspension AND announced awaiting-approval for unpersisted
             // runs).
-            if ($handle !== null) {
+            if ($handle instanceof AgentRunHandle) {
                 // Ownership-guarded so a reclaimed queued run is not clobbered by
                 // this worker's fail-closed settle.
                 $this->persister->settleFailed($handle, $approval, $ownerGuard);
             }
+
             $this->logger?->error('Agent run could not be suspended for approval; no resume is possible', ['run' => $runUuid]);
 
             return new AgentRunResult(
@@ -397,7 +400,7 @@ final readonly class AgentRunExecutor
             // must not be flipped to FAILED.
             $settled = true;
 
-            if ($handle !== null && $this->persister->suspendForInput($handle, $input->state)) {
+            if ($handle instanceof AgentRunHandle && $this->persister->suspendForInput($handle, $input->state)) {
                 return new AgentRunResult(
                     outcome: AgentRunOutcome::AWAITING_INPUT,
                     runUuid: $runUuid,
@@ -410,11 +413,12 @@ final readonly class AgentRunExecutor
             // refused or errored, a concurrent cancel terminated the row, or the
             // run was never persisted (null handle) — there is nothing to resume,
             // so promising an input flow would strand the client.
-            if ($handle !== null) {
+            if ($handle instanceof AgentRunHandle) {
                 // Ownership-guarded so a reclaimed queued run is not clobbered by
                 // this worker's fail-closed settle.
                 $this->persister->settleFailed($handle, $input, $ownerGuard);
             }
+
             $this->logger?->error('Agent run could not be suspended for input; no resume is possible', ['run' => $runUuid]);
 
             return new AgentRunResult(
@@ -427,7 +431,7 @@ final readonly class AgentRunExecutor
             // ADR-085/086: a guardrail verdict is a policy outcome, not a
             // failure — and an approval that was required but never obtained
             // is not recorded as an outright denial (ADR-092).
-            if ($handle !== null) {
+            if ($handle instanceof AgentRunHandle) {
                 $settledOk = $this->persister->settlePolicyStopped(
                     $handle,
                     $guardrail,
@@ -446,6 +450,7 @@ final readonly class AgentRunExecutor
                     return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $trace->getSteps(), error: $guardrail);
                 }
             }
+
             $settled = true;
             $this->logger?->warning('Agent run blocked by guardrail', ['exception' => $guardrail, 'run' => $runUuid]);
 
@@ -477,7 +482,7 @@ final readonly class AgentRunExecutor
             // when it handles the failure, settles the row itself and returns
             // the replacement outcome. Only an interactive run (no recover) or a
             // recover that declines (null) falls through to the default settle.
-            if ($recover !== null) {
+            if ($recover instanceof Closure) {
                 $recovery = $recover($e, $trace->getSteps());
                 if ($recovery instanceof AgentRunResult) {
                     $settled = true;
@@ -486,7 +491,7 @@ final readonly class AgentRunExecutor
                 }
             }
 
-            if ($handle !== null) {
+            if ($handle instanceof AgentRunHandle) {
                 $settledOk = $this->persister->settleFailed($handle, $e, $ownerGuard);
                 if ($ownerGuard !== null && !$settledOk) {
                     $settled = true;
@@ -495,6 +500,7 @@ final readonly class AgentRunExecutor
                     return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $trace->getSteps(), error: $e);
                 }
             }
+
             $settled = true;
             $this->logger?->error('Agent run failed', ['exception' => $e, 'run' => $runUuid]);
 
@@ -511,7 +517,7 @@ final readonly class AgentRunExecutor
             // finally-block settle. Guarded by $settled: a suspended run is
             // WAITING_FOR_APPROVAL or WAITING_FOR_INPUT — both non-terminal — and
             // settling it here would destroy its resumable state.
-            if ($handle !== null && !$settled) {
+            if ($handle instanceof AgentRunHandle && !$settled) {
                 // Ownership-guarded so this safety-net settle cannot clobber a
                 // queued run the reaper reclaimed to another worker.
                 $this->persister->settleFailed($handle, new RuntimeException('Agent run did not complete'), $ownerGuard);

--- a/Classes/Service/Agent/AgentRunRequestCodec.php
+++ b/Classes/Service/Agent/AgentRunRequestCodec.php
@@ -80,7 +80,7 @@ final readonly class AgentRunRequestCodec
             // effective system prompt into the transcript (ADR-060 assembly),
             // which a null-augmentation run() would not do — losing the
             // distinction would silently change the prompt composition.
-            'augmentation'     => $augmentation === null ? null : [
+            'augmentation'     => $augmentation instanceof RunAugmentation ? [
                 'forcedSkillUids'   => array_values(array_filter(array_map(
                     static fn(Skill $skill): int => $skill->getUid() ?? 0,
                     $augmentation->forcedSkills,
@@ -90,7 +90,7 @@ final readonly class AgentRunRequestCodec
                     $augmentation->forcedSnippets,
                 ))),
                 'dryRun'            => $augmentation->dryRun,
-            ],
+            ] : null,
         ];
     }
 
@@ -144,6 +144,7 @@ final readonly class AgentRunRequestCodec
             if (is_float($plannedCost) || is_int($plannedCost)) {
                 $options = $options->withPlannedCost((float)$plannedCost);
             }
+
             $idempotencyKey = $data['idempotencyKey'] ?? null;
             if (is_string($idempotencyKey) && $idempotencyKey !== '') {
                 $options = $options->withIdempotencyKey($idempotencyKey);
@@ -214,7 +215,7 @@ final readonly class AgentRunRequestCodec
      */
     private function skillsByUids(array $uids): array
     {
-        if ($uids === [] || $this->skillRepository === null) {
+        if ($uids === [] || !$this->skillRepository instanceof SkillRepository) {
             return [];
         }
 
@@ -242,7 +243,7 @@ final readonly class AgentRunRequestCodec
      */
     private function snippetsByUids(array $uids): array
     {
-        if ($uids === [] || $this->promptSnippetRepository === null) {
+        if ($uids === [] || !$this->promptSnippetRepository instanceof PromptSnippetRepository) {
             return [];
         }
 

--- a/Classes/Service/Agent/AgentRuntime.php
+++ b/Classes/Service/Agent/AgentRuntime.php
@@ -222,7 +222,7 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         // Authorised like approve/submitInput: only the run's owner, an admin or
         // a service account may cancel it (a guessed uuid is never enough).
         $run = $this->persister->findRun($runUuid);
-        if ($run === null || !$actor->mayActOnRun($run, ServiceAccountScope::AGENT_CANCEL)) {
+        if (!$run instanceof AgentRun || !$actor->mayActOnRun($run, ServiceAccountScope::AGENT_CANCEL)) {
             return false;
         }
 
@@ -232,7 +232,7 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
     public function events(AiActorContext $actor, string $runUuid, int $afterSequence = -1): array
     {
         $run = $this->persister->findRun($runUuid);
-        if ($run === null || !$actor->mayActOnRun($run, ServiceAccountScope::AGENT_READ)) {
+        if (!$run instanceof AgentRun || !$actor->mayActOnRun($run, ServiceAccountScope::AGENT_READ)) {
             return [];
         }
 
@@ -243,7 +243,7 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
     public function status(AiActorContext $actor, string $runUuid): ?AgentRun
     {
         $run = $this->persister->findRun($runUuid);
-        if ($run === null || !$actor->mayActOnRun($run, ServiceAccountScope::AGENT_READ)) {
+        if (!$run instanceof AgentRun || !$actor->mayActOnRun($run, ServiceAccountScope::AGENT_READ)) {
             return null;
         }
 

--- a/Classes/Service/Agent/Inbox/WaitingRunViewFactory.php
+++ b/Classes/Service/Agent/Inbox/WaitingRunViewFactory.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Service\Tool\SchemaPropertyClassifier;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 
 /**
@@ -83,7 +84,7 @@ final readonly class WaitingRunViewFactory
     public function turnDigestForRun(AgentRun $run): ?string
     {
         $state = $this->decodeState($run);
-        if ($state === null || $state->inputToolName !== null) {
+        if (!$state instanceof SuspendedRunState || $state->inputToolName !== null) {
             return null;
         }
 
@@ -101,7 +102,7 @@ final readonly class WaitingRunViewFactory
     public function inputSchemaForRun(AgentRun $run): ?array
     {
         $state = $this->decodeState($run);
-        if ($state === null || $state->inputToolName === null || !$this->isRenderableObjectSchema($state->inputSchema)) {
+        if (!$state instanceof SuspendedRunState || $state->inputToolName === null || !$this->isRenderableObjectSchema($state->inputSchema)) {
             return null;
         }
 
@@ -111,7 +112,7 @@ final readonly class WaitingRunViewFactory
     private function buildWaitingOne(AgentRun $run): WaitingRunView
     {
         $state = $this->decodeState($run);
-        if ($state === null) {
+        if (!$state instanceof SuspendedRunState) {
             return $this->unreadable($run, 'state-unreadable');
         }
 
@@ -131,10 +132,11 @@ final readonly class WaitingRunViewFactory
             if (!$call instanceof ToolCall) {
                 continue;
             }
+
             $calls[] = new PendingCallView(
                 name: $call->name,
                 argumentsJson: $this->encodeArguments($call->arguments),
-                toolStillRegistered: $this->registry->get($call->name) !== null,
+                toolStillRegistered: $this->registry->get($call->name) instanceof ToolInterface,
             );
         }
 
@@ -208,6 +210,7 @@ final readonly class WaitingRunViewFactory
             if (!is_array($propSchema)) {
                 continue;
             }
+
             /** @var array<string, mixed> $propSchema */
             $name        = (string)$name;
             $controlType = $this->classifier->classify($propSchema);

--- a/Classes/Service/Agent/Queue/AgentRunQueuedHandler.php
+++ b/Classes/Service/Agent/Queue/AgentRunQueuedHandler.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Agent\Queue;
 
+use Netresearch\NrLlm\Service\Agent\AgentRunResult;
 use Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -35,7 +36,7 @@ final readonly class AgentRunQueuedHandler
 
     public function __invoke(AgentRunQueuedMessage $message): void
     {
-        if ($this->agentRuntime->runQueued($message->runUuid) === null) {
+        if (!$this->agentRuntime->runQueued($message->runUuid) instanceof AgentRunResult) {
             $this->logger?->info('Queued agent run was not claimable (already claimed, cancelled, or unknown)', [
                 'run' => $message->runUuid,
             ]);

--- a/Classes/Service/Agent/QueuedRunCoordinator.php
+++ b/Classes/Service/Agent/QueuedRunCoordinator.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Service\Agent;
 use Closure;
 use Netresearch\NrLlm\Domain\Enum\AgentRunOutcome;
 use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Service\Agent\Exception\RunEnqueueFailedException;
 use Netresearch\NrLlm\Service\Agent\Queue\AgentRunQueuedMessage;
@@ -54,7 +55,7 @@ final readonly class QueuedRunCoordinator
 
     public function enqueue(AgentRunRequest $request): string
     {
-        if ($this->messageBus === null) {
+        if (!$this->messageBus instanceof MessageBusInterface) {
             throw RunEnqueueFailedException::forRun('');
         }
 
@@ -75,7 +76,7 @@ final readonly class QueuedRunCoordinator
         // Fail-closed, unlike run(): a live run can proceed unpersisted, but a
         // queued run without a stored row simply does not exist.
         $handle = $this->persister->enqueue($request->configuration, $request->actor->backendUserUid, $requestJson);
-        if ($handle === null) {
+        if (!$handle instanceof AgentRunHandle) {
             throw RunEnqueueFailedException::forRun('');
         }
 
@@ -112,7 +113,7 @@ final readonly class QueuedRunCoordinator
     public function runQueued(string $runUuid, ?Closure $onStep = null): ?AgentRunResult
     {
         $run = $this->persister->findRun($runUuid);
-        if ($run === null || $run->statusEnum() !== AgentRunStatus::QUEUED || $run->queuedRequest === null) {
+        if (!$run instanceof AgentRun || $run->statusEnum() !== AgentRunStatus::QUEUED || $run->queuedRequest === null) {
             return null;
         }
 
@@ -130,8 +131,8 @@ final readonly class QueuedRunCoordinator
         // like AgentRuntime::approve(): a null position settles the run FAILED rather than
         // stranding it RUNNING (the claim is already won).
         $claimed = $this->persister->findRun($runUuid);
-        $handle  = $claimed !== null ? $this->persister->resumeHandle($claimed) : null;
-        if ($handle === null) {
+        $handle  = $claimed instanceof AgentRun ? $this->persister->resumeHandle($claimed) : null;
+        if (!$handle instanceof AgentRunHandle) {
             $fallback = new AgentRunHandle($run->uid, $run->uuid);
             $this->persister->settleFailed(
                 $fallback,

--- a/Classes/Service/Agent/QueuedRunFailureRecovery.php
+++ b/Classes/Service/Agent/QueuedRunFailureRecovery.php
@@ -76,6 +76,7 @@ final readonly class QueuedRunFailureRecovery
 
                     return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $steps, error: $e);
                 }
+
                 $this->logger?->warning('Queued agent run failed with a non-retryable error; dead-lettered', ['run' => $runUuid, 'class' => $class->value]);
 
                 return new AgentRunResult(outcome: AgentRunOutcome::FAILED, runUuid: $runUuid, steps: $steps, error: $e);
@@ -93,6 +94,7 @@ final readonly class QueuedRunFailureRecovery
                 if (!$this->persister->settleDeadLettered($handle, $e, AgentRunTerminationReason::NOT_RETRYABLE, $workerIdentity)) {
                     return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $steps, error: $e);
                 }
+
                 $this->logger?->warning('Queued agent run failed mid non-idempotent write; dead-lettered instead of retried (ADR-111)', ['run' => $runUuid]);
 
                 return new AgentRunResult(outcome: AgentRunOutcome::FAILED, runUuid: $runUuid, steps: $steps, error: $e);
@@ -105,6 +107,7 @@ final readonly class QueuedRunFailureRecovery
 
                     return new AgentRunResult(outcome: AgentRunOutcome::LEASE_LOST, runUuid: $runUuid, steps: $steps, error: $e);
                 }
+
                 $this->logger?->warning('Queued agent run exhausted its retry budget; dead-lettered', ['run' => $runUuid, 'requeueCount' => $count]);
 
                 return new AgentRunResult(outcome: AgentRunOutcome::FAILED, runUuid: $runUuid, steps: $steps, error: $e);
@@ -148,7 +151,7 @@ final readonly class QueuedRunFailureRecovery
      */
     private function dispatchRequeue(string $uuid, int $priorRequeueCount): void
     {
-        if ($this->messageBus === null) {
+        if (!$this->messageBus instanceof MessageBusInterface) {
             throw RunEnqueueFailedException::forRun($uuid);
         }
 

--- a/Classes/Service/Agent/ResumeCoordinator.php
+++ b/Classes/Service/Agent/ResumeCoordinator.php
@@ -13,6 +13,7 @@ use Closure;
 use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
 use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
@@ -81,9 +82,10 @@ final readonly class ResumeCoordinator
     public function approve(AiActorContext $actor, string $runUuid, ApprovalDecision $decision, ?Closure $onStep = null): AgentRunResult
     {
         $run = $this->persister->findRun($runUuid);
-        if ($run === null || $run->statusEnum() !== AgentRunStatus::WAITING_FOR_APPROVAL || $run->suspendedState === null) {
+        if (!$run instanceof AgentRun || $run->statusEnum() !== AgentRunStatus::WAITING_FOR_APPROVAL || $run->suspendedState === null) {
             throw RunNotAwaitingApprovalException::forRun($runUuid);
         }
+
         if (!$actor->mayActOnRun($run, ServiceAccountScope::AGENT_APPROVE)) {
             throw RunAccessDeniedException::forActor($actor, $runUuid);
         }
@@ -97,13 +99,14 @@ final readonly class ResumeCoordinator
         if (!is_array($decoded)) {
             throw CorruptSuspendedStateException::forRun($runUuid);
         }
+
         /** @var array<string, mixed> $decoded */
         $state = SuspendedRunState::fromArray($decoded);
 
         // Probe the event-stream position BEFORE the claim: a failure here
         // refuses the resume while the run is still WAITING_FOR_APPROVAL, so
         // the approval can simply be retried (nothing was claimed or executed).
-        if ($this->persister->resumeHandle($run) === null) {
+        if (!$this->persister->resumeHandle($run) instanceof AgentRunHandle) {
             throw RunStateUnavailableException::forRun($runUuid);
         }
 
@@ -121,8 +124,8 @@ final readonly class ResumeCoordinator
         // interleave segments. The claim is won, so a failure now settles the
         // run rather than stranding it RUNNING (fail-closed either way).
         $claimed = $this->persister->findRun($runUuid);
-        $handle  = $claimed !== null ? $this->persister->resumeHandle($claimed) : null;
-        if ($handle === null) {
+        $handle  = $claimed instanceof AgentRun ? $this->persister->resumeHandle($claimed) : null;
+        if (!$handle instanceof AgentRunHandle) {
             $this->persister->settleFailed(
                 new AgentRunHandle($run->uid, $run->uuid),
                 new RuntimeException('The event-stream position could not be determined after the resume claim'),
@@ -169,9 +172,10 @@ final readonly class ResumeCoordinator
     public function submitInput(AiActorContext $actor, string $runUuid, InputSubmission $submission, ?Closure $onStep = null): AgentRunResult
     {
         $run = $this->persister->findRun($runUuid);
-        if ($run === null || $run->statusEnum() !== AgentRunStatus::WAITING_FOR_INPUT || $run->suspendedState === null) {
+        if (!$run instanceof AgentRun || $run->statusEnum() !== AgentRunStatus::WAITING_FOR_INPUT || $run->suspendedState === null) {
             throw RunNotAwaitingInputException::forRun($runUuid);
         }
+
         if (!$actor->mayActOnRun($run, ServiceAccountScope::AGENT_APPROVE)) {
             throw RunAccessDeniedException::forActor($actor, $runUuid);
         }
@@ -185,6 +189,7 @@ final readonly class ResumeCoordinator
         if (!is_array($decoded)) {
             throw CorruptSuspendedStateException::forRun($runUuid);
         }
+
         /** @var array<string, mixed> $decoded */
         $state = SuspendedRunState::fromArray($decoded);
 
@@ -206,7 +211,7 @@ final readonly class ResumeCoordinator
 
         // From here the flow is identical to approve(): probe-before-claim,
         // atomic claim, re-resolve the stream position from a fresh row.
-        if ($this->persister->resumeHandle($run) === null) {
+        if (!$this->persister->resumeHandle($run) instanceof AgentRunHandle) {
             throw RunStateUnavailableException::forRun($runUuid);
         }
 
@@ -215,8 +220,8 @@ final readonly class ResumeCoordinator
         }
 
         $claimed = $this->persister->findRun($runUuid);
-        $handle  = $claimed !== null ? $this->persister->resumeHandle($claimed) : null;
-        if ($handle === null) {
+        $handle  = $claimed instanceof AgentRun ? $this->persister->resumeHandle($claimed) : null;
+        if (!$handle instanceof AgentRunHandle) {
             $this->persister->settleFailed(
                 new AgentRunHandle($run->uid, $run->uuid),
                 new RuntimeException('The event-stream position could not be determined after the resume claim'),

--- a/Classes/Service/BudgetService.php
+++ b/Classes/Service/BudgetService.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Service;
 use DateTimeImmutable;
 use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\UserBudget;
 use Netresearch\NrLlm\Domain\Repository\UserBudgetRepository;
 use Netresearch\NrLlm\Service\Budget\BudgetUsageWindowsInterface;
 
@@ -63,8 +64,8 @@ final readonly class BudgetService implements BudgetServiceInterface
 
         $result = $this->checkUserBudget($beUserUid, $plannedCost);
 
-        if ($result->allowed && $configuration !== null) {
-            $result = $this->checkConfigurationLimits($configuration, $plannedCost);
+        if ($result->allowed && $configuration instanceof LlmConfiguration) {
+            return $this->checkConfigurationLimits($configuration, $plannedCost);
         }
 
         return $result;
@@ -73,7 +74,7 @@ final readonly class BudgetService implements BudgetServiceInterface
     private function checkUserBudget(int $beUserUid, float $plannedCost): BudgetCheckResult
     {
         $budget = $beUserUid > 0 ? $this->repository->findOneByBeUser($beUserUid) : null;
-        if ($budget === null || !$budget->isActive() || !$budget->hasAnyLimit()) {
+        if (!$budget instanceof UserBudget || !$budget->isActive() || !$budget->hasAnyLimit()) {
             return BudgetCheckResult::allowed();
         }
 
@@ -113,7 +114,7 @@ final readonly class BudgetService implements BudgetServiceInterface
         }
 
         if ($result->allowed && $hasMonthlyLimits) {
-            $result = $this->compare(
+            return $this->compare(
                 usage: $windows['monthly'],
                 plannedCost: $plannedCost,
                 requestLimit: $budget->getMaxRequestsPerMonth(),
@@ -198,6 +199,7 @@ final readonly class BudgetService implements BudgetServiceInterface
                 $costLimit,
             );
         }
+
         return $result;
     }
 }

--- a/Classes/Service/CacheManager.php
+++ b/Classes/Service/CacheManager.php
@@ -25,9 +25,10 @@ final class CacheManager implements CacheManagerInterface, SingletonInterface
 
     private function getCache(): FrontendInterface
     {
-        if ($this->cache === null) {
+        if (!$this->cache instanceof FrontendInterface) {
             $this->cache = $this->cacheManager->getCache(self::CACHE_IDENTIFIER);
         }
+
         return $this->cache;
     }
 
@@ -65,6 +66,7 @@ final class CacheManager implements CacheManagerInterface, SingletonInterface
         if ($data === false || !is_array($data)) {
             return null;
         }
+
         /** @var array<string, mixed> $data */
         return $data;
     }
@@ -276,6 +278,7 @@ final class CacheManager implements CacheManagerInterface, SingletonInterface
                 $this->sortRecursive($value);
             }
         }
+
         ksort($array);
     }
 }

--- a/Classes/Service/ConfigurationResolver.php
+++ b/Classes/Service/ConfigurationResolver.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Service;
 
 use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
 use Netresearch\NrLlm\Exception\AccessDeniedException;
@@ -77,8 +78,8 @@ final readonly class ConfigurationResolver
         // otherwise getProvider(null) throws. The generic chat()/complete()/streamChat()
         // path has no backend-user context to enforce group membership against (notably the CLI
         // worker), so an access-restricted default must not be auto-applied to arbitrary callers.
-        if ($configuration === null
-            || $configuration->getLlmModel() === null
+        if (!$configuration instanceof LlmConfiguration
+            || !$configuration->getLlmModel() instanceof Model
             || $configuration->hasAccessRestrictions()
         ) {
             return null;
@@ -109,7 +110,7 @@ final readonly class ConfigurationResolver
     {
         $configuration = $this->configurationRepository?->findOneByIdentifier($identifier);
 
-        if ($configuration === null) {
+        if (!$configuration instanceof LlmConfiguration) {
             throw new ConfigurationNotFoundException(
                 sprintf('LLM configuration "%s" not found', $identifier),
                 1784211001,
@@ -158,7 +159,7 @@ final readonly class ConfigurationResolver
     {
         $configuration = $this->configurationRepository?->findOneByIdentifier($identifier);
 
-        if ($configuration === null) {
+        if (!$configuration instanceof LlmConfiguration) {
             throw new ConfigurationNotFoundException(
                 sprintf('LLM configuration "%s" not found', $identifier),
                 1784211001,

--- a/Classes/Service/Context/ContextWindowManager.php
+++ b/Classes/Service/Context/ContextWindowManager.php
@@ -61,7 +61,7 @@ final class ContextWindowManager implements ContextWindowManagerInterface
         // per-run calibration state here so a single shared manager instance
         // (ToolLoopService is a shared service) never carries one run's
         // calibration into the next.
-        if ($lastUsage === null) {
+        if (!$lastUsage instanceof UsageStatistics) {
             $this->calibration      = self::CALIBRATION_SEED;
             $this->lastSentEstimate = null;
         }
@@ -115,9 +115,10 @@ final class ContextWindowManager implements ContextWindowManagerInterface
 
     private function recalibrate(?UsageStatistics $lastUsage): void
     {
-        if ($lastUsage === null || $this->lastSentEstimate === null || $this->lastSentEstimate <= 0) {
+        if (!$lastUsage instanceof UsageStatistics || $this->lastSentEstimate === null || $this->lastSentEstimate <= 0) {
             return;
         }
+
         $ratio = $lastUsage->promptTokens / $this->lastSentEstimate;
         // Monotone up: never trust an estimate below observed reality.
         $this->calibration = max($this->calibration, $ratio);
@@ -129,6 +130,7 @@ final class ContextWindowManager implements ContextWindowManagerInterface
         if ($optionMax > 0) {
             return $optionMax;
         }
+
         $modelMax = $configuration->getLlmModel()?->getMaxOutputTokens() ?? 0;
         if ($modelMax > 0) {
             return $modelMax;
@@ -145,6 +147,7 @@ final class ContextWindowManager implements ContextWindowManagerInterface
         if (isset($messages[0]) && $this->roleOf($messages[0]) === 'system') {
             return 0;
         }
+
         $systemPrompt = $configuration->getSystemPrompt();
         if ($systemPrompt === '') {
             return 0;
@@ -174,6 +177,7 @@ final class ContextWindowManager implements ContextWindowManagerInterface
                 break;
             }
         }
+
         if (!$seenUser) {
             return [$head, []];
         }
@@ -188,6 +192,7 @@ final class ContextWindowManager implements ContextWindowManagerInterface
                 if ($current !== null) {
                     $turns[] = $current;
                 }
+
                 $current = [$message];
             } elseif ($current === null) {
                 $current = [$message];
@@ -195,6 +200,7 @@ final class ContextWindowManager implements ContextWindowManagerInterface
                 $current[] = $message;
             }
         }
+
         if ($current !== null) {
             $turns[] = $current;
         }

--- a/Classes/Service/Context/TranscriptEstimator.php
+++ b/Classes/Service/Context/TranscriptEstimator.php
@@ -60,6 +60,7 @@ final class TranscriptEstimator
             } else {
                 $proseChars += strlen($content);
             }
+
             $denseChars += strlen(is_string($data['tool_call_id'] ?? null) ? $data['tool_call_id'] : '');
 
             $toolCalls = is_array($data['tool_calls'] ?? null) ? $data['tool_calls'] : [];

--- a/Classes/Service/Evaluation/Assertion.php
+++ b/Classes/Service/Evaluation/Assertion.php
@@ -33,7 +33,8 @@ final readonly class Assertion
                 1794000001,
             );
         }
-        if ($type === AssertionType::REGEX && !self::isValidPattern($value)) {
+
+        if ($type === AssertionType::REGEX && !$this->isValidPattern($value)) {
             throw new InvalidArgumentException(
                 sprintf('Assertion regex "%s" is not a valid PCRE pattern.', $value),
                 1794000002,
@@ -46,7 +47,7 @@ final readonly class Assertion
      * `@` suppression operator (a temporary error handler swallows the
      * warning an invalid pattern would emit).
      */
-    private static function isValidPattern(string $pattern): bool
+    private function isValidPattern(string $pattern): bool
     {
         set_error_handler(static fn(): bool => true);
         try {

--- a/Classes/Service/Evaluation/EvaluatableRetrieverRegistry.php
+++ b/Classes/Service/Evaluation/EvaluatableRetrieverRegistry.php
@@ -39,6 +39,7 @@ final class EvaluatableRetrieverRegistry
                     1794000060,
                 );
             }
+
             $this->byIdentifier[$identifier] = $retriever;
         }
     }

--- a/Classes/Service/Evaluation/EvaluationResultRepository.php
+++ b/Classes/Service/Evaluation/EvaluationResultRepository.php
@@ -60,7 +60,7 @@ final readonly class EvaluationResultRepository implements EvaluationResultRepos
         $connection   = $this->connectionPool->getConnectionForTable(self::TABLE);
         $queryBuilder = $connection->createQueryBuilder();
 
-        return (int)$queryBuilder
+        return $queryBuilder
             ->delete(self::TABLE)
             ->where($queryBuilder->expr()->lt('run_date', $queryBuilder->createNamedParameter($timestamp)))
             ->executeStatement();
@@ -117,6 +117,7 @@ final readonly class EvaluationResultRepository implements EvaluationResultRepos
             if (isset($seenSets[$setIdentifier])) {
                 continue;
             }
+
             $seenSets[$setIdentifier] = true;
             $scores[] = $this->toFloat($row['mean_score'] ?? 0);
         }

--- a/Classes/Service/Evaluation/GoldenPrompt.php
+++ b/Classes/Service/Evaluation/GoldenPrompt.php
@@ -36,12 +36,14 @@ final readonly class GoldenPrompt
         if ($id === '') {
             throw new InvalidArgumentException('Golden prompt id must not be empty.', 1794000010);
         }
+
         if ($prompt === '') {
             throw new InvalidArgumentException(
                 sprintf('Golden prompt "%s" must declare a non-empty prompt.', $id),
                 1794000011,
             );
         }
+
         if ($assertions === [] && ($reference === null || $reference === '')) {
             throw new InvalidArgumentException(
                 sprintf('Golden prompt "%s" must declare at least one assertion or a reference answer.', $id),

--- a/Classes/Service/Evaluation/GoldenPromptSet.php
+++ b/Classes/Service/Evaluation/GoldenPromptSet.php
@@ -50,18 +50,21 @@ final readonly class GoldenPromptSet
                 1794000020,
             );
         }
+
         if ($name === '') {
             throw new InvalidArgumentException(
                 sprintf('Golden set "%s" must declare a non-empty name.', $identifier),
                 1794000021,
             );
         }
+
         if ($prompts === []) {
             throw new InvalidArgumentException(
                 sprintf('Golden set "%s" must declare at least one prompt.', $identifier),
                 1794000022,
             );
         }
+
         $seen = [];
         foreach ($prompts as $prompt) {
             if (isset($seen[$prompt->id])) {
@@ -70,6 +73,7 @@ final readonly class GoldenPromptSet
                     1794000023,
                 );
             }
+
             $seen[$prompt->id] = true;
         }
     }

--- a/Classes/Service/Evaluation/GoldenPromptSetRegistry.php
+++ b/Classes/Service/Evaluation/GoldenPromptSetRegistry.php
@@ -41,6 +41,7 @@ final class GoldenPromptSetRegistry
                         1794000030,
                     );
                 }
+
                 $this->byIdentifier[$set->identifier] = $set;
             }
         }

--- a/Classes/Service/Evaluation/GoldenQuestion.php
+++ b/Classes/Service/Evaluation/GoldenQuestion.php
@@ -45,12 +45,14 @@ final readonly class GoldenQuestion
         if ($id === '') {
             throw new InvalidArgumentException('Golden question id must not be empty.', 1794000050);
         }
+
         if ($question === '') {
             throw new InvalidArgumentException(
                 sprintf('Golden question "%s" must declare a non-empty question.', $id),
                 1794000051,
             );
         }
+
         $seen = [];
         foreach ($expectedDocumentIds as $documentId) {
             if ($documentId === '') {
@@ -59,14 +61,17 @@ final readonly class GoldenQuestion
                     1794000052,
                 );
             }
+
             if (isset($seen[$documentId])) {
                 throw new InvalidArgumentException(
                     sprintf('Golden question "%s" declares duplicate expected document id "%s".', $id, $documentId),
                     1794000053,
                 );
             }
+
             $seen[$documentId] = true;
         }
+
         if ($hardClass === '') {
             throw new InvalidArgumentException(
                 sprintf('Golden question "%s" must declare a non-empty hard class or none.', $id),

--- a/Classes/Service/Evaluation/GoldenQuestionSet.php
+++ b/Classes/Service/Evaluation/GoldenQuestionSet.php
@@ -47,18 +47,21 @@ final readonly class GoldenQuestionSet
                 1794000055,
             );
         }
+
         if ($name === '') {
             throw new InvalidArgumentException(
                 sprintf('Golden question set "%s" must declare a non-empty name.', $identifier),
                 1794000056,
             );
         }
+
         if ($questions === []) {
             throw new InvalidArgumentException(
                 sprintf('Golden question set "%s" must declare at least one question.', $identifier),
                 1794000057,
             );
         }
+
         $seen = [];
         foreach ($questions as $question) {
             if (isset($seen[$question->id])) {
@@ -67,6 +70,7 @@ final readonly class GoldenQuestionSet
                     1794000058,
                 );
             }
+
             $seen[$question->id] = true;
         }
     }

--- a/Classes/Service/Evaluation/GoldenQuestionSetRegistry.php
+++ b/Classes/Service/Evaluation/GoldenQuestionSetRegistry.php
@@ -41,6 +41,7 @@ final class GoldenQuestionSetRegistry
                         1794000059,
                     );
                 }
+
                 $this->byIdentifier[$set->identifier] = $set;
             }
         }

--- a/Classes/Service/Evaluation/Grader/LlmJudgeGrader.php
+++ b/Classes/Service/Evaluation/Grader/LlmJudgeGrader.php
@@ -71,6 +71,7 @@ final readonly class LlmJudgeGrader implements GraderInterface
             $parts[] = 'REFERENCE ANSWER (an ideal response):';
             $parts[] = $prompt->reference;
         }
+
         $parts[] = '';
         $parts[] = 'RESPONSE TO GRADE:';
         $parts[] = $response;

--- a/Classes/Service/Evaluation/LexicalSearchRetriever.php
+++ b/Classes/Service/Evaluation/LexicalSearchRetriever.php
@@ -45,6 +45,7 @@ final readonly class LexicalSearchRetriever implements EvaluatableRetrieverInter
             // Truncation can expose interior whitespace at the cut — trim again.
             $question = trim(mb_substr($question, 0, RetrievalQuery::MAX_QUERY_LENGTH));
         }
+
         if (mb_strlen($question) < RetrievalQuery::MIN_QUERY_LENGTH) {
             return [];
         }

--- a/Classes/Service/Evaluation/QualityAwareModelSelector.php
+++ b/Classes/Service/Evaluation/QualityAwareModelSelector.php
@@ -54,6 +54,7 @@ final readonly class QualityAwareModelSelector
             if ($minQuality > 0.0 && ($score === null || $score < $minQuality)) {
                 continue;
             }
+
             $ranked[] = ['model' => $model, 'score' => $score, 'order' => $order];
         }
 
@@ -66,12 +67,15 @@ final readonly class QualityAwareModelSelector
             if ($a['score'] === null && $b['score'] === null) {
                 return $a['order'] <=> $b['order'];
             }
+
             if ($a['score'] === null) {
                 return 1;
             }
+
             if ($b['score'] === null) {
                 return -1;
             }
+
             if ($a['score'] === $b['score']) {
                 return $a['order'] <=> $b['order'];
             }

--- a/Classes/Service/Evaluation/RegressionDetector.php
+++ b/Classes/Service/Evaluation/RegressionDetector.php
@@ -24,7 +24,7 @@ final readonly class RegressionDetector
         ?EvaluationResultSummary $previous,
         RegressionThresholds $thresholds,
     ): RegressionReport {
-        if ($previous === null) {
+        if (!$previous instanceof EvaluationResultSummary) {
             return new RegressionReport(
                 $current->setIdentifier,
                 $current->model,
@@ -72,6 +72,7 @@ final readonly class RegressionDetector
         if ($passRateRegressed) {
             $causes[] = sprintf('pass rate dropped %.1f pp', -$passRateDelta * 100);
         }
+
         if ($meanScoreRegressed) {
             $causes[] = sprintf('mean score dropped %.3f', -$meanScoreDelta);
         }

--- a/Classes/Service/Evaluation/RetrievalEvaluationService.php
+++ b/Classes/Service/Evaluation/RetrievalEvaluationService.php
@@ -64,7 +64,8 @@ final readonly class RetrievalEvaluationService
             $documents = $this->distinctTopDocuments($ranked);
 
             if ($question->expectsNoResult()) {
-                $top1Hit = $top3Hit = $documents === [];
+                $top1Hit = $documents === [];
+                $top3Hit = $documents === [];
             } else {
                 $top1Hit = $documents !== [] && in_array($documents[0], $question->expectedDocumentIds, true);
                 $top3Hit = array_intersect($documents, $question->expectedDocumentIds) !== [];
@@ -97,9 +98,14 @@ final readonly class RetrievalEvaluationService
     {
         $documents = [];
         foreach ($ranked as $documentId) {
-            if ($documentId === '' || in_array($documentId, $documents, true)) {
+            if ($documentId === '') {
                 continue;
             }
+
+            if (in_array($documentId, $documents, true)) {
+                continue;
+            }
+
             $documents[] = $documentId;
             if (count($documents) === self::TOP_K) {
                 break;

--- a/Classes/Service/Evaluation/RetrievalSetEvaluationResult.php
+++ b/Classes/Service/Evaluation/RetrievalSetEvaluationResult.php
@@ -170,6 +170,7 @@ final readonly class RetrievalSetEvaluationResult
             if ($key === null) {
                 continue;
             }
+
             $grouped[$key][] = $evaluation;
         }
 

--- a/Classes/Service/Feature/CompletionService.php
+++ b/Classes/Service/Feature/CompletionService.php
@@ -275,6 +275,7 @@ final readonly class CompletionService implements CompletionServiceInterface
         if (!is_array($decoded)) {
             return null;
         }
+
         if (!$this->schemaValidator->validate($decoded, $schema)) {
             return null;
         }
@@ -436,8 +437,9 @@ final readonly class CompletionService implements CompletionServiceInterface
         if ($options->getTemperature() === null) {
             $options = $options->withTemperature(0.2);
         }
+
         if ($options->getTopP() === null) {
-            $options = $options->withTopP(0.9);
+            return $options->withTopP(0.9);
         }
 
         return $options;
@@ -452,11 +454,13 @@ final readonly class CompletionService implements CompletionServiceInterface
         if ($options->getTemperature() === null) {
             $options = $options->withTemperature(1.2);
         }
+
         if ($options->getTopP() === null) {
             $options = $options->withTopP(1.0);
         }
+
         if ($options->getPresencePenalty() === null) {
-            $options = $options->withPresencePenalty(0.6);
+            return $options->withPresencePenalty(0.6);
         }
 
         return $options;

--- a/Classes/Service/Feature/ConversationService.php
+++ b/Classes/Service/Feature/ConversationService.php
@@ -71,7 +71,7 @@ final readonly class ConversationService implements ConversationServiceInterface
         $this->sessions->startSession($uuid, $actor->backendUserUid, $configuration?->getIdentifier() ?? '', $title);
 
         $session = $this->sessions->findByUuid($uuid);
-        if ($session === null) {
+        if (!$session instanceof AiSession) {
             throw new RuntimeException('The conversation session could not be loaded immediately after creation.', 1784600002);
         }
 
@@ -81,7 +81,7 @@ final readonly class ConversationService implements ConversationServiceInterface
     public function send(AiActorContext $actor, string $sessionUuid, string $userMessage, ?ChatOptions $options = null): CompletionResponse
     {
         $session = $this->sessions->findByUuid($sessionUuid);
-        if ($session === null) {
+        if (!$session instanceof AiSession) {
             throw new InvalidArgumentException(sprintf('Unknown AI session "%s".', $sessionUuid), 1784600001);
         }
 
@@ -104,9 +104,11 @@ final readonly class ConversationService implements ConversationServiceInterface
         if (is_string($systemPrompt) && $systemPrompt !== '') {
             $messages[] = ChatMessage::system($systemPrompt);
         }
+
         foreach ($history as $message) {
             $messages[] = $message->toChatMessage();
         }
+
         $messages[] = ChatMessage::user($userMessage);
 
         // A conversation replays its whole history on every turn, so it is the
@@ -116,7 +118,7 @@ final readonly class ConversationService implements ConversationServiceInterface
         // turn is not merely a log line.
         $configuration = $this->resolveTurnConfiguration($session, $actor);
         $droppedTurns  = null;
-        if ($this->contextWindow !== null && $configuration !== null) {
+        if ($this->contextWindow instanceof ContextWindowManagerInterface && $configuration instanceof LlmConfiguration) {
             // lastUsage is null: each turn is a fresh assembly, so the
             // manager's calibration starts from its seed rather than carrying a
             // ratio over from an unrelated turn.
@@ -190,7 +192,7 @@ final readonly class ConversationService implements ConversationServiceInterface
      */
     private function dispatch(array $messages, ?LlmConfiguration $configuration, ChatOptions $options): CompletionResponse
     {
-        if ($configuration === null) {
+        if (!$configuration instanceof LlmConfiguration) {
             return $this->llmManager->chat($messages, $options);
         }
 

--- a/Classes/Service/Feature/EmbeddingService.php
+++ b/Classes/Service/Feature/EmbeddingService.php
@@ -77,7 +77,7 @@ final readonly class EmbeddingService implements EmbeddingServiceInterface
      */
     public function embedBatch(array $texts, ?EmbeddingOptions $options = null): array
     {
-        if (empty($texts)) {
+        if ($texts === []) {
             return [];
         }
 
@@ -121,7 +121,7 @@ final readonly class EmbeddingService implements EmbeddingServiceInterface
      */
     public function embedBatchForConfiguration(array $texts, LlmConfiguration $configuration, ?EmbeddingOptions $options = null): array
     {
-        if (empty($texts)) {
+        if ($texts === []) {
             return [];
         }
 
@@ -163,7 +163,7 @@ final readonly class EmbeddingService implements EmbeddingServiceInterface
         array $candidateVectors,
         int $topK = 5,
     ): array {
-        if (empty($candidateVectors)) {
+        if ($candidateVectors === []) {
             return [];
         }
 
@@ -178,7 +178,7 @@ final readonly class EmbeddingService implements EmbeddingServiceInterface
         }
 
         // Sort by similarity descending
-        usort($similarities, static fn($a, $b) => $b['similarity'] <=> $a['similarity']);
+        usort($similarities, static fn(array $a, array $b): int => $b['similarity'] <=> $a['similarity']);
 
         // Return top K results
         return array_slice($similarities, 0, $topK);
@@ -217,13 +217,13 @@ final readonly class EmbeddingService implements EmbeddingServiceInterface
      */
     public function normalize(array $vector): array
     {
-        $magnitude = sqrt(array_sum(array_map(static fn($x) => $x * $x, $vector)));
+        $magnitude = sqrt(array_sum(array_map(static fn(float $x): float => $x * $x, $vector)));
 
         if ($magnitude === 0.0) {
             return $vector;
         }
 
-        return array_map(static fn($x) => $x / $magnitude, $vector);
+        return array_map(static fn(float $x): float => $x / $magnitude, $vector);
     }
 
     // `autoPopulateBeUserUid()` is provided by `AutoPopulatesBeUserUidTrait`.

--- a/Classes/Service/Feature/TranslationService.php
+++ b/Classes/Service/Feature/TranslationService.php
@@ -53,7 +53,9 @@ use Netresearch\NrLlm\Specialized\Translation\TranslatorResult;
 final readonly class TranslationService implements TranslationServiceInterface
 {
     private const EMPTY_TEXT_ERROR = 'Text cannot be empty';
+
     private const SUPPORTED_FORMALITIES = ['default', 'formal', 'informal'];
+
     private const SUPPORTED_DOMAINS = ['general', 'technical', 'medical', 'legal', 'marketing'];
 
     public function __construct(
@@ -180,9 +182,11 @@ final readonly class TranslationService implements TranslationServiceInterface
         if ($options->getTemperature() !== null) {
             $overrides['temperature'] = $options->getTemperature();
         }
+
         if ($options->getMaxTokens() !== null) {
             $overrides['max_tokens'] = $options->getMaxTokens();
         }
+
         if ($options->getModel() !== null) {
             $overrides['model'] = $options->getModel();
         }
@@ -213,7 +217,7 @@ final readonly class TranslationService implements TranslationServiceInterface
         ?string $sourceLanguage = null,
         ?TranslationOptions $options = null,
     ): array {
-        if (empty($texts)) {
+        if ($texts === []) {
             return [];
         }
 
@@ -286,7 +290,7 @@ final readonly class TranslationService implements TranslationServiceInterface
         // to be marked just to auto-detect (issue #520). Only the generic
         // translate() path (no configuration) uses the default-resolving chat()
         // entry point. Suppression is carried as pipeline metadata (issue #473).
-        if ($configuration !== null) {
+        if ($configuration instanceof LlmConfiguration) {
             $metadata = $this->budgetMetadata($options);
             if (!$countsAsRequest) {
                 $metadata[UsageMiddleware::METADATA_SKIP_REQUEST_COUNT] = true;
@@ -390,7 +394,7 @@ final readonly class TranslationService implements TranslationServiceInterface
         $options ??= new TranslationOptions();
         $optionsArray = $this->attachBeUserUid($options->toArray(), $options);
 
-        if (empty($text)) {
+        if ($text === '' || $text === '0') {
             throw new InvalidArgumentException(self::EMPTY_TEXT_ERROR, 3459949413);
         }
 
@@ -421,7 +425,7 @@ final readonly class TranslationService implements TranslationServiceInterface
         ?string $sourceLanguage = null,
         ?TranslationOptions $options = null,
     ): array {
-        if (empty($texts)) {
+        if ($texts === []) {
             return [];
         }
 
@@ -559,7 +563,7 @@ final readonly class TranslationService implements TranslationServiceInterface
         int $emptyTextErrorCode,
         ?LlmConfiguration $configuration = null,
     ): array {
-        if (empty($text)) {
+        if ($text === '' || $text === '0') {
             throw new InvalidArgumentException(self::EMPTY_TEXT_ERROR, $emptyTextErrorCode);
         }
 

--- a/Classes/Service/Feature/VisionService.php
+++ b/Classes/Service/Feature/VisionService.php
@@ -31,7 +31,9 @@ final readonly class VisionService implements VisionServiceInterface
     use AutoPopulatesBeUserUidTrait;
 
     private const PROMPT_ALT_TEXT = 'Generate a concise alt text for this image, under 125 characters, focused on essential information for screen readers. Be descriptive but brief.';
+
     private const PROMPT_SEO_TITLE = 'Generate an SEO-optimized title for this image, under 60 characters, that is compelling and keyword-rich for search rankings.';
+
     private const PROMPT_DESCRIPTION = 'Provide a comprehensive description of this image including subjects, setting, colors, mood, composition, and notable details.';
 
     public function __construct(
@@ -55,6 +57,7 @@ final readonly class VisionService implements VisionServiceInterface
         if ($options->getMaxTokens() === null) {
             $options = $options->withMaxTokens(100);
         }
+
         if ($options->getTemperature() === null) {
             $options = $options->withTemperature(0.5);
         }
@@ -82,6 +85,7 @@ final readonly class VisionService implements VisionServiceInterface
         if ($options->getMaxTokens() === null) {
             $options = $options->withMaxTokens(50);
         }
+
         if ($options->getTemperature() === null) {
             $options = $options->withTemperature(0.7);
         }
@@ -109,6 +113,7 @@ final readonly class VisionService implements VisionServiceInterface
         if ($options->getMaxTokens() === null) {
             $options = $options->withMaxTokens(500);
         }
+
         if ($options->getTemperature() === null) {
             $options = $options->withTemperature(0.7);
         }

--- a/Classes/Service/Governance/GovernanceEventRepository.php
+++ b/Classes/Service/Governance/GovernanceEventRepository.php
@@ -60,7 +60,7 @@ final readonly class GovernanceEventRepository implements GovernanceEventReposit
         $connection   = $this->connectionPool->getConnectionForTable(self::TABLE);
         $queryBuilder = $connection->createQueryBuilder();
 
-        return (int)$queryBuilder
+        return $queryBuilder
             ->delete(self::TABLE)
             ->where($queryBuilder->expr()->lt('crdate', $queryBuilder->createNamedParameter($timestamp)))
             ->executeStatement();
@@ -79,6 +79,7 @@ final readonly class GovernanceEventRepository implements GovernanceEventReposit
                 $queryBuilder->expr()->gte('crdate', $queryBuilder->createNamedParameter($since, Connection::PARAM_INT)),
             );
         }
+
         $rows = $queryBuilder
             ->groupBy('decision')
             ->executeQuery()
@@ -103,6 +104,7 @@ final readonly class GovernanceEventRepository implements GovernanceEventReposit
                 $queryBuilder->expr()->gte('crdate', $queryBuilder->createNamedParameter($since, Connection::PARAM_INT)),
             );
         }
+
         $rows = $queryBuilder
             ->groupBy('reason')
             ->executeQuery()
@@ -127,6 +129,7 @@ final readonly class GovernanceEventRepository implements GovernanceEventReposit
                 $queryBuilder->expr()->gte('crdate', $queryBuilder->createNamedParameter($since, Connection::PARAM_INT)),
             );
         }
+
         $rows = $queryBuilder
             ->groupBy('tool_name')
             ->orderBy('event_count', 'DESC')
@@ -151,6 +154,7 @@ final readonly class GovernanceEventRepository implements GovernanceEventReposit
             if ($key === '') {
                 continue;
             }
+
             $out[$key] = self::toInt($row[$countColumn] ?? 0);
         }
 

--- a/Classes/Service/Guardrail/GuardrailPolicyResolver.php
+++ b/Classes/Service/Guardrail/GuardrailPolicyResolver.php
@@ -41,7 +41,7 @@ final readonly class GuardrailPolicyResolver
     {
         $all = $guardrails instanceof Traversable ? iterator_to_array($guardrails, false) : array_values($guardrails);
 
-        if ($configuration === null) {
+        if (!$configuration instanceof LlmConfiguration) {
             return $all;
         }
 

--- a/Classes/Service/Guardrail/GuardrailRegistry.php
+++ b/Classes/Service/Guardrail/GuardrailRegistry.php
@@ -103,12 +103,14 @@ final class GuardrailRegistry
                     $id,
                 ), 1752000000);
             }
+
             if ($flag['hasMandatory']) {
                 $mandatory[$id] = true;
             } else {
                 $selectable[] = $id;
             }
         }
+
         sort($selectable);
 
         $this->mandatory  = $mandatory;

--- a/Classes/Service/Guardrail/SecretRedactionGuardrail.php
+++ b/Classes/Service/Guardrail/SecretRedactionGuardrail.php
@@ -26,6 +26,7 @@ use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
 final readonly class SecretRedactionGuardrail implements GuardrailInterface, StreamRedactableInterface
 {
     use RedactsSecretsTrait;
+
     public function getIdentifier(): string
     {
         return 'secret-redaction';

--- a/Classes/Service/Guardrail/SecretRedactionInputGuardrail.php
+++ b/Classes/Service/Guardrail/SecretRedactionInputGuardrail.php
@@ -25,6 +25,7 @@ use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
 final readonly class SecretRedactionInputGuardrail implements InputGuardrailInterface
 {
     use RedactsSecretsTrait;
+
     public function getIdentifier(): string
     {
         return 'secret-redaction';

--- a/Classes/Service/Health/ProviderHealthService.php
+++ b/Classes/Service/Health/ProviderHealthService.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service\Health;
 
 use Netresearch\NrLlm\Domain\DTO\FallbackChain;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Throwable;
 use TYPO3\CMS\Core\Cache\CacheManager as Typo3CacheManager;
@@ -103,7 +104,7 @@ final class ProviderHealthService implements ProviderHealthServiceInterface
     private function providerForIdentifier(string $identifier): ?string
     {
         $configuration = $this->configurationRepository->findOneByIdentifier($identifier);
-        if ($configuration === null) {
+        if (!$configuration instanceof LlmConfiguration) {
             return null;
         }
 

--- a/Classes/Service/KeyedProviderRegistry.php
+++ b/Classes/Service/KeyedProviderRegistry.php
@@ -89,7 +89,7 @@ final class KeyedProviderRegistry implements SingletonInterface
     {
         return array_filter(
             $this->providers,
-            static fn(ProviderInterface $provider) => $provider->isAvailable(),
+            static fn(ProviderInterface $provider): bool => $provider->isAvailable(),
         );
     }
 
@@ -110,6 +110,7 @@ final class KeyedProviderRegistry implements SingletonInterface
         foreach ($this->providers as $identifier => $provider) {
             $list[$identifier] = $provider->getName();
         }
+
         return $list;
     }
 

--- a/Classes/Service/LlmConfigurationService.php
+++ b/Classes/Service/LlmConfigurationService.php
@@ -42,7 +42,7 @@ final readonly class LlmConfigurationService implements LlmConfigurationServiceI
     {
         $configuration = $this->configurationRepository->findOneByIdentifier($identifier);
 
-        if ($configuration === null) {
+        if (!$configuration instanceof LlmConfiguration) {
             throw new ConfigurationNotFoundException(
                 sprintf('LLM configuration "%s" not found', $identifier),
                 8232736809,
@@ -71,7 +71,7 @@ final readonly class LlmConfigurationService implements LlmConfigurationServiceI
     {
         $configuration = $this->configurationRepository->findDefault();
 
-        if ($configuration === null) {
+        if (!$configuration instanceof LlmConfiguration) {
             throw new ConfigurationNotFoundException('No default LLM configuration found', 7230464472);
         }
 
@@ -139,7 +139,7 @@ final readonly class LlmConfigurationService implements LlmConfigurationServiceI
             $allowedGroupIds = $this->getConfigurationGroupIds($configuration);
 
             // Check if user is in any allowed group
-            $hasAccess = !empty(array_intersect($userGroupIds, $allowedGroupIds));
+            $hasAccess = array_intersect($userGroupIds, $allowedGroupIds) !== [];
         }
 
         return $hasAccess;

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -72,7 +72,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
      */
     private function injectConfigSkillsIntoPrompt(string $prompt, LlmConfiguration $configuration): string
     {
-        if ($this->skillInjection === null) {
+        if (!$this->skillInjection instanceof SkillInjectionService) {
             return $prompt;
         }
 
@@ -93,7 +93,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
      */
     private function injectConfigSkillsIntoMessages(array $messages, LlmConfiguration $configuration): array
     {
-        if ($this->skillInjection === null) {
+        if (!$this->skillInjection instanceof SkillInjectionService) {
             return $messages;
         }
 
@@ -217,7 +217,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         // no default configuration resolves and no provider is pinned, the call
         // throws (no extension-config fallback; see ADR-034).
         $defaultConfiguration = $this->configurationResolver->resolveDefaultConfiguration($providerKey);
-        if ($defaultConfiguration !== null) {
+        if ($defaultConfiguration instanceof LlmConfiguration) {
             return $this->chatWithConfiguration(
                 $this->injectConfigSkillsIntoMessages($messages, $defaultConfiguration),
                 $defaultConfiguration,
@@ -249,7 +249,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
 
         // Single source of truth: prefer the default DB configuration (see chat()).
         $defaultConfiguration = $this->configurationResolver->resolveDefaultConfiguration($providerKey);
-        if ($defaultConfiguration !== null) {
+        if ($defaultConfiguration instanceof LlmConfiguration) {
             return $this->completeWithConfiguration(
                 $this->injectConfigSkillsIntoPrompt($prompt, $defaultConfiguration),
                 $defaultConfiguration,
@@ -346,6 +346,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
                 if ($item instanceof VisionContent) {
                     return $item;
                 }
+
                 /** @var array{type?: string, text?: string, image_url?: array{url?: string}|string} $item */
                 return VisionContent::fromArray($item);
             },
@@ -360,6 +361,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
                 if (!$item->isText() || $item->text === null) {
                     return $item;
                 }
+
                 $screened = $this->screenInputPrompt($item->text);
 
                 return $screened === $item->text ? $item : VisionContent::text($screened);
@@ -405,7 +407,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         // Budget attribution is forwarded so the streaming lifecycle can gate the
         // same over-budget users the non-streaming path rejects.
         $defaultConfiguration = $this->configurationResolver->resolveDefaultConfiguration($providerKey);
-        if ($defaultConfiguration !== null) {
+        if ($defaultConfiguration instanceof LlmConfiguration) {
             return $this->streamChatWithConfiguration(
                 $this->injectConfigSkillsIntoMessages($messages, $defaultConfiguration),
                 $defaultConfiguration,
@@ -431,7 +433,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
 
         $configuration = $this->synthesizeTransientConfiguration(ProviderOperation::Stream, $providerKey);
 
-        if ($this->streaming === null) {
+        if (!$this->streaming instanceof StreamingDispatcher) {
             return $open();
         }
 
@@ -475,6 +477,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
                 if ($tool instanceof ToolSpec) {
                     return $tool;
                 }
+
                 /** @var array{type?: string, function: array{name: string, description?: string, parameters?: array<string, mixed>}} $tool */
                 return ToolSpec::fromArray($tool);
             },
@@ -533,6 +536,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
                 if ($tool instanceof ToolSpec) {
                     return $tool;
                 }
+
                 /** @var array{type?: string, function: array{name: string, description?: string, parameters?: array<string, mixed>}} $tool */
                 return ToolSpec::fromArray($tool);
             },
@@ -725,10 +729,10 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         // unchanged for fixed-mode configs — so both selection modes reach a concrete
         // model here. Without this, every *ForConfiguration() call on a criteria-mode
         // configuration threw "has no model assigned".
-        $llmModel = $this->modelSelectionService !== null
+        $llmModel = $this->modelSelectionService instanceof ModelSelectionServiceInterface
             ? $this->modelSelectionService->resolveModel($configuration)
             : $configuration->getLlmModel();
-        if ($llmModel === null) {
+        if (!$llmModel instanceof Model) {
             throw new ProviderException(
                 sprintf('Configuration "%s" has no model assigned', $configuration->getIdentifier()),
                 1735300100,
@@ -876,6 +880,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         if (is_string($systemPrompt) && $systemPrompt !== '') {
             $messages[] = ChatMessage::system($systemPrompt);
         }
+
         $messages[] = ChatMessage::user($prompt);
 
         return $this->chatWithConfiguration(
@@ -929,7 +934,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
     private function requireConfiguration(ProviderCallContext $context): LlmConfiguration
     {
         $configuration = $context->configuration;
-        if ($configuration === null) {
+        if (!$configuration instanceof LlmConfiguration) {
             throw new ProviderException('The pipeline context carried no configuration on a configuration-driven call.', 1784600700);
         }
 
@@ -1150,7 +1155,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             );
         };
 
-        if ($this->streaming === null) {
+        if (!$this->streaming instanceof StreamingDispatcher) {
             return $open($configuration);
         }
 

--- a/Classes/Service/ModelSelectionService.php
+++ b/Classes/Service/ModelSelectionService.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Service;
 
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 
 /**
@@ -55,7 +56,7 @@ final readonly class ModelSelectionService implements ModelSelectionServiceInter
     {
         $candidates = $this->findCandidates($criteria);
 
-        if (empty($candidates)) {
+        if ($candidates === []) {
             return null;
         }
 
@@ -150,7 +151,7 @@ final readonly class ModelSelectionService implements ModelSelectionServiceInter
         }
 
         $provider = $model->getProvider();
-        if ($provider === null) {
+        if (!$provider instanceof Provider) {
             return false;
         }
 
@@ -246,6 +247,7 @@ final readonly class ModelSelectionService implements ModelSelectionServiceInter
         if ($costA === 0) {
             $costA = PHP_INT_MAX;
         }
+
         if ($costB === 0) {
             $costB = PHP_INT_MAX;
         }

--- a/Classes/Service/Option/AbstractOptions.php
+++ b/Classes/Service/Option/AbstractOptions.php
@@ -113,6 +113,6 @@ abstract class AbstractOptions
      */
     protected function filterNull(array $array): array
     {
-        return array_filter($array, static fn($v) => $v !== null);
+        return array_filter($array, static fn($v): bool => $v !== null);
     }
 }

--- a/Classes/Service/Option/ToolOptions.php
+++ b/Classes/Service/Option/ToolOptions.php
@@ -69,8 +69,8 @@ class ToolOptions extends ChatOptions
     public static function auto(): static
     {
         return new static(
-            toolChoice: 'auto',
             temperature: 0.7,
+            toolChoice: 'auto',
         );
     }
 
@@ -80,8 +80,8 @@ class ToolOptions extends ChatOptions
     public static function required(): static
     {
         return new static(
-            toolChoice: 'required',
             temperature: 0.3,
+            toolChoice: 'required',
         );
     }
 
@@ -91,8 +91,8 @@ class ToolOptions extends ChatOptions
     public static function noTools(): static
     {
         return new static(
-            toolChoice: 'none',
             temperature: 0.7,
+            toolChoice: 'none',
         );
     }
 
@@ -102,9 +102,9 @@ class ToolOptions extends ChatOptions
     public static function parallel(): static
     {
         return new static(
+            temperature: 0.7,
             toolChoice: 'auto',
             parallelToolCalls: true,
-            temperature: 0.7,
         );
     }
 
@@ -177,7 +177,6 @@ class ToolOptions extends ChatOptions
         $stopSequences = is_array($stop) ? array_values(array_filter($stop, is_string(...))) : null;
 
         return new static(
-            beUserUid: $beUserUid,
             temperature: is_numeric($data['temperature'] ?? null) ? (float)$data['temperature'] : null,
             maxTokens: is_numeric($data['max_tokens'] ?? null) ? (int)$data['max_tokens'] : null,
             topP: is_numeric($data['top_p'] ?? null) ? (float)$data['top_p'] : null,
@@ -188,6 +187,7 @@ class ToolOptions extends ChatOptions
             stopSequences: $stopSequences,
             provider: is_string($data['provider'] ?? null) ? $data['provider'] : null,
             model: is_string($data['model'] ?? null) ? $data['model'] : null,
+            beUserUid: $beUserUid,
             think: is_bool($data['think'] ?? null) ? $data['think'] : null,
             toolChoice: is_string($data['tool_choice'] ?? null) ? $data['tool_choice'] : null,
             parallelToolCalls: is_bool($data['parallel_tool_calls'] ?? null) ? $data['parallel_tool_calls'] : null,

--- a/Classes/Service/Option/TranslationOptions.php
+++ b/Classes/Service/Option/TranslationOptions.php
@@ -19,6 +19,7 @@ class TranslationOptions extends AbstractOptions implements BudgetAwareOptionsIn
     use BudgetFieldsTrait;
 
     private const FORMALITIES = ['default', 'formal', 'informal'];
+
     private const DOMAINS = ['general', 'technical', 'medical', 'legal', 'marketing'];
 
     public function __construct(

--- a/Classes/Service/Overview/OverviewReadinessService.php
+++ b/Classes/Service/Overview/OverviewReadinessService.php
@@ -11,6 +11,8 @@ namespace Netresearch\NrLlm\Service\Overview;
 
 use DateTimeImmutable;
 use Netresearch\NrLlm\Domain\Enum\OverviewCardState;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
@@ -74,10 +76,10 @@ final readonly class OverviewReadinessService
         $providers        = $this->providerRepository->countActive();
         $models           = $this->modelRepository->countActive();
         $configurations   = $this->configurationRepository->countActive();
-        $configHasDefault = $this->configurationRepository->findDefault() !== null;
+        $configHasDefault = $this->configurationRepository->findDefault() instanceof LlmConfiguration;
         // Models carry a default too (used for fallback model selection); show
         // the same "default set" badge. Providers use priority, not a default.
-        $modelHasDefault  = $this->modelRepository->findDefault() !== null;
+        $modelHasDefault  = $this->modelRepository->findDefault() instanceof Model;
 
         // Critical path: the first incomplete step is Next, later steps Locked.
         $providersState      = $providers > 0 ? OverviewCardState::Ready : OverviewCardState::Next;

--- a/Classes/Service/Preset/ConfigurationPreset.php
+++ b/Classes/Service/Preset/ConfigurationPreset.php
@@ -75,6 +75,7 @@ final readonly class ConfigurationPreset
                 1789347001,
             );
         }
+
         if (strlen($identifier) > self::IDENTIFIER_MAX_LENGTH) {
             throw new InvalidArgumentException(
                 sprintf(
@@ -85,6 +86,7 @@ final readonly class ConfigurationPreset
                 1789347002,
             );
         }
+
         if ($criteria->capabilities === []) {
             throw new InvalidArgumentException(
                 sprintf(
@@ -94,6 +96,7 @@ final readonly class ConfigurationPreset
                 1789347003,
             );
         }
+
         if ($name === '' || mb_strlen($name) > self::NAME_MAX_LENGTH) {
             throw new InvalidArgumentException(
                 sprintf(
@@ -105,6 +108,7 @@ final readonly class ConfigurationPreset
                 1789347005,
             );
         }
+
         $this->validateSeeds();
     }
 
@@ -123,12 +127,14 @@ final readonly class ConfigurationPreset
                 1789347006,
             );
         }
+
         if ($this->maxTokens !== null && $this->maxTokens < 1) {
             throw new InvalidArgumentException(
                 sprintf('Preset "%s" maxTokens must be >= 1; got %d.', $this->identifier, $this->maxTokens),
                 1789347007,
             );
         }
+
         foreach (['maxRequestsPerDay' => $this->maxRequestsPerDay, 'maxTokensPerDay' => $this->maxTokensPerDay] as $field => $value) {
             if ($value !== null && $value < 0) {
                 throw new InvalidArgumentException(
@@ -137,6 +143,7 @@ final readonly class ConfigurationPreset
                 );
             }
         }
+
         if ($this->maxCostPerDay !== null && $this->maxCostPerDay < 0.0) {
             throw new InvalidArgumentException(
                 sprintf('Preset "%s" maxCostPerDay must be >= 0.0; got %s.', $this->identifier, $this->maxCostPerDay),

--- a/Classes/Service/Preset/ConfigurationPresetDiffService.php
+++ b/Classes/Service/Preset/ConfigurationPresetDiffService.php
@@ -51,21 +51,27 @@ final readonly class ConfigurationPresetDiffService
         if ($preset->systemPrompt !== null) {
             $this->addStringChange($changes, 'systemPrompt', $record->getSystemPrompt(), $preset->systemPrompt);
         }
+
         if ($preset->temperature !== null) {
             $this->addFloatChange($changes, 'temperature', $record->getTemperature(), $preset->temperature);
         }
+
         if ($preset->maxTokens !== null) {
             $this->addIntChange($changes, 'maxTokens', $record->getMaxTokens(), $preset->maxTokens);
         }
+
         if ($preset->maxRequestsPerDay !== null) {
             $this->addIntChange($changes, 'maxRequestsPerDay', $record->getMaxRequestsPerDay(), $preset->maxRequestsPerDay);
         }
+
         if ($preset->maxTokensPerDay !== null) {
             $this->addIntChange($changes, 'maxTokensPerDay', $record->getMaxTokensPerDay(), $preset->maxTokensPerDay);
         }
+
         if ($preset->maxCostPerDay !== null) {
             $this->addFloatChange($changes, 'maxCostPerDay', $record->getMaxCostPerDay(), $preset->maxCostPerDay);
         }
+
         if ($preset->allowedToolGroups !== []) {
             $this->addToolGroupsChange($changes, $record->getAllowedToolGroupsList(), $preset->allowedToolGroups);
         }

--- a/Classes/Service/Preset/ConfigurationPresetImportService.php
+++ b/Classes/Service/Preset/ConfigurationPresetImportService.php
@@ -70,7 +70,7 @@ final readonly class ConfigurationPresetImportService
     public function preflight(ConfigurationPreset $preset): PresetPreflightResult
     {
         $model = $this->modelSelectionService->findMatchingModel($preset->criteria->toArray());
-        if ($model !== null) {
+        if ($model instanceof Model) {
             $label = $model->getName() !== '' ? $model->getName() : $model->getModelId();
 
             return PresetPreflightResult::satisfiable($label);
@@ -91,7 +91,7 @@ final readonly class ConfigurationPresetImportService
      */
     public function import(ConfigurationPreset $preset): LlmConfiguration
     {
-        if ($this->configurationRepository->findOneByIdentifier($preset->identifier) !== null) {
+        if ($this->configurationRepository->findOneByIdentifier($preset->identifier) instanceof LlmConfiguration) {
             throw new InvalidArgumentException(
                 sprintf('A configuration with the identifier "%s" already exists.', $preset->identifier),
                 1789347005,
@@ -119,24 +119,31 @@ final readonly class ConfigurationPresetImportService
         if ($preset->systemPrompt !== null) {
             $configuration->setSystemPrompt($preset->systemPrompt);
         }
+
         if ($preset->temperature !== null) {
             $configuration->setTemperature($preset->temperature);
         }
+
         if ($preset->maxTokens !== null) {
             $configuration->setMaxTokens($preset->maxTokens);
         }
+
         if ($preset->maxRequestsPerDay !== null) {
             $configuration->setMaxRequestsPerDay($preset->maxRequestsPerDay);
         }
+
         if ($preset->maxTokensPerDay !== null) {
             $configuration->setMaxTokensPerDay($preset->maxTokensPerDay);
         }
+
         if ($preset->maxCostPerDay !== null) {
             $configuration->setMaxCostPerDay($preset->maxCostPerDay);
         }
+
         if ($preset->allowedToolGroups !== []) {
             $configuration->setAllowedToolGroups(implode(',', $preset->allowedToolGroups));
         }
+
         $configuration->setIsActive(true);
         $configuration->setPresetChecksum($preset->checksum());
 
@@ -185,24 +192,31 @@ final readonly class ConfigurationPresetImportService
         if ($preset->systemPrompt !== null) {
             $record->setSystemPrompt($preset->systemPrompt);
         }
+
         if ($preset->temperature !== null) {
             $record->setTemperature($preset->temperature);
         }
+
         if ($preset->maxTokens !== null) {
             $record->setMaxTokens($preset->maxTokens);
         }
+
         if ($preset->maxRequestsPerDay !== null) {
             $record->setMaxRequestsPerDay($preset->maxRequestsPerDay);
         }
+
         if ($preset->maxTokensPerDay !== null) {
             $record->setMaxTokensPerDay($preset->maxTokensPerDay);
         }
+
         if ($preset->maxCostPerDay !== null) {
             $record->setMaxCostPerDay($preset->maxCostPerDay);
         }
+
         if ($preset->allowedToolGroups !== []) {
             $record->setAllowedToolGroups(implode(',', $preset->allowedToolGroups));
         }
+
         $record->setPresetChecksum($preset->checksum());
 
         $this->configurationRepository->update($record);
@@ -324,7 +338,11 @@ final readonly class ConfigurationPresetImportService
         // round.
         $inactiveMatches = [];
         foreach ($this->modelRepository->findAll()->toArray() as $model) {
-            if (!$model instanceof Model || $model->isActive()) {
+            if (!$model instanceof Model) {
+                continue;
+            }
+
+            if ($model->isActive()) {
                 continue;
             }
 

--- a/Classes/Service/Preset/ConfigurationPresetRegistry.php
+++ b/Classes/Service/Preset/ConfigurationPresetRegistry.php
@@ -50,6 +50,7 @@ final class ConfigurationPresetRegistry
                         1789347004,
                     );
                 }
+
                 $this->byIdentifier[$preset->identifier] = $preset;
             }
         }
@@ -77,7 +78,7 @@ final class ConfigurationPresetRegistry
     {
         $pending = [];
         foreach ($this->byIdentifier as $identifier => $preset) {
-            if ($this->configurationRepository->findOneByIdentifier($identifier) === null) {
+            if (!$this->configurationRepository->findOneByIdentifier($identifier) instanceof LlmConfiguration) {
                 $pending[] = $preset;
             }
         }
@@ -102,9 +103,10 @@ final class ConfigurationPresetRegistry
         $drifted = [];
         foreach ($this->byIdentifier as $identifier => $preset) {
             $configuration = $this->configurationRepository->findOneByIdentifier($identifier);
-            if ($configuration === null) {
+            if (!$configuration instanceof LlmConfiguration) {
                 continue;
             }
+
             $storedChecksum = $configuration->getPresetChecksum();
             if ($storedChecksum !== '' && $storedChecksum !== $preset->checksum()) {
                 $drifted[] = ['preset' => $preset, 'configuration' => $configuration];

--- a/Classes/Service/Privacy/RunStepPrivacyFilter.php
+++ b/Classes/Service/Privacy/RunStepPrivacyFilter.php
@@ -113,6 +113,7 @@ final readonly class RunStepPrivacyFilter
                     $types[] = $artifact['type'];
                 }
             }
+
             $out['toolArtifactTypes'] = $types;
         }
 

--- a/Classes/Service/Rerank/HttpReranker.php
+++ b/Classes/Service/Rerank/HttpReranker.php
@@ -109,7 +109,11 @@ final readonly class HttpReranker implements RerankerInterface
 
             $id    = $entry['id'] ?? null;
             $score = $entry['score'] ?? null;
-            if (!is_string($id) || (!is_int($score) && !is_float($score))) {
+            if (!is_string($id)) {
+                continue;
+            }
+
+            if (!is_int($score) && !is_float($score)) {
                 continue;
             }
 

--- a/Classes/Service/Retrieval/DatabaseSearchBackend.php
+++ b/Classes/Service/Retrieval/DatabaseSearchBackend.php
@@ -184,6 +184,7 @@ final readonly class DatabaseSearchBackend implements SearchBackendInterface
             if ($header !== '') {
                 $parts[] = '## ' . $header;
             }
+
             if ($body !== '') {
                 $parts[] = $body;
             }
@@ -282,6 +283,7 @@ final readonly class DatabaseSearchBackend implements SearchBackendInterface
             if (!$this->ancestorsArePublic(self::toInt($row['pid'] ?? 0), $ancestorCache)) {
                 continue;
             }
+
             $titles[self::toInt($row['uid'] ?? 0)] = self::toStr($row['title'] ?? '');
         }
 
@@ -405,6 +407,7 @@ final readonly class DatabaseSearchBackend implements SearchBackendInterface
         foreach ($fields as $field) {
             $haystack .= ' ' . self::toStr($row[$field] ?? '');
         }
+
         $haystack = ExcerptBuilder::plain($haystack);
 
         return array_values(array_filter(
@@ -456,6 +459,7 @@ final readonly class DatabaseSearchBackend implements SearchBackendInterface
                 $public = $cache[$current];
                 break;
             }
+
             $chain[] = $current;
 
             $row = $this->ancestorRow($current);
@@ -463,6 +467,7 @@ final readonly class DatabaseSearchBackend implements SearchBackendInterface
                 $public = false;
                 break;
             }
+
             $current = self::toInt($row['pid'] ?? 0);
         }
 
@@ -571,13 +576,16 @@ final readonly class DatabaseSearchBackend implements SearchBackendInterface
             if ($value === '') {
                 continue;
             }
+
             $plain = ExcerptBuilder::plain($value);
             if ($fallback === '') {
                 $fallback = mb_substr($plain, 0, ExcerptBuilder::DEFAULT_LENGTH);
             }
+
             if (mb_stripos($plain, $query) !== false) {
                 return ['excerpt' => ExcerptBuilder::around($plain, $query), 'phrase' => true];
             }
+
             foreach ($words as $word) {
                 if (mb_stripos($plain, $word) !== false) {
                     return ['excerpt' => ExcerptBuilder::around($plain, $word), 'phrase' => false];

--- a/Classes/Service/Retrieval/IndexedSearchBackend.php
+++ b/Classes/Service/Retrieval/IndexedSearchBackend.php
@@ -130,6 +130,7 @@ final class IndexedSearchBackend implements SearchBackendInterface
         if (count($reference->parts) !== 1) {
             return null;
         }
+
         $phash = $reference->parts[0];
 
         $queryBuilder = $this->phashQueryBuilder();
@@ -331,6 +332,7 @@ final class IndexedSearchBackend implements SearchBackendInterface
         } catch (Throwable) {
             return null;
         }
+
         if ($siteIdentifier !== null && $site->getIdentifier() !== $siteIdentifier) {
             return null;
         }
@@ -352,6 +354,7 @@ final class IndexedSearchBackend implements SearchBackendInterface
         if ($pageType > 0) {
             $arguments['type'] = $pageType;
         }
+
         $arguments['_language'] = self::toInt($row['sys_language_uid'] ?? 0);
 
         try {

--- a/Classes/Service/Retrieval/KeSearchBackend.php
+++ b/Classes/Service/Retrieval/KeSearchBackend.php
@@ -135,6 +135,7 @@ final class KeSearchBackend implements SearchBackendInterface
         if ($abstract !== '') {
             $parts[] = $abstract;
         }
+
         if ($content !== '') {
             $parts[] = $content;
         }
@@ -237,6 +238,7 @@ final class KeSearchBackend implements SearchBackendInterface
             if ($siteIdentifier !== null) {
                 return null;
             }
+
             $url = self::toStr($row['params'] ?? '');
 
             return str_starts_with($url, 'https://') || str_starts_with($url, 'http://') ? $url : null;
@@ -252,6 +254,7 @@ final class KeSearchBackend implements SearchBackendInterface
         } catch (Throwable) {
             return null;
         }
+
         if ($siteIdentifier !== null && $site->getIdentifier() !== $siteIdentifier) {
             return null;
         }
@@ -261,6 +264,7 @@ final class KeSearchBackend implements SearchBackendInterface
         if ($params !== '') {
             parse_str($params, $arguments);
         }
+
         $arguments['_language'] = $languageId;
 
         try {

--- a/Classes/Service/Retrieval/KeywordSearchService.php
+++ b/Classes/Service/Retrieval/KeywordSearchService.php
@@ -44,6 +44,7 @@ final class KeywordSearchService implements KeywordSearchInterface
         if (mb_strlen($query) > RetrievalQuery::MAX_QUERY_LENGTH) {
             $query = trim(mb_substr($query, 0, RetrievalQuery::MAX_QUERY_LENGTH));
         }
+
         if (mb_strlen($query) < RetrievalQuery::MIN_QUERY_LENGTH) {
             return [];
         }
@@ -104,8 +105,10 @@ final class KeywordSearchService implements KeywordSearchInterface
                 if ($this->indexBackedOnly && $backend->getPriority() <= 0) {
                     continue;
                 }
+
                 $selected[] = $backend;
             }
+
             $this->selectedBackends = $selected;
         }
 

--- a/Classes/Service/Retrieval/RetrievalService.php
+++ b/Classes/Service/Retrieval/RetrievalService.php
@@ -67,6 +67,7 @@ final class RetrievalService
             if ($backend->getIdentifier() !== $reference->backend) {
                 continue;
             }
+
             if (!$this->available($backend)) {
                 return null;
             }
@@ -91,6 +92,7 @@ final class RetrievalService
             foreach ($this->backends as $backend) {
                 $backends[] = $backend;
             }
+
             usort(
                 $backends,
                 static fn(SearchBackendInterface $a, SearchBackendInterface $b): int => $b->getPriority() <=> $a->getPriority(),
@@ -123,6 +125,7 @@ final class RetrievalService
             if (isset($seen[$key])) {
                 continue;
             }
+
             $seen[$key] = true;
             $sources[] = $source;
             if (count($sources) >= $maxSources) {

--- a/Classes/Service/Retrieval/SolrSearchBackend.php
+++ b/Classes/Service/Retrieval/SolrSearchBackend.php
@@ -100,9 +100,10 @@ final class SolrSearchBackend implements SearchBackendInterface
 
             foreach ($this->select($endpoint, $parameters, $filters) as $document) {
                 $source = $this->toEvidence($document, $site, $query);
-                if ($source !== null) {
+                if ($source instanceof EvidenceSource) {
                     $sources[] = $source;
                 }
+
                 if (count($sources) >= $query->maxSources) {
                     return new EvidenceList(self::IDENTIFIER, $sources);
                 }
@@ -117,6 +118,7 @@ final class SolrSearchBackend implements SearchBackendInterface
         if (count($reference->parts) !== 4) {
             return null;
         }
+
         [$siteIdentifier, $type, $uid, $languageId] = $reference->parts;
         if (preg_match('/^[A-Za-z0-9_]{1,64}$/', $type) !== 1) {
             return null;
@@ -160,6 +162,7 @@ final class SolrSearchBackend implements SearchBackendInterface
         if ($documentUrl !== '' && $this->siteScopedUrl($documentUrl, $site) === null) {
             return null;
         }
+
         $title = ExcerptBuilder::plain(self::toStr($document['title'] ?? ''));
         $content = ExcerptBuilder::plain(self::toStr($document['content'] ?? ''));
 
@@ -202,6 +205,7 @@ final class SolrSearchBackend implements SearchBackendInterface
         foreach ($parameters as $name => $value) {
             $pairs[] = rawurlencode($name) . '=' . rawurlencode($value);
         }
+
         foreach ($filters as $filter) {
             $pairs[] = 'fq=' . rawurlencode($filter);
         }
@@ -215,10 +219,12 @@ final class SolrSearchBackend implements SearchBackendInterface
         if (!is_array($data)) {
             return [];
         }
+
         $responseNode = $data['response'] ?? null;
         if (!is_array($responseNode)) {
             return [];
         }
+
         $docs = $responseNode['docs'] ?? null;
         if (!is_array($docs)) {
             return [];
@@ -245,6 +251,7 @@ final class SolrSearchBackend implements SearchBackendInterface
         if ($type === '' || $uid < 1 || preg_match('/^[A-Za-z0-9_]{1,64}$/', $type) !== 1) {
             return null;
         }
+
         $url = $this->siteScopedUrl(self::toStr($document['url'] ?? ''), $site);
         if ($url === null) {
             return null;
@@ -308,6 +315,7 @@ final class SolrSearchBackend implements SearchBackendInterface
             if ($baseHost === '') {
                 return $url;
             }
+
             $origin = $scheme . '://' . $baseHost
                 . ($base->getPort() !== null ? ':' . $base->getPort() : '');
 
@@ -372,7 +380,7 @@ final class SolrSearchBackend implements SearchBackendInterface
         // carrying configuration rather than model input (ADR-093). A denial
         // returns null, the method's established "not configured" path, which
         // RetrievalService treats as an unavailable backend and skips.
-        if ($this->egressPolicy === null) {
+        if (!$this->egressPolicy instanceof EgressPolicyService) {
             return $url;
         }
 

--- a/Classes/Service/Schema/JsonSchemaValidator.php
+++ b/Classes/Service/Schema/JsonSchemaValidator.php
@@ -42,6 +42,7 @@ final readonly class JsonSchemaValidator
             if (!is_array($data) || ($data !== [] && array_is_list($data))) {
                 return false;
             }
+
             foreach ($schema['required'] as $key) {
                 if (!is_string($key) || !array_key_exists($key, $data)) {
                     return false;
@@ -72,6 +73,7 @@ final readonly class JsonSchemaValidator
         if (json_last_error() !== JSON_ERROR_NONE) {
             return false;
         }
+
         $schema = json_decode($schemaJson, true);
         if (!is_array($schema)) {
             return false;

--- a/Classes/Service/Session/AiSessionRepository.php
+++ b/Classes/Service/Session/AiSessionRepository.php
@@ -257,7 +257,7 @@ final readonly class AiSessionRepository implements AiSessionRepositoryInterface
                 ->executeStatement();
 
             $deleteBuilder = $sessionConnection->createQueryBuilder();
-            $deleted += (int)$deleteBuilder
+            $deleted += $deleteBuilder
                 ->delete(self::TABLE_SESSION)
                 ->where($deleteBuilder->expr()->in('uid', $deleteBuilder->createNamedParameter($chunk, Connection::PARAM_INT_ARRAY)))
                 ->executeStatement();

--- a/Classes/Service/SetupWizard/ConfigurationGenerator.php
+++ b/Classes/Service/SetupWizard/ConfigurationGenerator.php
@@ -97,7 +97,7 @@ final class ConfigurationGenerator
         // Find the best model to use for generation
         $generationModel = $this->selectGenerationModel($models);
 
-        if ($generationModel === null) {
+        if (!$generationModel instanceof DiscoveredModel) {
             return $this->getFallbackConfigurations($models);
         }
 
@@ -136,7 +136,7 @@ final class ConfigurationGenerator
     private function selectGenerationModel(array $models): ?DiscoveredModel
     {
         // Prefer recommended models, then by context length
-        $candidates = array_filter($models, fn(DiscoveredModel $m) => $m->recommended);
+        $candidates = array_filter($models, fn(DiscoveredModel $m): bool => $m->recommended);
 
         if ($candidates === []) {
             $candidates = $models;
@@ -149,7 +149,7 @@ final class ConfigurationGenerator
         // Sort by context length (prefer larger context)
         usort(
             $candidates,
-            fn(DiscoveredModel $a, DiscoveredModel $b)
+            fn(DiscoveredModel $a, DiscoveredModel $b): int
             => $b->contextLength <=> $a->contextLength,
         );
 
@@ -164,7 +164,7 @@ final class ConfigurationGenerator
     private function buildPrompt(array $models): string
     {
         $modelList = array_map(
-            fn(DiscoveredModel $m) => sprintf(
+            fn(DiscoveredModel $m): string => sprintf(
                 '- %s (%s): %s',
                 $m->name,
                 $m->modelId,
@@ -250,10 +250,12 @@ final class ConfigurationGenerator
         if (!is_array($content) || $content === []) {
             return '';
         }
+
         $firstBlock = $content[0] ?? [];
         if (!is_array($firstBlock)) {
             return '';
         }
+
         $text = $firstBlock['text'] ?? '';
         return is_string($text) ? $text : '';
     }
@@ -269,11 +271,13 @@ final class ConfigurationGenerator
         if ($candidates === []) {
             return '';
         }
+
         $content = $this->arrayAt($this->arrayAt($candidates, 0), 'content');
         $parts   = $this->arrayAt($content, 'parts');
         if ($parts === []) {
             return '';
         }
+
         $text = $this->arrayAt($parts, 0)['text'] ?? '';
         return is_string($text) ? $text : '';
     }
@@ -303,6 +307,7 @@ final class ConfigurationGenerator
         if ($choices === []) {
             return '';
         }
+
         $message = $this->arrayAt($this->arrayAt($choices, 0), 'message');
         $content = $message['content'] ?? '';
         return is_string($content) ? $content : '';
@@ -410,7 +415,7 @@ final class ConfigurationGenerator
             }
 
             $config = $this->buildConfiguration($item, $modelId);
-            if ($config !== null) {
+            if ($config instanceof SuggestedConfiguration) {
                 $configs[] = $config;
             }
         }

--- a/Classes/Service/SetupWizard/DTO/WizardResult.php
+++ b/Classes/Service/SetupWizard/DTO/WizardResult.php
@@ -36,8 +36,8 @@ final readonly class WizardResult
     {
         return [
             'provider' => $this->provider->toArray(),
-            'models' => array_map(fn(DiscoveredModel $m) => $m->toArray(), $this->models),
-            'configurations' => array_map(fn(SuggestedConfiguration $c) => $c->toArray(), $this->configurations),
+            'models' => array_map(fn(DiscoveredModel $m): array => $m->toArray(), $this->models),
+            'configurations' => array_map(fn(SuggestedConfiguration $c): array => $c->toArray(), $this->configurations),
             'connectionSuccessful' => $this->connectionSuccessful,
             'connectionMessage' => $this->connectionMessage,
         ];

--- a/Classes/Service/SetupWizard/ModelDiscovery.php
+++ b/Classes/Service/SetupWizard/ModelDiscovery.php
@@ -282,8 +282,17 @@ final class ModelDiscovery implements ModelDiscoveryInterface
                 if (!is_array($model)) {
                     continue;
                 }
+
                 $modelId = $model['id'] ?? '';
-                if (!is_string($modelId) || $modelId === '' || !$this->isRelevantOpenAIModel($modelId)) {
+                if (!is_string($modelId)) {
+                    continue;
+                }
+
+                if ($modelId === '') {
+                    continue;
+                }
+
+                if (!$this->isRelevantOpenAIModel($modelId)) {
                     continue;
                 }
 
@@ -291,7 +300,7 @@ final class ModelDiscovery implements ModelDiscoveryInterface
             }
 
             // Sort by recommendation
-            usort($models, fn(DiscoveredModel $a, DiscoveredModel $b) => $b->recommended <=> $a->recommended);
+            usort($models, fn(DiscoveredModel $a, DiscoveredModel $b): int => $b->recommended <=> $a->recommended);
 
             return $models !== [] ? $models : $this->asFallback($this->getOpenAIFallbackModels());
         } catch (Throwable $e) {
@@ -521,10 +530,10 @@ final class ModelDiscovery implements ModelDiscoveryInterface
                 'recommended' => false,
             ],
             // Specialized models — see specializedSpec() for the shared shape.
-            'gpt-image-2' => self::specializedSpec('GPT Image 2', 'Image generation model', 'image'),
-            'tts-1' => self::specializedSpec('TTS-1', 'Text-to-speech model optimized for speed', 'text_to_speech'),
-            'tts-1-hd' => self::specializedSpec('TTS-1 HD', 'Text-to-speech model optimized for quality', 'text_to_speech'),
-            'whisper-1' => self::specializedSpec('Whisper', 'Speech-to-text transcription model', 'transcription'),
+            'gpt-image-2' => $this->specializedSpec('GPT Image 2', 'Image generation model', 'image'),
+            'tts-1' => $this->specializedSpec('TTS-1', 'Text-to-speech model optimized for speed', 'text_to_speech'),
+            'tts-1-hd' => $this->specializedSpec('TTS-1 HD', 'Text-to-speech model optimized for quality', 'text_to_speech'),
+            'whisper-1' => $this->specializedSpec('Whisper', 'Speech-to-text transcription model', 'transcription'),
         ];
     }
 
@@ -557,7 +566,7 @@ final class ModelDiscovery implements ModelDiscoveryInterface
      *
      * @return array{name: string, description: string, capabilities: array<string>, contextLength: int, maxOutputTokens: int, costInput: int, costOutput: int, recommended: bool}
      */
-    private static function specializedSpec(string $name, string $description, string $capability): array
+    private function specializedSpec(string $name, string $description, string $capability): array
     {
         return [
             'name' => $name,
@@ -626,8 +635,13 @@ final class ModelDiscovery implements ModelDiscoveryInterface
                 if (!is_array($model)) {
                     continue;
                 }
+
                 $modelId = $model['id'] ?? '';
-                if (!is_string($modelId) || $modelId === '') {
+                if (!is_string($modelId)) {
+                    continue;
+                }
+
+                if ($modelId === '') {
                     continue;
                 }
 
@@ -636,7 +650,7 @@ final class ModelDiscovery implements ModelDiscoveryInterface
             }
 
             // Sort: recommended first, then by name
-            usort($models, fn(DiscoveredModel $a, DiscoveredModel $b) => $b->recommended <=> $a->recommended);
+            usort($models, fn(DiscoveredModel $a, DiscoveredModel $b): int => $b->recommended <=> $a->recommended);
 
             return $models !== [] ? $models : $this->asFallback($this->getAnthropicFallbackModels());
         } catch (Throwable $e) {
@@ -814,12 +828,18 @@ final class ModelDiscovery implements ModelDiscoveryInterface
                 if (!is_array($model)) {
                     continue;
                 }
+
                 $modelName = $model['name'] ?? '';
                 if (!is_string($modelName)) {
                     continue;
                 }
+
                 $modelId = str_replace('models/', '', $modelName);
-                if ($modelId === '' || !$this->isRelevantGeminiModel($modelId)) {
+                if ($modelId === '') {
+                    continue;
+                }
+
+                if (!$this->isRelevantGeminiModel($modelId)) {
                     continue;
                 }
 
@@ -847,14 +867,7 @@ final class ModelDiscovery implements ModelDiscoveryInterface
 
         // Exclude embedding models (not usable for chat)
         // and very old models (gemini-1.0, gemini-pro)
-        if (str_contains($modelId, 'embedding')
-            || str_starts_with($modelId, 'gemini-1.0')
-            || str_starts_with($modelId, 'gemini-pro')
-        ) {
-            return false;
-        }
-
-        return true;
+        return !(str_contains($modelId, 'embedding') || str_starts_with($modelId, 'gemini-1.0') || str_starts_with($modelId, 'gemini-pro'));
     }
 
     /**
@@ -1014,6 +1027,7 @@ final class ModelDiscovery implements ModelDiscoveryInterface
                 if (!is_array($model)) {
                     continue;
                 }
+
                 $modelId = isset($model['name']) && is_string($model['name']) ? $model['name'] : '';
                 if ($modelId === '') {
                     continue;
@@ -1251,8 +1265,9 @@ final class ModelDiscovery implements ModelDiscoveryInterface
                 if (!is_array($model)) {
                     continue;
                 }
+
                 $discovered = $this->mapOpenRouterModel($model);
-                if ($discovered !== null) {
+                if ($discovered instanceof DiscoveredModel) {
                     $models[] = $discovered;
                 }
             }
@@ -1323,6 +1338,7 @@ final class ModelDiscovery implements ModelDiscoveryInterface
                 if (!is_array($model)) {
                     continue;
                 }
+
                 $modelId = isset($model['id']) && is_string($model['id']) ? $model['id'] : '';
                 if ($modelId === '') {
                     continue;
@@ -1400,6 +1416,7 @@ final class ModelDiscovery implements ModelDiscoveryInterface
                 if (!is_array($model)) {
                     continue;
                 }
+
                 $modelId = isset($model['id']) && is_string($model['id']) ? $model['id'] : '';
                 if ($modelId === '') {
                     continue;

--- a/Classes/Service/SetupWizard/ProviderDetector.php
+++ b/Classes/Service/SetupWizard/ProviderDetector.php
@@ -279,6 +279,7 @@ final class ProviderDetector
         if (preg_match('/^([^.]+)\.openai\.azure\.com$/', $host, $matches)) {
             return $matches[1];
         }
+
         return '';
     }
 
@@ -297,10 +298,6 @@ final class ProviderDetector
         }
 
         // Check for 'openai' in the URL (common for compatible proxies)
-        if (str_contains(strtolower($endpoint), 'openai')) {
-            return true;
-        }
-
-        return false;
+        return str_contains(strtolower($endpoint), 'openai');
     }
 }

--- a/Classes/Service/Skill/GitHubClient.php
+++ b/Classes/Service/Skill/GitHubClient.php
@@ -55,6 +55,7 @@ final class GitHubClient implements GitHubClientInterface
         if (!isset($data['sha']) || !is_string($data['sha'])) {
             throw GitHubApiException::forStatus($url, 0);
         }
+
         return $data['sha'];
     }
 
@@ -71,6 +72,7 @@ final class GitHubClient implements GitHubClientInterface
         if (!isset($data['tree']) || !is_array($data['tree'])) {
             throw GitHubApiException::forMalformedResponse($url);
         }
+
         $tree = $data['tree'];
         $paths = [];
         foreach ($tree as $node) {
@@ -78,6 +80,7 @@ final class GitHubClient implements GitHubClientInterface
                 $paths[] = $node['path'];
             }
         }
+
         return $paths;
     }
 
@@ -113,6 +116,7 @@ final class GitHubClient implements GitHubClientInterface
 
             throw GitHubApiException::forMalformedResponse($url);
         }
+
         if (!is_array($decoded)) {
             $this->logger->warning('GitHub API response was not a JSON object', [
                 'url' => $url,
@@ -121,6 +125,7 @@ final class GitHubClient implements GitHubClientInterface
 
             throw GitHubApiException::forMalformedResponse($url);
         }
+
         /** @var array<string,mixed> $decoded */
         return $decoded;
     }
@@ -144,10 +149,12 @@ final class GitHubClient implements GitHubClientInterface
             // Rate-limit failures must abort the whole sync (re-thrown past per-file/per-repo isolation).
             throw GitHubApiException::forRateLimit((int)$response->getHeaderLine('X-RateLimit-Reset'));
         }
+
         if ($status >= 300) {
             // 3xx included: redirects are not followed (could escape the GitHub allowlist).
             throw GitHubApiException::forStatus($url, $status);
         }
+
         return (string)$response->getBody();
     }
 
@@ -160,18 +167,24 @@ final class GitHubClient implements GitHubClientInterface
         if ($status === 429) {
             return true;
         }
+
         if ($status === 403) {
-            return $response->getHeaderLine('X-RateLimit-Remaining') === '0'
-                || $response->hasHeader('Retry-After');
+            if ($response->getHeaderLine('X-RateLimit-Remaining') === '0') {
+                return true;
+            }
+
+            return $response->hasHeader('Retry-After');
         }
+
         return false;
     }
 
     private function send(RequestInterface $request): ResponseInterface
     {
-        if ($this->httpClient !== null) {
+        if ($this->httpClient instanceof ClientInterface) {
             return $this->httpClient->sendRequest($request);
         }
+
         // Production transport: nr-vault audited client (redirects disabled at factory default).
         return $this->vault->http()->withReason('nr-llm skill sync')->sendRequest($request);
     }

--- a/Classes/Service/Skill/MarketplaceParser.php
+++ b/Classes/Service/Skill/MarketplaceParser.php
@@ -23,22 +23,30 @@ final class MarketplaceParser
         if (!is_array($decoded)) {
             throw SkillParseException::forReason('marketplace.json', 'invalid JSON');
         }
+
         if (!isset($decoded['plugins']) || !is_array($decoded['plugins'])) {
             throw SkillParseException::forReason('marketplace.json', 'missing "plugins" array');
         }
 
         $entries = [];
         foreach ($decoded['plugins'] as $plugin) {
-            if (!is_array($plugin) || !isset($plugin['source'])) {
+            if (!is_array($plugin)) {
                 continue;
             }
+
+            if (!isset($plugin['source'])) {
+                continue;
+            }
+
             $ownerRepo = $this->extractOwnerRepo($plugin['source']);
             if ($ownerRepo === null) {
                 continue;
             }
+
             $ref = isset($plugin['ref']) && is_string($plugin['ref']) ? $plugin['ref'] : null;
             $entries[] = new MarketplaceEntry($ownerRepo[0], $ownerRepo[1], $ref);
         }
+
         return $entries;
     }
 
@@ -55,13 +63,16 @@ final class MarketplaceParser
         } elseif (is_array($source) && isset($source['url']) && is_string($source['url'])) {
             return $this->extractFromGitUrl($source['url']);
         }
+
         if ($slug === null || !str_contains($slug, '/')) {
             return null;
         }
+
         [$owner, $repo] = explode('/', $slug, 2);
         if ($owner === '' || $repo === '') {
             return null;
         }
+
         return [$owner, $repo];
     }
 
@@ -79,26 +90,32 @@ final class MarketplaceParser
         if (!is_array($parts)) {
             return null;
         }
+
         $host = $parts['host'] ?? null;
         if (!is_string($host) || !in_array(strtolower($host), ['github.com', 'www.github.com'], true)) {
             return null;
         }
+
         $path = $parts['path'] ?? null;
         if (!is_string($path)) {
             return null;
         }
+
         $segments = array_values(array_filter(explode('/', $path), static fn(string $s): bool => $s !== ''));
         if (count($segments) < 2) {
             return null;
         }
+
         $owner = $segments[0];
         $repo = $segments[1];
         if (str_ends_with($repo, '.git')) {
             $repo = substr($repo, 0, -4);
         }
+
         if ($repo === '') {
             return null;
         }
+
         return [$owner, $repo];
     }
 }

--- a/Classes/Service/Skill/PromptInjectionScanner.php
+++ b/Classes/Service/Skill/PromptInjectionScanner.php
@@ -122,7 +122,7 @@ final class PromptInjectionScanner
     {
         $normalised = trim((string)preg_replace('/\s+/', ' ', $match));
         if (mb_strlen($normalised) > self::EXCERPT_MAX_CHARS) {
-            $normalised = mb_substr($normalised, 0, self::EXCERPT_MAX_CHARS) . '…';
+            return mb_substr($normalised, 0, self::EXCERPT_MAX_CHARS) . '…';
         }
 
         return $normalised;

--- a/Classes/Service/Skill/SkillAuditRepository.php
+++ b/Classes/Service/Skill/SkillAuditRepository.php
@@ -113,7 +113,7 @@ final readonly class SkillAuditRepository implements SkillAuditRepositoryInterfa
         $connection   = $this->connectionPool->getConnectionForTable(self::TABLE);
         $queryBuilder = $connection->createQueryBuilder();
 
-        return (int)$queryBuilder
+        return $queryBuilder
             ->delete(self::TABLE)
             ->where($queryBuilder->expr()->lt('crdate', $queryBuilder->createNamedParameter($timestamp)))
             ->executeStatement();

--- a/Classes/Service/Skill/SkillComposer.php
+++ b/Classes/Service/Skill/SkillComposer.php
@@ -143,7 +143,11 @@ final readonly class SkillComposer
         $candidates = [];
         $seen       = [];
         foreach ([...$configSkills, ...$taskSkills] as $skill) {
-            if (!$skill->isEnabled() || $skill->isOrphaned()) {
+            if (!$skill->isEnabled()) {
+                continue;
+            }
+
+            if ($skill->isOrphaned()) {
                 continue;
             }
 
@@ -200,6 +204,7 @@ final readonly class SkillComposer
         if ($skill->getSupportStatusEnum() === SupportStatus::PARTIAL) {
             $body = $this->stripAssetReferences($body);
         }
+
         $body = $this->neutralizeFenceMarkers($body);
 
         return sprintf("### Skill: %s\n%s\n", $skill->getName(), $body);

--- a/Classes/Service/Skill/SkillDiscovery.php
+++ b/Classes/Service/Skill/SkillDiscovery.php
@@ -37,6 +37,7 @@ final class SkillDiscovery
                 }
             }
         }
+
         return $matched;
     }
 }

--- a/Classes/Service/Skill/SkillManifestVerifier.php
+++ b/Classes/Service/Skill/SkillManifestVerifier.php
@@ -72,6 +72,7 @@ final class SkillManifestVerifier
         if (!$this->isDeclared($expectedFingerprint)) {
             return false;
         }
+
         if ($identifierToChecksum === []) {
             return false;
         }

--- a/Classes/Service/Skill/SkillMarkdownParser.php
+++ b/Classes/Service/Skill/SkillMarkdownParser.php
@@ -45,12 +45,14 @@ final readonly class SkillMarkdownParser
         if (!preg_match('/^---\R(.*?)\R---\R?(.*)$/s', $content, $m)) {
             throw SkillParseException::forReason($path, 'missing YAML front-matter');
         }
+
         $frontmatterRaw = $m[1];
         $body = ltrim($m[2]);
 
         if (strlen($frontmatterRaw) > $this->maxFrontmatterBytes) {
             throw SkillParseException::forReason($path, 'front-matter exceeds size cap');
         }
+
         if (strlen($body) > $this->maxBodyBytes) {
             throw SkillParseException::forReason($path, 'body exceeds size cap');
         }
@@ -60,6 +62,7 @@ final readonly class SkillMarkdownParser
         } catch (ParseException $e) {
             throw SkillParseException::forReason($path, 'malformed YAML: ' . $e->getMessage());
         }
+
         if (!is_array($frontmatter) || array_is_list($frontmatter)) {
             throw SkillParseException::forReason($path, 'front-matter is not a mapping');
         }
@@ -69,6 +72,7 @@ final readonly class SkillMarkdownParser
         if ($name === '') {
             throw SkillParseException::forReason($path, 'missing or empty "name"');
         }
+
         if ($description === '') {
             throw SkillParseException::forReason($path, 'missing or empty "description"');
         }
@@ -95,15 +99,18 @@ final readonly class SkillMarkdownParser
         if (array_key_exists('allowed-tools', $frontmatter) || array_key_exists('allowed_tools', $frontmatter)) {
             $reasons[] = 'declares allowed-tools';
         }
+
         foreach (self::UNSUPPORTED_PATTERNS as $pattern) {
             if (preg_match($pattern, $body) === 1) {
                 $reasons[] = 'body references scripts/assets';
                 break;
             }
         }
+
         if ($reasons === []) {
             return [SupportStatus::FULL, ''];
         }
+
         return [SupportStatus::PARTIAL, implode('; ', array_unique($reasons))];
     }
 }

--- a/Classes/Service/Skill/SkillSyncService.php
+++ b/Classes/Service/Skill/SkillSyncService.php
@@ -46,8 +46,11 @@ final class SkillSyncService
     private const MARKETPLACE_INDEX_PATH = '.claude-plugin/marketplace.json';
 
     private int $syncDeadline = 0;
+
     private int $filesProcessed = 0;
+
     private bool $boundsExceeded = false;
+
     private int $lastHeartbeat = 0;
 
     /**
@@ -127,6 +130,7 @@ final class SkillSyncService
                         $errors[] = sprintf('duplicate identifier "%s", first wins', $identifier);
                         continue;
                     }
+
                     $seen[$identifier] = true;
                     [$outcome, $blocked] = $this->upsert($source, $identifier, $sha, $parsed);
                     $created += $outcome === 'created' ? 1 : 0;
@@ -152,6 +156,7 @@ final class SkillSyncService
                 if ($collected['rootSha'] !== null) {
                     $source->setPinnedSha($collected['rootSha']);
                 }
+
                 $source->setSyncError($this->sanitizeErrorMessage(implode("\n", $errors)));
             }
         } catch (Throwable $e) {
@@ -190,7 +195,7 @@ final class SkillSyncService
      */
     private function fingerprintRejected(SkillSource $source, array $parsed, string $sourcePrefix): bool
     {
-        if ($this->manifestVerifier === null || !$this->manifestVerifier->isDeclared($source->getExpectedFingerprint())) {
+        if (!$this->manifestVerifier instanceof SkillManifestVerifier || !$this->manifestVerifier->isDeclared($source->getExpectedFingerprint())) {
             return false;
         }
 
@@ -242,6 +247,7 @@ final class SkillSyncService
         if ($source->getSyncStatusEnum() !== SyncStatus::SYNCING || $this->isLockActive($source, time())) {
             return false;
         }
+
         $source->setSyncStatus(SyncStatus::ERROR->value);
         $source->setSyncError('The previous sync was interrupted before it finished. Trigger a new sync to retry.');
         $this->persistSource($source);
@@ -269,6 +275,7 @@ final class SkillSyncService
         if ($type === SkillSourceType::MARKETPLACE) {
             return $this->collectMarketplace($source, $errors);
         }
+
         // Non-marketplace sources address a single GitHub repo; an unparseable URL is fatal and
         // surfaces as a clear ERROR rather than a malformed API call against an empty owner/repo.
         [$owner, $repo] = $this->requireOwnerRepo($source->getUrl());
@@ -298,11 +305,13 @@ final class SkillSyncService
             if ($e->isRateLimit) {
                 throw $e;
             }
+
             if ($e->status === 404) {
                 // The file is gone at the resolved commit: drop it from discovered so it is orphaned.
                 // A non-404 (transient) error leaves it discovered (present) and does not orphan it.
                 $discovered = [];
             }
+
             $errors[] = $e->getMessage();
         } catch (SkillParseException $e) {
             $errors[] = $e->getMessage();
@@ -329,6 +338,7 @@ final class SkillSyncService
             if ($this->limitReached($source, $errors)) {
                 break;
             }
+
             $this->filesProcessed++;
             try {
                 $body = $this->gitHub->fetchRawBySha($owner, $repo, $sha, $path, $this->token($source));
@@ -337,6 +347,7 @@ final class SkillSyncService
                 if ($e->isRateLimit) {
                     throw $e;
                 }
+
                 $errors[] = $e->getMessage();
             } catch (SkillParseException $e) {
                 $errors[] = $e->getMessage();
@@ -372,6 +383,7 @@ final class SkillSyncService
                 $errors[] = sprintf('duplicate marketplace plugin "%s/%s", first wins', $entry->owner, $entry->repo);
                 continue;
             }
+
             // "Listed" = present in the parsed index this run, even if unreached below. A skill whose
             // prefix is no longer listed (plugin de-listed) IS orphaned; one listed-but-unreached is not.
             $listedPrefixes[]          = $prefix;
@@ -381,12 +393,14 @@ final class SkillSyncService
             if ($this->limitReached($source, $errors)) {
                 continue;
             }
+
             try {
                 $repoResult = $this->collectRepo($source, $entry->owner, $entry->repo, $entry->ref ?? 'HEAD', $errors);
             } catch (GitHubApiException $e) {
                 if ($e->isRateLimit) {
                     throw $e;
                 }
+
                 // An unreachable child repo is recorded and skipped (PARTIAL); it stays "listed" (so its
                 // existing skills are protected as a transient failure) but is excluded from "reached".
                 $errors[] = $e->getMessage();
@@ -400,6 +414,7 @@ final class SkillSyncService
             foreach ($repoResult['discovered'] as $path) {
                 $discovered[] = $prefix . $path;
             }
+
             foreach ($repoResult['parsed'] as $row) {
                 $parsed[] = [$row[0], new ParsedSkill(
                     $prefix . $row[1]->path,
@@ -428,6 +443,7 @@ final class SkillSyncService
         if ($this->boundsExceeded) {
             return true;
         }
+
         if ($this->filesProcessed >= $this->maxFiles || time() >= $this->syncDeadline) {
             $this->boundsExceeded = true;
             $errors[] = sprintf(
@@ -437,6 +453,7 @@ final class SkillSyncService
             );
             return true;
         }
+
         return false;
     }
 
@@ -453,6 +470,7 @@ final class SkillSyncService
         if ($now - $this->lastHeartbeat < $this->heartbeatSeconds) {
             return;
         }
+
         $this->lastHeartbeat = $now;
         $source->setLastSynced($now);
         $this->persistSource($source);
@@ -475,7 +493,7 @@ final class SkillSyncService
         $highConf = $scan?->hasHighConfidence() ?? false;
         $existing = $this->skillRepository->findBySourceAndIdentifier($source->getUid() ?? 0, $identifier);
 
-        if ($existing === null) {
+        if (!$existing instanceof Skill) {
             $skill = new Skill();
             $skill->setSource($source->getUid() ?? 0);
             $skill->setIdentifier($identifier);
@@ -510,6 +528,7 @@ final class SkillSyncService
             $existing->setEnabled(false);
             $outcome = $changed ? 'changed' : 'updated';
         }
+
         $this->skillRepository->update($existing);
         $this->audit?->recordSkillEvent(
             $outcome === 'changed' ? SkillAuditEvent::INGEST_DISABLED_ON_CHANGE : SkillAuditEvent::INGEST_UPDATED,
@@ -532,7 +551,7 @@ final class SkillSyncService
     private function applyIsolationMetadata(Skill $skill, SkillSource $source, ?InjectionScanResult $scan): void
     {
         $skill->setTrustLevel($source->getTrustLevel());
-        if ($scan !== null) {
+        if ($scan instanceof InjectionScanResult) {
             $skill->setInjectionScan((string)json_encode($scan->toArray()));
         }
     }
@@ -542,9 +561,10 @@ final class SkillSyncService
      */
     private function highConfidenceLabels(?InjectionScanResult $scan): string
     {
-        if ($scan === null) {
+        if (!$scan instanceof InjectionScanResult) {
             return '';
         }
+
         $labels = [];
         foreach ($scan->findings as $finding) {
             if ($finding->severity === InjectionSeverity::HIGH) {
@@ -579,6 +599,7 @@ final class SkillSyncService
             if (is_string($tools)) {
                 $tools = preg_split('/[\s,]+/', trim($tools), -1, PREG_SPLIT_NO_EMPTY) ?: [];
             }
+
             $skill->setAllowedTools((string)json_encode(is_array($tools) ? array_values($tools) : []));
         }
     }
@@ -596,6 +617,7 @@ final class SkillSyncService
         if ($prefixes === null) {
             return null;
         }
+
         return array_map(static fn(string $prefix): string => $sourcePrefix . $prefix, $prefixes);
     }
 
@@ -620,6 +642,7 @@ final class SkillSyncService
             if (isset($discoveredSet[$identifier])) {
                 continue;
             }
+
             if (
                 $reachedPrefixes !== null
                 && $listedPrefixes !== null
@@ -627,6 +650,7 @@ final class SkillSyncService
             ) {
                 continue;
             }
+
             if (!$skill->isOrphaned()) {
                 $skill->setOrphaned(true);
                 $skill->setEnabled(false);
@@ -634,6 +658,7 @@ final class SkillSyncService
                 $count++;
             }
         }
+
         return $count;
     }
 
@@ -649,8 +674,11 @@ final class SkillSyncService
      */
     private function orphanEligible(string $identifier, array $reachedPrefixes, array $listedPrefixes): bool
     {
-        return $this->inScope($identifier, $reachedPrefixes)
-            || !$this->inScope($identifier, $listedPrefixes);
+        if ($this->inScope($identifier, $reachedPrefixes)) {
+            return true;
+        }
+
+        return !$this->inScope($identifier, $listedPrefixes);
     }
 
     /**
@@ -663,6 +691,7 @@ final class SkillSyncService
                 return true;
             }
         }
+
         return false;
     }
 
@@ -680,6 +709,7 @@ final class SkillSyncService
                 // update but still flush any pending skill changes below.
             }
         }
+
         $this->persistenceManager->persistAll();
     }
 
@@ -766,6 +796,7 @@ final class SkillSyncService
         if ($owner === '' || $repo === '') {
             throw new RuntimeException(sprintf('Not a GitHub URL: %s', $url), 1719500201);
         }
+
         return [$owner, $repo];
     }
 
@@ -778,6 +809,7 @@ final class SkillSyncService
         if (preg_match('#github(?:usercontent)?\.com/([^/]+)/([^/]+)#', $url, $m) === 1) {
             return [$m[1], preg_replace('/\.git$/', '', $m[2]) ?? $m[2]];
         }
+
         return ['', ''];
     }
 
@@ -788,10 +820,12 @@ final class SkillSyncService
         if (preg_match('#raw\.githubusercontent\.com/[^/]+/[^/]+/[^/]+/(.+)$#', $url, $m) === 1) {
             return $m[1];
         }
+
         // blob URL: https://github.com/owner/repo/blob/ref/<path>
         if (preg_match('#github\.com/[^/]+/[^/]+/blob/[^/]+/(.+)$#', $url, $m) === 1) {
             return $m[1];
         }
+
         return 'SKILL.md';
     }
 

--- a/Classes/Service/Streaming/StreamRedactionWindow.php
+++ b/Classes/Service/Streaming/StreamRedactionWindow.php
@@ -102,6 +102,7 @@ final class StreamRedactionWindow
         if ($this->pending < self::BLOCK_BYTES) {
             return [];
         }
+
         $this->pending = 0;
         $out           = $this->emitStable(true);
         $this->bound();
@@ -148,6 +149,7 @@ final class StreamRedactionWindow
         if ($limit <= $this->emitted) {
             return [];
         }
+
         $delta         = \substr($full, $this->emitted, $limit - $this->emitted);
         $this->emitted = $limit;
 
@@ -159,9 +161,11 @@ final class StreamRedactionWindow
         if (\strlen($this->window) <= self::SOFT_CAP_BYTES) {
             return;
         }
+
         if ($this->pruneFront()) {
             return;
         }
+
         if (\strlen($this->window) >= self::HARD_CAP_BYTES) {
             $this->safeHold();
         }
@@ -182,6 +186,7 @@ final class StreamRedactionWindow
             if ($cut <= 0) {
                 break;
             }
+
             $head  = \substr($this->window, 0, $cut);
             $rHead = ($this->redact)($head);
             if (\strlen($rHead) <= $this->emitted
@@ -211,6 +216,7 @@ final class StreamRedactionWindow
         if (\strlen($this->window) <= 2 * $keep) {
             return;
         }
+
         $headLen   = $this->utf8SafeBack($this->window, $keep);
         $tailStart = $this->utf8SafeForward($this->window, \strlen($this->window) - $keep);
         $candidate = \substr($this->window, 0, $headLen) . \substr($this->window, $tailStart);
@@ -228,9 +234,11 @@ final class StreamRedactionWindow
         if ($length <= 0) {
             return 0;
         }
+
         if ($length >= \strlen($text)) {
             return \strlen($text);
         }
+
         while ($length > 0 && (\ord($text[$length]) & 0xC0) === 0x80) {
             --$length;
         }
@@ -246,9 +254,11 @@ final class StreamRedactionWindow
         if ($offset <= 0) {
             return 0;
         }
+
         if ($offset >= \strlen($text)) {
             return \strlen($text);
         }
+
         while ($offset < \strlen($text) && (\ord($text[$offset]) & 0xC0) === 0x80) {
             ++$offset;
         }

--- a/Classes/Service/Streaming/StreamingDispatcher.php
+++ b/Classes/Service/Streaming/StreamingDispatcher.php
@@ -13,6 +13,7 @@ use Generator;
 use Netresearch\NrLlm\Domain\Enum\GuardrailVerdict;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
@@ -207,6 +208,7 @@ final readonly class StreamingDispatcher
                 if ($firstTokenNs === null) {
                     $firstTokenNs = hrtime(true);
                 }
+
                 $chunk = $inner->current();
                 // Usage/telemetry count the RAW provider output. A bounded leading
                 // window is buffered raw for the end-of-stream audit (ADR-086).
@@ -215,7 +217,7 @@ final readonly class StreamingDispatcher
                     $completion .= $chunk;
                 }
 
-                if ($window === null) {
+                if (!$window instanceof StreamRedactionWindow) {
                     // No redaction-capable guardrail: verbatim pass-through.
                     yield $chunk;
                     $inner->next();
@@ -225,11 +227,12 @@ final readonly class StreamingDispatcher
                 foreach ($window->push($chunk) as $delta) {
                     yield $delta;
                 }
+
                 $inner->next();
             }
 
             // Flush the redacted remainder once the stream is complete.
-            if ($window !== null) {
+            if ($window instanceof StreamRedactionWindow) {
                 foreach ($window->flush() as $delta) {
                     yield $delta;
                 }
@@ -338,7 +341,7 @@ final readonly class StreamingDispatcher
         $chain = $primary->getFallbackChainDTO()->without($primary->getIdentifier());
         foreach ($chain->configurationIdentifiers as $identifier) {
             $fallback = $this->repository->findOneByIdentifier($identifier);
-            if ($fallback === null || !$fallback->isActive()) {
+            if (!$fallback instanceof LlmConfiguration || !$fallback->isActive()) {
                 $this->logger->warning(
                     'LLM streaming fallback configuration missing or inactive, skipping',
                     $this->logContext($context, ['configuration' => $identifier]),
@@ -545,7 +548,7 @@ final readonly class StreamingDispatcher
         $model    = $served->getLlmModel();
         $modelUid = $model?->getUid() ?? 0;
 
-        $cost = ($model !== null && $model->hasPricing())
+        $cost = ($model instanceof Model && $model->hasPricing())
             ? $model->estimateCost($promptTokens, $completionTokens)
             : null;
 

--- a/Classes/Service/Task/RecordTableReader.php
+++ b/Classes/Service/Task/RecordTableReader.php
@@ -59,6 +59,7 @@ final readonly class RecordTableReader implements RecordTableReaderInterface
             if ($this->isExcluded($table)) {
                 continue;
             }
+
             $allowed[] = [
                 'name'  => $table,
                 'label' => $this->formatTableLabel($table),
@@ -221,6 +222,7 @@ final readonly class RecordTableReader implements RecordTableReaderInterface
                 return true;
             }
         }
+
         return in_array($table, $this->excludedTableNames, true);
     }
 

--- a/Classes/Service/Task/TaskExecutionService.php
+++ b/Classes/Service/Task/TaskExecutionService.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Task;
 
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Task;
 use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
@@ -68,7 +69,7 @@ final readonly class TaskExecutionService implements TaskExecutionServiceInterfa
         // The effective configuration's skills form the baseline, the task's own
         // skills are additive (precedence + dedup handled by SkillComposer). The
         // applied identifiers therefore cover BOTH sets, deduped.
-        $configSkills = $configuration !== null
+        $configSkills = $configuration instanceof LlmConfiguration
             ? SkillInjectionService::toList($configuration->getSkills())
             : [];
         [$prompt, $appliedSkills] = $this->skillInjection->augmentPromptWithReport(
@@ -79,7 +80,7 @@ final readonly class TaskExecutionService implements TaskExecutionServiceInterfa
 
         // With no resolvable configuration the task cannot run; the generic path
         // raises the existing "no provider specified" error — preserve that.
-        $response = $configuration !== null
+        $response = $configuration instanceof LlmConfiguration
             ? $this->llmServiceManager->completeWithConfiguration($prompt, $configuration, $metadata)
             : $this->llmServiceManager->complete($prompt, new ChatOptions());
 

--- a/Classes/Service/Task/TaskInputResolver.php
+++ b/Classes/Service/Task/TaskInputResolver.php
@@ -40,6 +40,7 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 final readonly class TaskInputResolver implements TaskInputResolverInterface
 {
     private const SYSLOG_DEFAULT_LIMIT = 50;
+
     private const TABLE_DEFAULT_LIMIT = 50;
 
     public function __construct(

--- a/Classes/Service/Telemetry/TelemetryRepository.php
+++ b/Classes/Service/Telemetry/TelemetryRepository.php
@@ -53,7 +53,7 @@ final readonly class TelemetryRepository implements TelemetryRepositoryInterface
         $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
         $queryBuilder = $connection->createQueryBuilder();
 
-        return (int)$queryBuilder
+        return $queryBuilder
             ->delete(self::TABLE)
             ->where($queryBuilder->expr()->lt('crdate', $queryBuilder->createNamedParameter($timestamp)))
             ->executeStatement();
@@ -75,6 +75,7 @@ final readonly class TelemetryRepository implements TelemetryRepositoryInterface
         if (!is_array($row)) {
             return 0;
         }
+
         $total = is_numeric($row['total'] ?? null) ? (int)$row['total'] : 0;
         $ok    = is_numeric($row['ok'] ?? null) ? (int)$row['ok'] : 0;
 

--- a/Classes/Service/Tool/AgentRunPersister.php
+++ b/Classes/Service/Tool/AgentRunPersister.php
@@ -292,7 +292,7 @@ final readonly class AgentRunPersister
     public function cancel(string $uuid): bool
     {
         $run = $this->findRun($uuid);
-        if ($run === null) {
+        if (!$run instanceof AgentRun) {
             return false;
         }
 

--- a/Classes/Service/Tool/AgentRunRepository.php
+++ b/Classes/Service/Tool/AgentRunRepository.php
@@ -617,6 +617,7 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
                 $queryBuilder->expr()->gte('crdate', $queryBuilder->createNamedParameter($since, Connection::PARAM_INT)),
             );
         }
+
         $rows = $queryBuilder
             ->groupBy('status')
             ->executeQuery()
@@ -641,6 +642,7 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
                 $queryBuilder->expr()->gte('crdate', $queryBuilder->createNamedParameter($since, Connection::PARAM_INT)),
             );
         }
+
         $rows = $queryBuilder
             ->groupBy('termination_reason')
             ->executeQuery()
@@ -681,6 +683,7 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
             if ($key === '') {
                 continue;
             }
+
             $out[$key] = self::toInt($row[$countColumn] ?? 0);
         }
 
@@ -750,7 +753,7 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
                 ->executeStatement();
 
             $deleteBuilder = $runConnection->createQueryBuilder();
-            $deleted += (int)$deleteBuilder
+            $deleted += $deleteBuilder
                 ->delete(self::TABLE_RUN)
                 ->where($deleteBuilder->expr()->in('uid', $deleteBuilder->createNamedParameter($chunk, Connection::PARAM_INT_ARRAY)))
                 ->executeStatement();

--- a/Classes/Service/Tool/AgentStateEnvelopeRotator.php
+++ b/Classes/Service/Tool/AgentStateEnvelopeRotator.php
@@ -111,7 +111,11 @@ final readonly class AgentStateEnvelopeRotator implements ForeignEnvelopeRotator
                     // every legacy row — found by the SQL predicate, then silently
                     // passed over, and left wrapped under the retired key.
                     $sealed = AgentStateEnvelopeMarker::normalise($row['value']);
-                    if ($sealed === null || !$context->isSealed($sealed)) {
+                    if ($sealed === null) {
+                        continue;
+                    }
+
+                    if (!$context->isSealed($sealed)) {
                         continue;
                     }
 

--- a/Classes/Service/Tool/AllowedToolsResolver.php
+++ b/Classes/Service/Tool/AllowedToolsResolver.php
@@ -39,7 +39,7 @@ final readonly class AllowedToolsResolver
     public function resolve(LlmConfiguration $config, ?Task $task = null): ?array
     {
         $configSkills = $this->toList($config->getSkills());
-        $taskSkills   = $task !== null ? $this->toList($task->getSkills()) : [];
+        $taskSkills   = $task instanceof Task ? $this->toList($task->getSkills()) : [];
 
         $declared = [];
         $any      = false;
@@ -48,6 +48,7 @@ final readonly class AllowedToolsResolver
             if ($list === null) {
                 continue;
             }
+
             $any = true;
             foreach ($list as $name) {
                 $declared[$name] = true;
@@ -84,7 +85,7 @@ final readonly class AllowedToolsResolver
         $inGroups = [];
         foreach ($this->registry->names() as $name) {
             $tool = $this->registry->get($name);
-            if ($tool !== null && in_array($tool->getGroup(), $groupSet, true)) {
+            if ($tool instanceof ToolInterface && in_array($tool->getGroup(), $groupSet, true)) {
                 $inGroups[] = $name;
             }
         }

--- a/Classes/Service/Tool/Builtin/BrowseFalFolderTool.php
+++ b/Classes/Service/Tool/Builtin/BrowseFalFolderTool.php
@@ -16,6 +16,8 @@ use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
 use Throwable;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Resource\ResourceStorage;
 use TYPO3\CMS\Core\Resource\StorageRepository;
 
 /**
@@ -84,16 +86,18 @@ final readonly class BrowseFalFolderTool implements ToolInterface
 
         try {
             $storage = $this->storageRepository->findByUid($storageUid);
-            if ($storage === null || !$storage->isOnline()) {
+            if (!$storage instanceof ResourceStorage || !$storage->isOnline()) {
                 return ToolResult::text(self::NOT_PERMITTED);
             }
+
             // Folder-level enforcement on top of the storage gate: with
             // evaluatePermissions the read calls below check the acting
             // user's file-mount boundaries and throw outside them — which
             // collapses into the neutral denial.
-            if ($user !== null && !$user->isAdmin()) {
+            if ($user instanceof BackendUserAuthentication && !$user->isAdmin()) {
                 $storage->setEvaluatePermissions(true);
             }
+
             $folder = $storage->getFolder($folderId);
 
             $lines   = [];
@@ -105,6 +109,7 @@ final readonly class BrowseFalFolderTool implements ToolInterface
                     ++$skipped;
                     continue;
                 }
+
                 $lines[] = sprintf(
                     '- %s/ (%d files)',
                     $subfolder->getName(),
@@ -118,6 +123,7 @@ final readonly class BrowseFalFolderTool implements ToolInterface
                     ++$skipped;
                     continue;
                 }
+
                 $lines[] = sprintf(
                     '- %s (%s, %s)',
                     $file->getName(),
@@ -168,6 +174,7 @@ final readonly class BrowseFalFolderTool implements ToolInterface
         if ($bytes >= 1048576) {
             return sprintf('%.1f MiB', $bytes / 1048576);
         }
+
         if ($bytes >= 1024) {
             return sprintf('%.1f KiB', $bytes / 1024);
         }

--- a/Classes/Service/Tool/Builtin/CheckTypoScriptTool.php
+++ b/Classes/Service/Tool/Builtin/CheckTypoScriptTool.php
@@ -135,6 +135,7 @@ final readonly class CheckTypoScriptTool implements ToolInterface
                     count($sysTemplateRows) === 1 ? '' : 's',
                 );
             }
+
             if ($site->isTypoScriptRoot()) {
                 $sources[] = 'site-set TypoScript';
             }

--- a/Classes/Service/Tool/Builtin/FetchLogsTool.php
+++ b/Classes/Service/Tool/Builtin/FetchLogsTool.php
@@ -46,7 +46,7 @@ final readonly class FetchLogsTool implements ToolInterface
     private const DEFAULT_LIMIT = 20;
 
     public function __construct(
-        protected ConnectionPool $connectionPool,
+        private ConnectionPool $connectionPool,
     ) {}
 
     public function getSpec(): ToolSpec
@@ -77,6 +77,7 @@ final readonly class FetchLogsTool implements ToolInterface
         if ($limit < 1) {
             $limit = self::DEFAULT_LIMIT;
         }
+
         $limit = min($limit, self::HARD_LIMIT);
 
         $level = self::toStr($arguments['level'] ?? '');

--- a/Classes/Service/Tool/Builtin/FindMissingFilesTool.php
+++ b/Classes/Service/Tool/Builtin/FindMissingFilesTool.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Service\Tool\FalStorageGate;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 
@@ -88,7 +89,7 @@ final readonly class FindMissingFilesTool implements ToolInterface
         $limit = self::toInt($arguments['limit'] ?? self::DEFAULT_LIMIT);
         $limit = max(1, min(self::MAX_LIMIT, $limit));
 
-        $isAdmin = $user !== null && $user->isAdmin();
+        $isAdmin = $user instanceof BackendUserAuthentication && $user->isAdmin();
 
         $countQuery = $this->connectionPool->getQueryBuilderForTable('sys_file');
         $countQuery->getRestrictions()->removeAll();

--- a/Classes/Service/Tool/Builtin/FluidResolveTool.php
+++ b/Classes/Service/Tool/Builtin/FluidResolveTool.php
@@ -75,11 +75,13 @@ final readonly class FluidResolveTool implements ToolInterface
         if ($name === '') {
             return ToolResult::text('Provide a template/partial/layout name.');
         }
+
         // Reject path traversal outright — names address files under the
         // extension's private folder, never elsewhere.
         if (str_contains($name, '..')) {
             return ToolResult::text('Invalid name.');
         }
+
         $name = preg_replace('/\.html$/i', '', $name) ?? $name;
 
         $type = strtolower(trim(self::toStr($arguments['type'] ?? 'template')));
@@ -91,6 +93,7 @@ final readonly class FluidResolveTool implements ToolInterface
         if ($extension === '') {
             return ToolResult::text('Provide the "extension" key so the Fluid root paths can be resolved.');
         }
+
         if (preg_match('/^[a-z0-9_]+$/', $extension) !== 1) {
             return ToolResult::text('Invalid extension key.');
         }

--- a/Classes/Service/Tool/Builtin/GetFalReferencesTool.php
+++ b/Classes/Service/Tool/Builtin/GetFalReferencesTool.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\WorkspaceRestriction;
@@ -117,7 +118,7 @@ final readonly class GetFalReferencesTool implements ToolInterface
             ->executeQuery()
             ->fetchAllAssociative();
 
-        $isAdmin = $user !== null && $user->isAdmin();
+        $isAdmin = $user instanceof BackendUserAuthentication && $user->isAdmin();
 
         $lines   = [];
         $skipped = 0;
@@ -127,14 +128,17 @@ final readonly class GetFalReferencesTool implements ToolInterface
             if ($table === '') {
                 continue;
             }
+
             // Non-admins only see references from tables they may read.
             if (!$isAdmin && !$this->tableAccess->canReadTable($user, $table)) {
                 continue;
             }
+
             if (count($lines) >= self::MAX_REFERENCES) {
                 ++$skipped;
                 continue;
             }
+
             $lines[] = sprintf(
                 '- %s:%d (field %s)%s',
                 $table,

--- a/Classes/Service/Tool/Builtin/GetFlexFormSchemaTool.php
+++ b/Classes/Service/Tool/Builtin/GetFlexFormSchemaTool.php
@@ -92,6 +92,7 @@ final readonly class GetFlexFormSchemaTool implements ToolInterface
         if (!is_array($conf)) {
             return ToolResult::text(sprintf('Field %s.%s not found.', $table, $field));
         }
+
         if (self::toStr($conf['type'] ?? '') !== 'flex') {
             return ToolResult::text(sprintf('Field %s.%s is not a FlexForm field (type=%s).', $table, $field, self::toStr($conf['type'] ?? '?')));
         }
@@ -214,6 +215,7 @@ final readonly class GetFlexFormSchemaTool implements ToolInterface
                 if (!is_array($elConf)) {
                     continue;
                 }
+
                 $config = is_array($elConf['config'] ?? null) ? $elConf['config'] : [];
                 $type   = self::toStr($config['type'] ?? '') ?: '?';
                 $label  = $this->resolveLabel(self::toStr($elConf['label'] ?? ''));

--- a/Classes/Service/Tool/Builtin/GetFullTcaTool.php
+++ b/Classes/Service/Tool/Builtin/GetFullTcaTool.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 
 /**
  * Navigation index over the whole TCA (ADR-045).
@@ -47,7 +48,7 @@ final readonly class GetFullTcaTool implements ToolInterface
         return ToolSpec::function(
             'get_full_tca',
             'List all accessible TYPO3 tables (the TCA index) with their titles. Use this to discover which '
-            . 'tables exist, then call get_table_schema(table) for a table\'s fields and relations. Names only, no data.',
+            . "tables exist, then call get_table_schema(table) for a table's fields and relations. Names only, no data.",
             [
                 'type'       => 'object',
                 'properties' => [
@@ -72,7 +73,7 @@ final readonly class GetFullTcaTool implements ToolInterface
         }
 
         $user = $context->actingBackendUser();
-        if ($user === null) {
+        if (!$user instanceof BackendUserAuthentication) {
             return ToolResult::text('Accessible tables (0).');
         }
 
@@ -92,9 +93,11 @@ final readonly class GetFullTcaTool implements ToolInterface
             if ($filter !== '' && !str_contains(mb_strtolower($table), $filter)) {
                 continue;
             }
+
             if ($extPrefix !== '' && !str_starts_with($table, $extPrefix)) {
                 continue;
             }
+
             if (!$this->tableAccess->canReadTable($user, $table)) {
                 continue;
             }

--- a/Classes/Service/Tool/Builtin/GetLastExceptionTool.php
+++ b/Classes/Service/Tool/Builtin/GetLastExceptionTool.php
@@ -104,6 +104,7 @@ final readonly class GetLastExceptionTool implements ToolInterface, ToolDataClas
         if ($entry->exceptionClass !== null) {
             $lines[] = 'Exception: ' . $entry->exceptionClass;
         }
+
         $lines[] = 'Message: ' . $this->sanitizeErrorMessage($entry->message);
         $lines[] = '';
 
@@ -117,8 +118,11 @@ final readonly class GetLastExceptionTool implements ToolInterface, ToolDataClas
         $expanded = 0;
         foreach ($entry->frames as $i => $frame) {
             $lines[] = sprintf('#%d %s:%d — %s', $i, $frame['file'], $frame['line'], $frame['call']);
+            if ($expanded >= self::MAX_EXPANDED_FRAMES) {
+                continue;
+            }
 
-            if ($expanded >= self::MAX_EXPANDED_FRAMES || !$this->isProjectFrame($frame['file'])) {
+            if (!$this->isProjectFrame($frame['file'])) {
                 continue;
             }
 
@@ -126,6 +130,7 @@ final readonly class GetLastExceptionTool implements ToolInterface, ToolDataClas
             if ($sourceLines === []) {
                 continue;
             }
+
             $expanded++;
             foreach ($sourceLines as $sourceLine) {
                 $lines[] = $sourceLine;

--- a/Classes/Service/Tool/Builtin/GetPageContentTool.php
+++ b/Classes/Service/Tool/Builtin/GetPageContentTool.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\EndTimeRestriction;
@@ -59,7 +60,7 @@ final readonly class GetPageContentTool implements ToolInterface
     private const NON_INLINE_TAG_PATTERN = '/<(?!\/?(?:a|abbr|b|bdi|bdo|cite|code|data|dfn|em|i|kbd|mark|q|s|samp|small|span|strong|sub|sup|time|u|var|wbr)\b)/i';
 
     public function __construct(
-        protected ConnectionPool $connectionPool,
+        private ConnectionPool $connectionPool,
     ) {}
 
     public function getSpec(): ToolSpec
@@ -88,7 +89,7 @@ final readonly class GetPageContentTool implements ToolInterface
     public function execute(array $arguments, ToolExecutionContext $context): ToolResult
     {
         $user = $context->actingBackendUser();
-        if ($user === null) {
+        if (!$user instanceof BackendUserAuthentication) {
             return ToolResult::text(self::NOT_PERMITTED);
         }
 

--- a/Classes/Service/Tool/Builtin/GetPageTreeTool.php
+++ b/Classes/Service/Tool/Builtin/GetPageTreeTool.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\WorkspaceRestriction;
@@ -50,7 +51,7 @@ final readonly class GetPageTreeTool implements ToolInterface
     private const NODE_CAP = 200;
 
     public function __construct(
-        protected ConnectionPool $connectionPool,
+        private ConnectionPool $connectionPool,
     ) {}
 
     public function getSpec(): ToolSpec
@@ -86,6 +87,7 @@ final readonly class GetPageTreeTool implements ToolInterface
         if ($depth < 1) {
             $depth = self::DEFAULT_DEPTH;
         }
+
         $depth = min($depth, self::MAX_DEPTH);
 
         $lines = [];
@@ -127,9 +129,10 @@ final readonly class GetPageTreeTool implements ToolInterface
         // Respect the acting user's page permissions: a non-admin only sees
         // pages they may show. No backend user → no pages (fail-closed).
         $user = $context->actingBackendUser();
-        if ($user === null) {
+        if (!$user instanceof BackendUserAuthentication) {
             return;
         }
+
         $permsClause = $user->getPagePermsClause(Permission::PAGE_SHOW);
 
         // Default restrictions (no removeAll) already drop soft-deleted rows;

--- a/Classes/Service/Tool/Builtin/GetRecordHistoryTool.php
+++ b/Classes/Service/Tool/Builtin/GetRecordHistoryTool.php
@@ -104,7 +104,7 @@ final readonly class GetRecordHistoryTool implements ToolInterface
         // Non-admins must hold PAGE_SHOW on the record's page (same gate as
         // read_records) — history values must not leak from unreadable pages.
         // Fail-closed: an unresolvable record (e.g. hard-deleted) denies too.
-        if ($user !== null && !$user->isAdmin() && !$this->recordPageIsReadable($user, $table, $uid)) {
+        if ($user instanceof BackendUserAuthentication && !$user->isAdmin() && !$this->recordPageIsReadable($user, $table, $uid)) {
             return ToolResult::text(self::NOT_PERMITTED);
         }
 
@@ -243,6 +243,7 @@ final readonly class GetRecordHistoryTool implements ToolInterface
                 }
             }
         }
+
         if ($uids === []) {
             return [];
         }
@@ -298,11 +299,13 @@ final readonly class GetRecordHistoryTool implements ToolInterface
             if ($fieldFilter !== '' && $fieldName !== $fieldFilter) {
                 continue;
             }
+
             // Credential-like fields: the change is visible, the values are not.
             if ($this->tableAccess->isSensitiveField($fieldName)) {
                 $parts[] = sprintf('%s: [changed — detail withheld]', $fieldName);
                 continue;
             }
+
             $parts[] = sprintf(
                 "%s: '%s' → '%s'",
                 $fieldName,
@@ -323,6 +326,7 @@ final readonly class GetRecordHistoryTool implements ToolInterface
         if ($value === null) {
             return '(unset)';
         }
+
         if (!is_scalar($value)) {
             return '[complex value]';
         }

--- a/Classes/Service/Tool/Builtin/GetSiteConfigTool.php
+++ b/Classes/Service/Tool/Builtin/GetSiteConfigTool.php
@@ -81,9 +81,11 @@ final readonly class GetSiteConfigTool implements ToolInterface, ToolDataClassIn
                     $site->getRootPageId(),
                 );
             }
+
             if ($lines === []) {
                 return ToolResult::text('No sites configured.');
             }
+
             sort($lines);
 
             return ToolResult::text(sprintf(
@@ -160,6 +162,7 @@ final readonly class GetSiteConfigTool implements ToolInterface, ToolDataClassIn
                     $lines[] = sprintf('%s: []', $path);
                     continue;
                 }
+
                 $this->flatten($value, $path, $lines);
                 continue;
             }
@@ -173,6 +176,7 @@ final readonly class GetSiteConfigTool implements ToolInterface, ToolDataClassIn
         if (is_bool($value)) {
             return $value ? 'true' : 'false';
         }
+
         if ($value === null) {
             return 'null';
         }

--- a/Classes/Service/Tool/Builtin/GetTableSchemaTool.php
+++ b/Classes/Service/Tool/Builtin/GetTableSchemaTool.php
@@ -48,7 +48,7 @@ final readonly class GetTableSchemaTool implements ToolInterface
     {
         return ToolSpec::function(
             'get_table_schema',
-            'Describe one TYPO3 table\'s schema in a readable form: control settings plus, per field, its type '
+            "Describe one TYPO3 table's schema in a readable form: control settings plus, per field, its type "
             . 'and — for relations — the foreign table and relation kind. Richer than get_tca. Schema only, no data.',
             [
                 'type'       => 'object',
@@ -91,6 +91,7 @@ final readonly class GetTableSchemaTool implements ToolInterface
         if ($title !== '') {
             $lines[] = sprintf('Title: %s', $title);
         }
+
         $lines[] = 'Control: ' . $this->ctrlSummary($ctrl);
         $lines[] = '';
         $lines[] = 'Fields:';
@@ -101,6 +102,7 @@ final readonly class GetTableSchemaTool implements ToolInterface
                 $lines[] = sprintf('… [%d fields not shown]', count($tca['columns']) - self::MAX_COLUMNS);
                 break;
             }
+
             $lines[] = '- ' . $this->describeField((string)$field, $config);
             ++$count;
         }
@@ -135,6 +137,7 @@ final readonly class GetTableSchemaTool implements ToolInterface
                 $parts[] = sprintf('%s=%s', $key, $value);
             }
         }
+
         $enablecolumns = is_array($ctrl['enablecolumns'] ?? null) ? $ctrl['enablecolumns'] : [];
         if ($enablecolumns !== []) {
             $parts[] = 'enable=' . implode('/', array_map(
@@ -142,6 +145,7 @@ final readonly class GetTableSchemaTool implements ToolInterface
                 $enablecolumns,
             ));
         }
+
         // versioningWS may be a bool or an int (legacy 1/2) — !empty() catches
         // both; a strict === true would miss integer-configured tables.
         if (!empty($ctrl['versioningWS'])) {

--- a/Classes/Service/Tool/Builtin/GetTcaTool.php
+++ b/Classes/Service/Tool/Builtin/GetTcaTool.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Service\Tool\TableReadAccessService;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 
 /**
  * Describe the TYPO3 table schema from `$GLOBALS['TCA']`.
@@ -36,7 +37,7 @@ final readonly class GetTcaTool implements ToolInterface
     private const MAX_ITEMS = 500;
 
     public function __construct(
-        private readonly TableReadAccessService $tableAccess,
+        private TableReadAccessService $tableAccess,
     ) {}
 
     public function getSpec(): ToolSpec
@@ -93,7 +94,7 @@ final readonly class GetTcaTool implements ToolInterface
         // backend user → no tables (fail-closed); return early so the whole TCA
         // is not mapped/filtered for nothing.
         $user = $context->actingBackendUser();
-        if ($user === null) {
+        if (!$user instanceof BackendUserAuthentication) {
             return "TCA tables (0):\n";
         }
 
@@ -123,7 +124,7 @@ final readonly class GetTcaTool implements ToolInterface
         // unknown) table returns the same neutral string so the tool never
         // confirms a table's existence to someone without access.
         $user = $context->actingBackendUser();
-        if ($user === null || !$this->tableAccess->canReadTable($user, $table)) {
+        if (!$user instanceof BackendUserAuthentication || !$this->tableAccess->canReadTable($user, $table)) {
             return 'Unknown TCA table.';
         }
 
@@ -143,6 +144,7 @@ final readonly class GetTcaTool implements ToolInterface
             if (is_array($config) && isset($config['config']) && is_array($config['config'])) {
                 $type = self::toStr($config['config']['type'] ?? '');
             }
+
             $lines[] = sprintf('%s: %s', (string)$field, $type !== '' ? $type : '?');
             ++$count;
         }

--- a/Classes/Service/Tool/Builtin/GetTsConfigTool.php
+++ b/Classes/Service/Tool/Builtin/GetTsConfigTool.php
@@ -41,7 +41,7 @@ final readonly class GetTsConfigTool implements ToolInterface
     private const NOT_FOUND = 'Page not found.';
 
     public function __construct(
-        protected ConnectionPool $connectionPool,
+        private ConnectionPool $connectionPool,
     ) {}
 
     public function getSpec(): ToolSpec
@@ -109,6 +109,7 @@ final readonly class GetTsConfigTool implements ToolInterface
             $lastSegment = substr((string)strrchr('.' . $path, '.'), 1);
             $lines[]     = sprintf('%s = %s', $path, $this->redactSecretValue($lastSegment, $value));
         }
+
         if ($subtree !== null) {
             $this->renderTree($subtree, $lines, 0);
         }

--- a/Classes/Service/Tool/Builtin/GetTypoScriptTool.php
+++ b/Classes/Service/Tool/Builtin/GetTypoScriptTool.php
@@ -50,10 +50,10 @@ final readonly class GetTypoScriptTool implements ToolInterface
     private const TYPE_CONSTANTS = 'constants';
 
     public function __construct(
-        protected FrontendTypoScriptFactory $typoScriptFactory,
-        protected SysTemplateRepository $sysTemplateRepository,
-        protected SiteFinder $siteFinder,
-        protected CacheManager $cacheManager,
+        private FrontendTypoScriptFactory $typoScriptFactory,
+        private SysTemplateRepository $sysTemplateRepository,
+        private SiteFinder $siteFinder,
+        private CacheManager $cacheManager,
     ) {}
 
     public function getSpec(): ToolSpec
@@ -206,6 +206,7 @@ final readonly class GetTypoScriptTool implements ToolInterface
             $lastSegment = substr((string)strrchr('.' . $path, '.'), 1);
             $lines[]     = sprintf('%s = %s', $path, $this->redactSecretValue($lastSegment, $value));
         }
+
         if ($subtree !== null) {
             $this->renderTree($subtree, $lines, 0);
         }
@@ -229,10 +230,12 @@ final readonly class GetTypoScriptTool implements ToolInterface
             if ($path !== '' && $key !== $path && !str_starts_with($key, $path . '.')) {
                 continue;
             }
+
             if (count($lines) >= self::MAX_LINES) {
                 $lines[] = sprintf('… [output truncated at %d lines]', self::MAX_LINES);
                 break;
             }
+
             $lastSegment = substr((string)strrchr('.' . $key, '.'), 1);
             $lines[]     = sprintf('%s = %s', $key, $this->redactSecretValue($lastSegment, $value));
         }

--- a/Classes/Service/Tool/Builtin/ListBeGroupsTool.php
+++ b/Classes/Service/Tool/Builtin/ListBeGroupsTool.php
@@ -39,7 +39,7 @@ final readonly class ListBeGroupsTool implements ToolInterface, ToolDataClassInt
     private const HARD_LIMIT = 200;
 
     public function __construct(
-        protected ConnectionPool $connectionPool,
+        private ConnectionPool $connectionPool,
     ) {}
 
     public function getSpec(): ToolSpec

--- a/Classes/Service/Tool/Builtin/ListBeUsersRawTool.php
+++ b/Classes/Service/Tool/Builtin/ListBeUsersRawTool.php
@@ -54,7 +54,7 @@ final readonly class ListBeUsersRawTool implements ToolInterface, ToolDataClassI
     private const CREDENTIAL_COLUMNS = ['password', 'mfa'];
 
     public function __construct(
-        protected ConnectionPool $connectionPool,
+        private ConnectionPool $connectionPool,
     ) {}
 
     public function getSpec(): ToolSpec
@@ -99,6 +99,7 @@ final readonly class ListBeUsersRawTool implements ToolInterface, ToolDataClassI
             foreach ($row as $key => $value) {
                 $pairs[] = sprintf('  %s: %s', (string)$key, $this->truncate(self::toStr($value)));
             }
+
             $blocks[] = sprintf('[%d]', self::toInt($row['uid'] ?? 0)) . "\n" . implode("\n", $pairs);
         }
 

--- a/Classes/Service/Tool/Builtin/ListBeUsersTool.php
+++ b/Classes/Service/Tool/Builtin/ListBeUsersTool.php
@@ -38,7 +38,7 @@ final readonly class ListBeUsersTool implements ToolInterface, ToolDataClassInte
     private const HARD_LIMIT = 200;
 
     public function __construct(
-        protected ConnectionPool $connectionPool,
+        private ConnectionPool $connectionPool,
     ) {}
 
     public function getSpec(): ToolSpec

--- a/Classes/Service/Tool/Builtin/ListDeprecationsTool.php
+++ b/Classes/Service/Tool/Builtin/ListDeprecationsTool.php
@@ -87,8 +87,10 @@ final readonly class ListDeprecationsTool implements ToolInterface
             if ($message === '') {
                 continue;
             }
+
             $counts[$message] = ($counts[$message] ?? 0) + 1;
         }
+
         if ($counts === []) {
             return ToolResult::text(self::NO_LOG);
         }
@@ -142,20 +144,24 @@ final readonly class ListDeprecationsTool implements ToolInterface
         if (!is_file($file) || !is_readable($file)) {
             return '';
         }
+
         $size = (int)filesize($file);
         if ($size < 1) {
             return '';
         }
+
         $handle = fopen($file, 'r');
         if ($handle === false) {
             return '';
         }
+
         try {
             if ($size > self::TAIL_BYTES) {
                 fseek($handle, -self::TAIL_BYTES, SEEK_END);
                 // Drop the (likely partial) first line of the window.
                 fgets($handle);
             }
+
             $content = stream_get_contents($handle);
         } finally {
             fclose($handle);

--- a/Classes/Service/Tool/Builtin/ListFalStoragesTool.php
+++ b/Classes/Service/Tool/Builtin/ListFalStoragesTool.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Service\Tool\FalStorageGate;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Throwable;
+use TYPO3\CMS\Core\Resource\ResourceStorage;
 use TYPO3\CMS\Core\Resource\StorageRepository;
 
 /**
@@ -57,7 +58,8 @@ final readonly class ListFalStoragesTool implements ToolInterface
             } catch (Throwable) {
                 $storage = null;
             }
-            if ($storage === null) {
+
+            if (!$storage instanceof ResourceStorage) {
                 continue;
             }
 
@@ -66,6 +68,7 @@ final readonly class ListFalStoragesTool implements ToolInterface
             if ($storage->isBrowsable()) {
                 $flags[] = 'browsable';
             }
+
             if ($storage->isPublic()) {
                 $flags[] = 'public';
             }

--- a/Classes/Service/Tool/Builtin/ListMiddlewaresTool.php
+++ b/Classes/Service/Tool/Builtin/ListMiddlewaresTool.php
@@ -77,6 +77,7 @@ final readonly class ListMiddlewaresTool implements ToolInterface
                     $lines[] = '… more entries not shown';
                     break;
                 }
+
                 ++$shown;
                 $lines[] = sprintf('%2d. %s (%s)', $shown, (string)$identifier, self::toStr($className));
             }

--- a/Classes/Service/Tool/Builtin/ListSchedulerTasksTool.php
+++ b/Classes/Service/Tool/Builtin/ListSchedulerTasksTool.php
@@ -69,6 +69,7 @@ final readonly class ListSchedulerTasksTool implements ToolInterface
         } catch (Throwable) {
             return ToolResult::text(self::NOT_INSTALLED);
         }
+
         if ($available === []) {
             return ToolResult::text(self::NOT_INSTALLED);
         }
@@ -102,6 +103,7 @@ final readonly class ListSchedulerTasksTool implements ToolInterface
             if ($label === '') {
                 $label = self::toStr($row['tasktype'] ?? '') ?: '(no description)';
             }
+
             $label = mb_strimwidth(trim((string)preg_replace('/\s+/', ' ', $label)), 0, 100, '…');
 
             $next = self::toInt($row['nextexecution'] ?? 0);
@@ -115,9 +117,11 @@ final readonly class ListSchedulerTasksTool implements ToolInterface
             if ($lastRun > 0) {
                 $flags[] = 'last run ' . gmdate('Y-m-d H:i', $lastRun) . ' UTC';
             }
+
             if (self::toInt($row['disable'] ?? 0) === 1) {
                 $flags[] = 'DISABLED';
             }
+
             if ($failed) {
                 $flags[] = 'LAST RUN FAILED';
             }

--- a/Classes/Service/Tool/Builtin/ProbeUrlTool.php
+++ b/Classes/Service/Tool/Builtin/ProbeUrlTool.php
@@ -70,7 +70,7 @@ final readonly class ProbeUrlTool implements ToolInterface
             'probe_url',
             'GET a URL of THIS TYPO3 instance and report status, headers, timing and a short body '
             . 'excerpt. On a 5xx the matching exception from the TYPO3 logs is appended automatically. '
-            . 'Only the instance\'s own site hosts are allowed; redirects are reported, not followed.',
+            . "Only the instance's own site hosts are allowed; redirects are reported, not followed.",
             [
                 'type'       => 'object',
                 'properties' => [
@@ -184,6 +184,7 @@ final readonly class ProbeUrlTool implements ToolInterface
         if ($text === '') {
             return '';
         }
+
         if (strlen($text) > self::BODY_EXCERPT_BYTES) {
             $text = mb_strcut($text, 0, self::BODY_EXCERPT_BYTES, 'UTF-8') . '…';
         }
@@ -223,6 +224,7 @@ final readonly class ProbeUrlTool implements ToolInterface
                 $lines[] = sprintf('  at %s:%d', $entry->frames[0]['file'], $entry->frames[0]['line']);
             }
         }
+
         $lines[] = 'Use get_last_exception for the full stack trace and source context.';
 
         return implode("\n", $lines);

--- a/Classes/Service/Tool/Builtin/ReadFalAssetMetaTool.php
+++ b/Classes/Service/Tool/Builtin/ReadFalAssetMetaTool.php
@@ -46,8 +46,8 @@ final readonly class ReadFalAssetMetaTool implements ToolInterface
      * @param list<int> $allowedStorages sys_file_storage uids this tool may read from
      */
     public function __construct(
-        protected ConnectionPool $connectionPool,
-        protected array $allowedStorages = [1],
+        private ConnectionPool $connectionPool,
+        private array $allowedStorages = [1],
     ) {}
 
     public function getSpec(): ToolSpec
@@ -125,6 +125,7 @@ final readonly class ReadFalAssetMetaTool implements ToolInterface
             if ($title !== '') {
                 $lines[] = 'title: ' . $title;
             }
+
             $alt = self::toStr($meta['alternative'] ?? '');
             if ($alt !== '') {
                 $lines[] = 'alt: ' . $alt;

--- a/Classes/Service/Tool/Builtin/ReadRecordsTool.php
+++ b/Classes/Service/Tool/Builtin/ReadRecordsTool.php
@@ -18,6 +18,7 @@ use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\WorkspaceRestriction;
@@ -59,8 +60,8 @@ final readonly class ReadRecordsTool implements ToolInterface
     private const VALUE_CAP = 300;
 
     public function __construct(
-        protected ConnectionPool $connectionPool,
-        protected TableReadAccessService $tableAccess,
+        private ConnectionPool $connectionPool,
+        private TableReadAccessService $tableAccess,
     ) {}
 
     public function getSpec(): ToolSpec
@@ -112,7 +113,7 @@ final readonly class ReadRecordsTool implements ToolInterface
     public function execute(array $arguments, ToolExecutionContext $context): ToolResult
     {
         $user = $context->actingBackendUser();
-        if ($user === null) {
+        if (!$user instanceof BackendUserAuthentication) {
             return ToolResult::text(self::NOT_PERMITTED);
         }
 
@@ -146,6 +147,7 @@ final readonly class ReadRecordsTool implements ToolInterface
         if ($limit < 1) {
             $limit = self::DEFAULT_LIMIT;
         }
+
         $limit = min($limit, self::MAX_LIMIT);
 
         $offset = self::toInt($arguments['offset'] ?? 0);
@@ -194,6 +196,7 @@ final readonly class ReadRecordsTool implements ToolInterface
                     $lines[] = sprintf('  %s: %s', $field, $value);
                 }
             }
+
             $artifactRows[] = $artifactRow;
         }
 
@@ -258,12 +261,18 @@ final readonly class ReadRecordsTool implements ToolInterface
         if (is_array($requested) && $requested !== []) {
             foreach ($requested as $field) {
                 $field = trim(self::toStr($field));
-                if ($field === '' || $this->tableAccess->isSensitiveField($field)) {
+                if ($field === '') {
                     continue;
                 }
+
+                if ($this->tableAccess->isSensitiveField($field)) {
+                    continue;
+                }
+
                 if ($field !== 'uid' && $field !== 'pid' && !isset($columns[$field])) {
                     continue;
                 }
+
                 $fields[] = $field;
             }
         } else {
@@ -274,6 +283,7 @@ final readonly class ReadRecordsTool implements ToolInterface
             if ($label !== '' && isset($columns[$label]) && !$this->tableAccess->isSensitiveField($label)) {
                 $fields[] = $label;
             }
+
             foreach (explode(',', self::toStr($ctrl['label_alt'] ?? '')) as $alt) {
                 $alt = trim($alt);
                 if ($alt !== '' && isset($columns[$alt]) && !$this->tableAccess->isSensitiveField($alt)) {
@@ -320,16 +330,20 @@ final readonly class ReadRecordsTool implements ToolInterface
                 if (++$count > self::MAX_FILTERS) {
                     return null;
                 }
+
                 $field = trim(self::toStr($field));
                 if ($field === '' || $this->tableAccess->isSensitiveField($field)) {
                     return null;
                 }
+
                 if ($field !== 'uid' && $field !== 'pid' && !isset($columns[$field])) {
                     return null;
                 }
+
                 if (!is_scalar($value)) {
                     return null;
                 }
+
                 $filters[$field] = is_int($value) ? $value : self::toStr($value);
             }
         }
@@ -399,6 +413,7 @@ final readonly class ReadRecordsTool implements ToolInterface
         if ($value === null) {
             return 'null';
         }
+
         if (is_bool($value)) {
             return $value ? 'true' : 'false';
         }

--- a/Classes/Service/Tool/Builtin/ReadSourceTool.php
+++ b/Classes/Service/Tool/Builtin/ReadSourceTool.php
@@ -78,6 +78,7 @@ final readonly class ReadSourceTool implements ToolInterface
         if ($lines < 1) {
             $lines = self::DEFAULT_LINES;
         }
+
         $lines = min($lines, self::MAX_LINES);
 
         $read = $this->guard->readLines($path, $fromLine, $lines);

--- a/Classes/Service/Tool/Builtin/RendersTypoScriptTreeTrait.php
+++ b/Classes/Service/Tool/Builtin/RendersTypoScriptTreeTrait.php
@@ -73,6 +73,7 @@ trait RendersTypoScriptTreeTrait
             if ($subtree === null) {
                 return [null, null];
             }
+
             $node = $subtree;
         }
 
@@ -100,6 +101,7 @@ trait RendersTypoScriptTreeTrait
                 if (!is_array($value)) {
                     continue;
                 }
+
                 $lines[] = str_repeat('  ', $level) . rtrim($key, '.') . ' {';
                 $this->renderTree($value, $lines, $level + 1);
                 if (end($lines) !== sprintf('… [output truncated at %d lines]', self::MAX_LINES)) {
@@ -157,9 +159,11 @@ trait RendersTypoScriptTreeTrait
         if ($value === '') {
             return $value;
         }
+
         if (preg_match(self::SECRET_KEY_PATTERN, $key) === 1) {
             return '[redacted]';
         }
+
         // Mask an inline connection-string password even under a benign key name.
         $masked = preg_replace(self::SECRET_URL_PATTERN, '$1:***@', $value);
 

--- a/Classes/Service/Tool/Builtin/ResolveUrlTool.php
+++ b/Classes/Service/Tool/Builtin/ResolveUrlTool.php
@@ -16,12 +16,14 @@ use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
 use Throwable;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Routing\PageArguments;
 use TYPO3\CMS\Core\Routing\RouteNotFoundException;
 use TYPO3\CMS\Core\Routing\SiteMatcher;
 use TYPO3\CMS\Core\Routing\SiteRouteResult;
 use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Type\Bitmask\Permission;
 
@@ -84,7 +86,7 @@ final readonly class ResolveUrlTool implements ToolInterface
         }
 
         $user = $context->actingBackendUser();
-        if ($user === null) {
+        if (!$user instanceof BackendUserAuthentication) {
             return ToolResult::text(self::NOT_PERMITTED);
         }
 
@@ -103,6 +105,7 @@ final readonly class ResolveUrlTool implements ToolInterface
         if (!$routeResult instanceof SiteRouteResult) {
             return ToolResult::text(self::NO_SITE);
         }
+
         $site = $routeResult->getSite();
         if (!$site instanceof Site) {
             // NullSite: the host/path prefix belongs to no configured site.
@@ -183,9 +186,11 @@ final readonly class ResolveUrlTool implements ToolInterface
             if ($base === '') {
                 continue;
             }
+
             if ($site->getBase()->getHost() !== '') {
                 return $base;
             }
+
             $relativeBase ??= $base;
         }
 
@@ -217,8 +222,8 @@ final readonly class ResolveUrlTool implements ToolInterface
         // and a denied page are indistinguishable in the reply (fail-closed).
         if (!$isAdmin) {
             $user        = $context->actingBackendUser();
-            $permsClause = $user !== null ? self::toStr($user->getPagePermsClause(Permission::PAGE_SHOW)) : '1=0';
-            if ($user === null || !is_array(BackendUtility::readPageAccess($pageUid, $permsClause))) {
+            $permsClause = $user instanceof BackendUserAuthentication ? self::toStr($user->getPagePermsClause(Permission::PAGE_SHOW)) : '1=0';
+            if (!$user instanceof BackendUserAuthentication || !is_array(BackendUtility::readPageAccess($pageUid, $permsClause))) {
                 return self::NOT_PERMITTED;
             }
         }
@@ -232,9 +237,10 @@ final readonly class ResolveUrlTool implements ToolInterface
 
         $lines   = [];
         $lines[] = sprintf('Site: %s (base %s)', $site->getIdentifier(), (string)$site->getBase());
-        if ($language !== null) {
+        if ($language instanceof SiteLanguage) {
             $lines[] = sprintf('Language: %d (%s)', $language->getLanguageId(), (string)$language->getLocale());
         }
+
         $lines[] = sprintf(
             'Page: [%d] %s (doktype %d, slug %s)%s',
             self::toInt($page['uid'] ?? 0),
@@ -248,6 +254,7 @@ final readonly class ResolveUrlTool implements ToolInterface
         if ($routeArguments !== []) {
             $lines[] = 'Route arguments: ' . $this->renderArguments($routeArguments);
         }
+
         $queryArguments = $pageArguments->getQueryArguments();
         if ($queryArguments !== []) {
             $lines[] = 'Query arguments: ' . $this->renderArguments($queryArguments);

--- a/Classes/Service/Tool/Builtin/SearchCodeTool.php
+++ b/Classes/Service/Tool/Builtin/SearchCodeTool.php
@@ -99,6 +99,7 @@ final readonly class SearchCodeTool implements ToolInterface
             } finally {
                 restore_error_handler();
             }
+
             if (!$patternIsValid) {
                 return ToolResult::text(sprintf('Error: invalid regular expression "%s".', $pattern));
             }
@@ -108,6 +109,7 @@ final readonly class SearchCodeTool implements ToolInterface
         if ($maxResults < 1) {
             $maxResults = self::DEFAULT_RESULTS;
         }
+
         $maxResults = min($maxResults, self::MAX_RESULTS);
 
         $root = $this->guard->rootPath();
@@ -122,9 +124,11 @@ final readonly class SearchCodeTool implements ToolInterface
             if ($candidate === false || !is_dir($candidate) || !str_starts_with($candidate . '/', $root . '/')) {
                 return ToolResult::text(sprintf('Denied or not found: search path "%s".', $subPath));
             }
+
             if ($this->guard->isDeniedRelativePath(substr($candidate, strlen($root) + 1) . '/x')) {
                 return ToolResult::text(sprintf('Denied: search path "%s".', $subPath));
             }
+
             $base = $candidate;
         }
 
@@ -152,10 +156,12 @@ final readonly class SearchCodeTool implements ToolInterface
             if (!$file->isReadable()) {
                 continue;
             }
+
             $content = file_get_contents($file->getPathname(), false, null, 0, 2_000_000);
             if ($content === false) {
                 continue;
             }
+
             if ($regex === null && !str_contains($content, $pattern)) {
                 continue;
             }
@@ -172,6 +178,7 @@ final readonly class SearchCodeTool implements ToolInterface
                 if (mb_strlen($trimmed) > self::MAX_LINE_LENGTH) {
                     $trimmed = mb_substr($trimmed, 0, self::MAX_LINE_LENGTH) . '…';
                 }
+
                 $hits[] = sprintf('%s:%d: %s', $relative, $lineNumber + 1, $trimmed);
 
                 if (count($hits) >= $maxResults) {
@@ -231,6 +238,7 @@ final readonly class SearchCodeTool implements ToolInterface
                 if (str_starts_with($name, '.')) {
                     return false;
                 }
+
                 if ($current->isDir()) {
                     return !in_array($name, SourcePathGuard::SKIPPED_DIRECTORIES, true);
                 }
@@ -239,7 +247,6 @@ final readonly class SearchCodeTool implements ToolInterface
             },
         );
 
-        /** @var iterable<SplFileInfo> */
         return new RecursiveIteratorIterator($filtered);
     }
 }

--- a/Classes/Service/Tool/Builtin/SearchFalFilesTool.php
+++ b/Classes/Service/Tool/Builtin/SearchFalFilesTool.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Service\Tool\FalStorageGate;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 
@@ -99,7 +100,7 @@ final readonly class SearchFalFilesTool implements ToolInterface
         $limit = self::toInt($arguments['limit'] ?? self::DEFAULT_LIMIT);
         $limit = max(1, min(self::MAX_LIMIT, $limit));
 
-        $isAdmin = $user !== null && $user->isAdmin();
+        $isAdmin = $user instanceof BackendUserAuthentication && $user->isAdmin();
 
         // sys_file has no enable columns; metadata is language-pinned below
         // and the storage gate is the access boundary (cf. read_fal_asset_meta).
@@ -164,6 +165,7 @@ final readonly class SearchFalFilesTool implements ToolInterface
                 self::toInt($row['size'] ?? 0),
             );
         }
+
         $lines[] = 'Use read_fal_asset_meta(uid) for title/alternative detail.';
 
         return ToolResult::text(implode("\n", $lines));

--- a/Classes/Service/Tool/Builtin/SearchRecordsTool.php
+++ b/Classes/Service/Tool/Builtin/SearchRecordsTool.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\WorkspaceRestriction;
 use TYPO3\CMS\Core\Schema\SearchableSchemaFieldsCollector;
@@ -61,9 +62,9 @@ final readonly class SearchRecordsTool implements ToolInterface
     private const NON_INLINE_TAG_PATTERN = '/<(?!\/?(?:a|abbr|b|bdi|bdo|cite|code|data|dfn|em|i|kbd|mark|q|s|samp|small|span|strong|sub|sup|time|u|var|wbr)\b)/i';
 
     public function __construct(
-        protected ConnectionPool $connectionPool,
-        protected TableReadAccessService $tableAccess,
-        protected SearchableSchemaFieldsCollector $searchableFields,
+        private ConnectionPool $connectionPool,
+        private TableReadAccessService $tableAccess,
+        private SearchableSchemaFieldsCollector $searchableFields,
     ) {}
 
     public function getSpec(): ToolSpec
@@ -97,7 +98,7 @@ final readonly class SearchRecordsTool implements ToolInterface
     public function execute(array $arguments, ToolExecutionContext $context): ToolResult
     {
         $user = $context->actingBackendUser();
-        if ($user === null) {
+        if (!$user instanceof BackendUserAuthentication) {
             return ToolResult::text('Not permitted.');
         }
 
@@ -105,12 +106,14 @@ final readonly class SearchRecordsTool implements ToolInterface
         if (mb_strlen($query) < self::MIN_QUERY_LENGTH) {
             return ToolResult::text('Query too short (minimum 2 characters).');
         }
+
         $query = mb_substr($query, 0, self::MAX_QUERY_LENGTH);
 
         $limit = self::toInt($arguments['limit'] ?? self::DEFAULT_LIMIT);
         if ($limit < 1) {
             $limit = self::DEFAULT_LIMIT;
         }
+
         $limit = min($limit, self::MAX_LIMIT);
 
         $restrictTable = trim(self::toStr($arguments['table'] ?? ''));
@@ -185,6 +188,7 @@ final readonly class SearchRecordsTool implements ToolInterface
             if ($restrictTable !== '' && $table !== $restrictTable) {
                 continue;
             }
+
             if (!$this->tableAccess->canReadTable($user, $table)) {
                 continue;
             }
@@ -294,6 +298,7 @@ final readonly class SearchRecordsTool implements ToolInterface
             if ($value === '') {
                 continue;
             }
+
             // Space before each non-inline tag so adjacent text nodes stay
             // separated after strip_tags; the collapse removes the extra spaces.
             $spaced   = (string)preg_replace(self::NON_INLINE_TAG_PATTERN, ' <', $value);
@@ -303,7 +308,7 @@ final readonly class SearchRecordsTool implements ToolInterface
                 continue;
             }
 
-            $start   = max(0, $position - (int)(self::EXCERPT_LENGTH / 2));
+            $start   = max(0, $position - self::EXCERPT_LENGTH / 2);
             $excerpt = mb_substr($plain, $start, self::EXCERPT_LENGTH);
 
             return $line . "\n" . sprintf(

--- a/Classes/Service/Tool/Builtin/SiteFetchSourceTool.php
+++ b/Classes/Service/Tool/Builtin/SiteFetchSourceTool.php
@@ -17,6 +17,7 @@ use Netresearch\NrLlm\Service\Retrieval\SourceReference;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 
 /**
  * Companion to site_rag_query (ADR-049): resolves one of its source ids
@@ -61,12 +62,12 @@ final readonly class SiteFetchSourceTool implements ToolInterface
     public function execute(array $arguments, ToolExecutionContext $context): ToolResult
     {
         $user = $context->actingBackendUser();
-        if ($user === null) {
+        if (!$user instanceof BackendUserAuthentication) {
             return ToolResult::text('Not permitted.');
         }
 
         $reference = SourceReference::parse(trim(self::toStr($arguments['source_id'] ?? '')));
-        if ($reference === null) {
+        if (!$reference instanceof SourceReference) {
             return ToolResult::text('Invalid source_id.');
         }
 

--- a/Classes/Service/Tool/Builtin/SiteRagQueryTool.php
+++ b/Classes/Service/Tool/Builtin/SiteRagQueryTool.php
@@ -18,6 +18,7 @@ use Netresearch\NrLlm\Service\Retrieval\RetrievalService;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 
 /**
  * Site-content RAG retrieval (ADR-049): question in, curated evidence
@@ -47,11 +48,11 @@ final readonly class SiteRagQueryTool implements ToolInterface
     {
         return ToolSpec::function(
             'site_rag_query',
-            'Retrieve evidence about the website\'s own PUBLIC content for a question: returns curated '
+            "Retrieve evidence about the website's own PUBLIC content for a question: returns curated "
             . 'sources (source_id, title, URL, excerpt) from the installed search index (Solr, ke_search, '
             . 'indexed_search) or a database fallback. Base statements about site content ONLY on this '
             . 'evidence and cite the source URLs; when the evidence is insufficient, say so instead of '
-            . 'guessing. Use site_fetch_source(source_id) to read a source\'s full indexed text.',
+            . "guessing. Use site_fetch_source(source_id) to read a source's full indexed text.",
             [
                 'type' => 'object',
                 'properties' => [
@@ -80,7 +81,7 @@ final readonly class SiteRagQueryTool implements ToolInterface
     public function execute(array $arguments, ToolExecutionContext $context): ToolResult
     {
         $user = $context->actingBackendUser();
-        if ($user === null) {
+        if (!$user instanceof BackendUserAuthentication) {
             return ToolResult::text('Not permitted.');
         }
 
@@ -96,6 +97,7 @@ final readonly class SiteRagQueryTool implements ToolInterface
         if ($maxSources < 1) {
             $maxSources = self::DEFAULT_SOURCES;
         }
+
         $maxSources = min($maxSources, RetrievalQuery::MAX_SOURCES);
 
         $site = trim(self::toStr($arguments['site'] ?? ''));
@@ -144,11 +146,13 @@ final readonly class SiteRagQueryTool implements ToolInterface
                 if ($source->url !== '') {
                     $lines[] = '   ' . $source->url;
                 }
+
                 if ($source->excerpt !== '') {
                     $lines[] = '   ' . $source->excerpt;
                 }
             }
-            $lines[] = 'Use site_fetch_source(source_id) for a source\'s full indexed text; cite URLs in answers.';
+
+            $lines[] = "Use site_fetch_source(source_id) for a source's full indexed text; cite URLs in answers.";
         }
 
         foreach ($result->notes as $note) {

--- a/Classes/Service/Tool/Builtin/ValidateTcaTool.php
+++ b/Classes/Service/Tool/Builtin/ValidateTcaTool.php
@@ -95,9 +95,14 @@ final readonly class ValidateTcaTool implements ToolInterface
         $checked  = 0;
         foreach ($allTca as $name => $definition) {
             $tableName = (string)$name;
-            if (!is_array($definition) || !$this->tableAccess->canReadTable($user, $tableName)) {
+            if (!is_array($definition)) {
                 continue;
             }
+
+            if (!$this->tableAccess->canReadTable($user, $tableName)) {
+                continue;
+            }
+
             ++$checked;
             foreach ($this->validateTable($tableName, $definition, $allTca) as $finding) {
                 $findings[] = $finding;
@@ -228,8 +233,15 @@ final readonly class ValidateTcaTool implements ToolInterface
         foreach (explode(',', $showitem) as $item) {
             $parts     = explode(';', trim($item));
             $fieldName = trim($parts[0]);
+            if ($fieldName === '') {
+                continue;
+            }
 
-            if ($fieldName === '' || $fieldName === '--div--' || $fieldName === '--linebreak--') {
+            if ($fieldName === '--div--') {
+                continue;
+            }
+
+            if ($fieldName === '--linebreak--') {
                 continue;
             }
 
@@ -240,6 +252,7 @@ final readonly class ValidateTcaTool implements ToolInterface
                 } elseif ($paletteName === '' || !is_array($palettes[$paletteName] ?? null)) {
                     $findings[] = sprintf('references unknown palette "%s"', $paletteName);
                 }
+
                 continue;
             }
 

--- a/Classes/Service/Tool/EgressPolicyService.php
+++ b/Classes/Service/Tool/EgressPolicyService.php
@@ -104,11 +104,13 @@ final readonly class EgressPolicyService
         if (!is_array($parts)) {
             return null;
         }
+
         // Reject userinfo (user:pass@host): the URL may be echoed back into the
         // tool output, so credentials must never reach the LLM or the logs.
         if (isset($parts['user']) || isset($parts['pass'])) {
             return null;
         }
+
         $scheme = strtolower(self::toStr($parts['scheme'] ?? ''));
         $host   = strtolower(self::toStr($parts['host'] ?? ''));
         if (!in_array($scheme, ['http', 'https'], true) || $host === '') {
@@ -146,6 +148,7 @@ final readonly class EgressPolicyService
         if (!is_array($parts)) {
             return null;
         }
+
         if (isset($parts['user']) || isset($parts['pass'])) {
             return null;
         }
@@ -195,6 +198,7 @@ final readonly class EgressPolicyService
                 if ($host === '') {
                     continue;
                 }
+
                 $scheme  = strtolower($base->getScheme() ?: 'http');
                 $port    = $base->getPort() ?? ($scheme === 'https' ? 443 : 80);
                 $hosts[] = $host . ':' . $port;

--- a/Classes/Service/Tool/FalStorageGate.php
+++ b/Classes/Service/Tool/FalStorageGate.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Service\Tool;
 
 use Throwable;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Resource\ResourceStorage;
 use TYPO3\CMS\Core\Resource\StorageRepository;
 
 /**
@@ -47,7 +48,7 @@ final readonly class FalStorageGate
      */
     public function effectiveStorages(?BackendUserAuthentication $user): array
     {
-        if ($user === null) {
+        if (!$user instanceof BackendUserAuthentication) {
             return [];
         }
 
@@ -86,7 +87,7 @@ final readonly class FalStorageGate
      */
     public function isFileAccessible(?BackendUserAuthentication $user, int $storageUid, string $identifier): bool
     {
-        if (!$this->isAllowed($user, $storageUid) || $user === null || $identifier === '') {
+        if (!$this->isAllowed($user, $storageUid) || !$user instanceof BackendUserAuthentication || $identifier === '') {
             return false;
         }
 
@@ -94,15 +95,16 @@ final readonly class FalStorageGate
             return true;
         }
 
-        if ($this->storageRepository === null) {
+        if (!$this->storageRepository instanceof StorageRepository) {
             return false;
         }
 
         try {
             $storage = $this->storageRepository->findByUid($storageUid);
-            if ($storage === null) {
+            if (!$storage instanceof ResourceStorage) {
                 return false;
             }
+
             // findByUid returns a request-shared, cached storage; restore its
             // prior evaluatePermissions so this check does not leak into other
             // consumers of the same instance in the request.

--- a/Classes/Service/Tool/LogExceptionReader.php
+++ b/Classes/Service/Tool/LogExceptionReader.php
@@ -71,12 +71,15 @@ final readonly class LogExceptionReader
                 if ($sinceTs !== null && $entry->timestamp < $sinceTs) {
                     continue;
                 }
+
                 if ($untilTs !== null && $entry->timestamp > $untilTs) {
                     continue;
                 }
+
                 if ($search !== null && $search !== '' && !$this->matchesSearch($entry, $search)) {
                     continue;
                 }
+
                 $entries[] = $entry;
             }
         }
@@ -110,6 +113,7 @@ final readonly class LogExceptionReader
         if (!is_readable($file)) {
             return [];
         }
+
         $size   = (int)filesize($file);
         $offset = max(0, $size - self::TAIL_BYTES);
         $raw    = file_get_contents($file, false, null, $offset);
@@ -127,13 +131,16 @@ final readonly class LogExceptionReader
                 if ($current !== null) {
                     $records[] = $current;
                 }
+
                 $current = $line;
                 continue;
             }
+
             if ($current !== null) {
                 $current .= "\n" . $line;
             }
         }
+
         if ($current !== null) {
             $records[] = $current;
         }

--- a/Classes/Service/Tool/RunTrace.php
+++ b/Classes/Service/Tool/RunTrace.php
@@ -68,7 +68,7 @@ final class RunTrace
      */
     public function beforeToolExecution(string $toolName): void
     {
-        if ($this->onBeforeTool !== null) {
+        if ($this->onBeforeTool instanceof Closure) {
             ($this->onBeforeTool)($toolName);
         }
     }
@@ -89,7 +89,7 @@ final class RunTrace
             kind: RunStep::KIND_REQUEST,
             round: $round,
             durationMs: 0.0,
-            messagesSent: self::snapshotMessages($messagesSent),
+            messagesSent: $this->snapshotMessages($messagesSent),
             toolSpecs: $toolSpecs,
         ));
     }
@@ -180,7 +180,7 @@ final class RunTrace
             kind: RunStep::KIND_ASSEMBLED,
             round: 0,
             durationMs: 0.0,
-            messagesSent: self::snapshotMessages($messages),
+            messagesSent: $this->snapshotMessages($messages),
         ));
     }
 
@@ -199,7 +199,7 @@ final class RunTrace
     private function add(RunStep $step): void
     {
         $this->steps[] = $step;
-        if ($this->onRecord !== null) {
+        if ($this->onRecord instanceof Closure) {
             ($this->onRecord)($step);
         }
     }
@@ -212,7 +212,7 @@ final class RunTrace
      *
      * @return list<array<string, mixed>>
      */
-    private static function snapshotMessages(array $messages): array
+    private function snapshotMessages(array $messages): array
     {
         $out = [];
         foreach ($messages as $message) {

--- a/Classes/Service/Tool/SchemaInputCoercer.php
+++ b/Classes/Service/Tool/SchemaInputCoercer.php
@@ -60,6 +60,7 @@ final readonly class SchemaInputCoercer
                 /** @var array<string, mixed> $propSchema a JSON-Schema property object is keyed by string */
                 $type = $this->classifier->classify($propSchema);
             }
+
             $isRequired = in_array($name, $required, true);
             $posted     = $rawInput[$name] ?? null;
 
@@ -85,7 +86,11 @@ final readonly class SchemaInputCoercer
             // text / integer / number: an empty value is OMITTED. Optional →
             // the validator accepts the absence; required → the required-key
             // check fails with a clear per-field 422, not a silent wrong type.
-            if ($posted === null || $posted === '') {
+            if ($posted === null) {
+                continue;
+            }
+
+            if ($posted === '') {
                 continue;
             }
 

--- a/Classes/Service/Tool/SourcePathGuard.php
+++ b/Classes/Service/Tool/SourcePathGuard.php
@@ -141,6 +141,7 @@ final readonly class SourcePathGuard
         if (!is_readable($real)) {
             return null;
         }
+
         $content = file_get_contents($real, false, null, 0, 2_000_000);
         if ($content === false) {
             return null;

--- a/Classes/Service/Tool/TableReadAccessService.php
+++ b/Classes/Service/Tool/TableReadAccessService.php
@@ -86,7 +86,7 @@ final readonly class TableReadAccessService
      */
     public function canReadTable(?BackendUserAuthentication $user, string $table): bool
     {
-        if ($user === null || $table === '') {
+        if (!$user instanceof BackendUserAuthentication || $table === '') {
             return false;
         }
 
@@ -98,6 +98,7 @@ final readonly class TableReadAccessService
         if (!is_array($allTca)) {
             return false;
         }
+
         $tca = $allTca[$table] ?? null;
         if (!is_array($tca)) {
             return false;

--- a/Classes/Service/Tool/ToolAvailabilityService.php
+++ b/Classes/Service/Tool/ToolAvailabilityService.php
@@ -48,7 +48,7 @@ final readonly class ToolAvailabilityService implements ToolAvailabilityServiceI
         $states = [];
         foreach ($this->registry->names() as $name) {
             $tool = $this->registry->get($name);
-            if ($tool === null) {
+            if (!$tool instanceof ToolInterface) {
                 continue;
             }
 
@@ -84,13 +84,15 @@ final readonly class ToolAvailabilityService implements ToolAvailabilityServiceI
         $groups = [];
         foreach ($this->registry->names() as $name) {
             $tool = $this->registry->get($name);
-            if ($tool === null) {
+            if (!$tool instanceof ToolInterface) {
                 continue;
             }
+
             $group = $tool->getGroup();
             if (isset($groups[$group])) {
                 continue;
             }
+
             $groups[$group] = [
                 'name'       => $group,
                 'enabled'    => $groupOverrides[$group] ?? true,

--- a/Classes/Service/Tool/ToolCallPolicy.php
+++ b/Classes/Service/Tool/ToolCallPolicy.php
@@ -54,7 +54,7 @@ final readonly class ToolCallPolicy implements ToolCallPolicyInterface
         $ceiling = $zone->maxDataClass();
 
         $tool = $this->registry->get($toolName);
-        if ($tool === null) {
+        if (!$tool instanceof ToolInterface) {
             return $this->denial($toolName, ToolDataClass::SECRET_ADJACENT, $zone, $ceiling, ToolDenialReason::NOT_REGISTERED);
         }
 
@@ -65,7 +65,7 @@ final readonly class ToolCallPolicy implements ToolCallPolicyInterface
         }
 
         // Fail-closed: no user is not an admin.
-        if ($tool->requiresAdmin() && ($user === null || !$user->isAdmin())) {
+        if ($tool->requiresAdmin() && (!$user instanceof BackendUserAuthentication || !$user->isAdmin())) {
             return $this->denial($toolName, $dataClass, $zone, $ceiling, ToolDenialReason::REQUIRES_ADMIN);
         }
 
@@ -154,6 +154,6 @@ final readonly class ToolCallPolicy implements ToolCallPolicyInterface
 
         $mode = $tools['dataClassEnforcement'] ?? null;
 
-        return !(is_string($mode) && strtolower(trim($mode)) === self::OBSERVE);
+        return !is_string($mode) || strtolower(trim($mode)) !== self::OBSERVE;
     }
 }

--- a/Classes/Service/Tool/ToolDataClassResolver.php
+++ b/Classes/Service/Tool/ToolDataClassResolver.php
@@ -67,7 +67,7 @@ final readonly class ToolDataClassResolver
     {
         $tool = $this->registry->get($toolName);
 
-        return $tool === null ? ToolDataClass::SECRET_ADJACENT : $this->classForTool($tool);
+        return $tool instanceof ToolInterface ? $this->classForTool($tool) : ToolDataClass::SECRET_ADJACENT;
     }
 
     /**

--- a/Classes/Service/Tool/ToolEffectResolver.php
+++ b/Classes/Service/Tool/ToolEffectResolver.php
@@ -50,6 +50,6 @@ final readonly class ToolEffectResolver
     {
         $tool = $this->registry->get($toolName);
 
-        return $tool === null ? ToolEffect::NON_IDEMPOTENT_WRITE : $this->effectForTool($tool);
+        return $tool instanceof ToolInterface ? $this->effectForTool($tool) : ToolEffect::NON_IDEMPOTENT_WRITE;
     }
 }

--- a/Classes/Service/Tool/ToolExecutionContext.php
+++ b/Classes/Service/Tool/ToolExecutionContext.php
@@ -72,7 +72,7 @@ final readonly class ToolExecutionContext
      */
     public static function none(): self
     {
-        return new self(AiActorContext::anonymous(), null);
+        return new self(AiActorContext::anonymous());
     }
 
     /**

--- a/Classes/Service/Tool/ToolGroupStateRepository.php
+++ b/Classes/Service/Tool/ToolGroupStateRepository.php
@@ -53,6 +53,7 @@ final readonly class ToolGroupStateRepository
             if ($name === '') {
                 continue;
             }
+
             $overrides[$name] = self::toInt($row['enabled'] ?? 0) === 1;
         }
 

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -186,10 +186,11 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
 
                 return $this->contextTruncatedResult([], $seedIterations + 1, $seedPromptTokens, $seedCompletionTokens);
             }
+
             $runTrace?->recordRequest(1, $messages, []);
             $t0   = hrtime(true);
             $resp = $this->mgr->chatWithConfiguration($messages, $configuration, $this->budgetMetadata($options));
-            $runTrace?->recordLlmCall(1, self::elapsedMs($t0), $resp);
+            $runTrace?->recordLlmCall(1, $this->elapsedMs($t0), $resp);
 
             // Fold in any carried-over counters (a resume whose continuation has
             // no offered tools still ran this synthesis round on top of the
@@ -237,7 +238,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                 $runTrace?->recordRequest($iterations, $messages, $allowedNames);
                 $t0   = hrtime(true);
                 $resp = $this->mgr->chatWithToolsForConfiguration($messages, $specs, $configuration, $options);
-                $runTrace?->recordLlmCall($iterations, self::elapsedMs($t0), $resp);
+                $runTrace?->recordLlmCall($iterations, $this->elapsedMs($t0), $resp);
                 $lastUsage         = $resp->usage;
                 $promptTokens     += $resp->usage->promptTokens;
                 $completionTokens += $resp->usage->completionTokens;
@@ -301,6 +302,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                                 1784600105,
                             );
                         }
+
                         throw ToolInputRequiredException::fromState(new SuspendedRunState(
                             array_map(static fn(ChatMessage|array $m): array => $m instanceof ChatMessage ? $m->toArray() : $m, $messages),
                             array_map(static fn(ToolCall $c): array => $c->toArray(), $resp->toolCalls ?? []),
@@ -325,7 +327,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                     // WIRE: content ONLY — artifacts are run-scoped and never egress to the provider.
                     $messages[] = ChatMessage::toolResult($call->id, $tr->content);
                     $trace[]    = new ToolInvocation($call->name, $call->arguments, $tr->content, $tr->isError, $tr->artifacts);
-                    $runTrace?->recordToolExecution($iterations, self::elapsedMs($tt0), $call->name, $call->arguments, $tr->content, $tr->isError, $tr->artifacts);
+                    $runTrace?->recordToolExecution($iterations, $this->elapsedMs($tt0), $call->name, $call->arguments, $tr->content, $tr->isError, $tr->artifacts);
                 }
             }
 
@@ -348,7 +350,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                 $configuration,
                 $this->budgetMetadata($options),
             );
-            $runTrace?->recordLlmCall($iterations + 1, self::elapsedMs($t0), $final);
+            $runTrace?->recordLlmCall($iterations + 1, $this->elapsedMs($t0), $final);
             $promptTokens     += $final->usage->promptTokens;
             $completionTokens += $final->usage->completionTokens;
 
@@ -411,7 +413,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         int $iteration,
         array $toolSpecs,
     ): array {
-        if ($this->contextWindow === null) {
+        if (!$this->contextWindow instanceof ContextWindowManagerInterface) {
             return $messages;
         }
 
@@ -512,8 +514,9 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                 $runTrace?->beforeToolExecution($call->name);
                 $tr     = $this->invoke($call, $offered, $context);
                 $result = $tr->content;
-                $runTrace?->recordToolExecution($state->iterations, self::elapsedMs($tt0), $call->name, $call->arguments, $tr->content, $tr->isError, $tr->artifacts);
+                $runTrace?->recordToolExecution($state->iterations, $this->elapsedMs($tt0), $call->name, $call->arguments, $tr->content, $tr->isError, $tr->artifacts);
             }
+
             $messages[] = ChatMessage::toolResult($call->id, $result);
         }
 
@@ -583,7 +586,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                 $runTrace?->beforeToolExecution($call->name);
                 $tr = $this->invoke($this->withInput($call, $state->inputSchema, $inputData), $offered, $context);
                 $result = $tr->content;
-                $runTrace?->recordToolExecution($state->iterations, self::elapsedMs($tt0), $call->name, $call->arguments, $tr->content, $tr->isError, $tr->artifacts);
+                $runTrace?->recordToolExecution($state->iterations, $this->elapsedMs($tt0), $call->name, $call->arguments, $tr->content, $tr->isError, $tr->artifacts);
             } elseif ($this->registry->get($call->name) instanceof RequiresInputInterface) {
                 // A second input-requiring call in the same turn got no data —
                 // one submission satisfies one tool. Fail-closed refusal.
@@ -594,8 +597,9 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                 $runTrace?->beforeToolExecution($call->name);
                 $tr     = $this->invoke($call, $offered, $context);
                 $result = $tr->content;
-                $runTrace?->recordToolExecution($state->iterations, self::elapsedMs($tt0), $call->name, $call->arguments, $tr->content, $tr->isError, $tr->artifacts);
+                $runTrace?->recordToolExecution($state->iterations, $this->elapsedMs($tt0), $call->name, $call->arguments, $tr->content, $tr->isError, $tr->artifacts);
             }
+
             $messages[] = ChatMessage::toolResult($call->id, $result);
         }
 
@@ -658,10 +662,10 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         ?RunAugmentation $augmentation,
     ): array {
         $configSkills = SkillInjectionService::toList($configuration->getSkills());
-        $forcedSkills = $augmentation !== null ? $augmentation->forcedSkills : [];
+        $forcedSkills = $augmentation instanceof RunAugmentation ? $augmentation->forcedSkills : [];
         $messages     = $this->skillInjection?->augmentMessages($messages, $configSkills, $forcedSkills) ?? $messages;
 
-        if ($augmentation === null) {
+        if (!$augmentation instanceof RunAugmentation) {
             return [$messages, false];
         }
 
@@ -691,7 +695,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         return [$messages, $augmentation->dryRun];
     }
 
-    private static function elapsedMs(int $startNs): float
+    private function elapsedMs(int $startNs): float
     {
         return (hrtime(true) - $startNs) / 1_000_000;
     }
@@ -781,9 +785,10 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
     private function invoke(ToolCall $call, array $allowedNames, ToolExecutionContext $context): ToolResult
     {
         $tool = $this->registry->get($call->name);
-        if ($tool === null) {
+        if (!$tool instanceof ToolInterface) {
             return ToolResult::error(sprintf('Error: unknown tool "%s"', $call->name));
         }
+
         if (!in_array($call->name, $allowedNames, true)) {
             return ToolResult::error(sprintf('Error: tool "%s" not permitted', $call->name));
         }
@@ -940,7 +945,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         // Cast defends the string return type: mb_convert_encoding is typed
         // string|false, and false (unreachable for the literal 'UTF-8' names)
         // would otherwise be a TypeError.
-        return (string)mb_convert_encoding($result, 'UTF-8', 'UTF-8');
+        return mb_convert_encoding($result, 'UTF-8', 'UTF-8');
     }
 
     /**
@@ -952,7 +957,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
      */
     private function budgetMetadata(?ToolOptions $options): array
     {
-        if ($options === null) {
+        if (!$options instanceof ToolOptions) {
             return [];
         }
 

--- a/Classes/Service/Tool/ToolRegistry.php
+++ b/Classes/Service/Tool/ToolRegistry.php
@@ -49,7 +49,7 @@ final class ToolRegistry
     private array $byName = [];
 
     /** @var list<string> */
-    private array $builtinNames = [];
+    private readonly array $builtinNames;
 
     private bool $providersHydrated = false;
 
@@ -108,6 +108,7 @@ final class ToolRegistry
         if ($this->providersHydrated) {
             return;
         }
+
         $this->providersHydrated = true;
 
         foreach ($this->providers as $provider) {

--- a/Classes/Service/Tool/ToolRegistry.php
+++ b/Classes/Service/Tool/ToolRegistry.php
@@ -46,6 +46,7 @@ final class ToolRegistry
                     1782700001,
                 );
             }
+
             // ADR-105 M1: a tool may not be both approval- and input-gated. The
             // approval-resume path carries no user input and would silently drop
             // the mandatory data; the combination is unsupported, so reject it
@@ -59,6 +60,7 @@ final class ToolRegistry
                     1784600104,
                 );
             }
+
             $this->byName[$name] = $tool;
         }
     }
@@ -92,6 +94,7 @@ final class ToolRegistry
             if ($allowedNames !== null && !in_array($name, $allowedNames, true)) {
                 continue;
             }
+
             $specs[] = $tool->getSpec();
         }
 

--- a/Classes/Service/Tool/ToolStateRepository.php
+++ b/Classes/Service/Tool/ToolStateRepository.php
@@ -54,6 +54,7 @@ final readonly class ToolStateRepository
             if ($name === '') {
                 continue;
             }
+
             $overrides[$name] = self::toInt($row['enabled'] ?? 0) === 1;
         }
 

--- a/Classes/Service/Tool/TrustZoneResolver.php
+++ b/Classes/Service/Tool/TrustZoneResolver.php
@@ -61,7 +61,7 @@ final readonly class TrustZoneResolver
             $fallback = $this->configurationRepository?->findOneByIdentifier($identifier);
             $zone     = TrustZone::leastTrusted(
                 $zone,
-                $fallback === null ? TrustZone::EXTERNAL_GLOBAL : $this->zoneForProvider($fallback->getProvider()),
+                $fallback instanceof LlmConfiguration ? $this->zoneForProvider($fallback->getProvider()) : TrustZone::EXTERNAL_GLOBAL,
             );
         }
 

--- a/Classes/Service/UsageAnalyticsService.php
+++ b/Classes/Service/UsageAnalyticsService.php
@@ -138,6 +138,7 @@ final readonly class UsageAnalyticsService implements UsageAnalyticsServiceInter
                     continue;
                 }
             }
+
             $out[$key] = [
                 'cost'     => is_numeric($row['cost'] ?? null) ? (float)$row['cost'] : 0.0,
                 'requests' => is_numeric($row['requests'] ?? null) ? (int)$row['requests'] : 0,
@@ -209,6 +210,7 @@ final readonly class UsageAnalyticsService implements UsageAnalyticsServiceInter
             if ($ts === null) {
                 continue;
             }
+
             // setTimestamp() keeps the object's default (local) timezone; '@'.$ts
             // would force UTC and misbucket local-midnight request_date values.
             $key = (new DateTimeImmutable())->setTimestamp($ts)->format('Y-m-d');
@@ -254,6 +256,7 @@ final readonly class UsageAnalyticsService implements UsageAnalyticsServiceInter
             } else {
                 $label = 'user #' . $uid;
             }
+
             $out[] = [
                 'beUserUid' => $uid,
                 'label'     => $label,
@@ -332,6 +335,7 @@ final readonly class UsageAnalyticsService implements UsageAnalyticsServiceInter
             if ($label === '') {
                 $label = 'unknown';
             }
+
             $out[] = [
                 'label'    => $label,
                 'cost'     => is_numeric($row['cost'] ?? null) ? (float)$row['cost'] : 0.0,
@@ -357,6 +361,7 @@ final readonly class UsageAnalyticsService implements UsageAnalyticsServiceInter
                 $uids[$uid] = $uid;
             }
         }
+
         if ($uids === []) {
             return [];
         }
@@ -388,7 +393,7 @@ final readonly class UsageAnalyticsService implements UsageAnalyticsServiceInter
      */
     private function budgetConsumption(?UserBudget $budget, float $usedCost): ?array
     {
-        if ($budget === null || !$budget->isActive() || $budget->getMaxCostPerMonth() <= 0.0) {
+        if (!$budget instanceof UserBudget || !$budget->isActive() || $budget->getMaxCostPerMonth() <= 0.0) {
             return null;
         }
 

--- a/Classes/Service/WizardGeneratorService.php
+++ b/Classes/Service/WizardGeneratorService.php
@@ -51,7 +51,7 @@ final readonly class WizardGeneratorService implements WizardGeneratorServiceInt
     {
         if ($configurationUid !== null && $configurationUid > 0) {
             $config = $this->configurationRepository->findByUid($configurationUid);
-            if ($config instanceof LlmConfiguration && $config->getLlmModel() !== null) {
+            if ($config instanceof LlmConfiguration && $config->getLlmModel() instanceof Model) {
                 return $config;
             }
         }
@@ -67,7 +67,7 @@ final readonly class WizardGeneratorService implements WizardGeneratorServiceInt
     public function generateConfiguration(string $description, ?LlmConfiguration $config = null): array
     {
         $config ??= $this->getDefaultConfiguration();
-        if ($config === null) {
+        if (!$config instanceof LlmConfiguration) {
             return $this->fallbackConfiguration($description);
         }
 
@@ -103,7 +103,7 @@ final readonly class WizardGeneratorService implements WizardGeneratorServiceInt
     public function generateTask(string $description, ?LlmConfiguration $config = null): array
     {
         $config ??= $this->getDefaultConfiguration();
-        if ($config === null) {
+        if (!$config instanceof LlmConfiguration) {
             return $this->fallbackTask($description);
         }
 
@@ -142,7 +142,7 @@ final readonly class WizardGeneratorService implements WizardGeneratorServiceInt
     public function generateTaskWithChain(string $description, ?LlmConfiguration $config = null): array
     {
         $config ??= $this->getDefaultConfiguration();
-        if ($config === null) {
+        if (!$config instanceof LlmConfiguration) {
             return $this->fallbackTaskChain($description);
         }
 
@@ -224,13 +224,13 @@ final readonly class WizardGeneratorService implements WizardGeneratorServiceInt
     private function getDefaultConfiguration(): ?LlmConfiguration
     {
         $config = $this->configurationRepository->findDefault();
-        if ($config instanceof LlmConfiguration && $config->getLlmModel() !== null) {
+        if ($config instanceof LlmConfiguration && $config->getLlmModel() instanceof Model) {
             return $config;
         }
 
         // Try first active config
         foreach ($this->configurationRepository->findAll() as $c) {
-            if ($c instanceof LlmConfiguration && $c->isActive() && $c->getLlmModel() !== null) {
+            if ($c instanceof LlmConfiguration && $c->isActive() && $c->getLlmModel() instanceof Model) {
                 return $c;
             }
         }
@@ -317,6 +317,7 @@ final readonly class WizardGeneratorService implements WizardGeneratorServiceInt
             if (!$config instanceof LlmConfiguration) {
                 continue;
             }
+
             $configs[] = sprintf('- %s: %s', $config->getName(), $config->getDescription());
         }
 
@@ -324,6 +325,7 @@ final readonly class WizardGeneratorService implements WizardGeneratorServiceInt
         if ($models !== []) {
             $parts[] = "Available models:\n" . implode("\n", array_slice($models, 0, 10));
         }
+
         if ($configs !== []) {
             $parts[] = "Existing configurations (avoid duplicates):\n" . implode("\n", $configs);
         }
@@ -338,6 +340,7 @@ final readonly class WizardGeneratorService implements WizardGeneratorServiceInt
             if (!$config instanceof LlmConfiguration) {
                 continue;
             }
+
             $configs[] = sprintf('- %s (identifier: %s)', $config->getName(), $config->getIdentifier());
         }
 
@@ -410,7 +413,7 @@ final readonly class WizardGeneratorService implements WizardGeneratorServiceInt
         // Every strategy failed to yield a usable object: log the last parse error with a
         // content sample so a malformed LLM response is distinguishable from an empty one.
         // The caller still falls back to its defaults (behaviour unchanged on the happy path).
-        if ($result === null && $lastError !== null) {
+        if ($result === null && $lastError instanceof JsonException) {
             $this->logger->warning('Wizard could not parse LLM JSON response', [
                 'exception' => $lastError->getMessage(),
                 'sample'    => substr($content, 0, 200),
@@ -579,6 +582,7 @@ final readonly class WizardGeneratorService implements WizardGeneratorServiceInt
             if (!$config instanceof LlmConfiguration) {
                 continue;
             }
+
             $configs[] = sprintf(
                 '- %s (identifier: %s): %s',
                 $config->getName(),
@@ -594,6 +598,7 @@ final readonly class WizardGeneratorService implements WizardGeneratorServiceInt
         if ($models !== []) {
             $parts[] = "Available models (prefer these):\n" . implode("\n", array_slice($models, 0, 10));
         }
+
         if ($configs !== []) {
             $parts[] = "Existing configurations (for reference, avoid duplicate names):\n" . implode("\n", $configs);
         }

--- a/Classes/Specialized/AbstractSpecializedService.php
+++ b/Classes/Specialized/AbstractSpecializedService.php
@@ -71,7 +71,9 @@ abstract class AbstractSpecializedService
     use ServiceConfigurationTrait;
 
     protected string $apiKeyIdentifier = '';
+
     protected string $baseUrl = '';
+
     protected int $timeout;
 
     /**
@@ -358,6 +360,7 @@ abstract class AbstractSpecializedService
             $reason .= sprintf(' (%s)', $this->auditContext);
             $this->auditContext = '';
         }
+
         return $reason;
     }
 
@@ -376,7 +379,7 @@ abstract class AbstractSpecializedService
      */
     protected function getSecureClient(): ClientInterface
     {
-        if ($this->configuredHttpClient !== null) {
+        if ($this->configuredHttpClient instanceof ClientInterface) {
             return $this->configuredHttpClient;
         }
 
@@ -439,7 +442,7 @@ abstract class AbstractSpecializedService
      */
     protected function resolveDefaultModelFor(ModelCapability $capability, string $fallback): string
     {
-        if ($this->modelRepository === null) {
+        if (!$this->modelRepository instanceof ModelRepository) {
             return $fallback;
         }
 
@@ -450,21 +453,29 @@ abstract class AbstractSpecializedService
             $chosen = null;
             foreach ($this->modelRepository->findByCapability($capability->value) as $candidate) {
                 // @phpstan-ignore instanceof.alwaysTrue (defensive check for QueryResult)
-                if (!$candidate instanceof Model || $candidate->getModelId() === '') {
+                if (!$candidate instanceof Model) {
                     continue;
                 }
+
+                if ($candidate->getModelId() === '') {
+                    continue;
+                }
+
                 // The capability query is provider-agnostic, but model-id vocabularies
                 // are not (gpt-image-* vs flux-*): skip records this service cannot
                 // speak, so e.g. an OpenAI default never reaches the FAL endpoint.
                 if (!$this->acceptsModelId($candidate->getModelId())) {
                     continue;
                 }
+
                 if ($candidate->isDefault()) {
                     $chosen = $candidate;
                     break;
                 }
+
                 $chosen ??= $candidate;
             }
+
             if ($chosen instanceof Model) {
                 return $chosen->getModelId();
             }
@@ -486,7 +497,7 @@ abstract class AbstractSpecializedService
      */
     protected function resolveModelUid(string $modelId): int
     {
-        if ($this->modelRepository === null || $modelId === '') {
+        if (!$this->modelRepository instanceof ModelRepository || $modelId === '') {
             return 0;
         }
 
@@ -523,7 +534,7 @@ abstract class AbstractSpecializedService
     ): string {
         try {
             $model = $this->findActiveConfiguration($configurationIdentifier)?->getLlmModel();
-            if ($model !== null && $model->isActive() && $model->getModelId() !== ''
+            if ($model instanceof Model && $model->isActive() && $model->getModelId() !== ''
                 && $this->acceptsModelId($model->getModelId())
             ) {
                 return $model->getModelId();
@@ -534,7 +545,7 @@ abstract class AbstractSpecializedService
             // default so the service call never breaks on resolution.
         }
 
-        return $capability === null ? $fallback : $this->resolveDefaultModelFor($capability, $fallback);
+        return $capability instanceof ModelCapability ? $this->resolveDefaultModelFor($capability, $fallback) : $fallback;
     }
 
     /**
@@ -569,7 +580,7 @@ abstract class AbstractSpecializedService
     {
         $capability = $this->getModelCapability();
 
-        return $capability === null ? $fallback : $this->resolveDefaultModelFor($capability, $fallback);
+        return $capability instanceof ModelCapability ? $this->resolveDefaultModelFor($capability, $fallback) : $fallback;
     }
 
     /**
@@ -637,12 +648,12 @@ abstract class AbstractSpecializedService
      */
     private function findActiveConfiguration(string $identifier): ?LlmConfiguration
     {
-        if ($this->configurationRepository === null || $identifier === '') {
+        if (!$this->configurationRepository instanceof LlmConfigurationRepository || $identifier === '') {
             return null;
         }
 
         $configuration = $this->configurationRepository->findOneByIdentifier($identifier);
-        if ($configuration === null || !$configuration->isActive()) {
+        if (!$configuration instanceof LlmConfiguration || !$configuration->isActive()) {
             return null;
         }
 
@@ -716,6 +727,7 @@ abstract class AbstractSpecializedService
         if ($endpoint === '') {
             return $base;
         }
+
         return $base . '/' . $endpoint;
     }
 
@@ -750,6 +762,7 @@ abstract class AbstractSpecializedService
                 if ($responseBody === '') {
                     return [];
                 }
+
                 $decoded = json_decode($responseBody, true, 512, JSON_THROW_ON_ERROR);
                 if (!is_array($decoded)) {
                     return [];
@@ -827,6 +840,7 @@ abstract class AbstractSpecializedService
                 }
             }
         }
+
         return $this->unknownErrorLabel();
     }
 
@@ -896,6 +910,7 @@ abstract class AbstractSpecializedService
             if (!is_array($config)) {
                 return;
             }
+
             /** @var array<string, mixed> $config */
             $this->loadServiceConfiguration($config);
         } catch (Throwable $e) {

--- a/Classes/Specialized/Document/DocumentAnalysisService.php
+++ b/Classes/Specialized/Document/DocumentAnalysisService.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Document;
 
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Provider\Contract\DocumentCapableInterface;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Service\Budget\AutoPopulatesBeUserUidTrait;
@@ -105,7 +106,7 @@ final readonly class DocumentAnalysisService
         }
 
         $configuration = $this->llmManager->resolveEffectiveConfiguration();
-        if ($configuration !== null && $configuration->getProviderType() !== '') {
+        if ($configuration instanceof LlmConfiguration && $configuration->getProviderType() !== '') {
             return $configuration->getProviderType();
         }
 

--- a/Classes/Specialized/Document/PopplerPdfRenderer.php
+++ b/Classes/Specialized/Document/PopplerPdfRenderer.php
@@ -145,6 +145,7 @@ final readonly class PopplerPdfRenderer implements PdfRasterizerInterface
                 // nosemgrep: php.lang.security.unlink-use.unlink-use
                 unlink($stub);
             }
+
             $leftovers = glob($stub . '*.png');
             foreach ($leftovers === false ? [] : $leftovers as $leftover) {
                 if (is_file($leftover)) {
@@ -190,18 +191,22 @@ final readonly class PopplerPdfRenderer implements PdfRasterizerInterface
             if (stream_select($read, $write, $except, null) === false) {
                 break;
             }
+
             foreach ($open as $fd => $pipe) {
                 if (!\in_array($pipe, $read, true)) {
                     continue;
                 }
+
                 $chunk = fread($pipe, 65536);
                 if ($chunk === false || ($chunk === '' && feof($pipe))) {
                     unset($open[$fd]);
                     continue;
                 }
+
                 $output[$fd] .= $chunk;
             }
         }
+
         $stdout = $output[1];
         $stderr = $output[2];
         fclose($pipes[1]);

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -41,7 +41,9 @@ final class DallEImageService extends AbstractSpecializedService implements Imag
     use MultipartBodyBuilderTrait;
 
     private const API_URL = 'https://api.openai.com/v1/images';
+
     private const DEFAULT_MODEL = 'dall-e-3';
+
     private const DEFAULT_SIZE = '1024x1024';
 
     /** Model capabilities. */
@@ -167,6 +169,7 @@ final class DallEImageService extends AbstractSpecializedService implements Imag
             for ($i = 0; $i < $count; $i++) {
                 $results[] = $this->generate($prompt, $options);
             }
+
             return $results;
         }
 
@@ -236,7 +239,7 @@ final class DallEImageService extends AbstractSpecializedService implements Imag
         $this->ensureAvailable();
 
         $this->validateImageFile($imagePath);
-        $this->enforceBudget($beUserUid, null, null);
+        $this->enforceBudget($beUserUid, null);
 
         $count = min(max($count, 1), 10);
 
@@ -302,8 +305,9 @@ final class DallEImageService extends AbstractSpecializedService implements Imag
         if ($maskPath !== null) {
             $this->validateImageFile($maskPath);
         }
+
         $prompt = $this->screenPrompt($prompt);
-        $this->enforceBudget($beUserUid, null, null);
+        $this->enforceBudget($beUserUid, null);
 
         $response = $this->runLifecycle(
             $this->imageDispatchContext(ProviderOperation::ImageEdit, 'dall-e-2', $size, 'standard', null, $beUserUid),
@@ -420,6 +424,7 @@ final class DallEImageService extends AbstractSpecializedService implements Imag
                 ['provider' => $this->getServiceProvider(), 'type' => 'validation'],
             );
         }
+
         return parent::mapErrorStatus($statusCode, $errorMessage);
     }
 
@@ -504,7 +509,7 @@ final class DallEImageService extends AbstractSpecializedService implements Imag
      */
     private function validatePrompt(string $prompt, string $model): void
     {
-        if (empty(trim($prompt))) {
+        if (in_array(trim($prompt), ['', '0'], true)) {
             throw new ServiceUnavailableException(
                 'Prompt cannot be empty',
                 'image',
@@ -588,6 +593,7 @@ final class DallEImageService extends AbstractSpecializedService implements Imag
             if (isset($options['quality'])) {
                 $payload['quality'] = $options['quality'];
             }
+
             if (isset($options['style'])) {
                 $payload['style'] = $options['style'];
             }
@@ -636,6 +642,7 @@ final class DallEImageService extends AbstractSpecializedService implements Imag
                     ['provider' => 'dall-e', 'path' => $maskPath],
                 );
             }
+
             $parts[] = ['name' => 'mask', 'filename' => 'mask.png', 'content' => $maskContent, 'contentType' => 'image/png'];
         }
 

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -37,6 +37,7 @@ use Throwable;
 final class FalImageService extends AbstractSpecializedService implements ImageGeneratorInterface
 {
     private const API_URL = 'https://fal.run';
+
     private const QUEUE_API_URL = 'https://queue.fal.run';
 
     /** Default model endpoints. */
@@ -158,6 +159,7 @@ final class FalImageService extends AbstractSpecializedService implements ImageG
                 if (!is_array($imageData)) {
                     continue;
                 }
+
                 /** @var array<string, mixed> $imageData */
                 $imageUrl = isset($imageData['url']) && is_string($imageData['url']) ? $imageData['url'] : '';
                 $results[] = new ImageGenerationResult(
@@ -355,6 +357,7 @@ final class FalImageService extends AbstractSpecializedService implements ImageG
             if (is_string($detail) && $detail !== '') {
                 return $detail;
             }
+
             if (is_string($message) && $message !== '') {
                 return $message;
             }
@@ -377,6 +380,7 @@ final class FalImageService extends AbstractSpecializedService implements ImageG
                 ['provider' => $this->getServiceProvider()],
             );
         }
+
         return parent::mapErrorStatus($statusCode, $errorMessage);
     }
 
@@ -607,7 +611,7 @@ final class FalImageService extends AbstractSpecializedService implements ImageG
             $width = $image['width'];
             $height = $image['height'];
             if (is_scalar($width) && is_scalar($height)) {
-                return (string)$width . 'x' . (string)$height;
+                return $width . 'x' . $height;
             }
         }
 
@@ -639,6 +643,7 @@ final class FalImageService extends AbstractSpecializedService implements ImageG
         foreach ($this->getAdditionalHeaders() as $name => $value) {
             $request = $request->withHeader($name, $value);
         }
+
         $body = $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE));
         $request = $request->withBody($body);
 

--- a/Classes/Specialized/Image/ImageGenerationResult.php
+++ b/Classes/Specialized/Image/ImageGenerationResult.php
@@ -85,13 +85,13 @@ final readonly class ImageGenerationResult
         $content = $this->getBinaryContent();
 
         if ($content === null) {
-            $content = self::silenced(fn(): string|false => file_get_contents($this->url));
+            $content = $this->silenced(fn(): string|false => file_get_contents($this->url));
             if ($content === false) {
                 return false;
             }
         }
 
-        $result = self::silenced(static fn(): int|false => file_put_contents($path, $content));
+        $result = $this->silenced(static fn(): int|false => file_put_contents($path, $content));
         return $result !== false;
     }
 
@@ -102,7 +102,7 @@ final readonly class ImageGenerationResult
      */
     public function downloadFromUrl(): ?string
     {
-        $content = self::silenced(fn(): string|false => file_get_contents($this->url));
+        $content = $this->silenced(fn(): string|false => file_get_contents($this->url));
         return $content !== false ? $content : null;
     }
 
@@ -118,7 +118,7 @@ final readonly class ImageGenerationResult
      *
      * @return T
      */
-    private static function silenced(callable $fn): mixed
+    private function silenced(callable $fn): mixed
     {
         set_error_handler(static fn(): bool => true);
         try {
@@ -194,9 +194,7 @@ final readonly class ImageGenerationResult
      */
     public function wasPromptRevised(): bool
     {
-        return $this->revisedPrompt !== null
-            && $this->revisedPrompt !== ''
-            && $this->revisedPrompt !== $this->prompt;
+        return !in_array($this->revisedPrompt, [null, '', $this->prompt], true);
     }
 
     /**

--- a/Classes/Specialized/MultipartBodyBuilderTrait.php
+++ b/Classes/Specialized/MultipartBodyBuilderTrait.php
@@ -89,9 +89,7 @@ trait MultipartBodyBuilderTrait
                 : $this->encodeFieldPart($part, $name);
         }
 
-        $body .= "--{$boundary}--\r\n";
-
-        return $body;
+        return $body . "--{$boundary}--\r\n";
     }
 
     /**

--- a/Classes/Specialized/Option/DeepLOptions.php
+++ b/Classes/Specialized/Option/DeepLOptions.php
@@ -17,6 +17,7 @@ use Netresearch\NrLlm\Service\Option\AbstractOptions;
 final class DeepLOptions extends AbstractOptions
 {
     private const VALID_FORMALITIES = ['default', 'more', 'less', 'prefer_more', 'prefer_less'];
+
     private const VALID_TAG_HANDLING = ['xml', 'html'];
 
     /**
@@ -35,6 +36,7 @@ final class DeepLOptions extends AbstractOptions
         if ($this->formality !== null) {
             self::validateEnum($this->formality, self::VALID_FORMALITIES, 'formality');
         }
+
         if ($this->tagHandling !== null) {
             self::validateEnum($this->tagHandling, self::VALID_TAG_HANDLING, 'tagHandling');
         }
@@ -98,7 +100,7 @@ final class DeepLOptions extends AbstractOptions
      */
     public static function html(): self
     {
-        return new self(tagHandling: 'html', preserveFormatting: true);
+        return new self(preserveFormatting: true, tagHandling: 'html');
     }
 
     /**
@@ -106,7 +108,7 @@ final class DeepLOptions extends AbstractOptions
      */
     public static function xml(): self
     {
-        return new self(tagHandling: 'xml', preserveFormatting: true);
+        return new self(preserveFormatting: true, tagHandling: 'xml');
     }
 
     /**

--- a/Classes/Specialized/Option/ImageGenerationOptions.php
+++ b/Classes/Specialized/Option/ImageGenerationOptions.php
@@ -22,16 +22,24 @@ final class ImageGenerationOptions extends AbstractOptions implements BudgetAwar
     use BudgetFieldsTrait;
 
     private const SIZE_SQUARE = '1024x1024';
+
     private const VALID_MODELS = ['dall-e-2', 'dall-e-3'];
+
     private const VALID_QUALITIES = ['standard', 'hd'];
+
     private const VALID_STYLES = ['vivid', 'natural'];
+
     private const VALID_FORMATS = ['url', 'b64_json'];
+
     private const VALID_SIZES_DALLE3 = [self::SIZE_SQUARE, '1792x1024', '1024x1792'];
+
     private const VALID_SIZES_DALLE2 = ['256x256', '512x512', self::SIZE_SQUARE];
+
     // OpenAI's gpt-image-* family (gpt-image-1, -mini, -1.5, -2, …) replaced DALL·E. It exposes
     // a different square/landscape/portrait size set and always returns b64_json; `response_format`
     // and `style` are not accepted (the service omits them for non-DALL·E models).
     private const VALID_SIZES_GPT_IMAGE = [self::SIZE_SQUARE, '1536x1024', '1024x1536', 'auto'];
+
     private const GPT_IMAGE_PREFIX = 'gpt-image-';
 
     // Arbitrary WxH sizes for gpt-image-* (per OpenAI docs, June 2026): gpt-image-2
@@ -40,8 +48,11 @@ final class ImageGenerationOptions extends AbstractOptions implements BudgetAwar
     // 3840x2160. The standard sizes above remain valid (they satisfy these rules);
     // 'auto' lets the model pick. Other extensions rely on this contract.
     private const GPT_IMAGE_DIMENSION_STEP = 16;
+
     private const GPT_IMAGE_MAX_WIDTH = 3840;
+
     private const GPT_IMAGE_MAX_HEIGHT = 2160;
+
     private const GPT_IMAGE_MAX_ASPECT = 3;
 
     /**
@@ -77,15 +88,19 @@ final class ImageGenerationOptions extends AbstractOptions implements BudgetAwar
         if ($this->model !== null) {
             $this->validateModel($this->model);
         }
+
         if ($this->quality !== null) {
             self::validateEnum($this->quality, self::VALID_QUALITIES, 'quality');
         }
+
         if ($this->style !== null) {
             self::validateEnum($this->style, self::VALID_STYLES, 'style');
         }
+
         if ($this->format !== null) {
             self::validateEnum($this->format, self::VALID_FORMATS, 'format');
         }
+
         $this->validateSize();
         $this->validateBudgetFields();
     }
@@ -254,7 +269,7 @@ final class ImageGenerationOptions extends AbstractOptions implements BudgetAwar
      */
     public static function hd(string $size = self::SIZE_SQUARE): self
     {
-        return new self(quality: 'hd', size: $size);
+        return new self(size: $size, quality: 'hd');
     }
 
     /**

--- a/Classes/Specialized/Option/SpeechSynthesisOptions.php
+++ b/Classes/Specialized/Option/SpeechSynthesisOptions.php
@@ -21,7 +21,9 @@ final class SpeechSynthesisOptions extends AbstractOptions implements BudgetAwar
     use BudgetFieldsTrait;
 
     private const VALID_VOICES = ['alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer'];
+
     private const VALID_MODELS = ['tts-1', 'tts-1-hd'];
+
     private const VALID_FORMATS = ['mp3', 'opus', 'aac', 'flac', 'wav', 'pcm'];
 
     /**
@@ -52,15 +54,19 @@ final class SpeechSynthesisOptions extends AbstractOptions implements BudgetAwar
         if ($this->model !== null) {
             self::validateEnum($this->model, self::VALID_MODELS, 'model');
         }
+
         if ($this->voice !== null) {
             self::validateEnum($this->voice, self::VALID_VOICES, 'voice');
         }
+
         if ($this->format !== null) {
             self::validateEnum($this->format, self::VALID_FORMATS, 'format');
         }
+
         if ($this->speed !== null) {
             self::validateRange($this->speed, 0.25, 4.0, 'speed');
         }
+
         $this->validateBudgetFields();
     }
 

--- a/Classes/Specialized/Option/TranscriptionOptions.php
+++ b/Classes/Specialized/Option/TranscriptionOptions.php
@@ -51,9 +51,11 @@ final class TranscriptionOptions extends AbstractOptions implements BudgetAwareO
         if ($this->format !== null) {
             self::validateEnum($this->format, self::VALID_FORMATS, 'format');
         }
+
         if ($this->temperature !== null) {
             self::validateRange($this->temperature, 0.0, 1.0, 'temperature');
         }
+
         $this->validateBudgetFields();
     }
 
@@ -102,7 +104,7 @@ final class TranscriptionOptions extends AbstractOptions implements BudgetAwareO
      */
     public static function verbose(?string $language = null): self
     {
-        return new self(format: 'verbose_json', language: $language);
+        return new self(language: $language, format: 'verbose_json');
     }
 
     /**
@@ -110,6 +112,6 @@ final class TranscriptionOptions extends AbstractOptions implements BudgetAwareO
      */
     public static function subtitles(?string $language = null): self
     {
-        return new self(format: 'srt', language: $language);
+        return new self(language: $language, format: 'srt');
     }
 }

--- a/Classes/Specialized/Pricing/SpecializedCostCalculator.php
+++ b/Classes/Specialized/Pricing/SpecializedCostCalculator.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Specialized\Pricing;
 
+use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Throwable;
 
@@ -75,7 +76,7 @@ final readonly class SpecializedCostCalculator implements SpecializedCostCalcula
     {
         try {
             $modelRow = $this->modelRepository->findOneByIdentifier($model);
-            if ($modelRow !== null && $modelRow->hasPricing()) {
+            if ($modelRow instanceof Model && $modelRow->hasPricing()) {
                 return $modelRow->estimateCost($inputTokens, $outputTokens);
             }
         } catch (Throwable) {

--- a/Classes/Specialized/ServiceConfigurationTrait.php
+++ b/Classes/Specialized/ServiceConfigurationTrait.php
@@ -30,8 +30,10 @@ trait ServiceConfigurationTrait
             if (!is_array($current) || !array_key_exists($key, $current)) {
                 return null;
             }
+
             $current = $current[$key];
         }
+
         return $current;
     }
 

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -41,8 +41,11 @@ use Throwable;
 final class TextToSpeechService extends AbstractSpecializedService
 {
     private const API_URL = 'https://api.openai.com/v1/audio/speech';
+
     private const DEFAULT_MODEL = 'tts-1';
+
     private const DEFAULT_VOICE = 'alloy';
+
     private const MAX_INPUT_LENGTH = 4096;
 
     /** Available voices with their characteristics. */
@@ -293,7 +296,7 @@ final class TextToSpeechService extends AbstractSpecializedService
      */
     private function validateInput(string $text): void
     {
-        if (empty(trim($text))) {
+        if (in_array(trim($text), ['', '0'], true)) {
             throw new ServiceUnavailableException(
                 'Input text cannot be empty',
                 'speech',
@@ -353,6 +356,7 @@ final class TextToSpeechService extends AbstractSpecializedService
                 $chunks[] = $currentChunk;
                 $currentChunk = '';
             }
+
             foreach ($this->splitLongSentence($sentence) as $subChunk) {
                 $chunks[] = $subChunk;
             }
@@ -371,6 +375,7 @@ final class TextToSpeechService extends AbstractSpecializedService
         if ($currentChunk !== '') {
             $chunks[] = $currentChunk;
         }
+
         $currentChunk = $sentence;
     }
 
@@ -423,6 +428,7 @@ final class TextToSpeechService extends AbstractSpecializedService
             $chunks[] = rtrim($currentChunk, ', ');
             $currentChunk = '';
         }
+
         // A single comma-delimited part can itself exceed the limit
         // (e.g. a clause with no internal commas). Emitting it whole
         // would produce an over-limit chunk that synthesize() rejects,
@@ -456,6 +462,7 @@ final class TextToSpeechService extends AbstractSpecializedService
         foreach ($this->getAdditionalHeaders() as $name => $value) {
             $request = $request->withHeader($name, $value);
         }
+
         $request = $request->withBody(
             $this->streamFactory->createStream(json_encode($payload, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE)),
         );

--- a/Classes/Specialized/Speech/WhisperTranscriptionService.php
+++ b/Classes/Specialized/Speech/WhisperTranscriptionService.php
@@ -47,7 +47,9 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
     use MultipartBodyBuilderTrait;
 
     private const API_URL = 'https://api.openai.com/v1/audio';
+
     private const DEFAULT_MODEL = 'whisper-1';
+
     private const MAX_FILE_SIZE = 25 * 1024 * 1024; // 25 MB
 
     /** Supported input audio formats. */
@@ -279,6 +281,7 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
                 ['audioPath' => $audioPath],
             );
         }
+
         $parts = $this->buildTranscriptionParts(basename($audioPath), $content, $options);
 
         return $this->dispatchMultipart('transcriptions', $parts, $options);
@@ -316,6 +319,7 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
                 ['audioPath' => $audioPath],
             );
         }
+
         $parts = $this->buildTranscriptionParts(basename($audioPath), $content, $options);
 
         return $this->dispatchMultipart('translations', $parts, $options);
@@ -349,12 +353,15 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
         if ($options->language !== null) {
             $parts[] = ['name' => 'language', 'value' => $options->language];
         }
+
         if ($options->format !== null) {
             $parts[] = ['name' => 'response_format', 'value' => $options->format];
         }
+
         if ($options->prompt !== null) {
             $parts[] = ['name' => 'prompt', 'value' => $options->prompt];
         }
+
         if ($options->temperature !== null) {
             $parts[] = ['name' => 'temperature', 'value' => (string)$options->temperature];
         }
@@ -395,6 +402,7 @@ final class WhisperTranscriptionService extends AbstractSpecializedService
         foreach ($this->getAdditionalHeaders() as $name => $value) {
             $request = $request->withHeader($name, $value);
         }
+
         $request = $request->withBody($this->streamFactory->createStream($body));
 
         // Fail closed before the try (see AbstractSpecializedService, ADR-099).

--- a/Classes/Specialized/Translation/DeepLTranslator.php
+++ b/Classes/Specialized/Translation/DeepLTranslator.php
@@ -46,7 +46,9 @@ use Throwable;
 final class DeepLTranslator extends AbstractSpecializedService implements TranslatorInterface
 {
     private const API_VERSION = 'v2';
+
     private const FREE_API_URL = 'https://api-free.deepl.com';
+
     private const PRO_API_URL = 'https://api.deepl.com';
 
     /** DeepL supported source languages (ISO 639-1 codes). */
@@ -167,7 +169,7 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
         ?string $sourceLanguage = null,
         array $options = [],
     ): array {
-        if (empty($texts)) {
+        if ($texts === []) {
             return [];
         }
 
@@ -210,6 +212,7 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
                 ['provider' => 'deepl'],
             );
         }
+
         $results = [];
 
         foreach ($translations as $index => $translation) {
@@ -274,7 +277,7 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
         return array_values(array_unique(array_merge(
             self::SUPPORTED_SOURCE_LANGUAGES,
             array_map(
-                fn(string $lang) => explode('-', $lang)[0],
+                fn(string $lang): string => explode('-', $lang)[0],
                 self::SUPPORTED_TARGET_LANGUAGES,
             ),
         )));
@@ -476,6 +479,7 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
         if ($key !== '') {
             sodium_memzero($key);
         }
+
         $this->baseUrlResolved = true;
     }
 
@@ -498,6 +502,7 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
                 }
             }
         }
+
         return $this->unknownErrorLabel();
     }
 
@@ -514,6 +519,7 @@ final class DeepLTranslator extends AbstractSpecializedService implements Transl
                 ['provider' => $this->getServiceProvider()],
             );
         }
+
         return parent::mapErrorStatus($statusCode, $errorMessage);
     }
 

--- a/Classes/Specialized/Translation/LlmTranslator.php
+++ b/Classes/Specialized/Translation/LlmTranslator.php
@@ -162,7 +162,7 @@ final readonly class LlmTranslator implements TranslatorInterface
         ?string $sourceLanguage = null,
         array $options = [],
     ): array {
-        if (empty($texts)) {
+        if ($texts === []) {
             return [];
         }
 

--- a/Classes/Specialized/Translation/TranslatorRegistry.php
+++ b/Classes/Specialized/Translation/TranslatorRegistry.php
@@ -82,7 +82,7 @@ final class TranslatorRegistry implements TranslatorRegistryInterface, Singleton
     {
         return array_filter(
             $this->translators,
-            static fn(TranslatorInterface $t) => $t->isAvailable(),
+            static fn(TranslatorInterface $t): bool => $t->isAvailable(),
         );
     }
 

--- a/Classes/Specialized/Usage/DallEUsageExtractor.php
+++ b/Classes/Specialized/Usage/DallEUsageExtractor.php
@@ -48,7 +48,7 @@ final readonly class DallEUsageExtractor implements UsageMetricsExtractorInterfa
     public function extract(ProviderCallContext $context, mixed $result): ?ProviderUsageRecord
     {
         $intent = SpecializedUsageIntent::fromContext($context);
-        if ($intent === null) {
+        if (!$intent instanceof SpecializedUsageIntent) {
             return null;
         }
 
@@ -57,11 +57,13 @@ final readonly class DallEUsageExtractor implements UsageMetricsExtractorInterfa
         // and variation endpoints carry the n requested.
         $data       = is_array($result) && is_array($result['data'] ?? null) ? $result['data'] : [];
         $imageCount = count($data);
-
         // gpt-image-* responses include a `usage` token object; dall-e-2/3 never
         // send one — token metrics are omitted then (all-zero) so the cost falls
         // back to the per-image catalog instead of a fabricated token price.
-        $input = $output = $total = $imageInput = 0;
+        $input = 0;
+        $output = 0;
+        $total = 0;
+        $imageInput = 0;
         $usage = is_array($result) ? ($result['usage'] ?? null) : null;
         if (is_array($usage)) {
             $input  = is_numeric($usage['input_tokens'] ?? null) ? (int)$usage['input_tokens'] : 0;
@@ -80,6 +82,7 @@ final readonly class DallEUsageExtractor implements UsageMetricsExtractorInterfa
             $metrics['promptTokens']     = $input;
             $metrics['completionTokens'] = $output;
         }
+
         $metrics['cost'] = $this->costCalculator->estimateImageCost(
             $intent->modelId,
             $intent->quality ?? 'standard',

--- a/Classes/Specialized/Usage/DeepLUsageExtractor.php
+++ b/Classes/Specialized/Usage/DeepLUsageExtractor.php
@@ -37,7 +37,7 @@ final readonly class DeepLUsageExtractor implements UsageMetricsExtractorInterfa
     public function extract(ProviderCallContext $context, mixed $result): ?ProviderUsageRecord
     {
         $intent = SpecializedUsageIntent::fromContext($context);
-        if ($intent === null) {
+        if (!$intent instanceof SpecializedUsageIntent) {
             return null;
         }
 

--- a/Classes/Specialized/Usage/FalUsageExtractor.php
+++ b/Classes/Specialized/Usage/FalUsageExtractor.php
@@ -35,7 +35,7 @@ final readonly class FalUsageExtractor implements UsageMetricsExtractorInterface
     public function extract(ProviderCallContext $context, mixed $result): ?ProviderUsageRecord
     {
         $intent = SpecializedUsageIntent::fromContext($context);
-        if ($intent === null) {
+        if (!$intent instanceof SpecializedUsageIntent) {
             return null;
         }
 

--- a/Classes/Specialized/Usage/TextToSpeechUsageExtractor.php
+++ b/Classes/Specialized/Usage/TextToSpeechUsageExtractor.php
@@ -40,7 +40,7 @@ final readonly class TextToSpeechUsageExtractor implements UsageMetricsExtractor
     public function extract(ProviderCallContext $context, mixed $result): ?ProviderUsageRecord
     {
         $intent = SpecializedUsageIntent::fromContext($context);
-        if ($intent === null) {
+        if (!$intent instanceof SpecializedUsageIntent) {
             return null;
         }
 

--- a/Classes/Specialized/Usage/WhisperUsageExtractor.php
+++ b/Classes/Specialized/Usage/WhisperUsageExtractor.php
@@ -41,7 +41,7 @@ final readonly class WhisperUsageExtractor implements UsageMetricsExtractorInter
     public function extract(ProviderCallContext $context, mixed $result): ?ProviderUsageRecord
     {
         $intent = SpecializedUsageIntent::fromContext($context);
-        if ($intent === null) {
+        if (!$intent instanceof SpecializedUsageIntent) {
             return null;
         }
 

--- a/Classes/Updates/DataClassEnforcementDefaultUpdateWizard.php
+++ b/Classes/Updates/DataClassEnforcementDefaultUpdateWizard.php
@@ -74,6 +74,7 @@ final readonly class DataClassEnforcementDefaultUpdateWizard implements UpgradeW
     {
         $config = $this->extensionConfiguration->get(self::EXT_KEY);
         $config = is_array($config) ? $config : [];
+
         $tools  = is_array($config['tools'] ?? null) ? $config['tools'] : [];
 
         $tools['dataClassEnforcement'] = self::OBSERVE;

--- a/Classes/Updates/ProviderApiTimeoutUpdateWizard.php
+++ b/Classes/Updates/ProviderApiTimeoutUpdateWizard.php
@@ -31,7 +31,9 @@ use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 final readonly class ProviderApiTimeoutUpdateWizard implements UpgradeWizardInterface
 {
     private const TABLE = 'tx_nrllm_provider';
+
     private const OLD_DEFAULT = 30;
+
     private const NEW_DEFAULT = 120;
 
     public function __construct(

--- a/Classes/Widgets/DataProvider/AgentRunsByStatusDataProvider.php
+++ b/Classes/Widgets/DataProvider/AgentRunsByStatusDataProvider.php
@@ -81,6 +81,7 @@ final readonly class AgentRunsByStatusDataProvider implements ChartDataProviderI
             if ($count <= 0) {
                 continue;
             }
+
             $chartLabels[] = $labels[$case->value] ?? $case->value;
             $data[]        = $count;
             $colors[]      = self::STATUS_COLORS[$case->value] ?? '#9E9E9E';

--- a/Classes/Widgets/DataProvider/GovernanceBlocksOverTimeDataProvider.php
+++ b/Classes/Widgets/DataProvider/GovernanceBlocksOverTimeDataProvider.php
@@ -80,6 +80,7 @@ final readonly class GovernanceBlocksOverTimeDataProvider implements ChartDataPr
             if ($count <= 0) {
                 continue;
             }
+
             $chartLabels[] = $labels[$case->value] ?? $case->value;
             $data[]        = $count;
             $colors[]      = self::DECISION_COLORS[$case->value] ?? '#9E9E9E';

--- a/Classes/Widgets/DataProvider/RequestsByProviderDataProvider.php
+++ b/Classes/Widgets/DataProvider/RequestsByProviderDataProvider.php
@@ -24,6 +24,7 @@ use TYPO3\CMS\Dashboard\Widgets\ChartDataProviderInterface;
 final readonly class RequestsByProviderDataProvider implements ChartDataProviderInterface
 {
     private const TABLE = 'tx_nrllm_service_usage';
+
     private const DEFAULT_DAYS = 7;
 
     public function __construct(
@@ -73,6 +74,7 @@ final readonly class RequestsByProviderDataProvider implements ChartDataProvider
             if ($provider === '') {
                 continue;
             }
+
             $labels[] = $provider;
             /** @var mixed $rawCount */
             $rawCount = $row['total_requests'] ?? 0;

--- a/Classes/Widgets/DataProvider/RunTerminationReasonsDataProvider.php
+++ b/Classes/Widgets/DataProvider/RunTerminationReasonsDataProvider.php
@@ -89,6 +89,7 @@ final readonly class RunTerminationReasonsDataProvider implements ChartDataProvi
             if ($count <= 0) {
                 continue;
             }
+
             $chartLabels[] = $labels[$case->value] ?? $case->value;
             $data[]        = $count;
             $colors[]      = self::REASON_COLORS[$case->value] ?? '#9E9E9E';

--- a/Classes/Widgets/DataProvider/ToolDenialsByReasonDataProvider.php
+++ b/Classes/Widgets/DataProvider/ToolDenialsByReasonDataProvider.php
@@ -82,10 +82,12 @@ final readonly class ToolDenialsByReasonDataProvider implements ChartDataProvide
             if ($case === ToolDenialReason::NONE) {
                 continue;
             }
+
             $count = $counts[$case->value] ?? 0;
             if ($count <= 0) {
                 continue;
             }
+
             $chartLabels[] = $labels[$case->value] ?? $case->value;
             $data[]        = $count;
             $colors[]      = self::REASON_COLORS[$case->value] ?? '#9E9E9E';

--- a/Classes/Widgets/DataProvider/ToolUsageByNameDataProvider.php
+++ b/Classes/Widgets/DataProvider/ToolUsageByNameDataProvider.php
@@ -71,9 +71,14 @@ final readonly class ToolUsageByNameDataProvider implements ChartDataProviderInt
         $labels = [];
         $data   = [];
         foreach ($counts as $toolName => $count) {
-            if ($toolName === '' || $count <= 0) {
+            if ($toolName === '') {
                 continue;
             }
+
+            if ($count <= 0) {
+                continue;
+            }
+
             $labels[] = $toolName;
             $data[]   = $count;
         }

--- a/Tests/E2E/AbstractE2ETestCase.php
+++ b/Tests/E2E/AbstractE2ETestCase.php
@@ -30,7 +30,9 @@ use Psr\Log\NullLogger;
 abstract class AbstractE2ETestCase extends AbstractUnitTestCase
 {
     protected RequestFactoryInterface $requestFactory;
+
     protected StreamFactoryInterface $streamFactory;
+
     protected NullLogger $logger;
 
     protected function setUp(): void
@@ -65,7 +67,7 @@ abstract class AbstractE2ETestCase extends AbstractUnitTestCase
         $requests = [];
         $client = self::createStub(ClientInterface::class);
         $client->method('sendRequest')
-            ->willReturnCallback(function (RequestInterface $request) use ($response, &$requests) {
+            ->willReturnCallback(function (RequestInterface $request) use ($response, &$requests): ResponseInterface {
                 $requests[] = $request;
                 return $response;
             });
@@ -164,7 +166,7 @@ abstract class AbstractE2ETestCase extends AbstractUnitTestCase
                     'object' => 'embedding',
                     'index' => 0,
                     'embedding' => array_map(
-                        fn() => $this->faker->randomFloat(8, -1, 1),
+                        fn(): float => $this->faker->randomFloat(8, -1, 1),
                         range(1, $dimensions),
                     ),
                 ],

--- a/Tests/E2E/Backend/AbstractBackendE2ETestCase.php
+++ b/Tests/E2E/Backend/AbstractBackendE2ETestCase.php
@@ -55,9 +55,8 @@ abstract class AbstractBackendE2ETestCase extends AbstractFunctionalTestCase
     {
         $request = new ServerRequest('POST', $uri);
         $request = $request->withHeader('Content-Type', 'application/json');
-        $request = $request->withBody(Utils::streamFor(json_encode($data, JSON_THROW_ON_ERROR)));
 
-        return $request;
+        return $request->withBody(Utils::streamFor(json_encode($data, JSON_THROW_ON_ERROR)));
     }
 
     /**

--- a/Tests/E2E/Backend/ConfigurationManagementE2ETest.php
+++ b/Tests/E2E/Backend/ConfigurationManagementE2ETest.php
@@ -50,16 +50,25 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 final class ConfigurationManagementE2ETest extends AbstractBackendE2ETestCase
 {
     private const NO_CONFIGURATION_UID_SPECIFIED = 'No configuration UID specified';
+
     private const CONFIGURATION_NOT_FOUND = 'Configuration not found';
+
     private const AJAX_CONFIG_SETDEFAULT = '/ajax/config/setdefault';
+
     private const AJAX_CONFIG_GET_MODELS = '/ajax/config/get-models';
+
     private const AJAX_CONFIG_TOGGLE = '/ajax/config/toggle';
+
     private const AJAX_CONFIG_TEST = '/ajax/config/test';
 
     private ConfigurationController $controller;
+
     private LlmConfigurationRepository $configurationRepository;
+
     private ModelRepository $modelRepository;
+
     private ProviderRepository $providerRepository;
+
     private PersistenceManagerInterface $persistenceManager;
 
     protected function setUp(): void
@@ -166,6 +175,7 @@ final class ConfigurationManagementE2ETest extends AbstractBackendE2ETestCase
             if ($config->getIdentifier() !== 'no-model-config') {
                 self::assertNotNull($config->getLlmModel(), 'Configuration should have a model');
             }
+
             // isActive() and isDefault() return bool, getTemperature() returns float, getMaxTokens() returns int
             // Verify values are accessible (types are enforced by domain model)
             $config->isActive();
@@ -956,7 +966,7 @@ final class ConfigurationManagementE2ETest extends AbstractBackendE2ETestCase
     {
         $defaultConfig = $this->configurationRepository->findDefault();
 
-        if ($defaultConfig !== null) {
+        if ($defaultConfig instanceof LlmConfiguration) {
             self::assertTrue($defaultConfig->isDefault());
             self::assertTrue($defaultConfig->isActive());
         }
@@ -989,6 +999,7 @@ final class ConfigurationManagementE2ETest extends AbstractBackendE2ETestCase
                 $iterCount++;
             }
         }
+
         self::assertSame($iterCount, $count);
     }
 
@@ -1035,7 +1046,7 @@ final class ConfigurationManagementE2ETest extends AbstractBackendE2ETestCase
     {
         // Get or set a default configuration
         $default = $this->configurationRepository->findDefault();
-        if ($default === null) {
+        if (!$default instanceof LlmConfiguration) {
             $config = $this->configurationRepository->findActive()->getFirst();
             self::assertNotNull($config);
             $configUid = $config->getUid();
@@ -1381,6 +1392,7 @@ final class ConfigurationManagementE2ETest extends AbstractBackendE2ETestCase
 
         $this->configurationRepository->add($config1);
         $this->configurationRepository->add($config2);
+
         $this->persistenceManager->persistAll();
         $this->persistenceManager->clearState();
 
@@ -1530,6 +1542,7 @@ final class ConfigurationManagementE2ETest extends AbstractBackendE2ETestCase
         foreach ($allConfigs as $config) {
             $manualCount++;
         }
+
         self::assertSame($count, $manualCount);
     }
 
@@ -1986,6 +1999,7 @@ final class ConfigurationManagementE2ETest extends AbstractBackendE2ETestCase
         // Update
         $retrieved->setName('Updated Name');
         $retrieved->setTemperature(0.9);
+
         $this->configurationRepository->update($retrieved);
         $this->persistenceManager->persistAll();
         $this->persistenceManager->clearState();

--- a/Tests/E2E/Backend/DashboardE2ETest.php
+++ b/Tests/E2E/Backend/DashboardE2ETest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\E2E\Backend;
 use Netresearch\NrLlm\Controller\Backend\LlmModuleController;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
@@ -38,9 +39,13 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 final class DashboardE2ETest extends AbstractBackendE2ETestCase
 {
     private LlmModuleController $controller;
+
     private ProviderRepository $providerRepository;
+
     private ModelRepository $modelRepository;
+
     private LlmConfigurationRepository $configurationRepository;
+
     private TaskRepository $taskRepository;
 
     protected function setUp(): void
@@ -160,7 +165,7 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
         // Dashboard highlights the default configuration
         $defaultConfig = $this->configurationRepository->findDefault();
 
-        if ($defaultConfig !== null) {
+        if ($defaultConfig instanceof LlmConfiguration) {
             self::assertTrue($defaultConfig->isDefault());
             self::assertTrue($defaultConfig->isActive());
             self::assertNotEmpty($defaultConfig->getName());
@@ -719,6 +724,7 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
             if ($model->getIdentifier() === 'orphan-model') {
                 continue;
             }
+
             // Dashboard shows model capabilities
             self::assertNotEmpty($model->getModelId());
             self::assertGreaterThanOrEqual(0, $model->getContextLength());
@@ -732,7 +738,7 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
     {
         $defaultModel = $this->modelRepository->findDefault();
 
-        if ($defaultModel !== null) {
+        if ($defaultModel instanceof Model) {
             self::assertTrue($defaultModel->isDefault());
             self::assertTrue($defaultModel->isActive());
         }
@@ -774,6 +780,7 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
             if (!isset($tasksByCategory[$category])) {
                 $tasksByCategory[$category] = [];
             }
+
             $tasksByCategory[$category][] = $task;
         }
 
@@ -815,6 +822,7 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
             if ($model->getIdentifier() === 'orphan-model') {
                 continue;
             }
+
             $provider = $model->getProvider();
             self::assertNotNull($provider);
             $providerUid = $provider->getUid();
@@ -1132,7 +1140,7 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
     {
         $highestProvider = $this->providerRepository->findHighestPriority();
 
-        if ($highestProvider !== null) {
+        if ($highestProvider instanceof Provider) {
             self::assertTrue($highestProvider->isActive());
 
             // Should have highest priority among active providers
@@ -1158,6 +1166,7 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
             if (!isset($byType[$type])) {
                 $byType[$type] = 0;
             }
+
             $byType[$type]++;
         }
 
@@ -1179,6 +1188,7 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
             if (!isset($byCategory[$category])) {
                 $byCategory[$category] = 0;
             }
+
             $byCategory[$category]++;
         }
 
@@ -1199,6 +1209,7 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
             if (!isset($byInputType[$inputType])) {
                 $byInputType[$inputType] = 0;
             }
+
             $byInputType[$inputType]++;
         }
 
@@ -1286,6 +1297,7 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
             if ($model->getIdentifier() === 'orphan-model') {
                 continue;
             }
+
             $provider = $model->getProvider();
             self::assertNotNull($provider, 'Each model must have a provider');
             self::assertNotNull($provider->getUid());
@@ -1419,6 +1431,7 @@ final class DashboardE2ETest extends AbstractBackendE2ETestCase
             if ($model->getIdentifier() === 'orphan-model') {
                 continue;
             }
+
             self::assertNotNull($model->getProvider());
         }
     }

--- a/Tests/E2E/Backend/ErrorPathwaysE2ETest.php
+++ b/Tests/E2E/Backend/ErrorPathwaysE2ETest.php
@@ -59,30 +59,53 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 final class ErrorPathwaysE2ETest extends AbstractBackendE2ETestCase
 {
     private const LIT_0190A5E0_7A1C_7B2D_8F3E_4A5B6C7D8E9F = '0190a5e0-7a1c-7b2d-8f3e-4a5b6c7d8e9f';
+
     private const AJAX_CONFIGURATION_TOGGLE = '/ajax/configuration/toggle';
+
     private const AJAX_MODEL_DETECT_LIMITS = '/ajax/model/detect-limits';
+
     private const NO_PROVIDER_UID_SPECIFIED = 'No provider UID specified';
+
     private const AJAX_MODEL_SETDEFAULT = '/ajax/model/setdefault';
+
     private const NO_MODEL_UID_SPECIFIED = 'No model UID specified';
+
     private const AJAX_PROVIDER_TOGGLE = '/ajax/provider/toggle';
+
     private const AJAX_PROVIDER_TEST = '/ajax/provider/test';
+
     private const AJAX_MODEL_TOGGLE = '/ajax/model/toggle';
+
     private const AJAX_TASK_EXECUTE = '/ajax/task/execute';
+
     private const AJAX_MODEL_TEST = '/ajax/model/test';
+
     private const MODEL_NOT_FOUND = 'Model not found';
+
     private const NOT_FOUND = 'not found';
 
     private ProviderController $providerController;
+
     private ModelController $modelController;
+
     private ModelTestController $modelTestController;
+
     private ModelDiscoveryController $modelDiscoveryController;
+
     private ConfigurationController $configController;
+
     private TaskExecutionController $taskController;
+
     private LlmModuleController $dashboardController;
+
     private ProviderRepository $providerRepository;
+
     private ModelRepository $modelRepository;
+
     private LlmConfigurationRepository $configurationRepository;
+
     private TaskRepository $taskRepository;
+
     private PersistenceManagerInterface $persistenceManager;
 
     protected function setUp(): void
@@ -945,6 +968,7 @@ final class ErrorPathwaysE2ETest extends AbstractBackendE2ETestCase
                 $defaultCount++;
             }
         }
+
         self::assertSame(1, $defaultCount, 'Only one model should be default');
     }
 
@@ -1340,6 +1364,7 @@ final class ErrorPathwaysE2ETest extends AbstractBackendE2ETestCase
                 self::assertSame($lastModelUid, $m->getUid());
             }
         }
+
         self::assertSame(1, $defaultCount);
     }
 

--- a/Tests/E2E/Backend/ModelManagementE2ETest.php
+++ b/Tests/E2E/Backend/ModelManagementE2ETest.php
@@ -44,20 +44,33 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 final class ModelManagementE2ETest extends AbstractBackendE2ETestCase
 {
     private const AJAX_MODEL_DETECT_LIMITS = '/ajax/model/detect-limits';
+
     private const AJAX_MODEL_GETBYPROVIDER = '/ajax/model/getbyprovider';
+
     private const NO_PROVIDER_UID_SPECIFIED = 'No provider UID specified';
+
     private const AJAX_MODEL_SETDEFAULT = '/ajax/model/setdefault';
+
     private const NO_MODEL_UID_SPECIFIED = 'No model UID specified';
+
     private const AJAX_MODEL_TOGGLE = '/ajax/model/toggle';
+
     private const AJAX_MODEL_FETCH = '/ajax/model/fetch';
+
     private const AJAX_MODEL_TEST = '/ajax/model/test';
+
     private const MODEL_NOT_FOUND = 'Model not found';
 
     private ModelController $controller;
+
     private ModelTestController $testController;
+
     private ModelDiscoveryController $discoveryController;
+
     private ModelRepository $modelRepository;
+
     private ProviderRepository $providerRepository;
+
     private PersistenceManagerInterface $persistenceManager;
 
     protected function setUp(): void
@@ -216,6 +229,7 @@ final class ModelManagementE2ETest extends AbstractBackendE2ETestCase
             if ($providerUid === 0) {
                 continue;
             }
+
             self::assertGreaterThan(0, $providerUid);
             self::assertGreaterThan(0, $count);
         }
@@ -475,6 +489,7 @@ final class ModelManagementE2ETest extends AbstractBackendE2ETestCase
         // Restore
         $reloaded->setName($originalName);
         $reloaded->setContextLength($originalContextLength);
+
         $this->modelRepository->update($reloaded);
         $this->persistenceManager->persistAll();
     }
@@ -782,6 +797,7 @@ final class ModelManagementE2ETest extends AbstractBackendE2ETestCase
             if ($model->getIdentifier() === 'orphan-model') {
                 continue;
             }
+
             $provider = $model->getProvider();
             self::assertNotNull($provider, "Model {$model->getName()} must have a provider");
             self::assertNotNull($provider->getUid(), 'Provider must have UID');
@@ -1026,7 +1042,7 @@ final class ModelManagementE2ETest extends AbstractBackendE2ETestCase
     public function pathway3_17_findDefaultModel(): void
     {
         $models = $this->modelRepository->findActive()->toArray();
-        $defaults = array_filter($models, fn($m) => $m->isDefault());
+        $defaults = array_filter($models, fn(Model $m): bool => $m->isDefault());
 
         // Should have at most one default
         self::assertLessThanOrEqual(1, count($defaults));

--- a/Tests/E2E/Backend/MultiProviderWorkflowsE2ETest.php
+++ b/Tests/E2E/Backend/MultiProviderWorkflowsE2ETest.php
@@ -41,10 +41,15 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
     private const AJAX_CONFIG_TEST = '/ajax/config/test';
 
     private ProviderRepository $providerRepository;
+
     private ModelRepository $modelRepository;
+
     private LlmConfigurationRepository $configurationRepository;
+
     private TaskRepository $taskRepository;
+
     private PersistenceManagerInterface $persistenceManager;
+
     private ConfigurationController $configurationController;
 
     protected function setUp(): void
@@ -160,7 +165,7 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
         self::assertGreaterThanOrEqual(1, count($providers), 'Should have at least one active provider');
 
         // Each provider should have unique identifiers
-        $identifiers = array_map(fn($p) => $p->getIdentifier(), $providers);
+        $identifiers = array_map(fn(Provider $p): string => $p->getIdentifier(), $providers);
         self::assertSame(count($providers), count(array_unique($identifiers)), 'Provider identifiers should be unique');
     }
 
@@ -339,7 +344,7 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
         $newPrimary = $this->providerRepository->findHighestPriority();
 
         // Should have a different provider available (or null if only one existed)
-        if ($newPrimary !== null) {
+        if ($newPrimary instanceof Provider) {
             self::assertNotSame($primaryUid, $newPrimary->getUid(), 'Fallback provider should now be primary');
         }
 
@@ -433,6 +438,7 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
         $provider2->setPriority(100);
         $this->providerRepository->update($provider1);
         $this->providerRepository->update($provider2);
+
         $this->persistenceManager->persistAll();
         $this->persistenceManager->clearState();
 
@@ -452,10 +458,12 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
             $p1->setPriority($originalPriority1);
             $this->providerRepository->update($p1);
         }
+
         if ($p2 !== null) {
             $p2->setPriority($originalPriority2);
             $this->providerRepository->update($p2);
         }
+
         $this->persistenceManager->persistAll();
     }
 
@@ -572,6 +580,7 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
         $provider2->setIsActive(!$original2);
         $this->providerRepository->update($provider1);
         $this->providerRepository->update($provider2);
+
         $this->persistenceManager->persistAll();
         $this->persistenceManager->clearState();
 
@@ -593,6 +602,7 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
         $reloaded2->setIsActive($original2);
         $this->providerRepository->update($reloaded1);
         $this->providerRepository->update($reloaded2);
+
         $this->persistenceManager->persistAll();
     }
 
@@ -676,7 +686,7 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
                 self::assertInstanceOf(QueryResultInterface::class, $allConfigsQueryResult);
                 /** @var array<int, LlmConfiguration> $allConfigs */
                 $allConfigs = $allConfigsQueryResult->toArray();
-                $allConfigUids = array_map(fn(LlmConfiguration $c) => $c->getUid(), $allConfigs);
+                $allConfigUids = array_map(fn(LlmConfiguration $c): ?int => $c->getUid(), $allConfigs);
                 self::assertContains($taskConfig->getUid(), $allConfigUids);
             }
         }
@@ -743,7 +753,7 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
         self::assertGreaterThanOrEqual(1, count($allModels));
 
         // Each model should be uniquely identifiable
-        $modelUids = array_map(fn($m) => $m['model']->getUid(), $allModels);
+        $modelUids = array_map(fn(array $m) => $m['model']->getUid(), $allModels);
         self::assertSame(count($allModels), count(array_unique($modelUids)));
     }
 
@@ -753,7 +763,7 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
         // Only one model should be default across all providers
         $defaultModel = $this->modelRepository->findDefault();
 
-        if ($defaultModel !== null) {
+        if ($defaultModel instanceof Model) {
             self::assertTrue($defaultModel->isDefault());
 
             // Count total defaults - should be exactly 1
@@ -766,6 +776,7 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
                     $defaultCount++;
                 }
             }
+
             self::assertSame(1, $defaultCount, 'Only one model should be default');
         }
     }
@@ -861,6 +872,7 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
             foreach ($providerModels as $m) {
                 $modelUids[] = $m->getUid();
             }
+
             self::assertContains($model->getUid(), $modelUids);
         }
     }
@@ -1063,6 +1075,7 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
         foreach ($providerModels as $m) {
             $modelUids[] = $m->getUid();
         }
+
         self::assertContains($model->getUid(), $modelUids);
     }
 
@@ -1081,6 +1094,7 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
             if (!isset($byType[$type])) {
                 $byType[$type] = [];
             }
+
             $byType[$type][] = $provider;
         }
 
@@ -1200,6 +1214,7 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
             $provider->setIsActive(false);
             $this->providerRepository->update($provider);
         }
+
         $this->persistenceManager->persistAll();
         $this->persistenceManager->clearState();
 
@@ -1214,6 +1229,7 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
                 $this->providerRepository->update($provider);
             }
         }
+
         $this->persistenceManager->persistAll();
         $this->persistenceManager->clearState();
 
@@ -1236,6 +1252,7 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
             $model->setIsActive(false);
             $this->modelRepository->update($model);
         }
+
         $this->persistenceManager->persistAll();
         $this->persistenceManager->clearState();
 
@@ -1250,6 +1267,7 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
                 $this->modelRepository->update($model);
             }
         }
+
         $this->persistenceManager->persistAll();
         $this->persistenceManager->clearState();
 
@@ -1323,6 +1341,7 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
             if ($model->getIdentifier() === 'orphan-model') {
                 continue;
             }
+
             $provider = $model->getProvider();
             self::assertNotNull($provider, "Model {$model->getName()} must have a provider");
             self::assertNotNull($provider->getUid());
@@ -1517,6 +1536,7 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
             if ($model->getIdentifier() === 'orphan-model') {
                 continue;
             }
+
             $provider = $model->getProvider();
             self::assertNotNull($provider, "Model {$model->getIdentifier()} is orphaned");
 
@@ -1538,7 +1558,7 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
         $allModels = $modelQueryResult->toArray();
         $defaultModels = array_filter(
             $allModels,
-            fn(Model $m) => $m->isDefault(),
+            fn(Model $m): bool => $m->isDefault(),
         );
         self::assertLessThanOrEqual(1, count($defaultModels));
 
@@ -1549,7 +1569,7 @@ final class MultiProviderWorkflowsE2ETest extends AbstractBackendE2ETestCase
         $allConfigs = $configQueryResult->toArray();
         $defaultConfigs = array_filter(
             $allConfigs,
-            fn(LlmConfiguration $c) => $c->isDefault(),
+            fn(LlmConfiguration $c): bool => $c->isDefault(),
         );
         self::assertLessThanOrEqual(1, count($defaultConfigs));
     }

--- a/Tests/E2E/Backend/ProviderManagementE2ETest.php
+++ b/Tests/E2E/Backend/ProviderManagementE2ETest.php
@@ -33,15 +33,23 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 final class ProviderManagementE2ETest extends AbstractBackendE2ETestCase
 {
     private const LIT_0190A5E0_7A1C_7B2D_8F3E_4A5B6C7D8E9F = '0190a5e0-7a1c-7b2d-8f3e-4a5b6c7d8e9f';
+
     private const NO_PROVIDER_UID_SPECIFIED = 'No provider UID specified';
+
     private const HTTPS_API_OPENAI_COM_V1 = 'https://api.openai.com/v1';
+
     private const HTTP_LOCALHOST_11434 = 'http://localhost:11434';
+
     private const AJAX_PROVIDER_TOGGLE = '/ajax/provider/toggle';
+
     private const AJAX_PROVIDER_TEST = '/ajax/provider/test';
 
     private ProviderController $controller;
+
     private ProviderRepository $providerRepository;
+
     private ModelRepository $modelRepository;
+
     private PersistenceManagerInterface $persistenceManager;
 
     protected function setUp(): void
@@ -307,6 +315,7 @@ final class ProviderManagementE2ETest extends AbstractBackendE2ETestCase
         // Restore original values
         $reloaded->setName($originalName);
         $reloaded->setTimeout($originalTimeout);
+
         $this->providerRepository->update($reloaded);
         $this->persistenceManager->persistAll();
     }
@@ -392,7 +401,7 @@ final class ProviderManagementE2ETest extends AbstractBackendE2ETestCase
         self::assertGreaterThanOrEqual(1, count($activeProviders), 'Should have at least one active provider');
 
         // Each provider should have unique identifier
-        $identifiers = array_map(fn($p) => $p->getIdentifier(), $activeProviders);
+        $identifiers = array_map(fn(Provider $p): string => $p->getIdentifier(), $activeProviders);
         self::assertCount(count($activeProviders), array_unique($identifiers));
 
         // If only one provider, create another to test multi-provider scenario
@@ -419,7 +428,7 @@ final class ProviderManagementE2ETest extends AbstractBackendE2ETestCase
         // Get provider by priority
         $highestPriority = $this->providerRepository->findHighestPriority();
 
-        if ($highestPriority !== null) {
+        if ($highestPriority instanceof Provider) {
             // Verify it's actually the highest
             foreach ($this->providerRepository->findActive() as $provider) {
                 self::assertLessThanOrEqual(
@@ -478,6 +487,7 @@ final class ProviderManagementE2ETest extends AbstractBackendE2ETestCase
         // Identifier is required - setting empty should be handled
 
         $provider->setIdentifier('required-id-test-' . time());
+
         $this->providerRepository->add($provider);
         $this->persistenceManager->persistAll();
 
@@ -736,11 +746,11 @@ final class ProviderManagementE2ETest extends AbstractBackendE2ETestCase
         self::assertGreaterThanOrEqual(1, count($providers));
 
         // Verify providers can be sorted by priority
-        usort($providers, fn(Provider $a, Provider $b) => $b->getPriority() <=> $a->getPriority());
+        usort($providers, fn(Provider $a, Provider $b): int => $b->getPriority() <=> $a->getPriority());
 
         // First element should have highest priority
         $highest = $this->providerRepository->findHighestPriority();
-        if ($highest !== null && $providers !== []) {
+        if ($highest instanceof Provider && $providers !== []) {
             self::assertSame($providers[0]->getUid(), $highest->getUid());
         }
     }
@@ -770,6 +780,7 @@ final class ProviderManagementE2ETest extends AbstractBackendE2ETestCase
         $provider2->setPriority($originalPriority1);
         $this->providerRepository->update($provider1);
         $this->providerRepository->update($provider2);
+
         $this->persistenceManager->persistAll();
         $this->persistenceManager->clearState();
 
@@ -786,6 +797,7 @@ final class ProviderManagementE2ETest extends AbstractBackendE2ETestCase
         $reloaded2->setPriority($originalPriority2);
         $this->providerRepository->update($reloaded1);
         $this->providerRepository->update($reloaded2);
+
         $this->persistenceManager->persistAll();
     }
 

--- a/Tests/E2E/Backend/SetupWizardE2ETest.php
+++ b/Tests/E2E/Backend/SetupWizardE2ETest.php
@@ -35,25 +35,43 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 final class SetupWizardE2ETest extends AbstractBackendE2ETestCase
 {
     private const PROVIDER_AND_MODELS_ARE_REQUIRED = 'Provider and models are required';
+
     private const ENDPOINT_AND_MODELS_ARE_REQUIRED = 'Endpoint and models are required';
+
     private const HTTPS_API_ANTHROPIC_COM_V1 = 'https://api.anthropic.com/v1';
+
     private const HTTPS_API_EXAMPLE_COM_V1 = 'https://api.example.com/v1';
+
     private const HTTPS_API_OPENAI_COM_V1 = 'https://api.openai.com/v1';
+
     private const ENDPOINT_URL_IS_REQUIRED = 'Endpoint URL is required';
+
     private const HTTP_LOCALHOST_11434 = 'http://localhost:11434';
+
     private const AJAX_WIZARD_DISCOVER = '/ajax/wizard/discover';
+
     private const AJAX_WIZARD_GENERATE = '/ajax/wizard/generate';
+
     private const AJAX_WIZARD_DETECT = '/ajax/wizard/detect';
+
     private const AJAX_WIZARD_TEST = '/ajax/wizard/test';
+
     private const AJAX_WIZARD_SAVE = '/ajax/wizard/save';
+
     private const TEST_MODEL = 'Test Model';
+
     private const O4_MINI = 'O4 Mini';
+
     private const ANT = '-ant-';
 
     private SetupWizardController $controller;
+
     private ProviderRepository $providerRepository;
+
     private ModelRepository $modelRepository;
+
     private LlmConfigurationRepository $configurationRepository;
+
     private PersistenceManagerInterface $persistenceManager;
 
     protected function setUp(): void

--- a/Tests/E2E/Backend/TaskExecutionE2ETest.php
+++ b/Tests/E2E/Backend/TaskExecutionE2ETest.php
@@ -39,15 +39,23 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 final class TaskExecutionE2ETest extends AbstractBackendE2ETestCase
 {
     private const AJAX_TASK_REFRESH_INPUT = '/ajax/task/refresh-input';
+
     private const AJAX_TASK_LOAD_RECORD = '/ajax/task/load-record';
+
     private const AJAX_TASK_EXECUTE = '/ajax/task/execute';
+
     private const AJAX_TASK_RECORDS = '/ajax/task/records';
+
     private const TEST_INPUT = 'Test input';
+
     private const INPUT = '{{input}}';
 
     private TaskExecutionController $executionController;
+
     private TaskRecordsController $recordsController;
+
     private TaskRepository $taskRepository;
+
     private PersistenceManagerInterface $persistenceManager;
 
     protected function setUp(): void
@@ -2074,6 +2082,7 @@ final class TaskExecutionE2ETest extends AbstractBackendE2ETestCase
         // Update
         $retrieved->setName('Updated Task Name');
         $retrieved->setDescription('Added description');
+
         $this->taskRepository->update($retrieved);
         $this->persistenceManager->persistAll();
         $this->persistenceManager->clearState();

--- a/Tests/E2E/ChatCompletionWorkflowTest.php
+++ b/Tests/E2E/ChatCompletionWorkflowTest.php
@@ -35,6 +35,7 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 class ChatCompletionWorkflowTest extends AbstractE2ETestCase
 {
     use LlmServiceManagerTestFactory;
+
     private const FAKE_CLAUDE_VAULT_ID = '019650a0-1234-7abc-8def-0123456789ab';
 
     #[Test]
@@ -219,7 +220,7 @@ class ChatCompletionWorkflowTest extends AbstractE2ETestCase
         // Act: Request with specific options (provider pinned per-call; gpt-4o supports sampling params)
         $result = $completionService->complete(
             'Generate JSON',
-            new ChatOptions(provider: 'openai', model: 'gpt-4o', temperature: 0.1, maxTokens: 500),
+            new ChatOptions(temperature: 0.1, maxTokens: 500, provider: 'openai', model: 'gpt-4o'),
         );
 
         // Assert

--- a/Tests/E2E/EmbeddingWorkflowTest.php
+++ b/Tests/E2E/EmbeddingWorkflowTest.php
@@ -34,6 +34,7 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 class EmbeddingWorkflowTest extends AbstractE2ETestCase
 {
     use LlmServiceManagerTestFactory;
+
     #[Test]
     public function completeEmbeddingWorkflow(): void
     {
@@ -89,7 +90,7 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
         // CacheMiddleware persists) and is reconstructed via fromArray().
         $cachedResponse = (new EmbeddingResponse(
             embeddings: [
-                array_map(fn() => $this->faker->randomFloat(8, -1, 1), range(1, 1536)),
+                array_map(fn(): float => $this->faker->randomFloat(8, -1, 1), range(1, 1536)),
             ],
             model: 'text-embedding-3-small',
             usage: new UsageStatistics(10, 0, 10),
@@ -138,7 +139,7 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
                     'object' => 'embedding',
                     'index' => 0,
                     'embedding' => array_map(
-                        fn() => $this->faker->randomFloat(8, -1, 1),
+                        fn(): float => $this->faker->randomFloat(8, -1, 1),
                         range(1, 1536),
                     ),
                 ],
@@ -146,7 +147,7 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
                     'object' => 'embedding',
                     'index' => 1,
                     'embedding' => array_map(
-                        fn() => $this->faker->randomFloat(8, -1, 1),
+                        fn(): float => $this->faker->randomFloat(8, -1, 1),
                         range(1, 1536),
                     ),
                 ],
@@ -154,7 +155,7 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
                     'object' => 'embedding',
                     'index' => 2,
                     'embedding' => array_map(
-                        fn() => $this->faker->randomFloat(8, -1, 1),
+                        fn(): float => $this->faker->randomFloat(8, -1, 1),
                         range(1, 1536),
                     ),
                 ],
@@ -209,8 +210,8 @@ class EmbeddingWorkflowTest extends AbstractE2ETestCase
     public function semanticSimilarityWorkflow(): void
     {
         // Arrange: Create two embeddings that would be similar
-        $embedding1 = array_map(fn() => $this->faker->randomFloat(8, 0, 1), range(1, 1536));
-        $embedding2 = array_map(fn($i) => $embedding1[$i - 1] + $this->faker->randomFloat(8, -0.1, 0.1), range(1, 1536));
+        $embedding1 = array_map(fn(): float => $this->faker->randomFloat(8, 0, 1), range(1, 1536));
+        $embedding2 = array_map(fn($i): float => $embedding1[$i - 1] + $this->faker->randomFloat(8, -0.1, 0.1), range(1, 1536));
 
         $response1 = [
             'object' => 'list',

--- a/Tests/Functional/AbstractFunctionalTestCase.php
+++ b/Tests/Functional/AbstractFunctionalTestCase.php
@@ -105,11 +105,7 @@ abstract class AbstractFunctionalTestCase extends FunctionalTestCase
 
         // Check for LocalConfiguration
         $localConfigPath = dirname(__DIR__, 2) . '/typo3conf/LocalConfiguration.php';
-        if (file_exists($localConfigPath)) {
-            return true;
-        }
-
-        return false;
+        return file_exists($localConfigPath);
     }
 
     /**

--- a/Tests/Functional/Controller/Backend/ConfigurationControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ConfigurationControllerTest.php
@@ -48,14 +48,21 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 final class ConfigurationControllerTest extends AbstractFunctionalTestCase
 {
     private const NO_CONFIGURATION_UID_SPECIFIED = 'No configuration UID specified';
+
     private const AJAX_NRLLM_CONFIG_SETDEFAULT = '/ajax/nrllm/config/setdefault';
+
     private const AJAX_NRLLM_CONFIG_GET_MODELS = '/ajax/nrllm/config/get-models';
+
     private const AJAX_NRLLM_CONFIG_TOGGLE = '/ajax/nrllm/config/toggle';
+
     private const CONFIGURATION_NOT_FOUND = 'Configuration not found';
+
     private const AJAX_NRLLM_CONFIG_TEST = '/ajax/nrllm/config/test';
 
     private ConfigurationController $controller;
+
     private LlmConfigurationRepository $configurationRepository;
+
     private PersistenceManagerInterface $persistenceManager;
 
     protected function setUp(): void

--- a/Tests/Functional/Controller/Backend/ErrorHandlingTest.php
+++ b/Tests/Functional/Controller/Backend/ErrorHandlingTest.php
@@ -59,11 +59,15 @@ use TYPO3\CMS\Extbase\Mvc\Request as ExtbaseRequest;
 final class ErrorHandlingTest extends AbstractFunctionalTestCase
 {
     private const AJAX_CONFIG_TEST = '/ajax/nrllm/config/test';
+
     private const AJAX_TEST = '/ajax/test';
 
     private ConfigurationController $configController;
+
     private TaskExecutionController $taskController;
+
     private LlmModuleController $llmModuleController;
+
     private LlmConfigurationRepository $configurationRepository;
 
     protected function setUp(): void

--- a/Tests/Functional/Controller/Backend/ModelControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ModelControllerTest.php
@@ -43,19 +43,31 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 final class ModelControllerTest extends AbstractFunctionalTestCase
 {
     private const AJAX_NRLLM_MODEL_GET_BY_PROVIDER = '/ajax/nrllm/model/get-by-provider';
+
     private const AJAX_NRLLM_MODEL_FETCH_AVAILABLE = '/ajax/nrllm/model/fetch-available';
+
     private const AJAX_NRLLM_MODEL_DETECT_LIMITS = '/ajax/nrllm/model/detect-limits';
+
     private const AJAX_NRLLM_MODEL_SET_DEFAULT = '/ajax/nrllm/model/set-default';
+
     private const NO_PROVIDER_UID_SPECIFIED = 'No provider UID specified';
+
     private const AJAX_NRLLM_MODEL_TOGGLE = '/ajax/nrllm/model/toggle';
+
     private const NO_MODEL_UID_SPECIFIED = 'No model UID specified';
+
     private const AJAX_NRLLM_MODEL_TEST = '/ajax/nrllm/model/test';
+
     private const MODEL_NOT_FOUND = 'Model not found';
 
     private ModelController $controller;
+
     private ModelTestController $testController;
+
     private ModelDiscoveryController $discoveryController;
+
     private ModelRepository $modelRepository;
+
     private PersistenceManagerInterface $persistenceManager;
 
     protected function setUp(): void

--- a/Tests/Functional/Controller/Backend/MultiProviderWorkflowTest.php
+++ b/Tests/Functional/Controller/Backend/MultiProviderWorkflowTest.php
@@ -58,15 +58,23 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
 {
     private const AJAX_NRLLM_MODEL_GET_BY_PROVIDER = '/ajax/nrllm/model/get-by-provider';
+
     private const AJAX_NRLLM_PROVIDER_TOGGLE = '/ajax/nrllm/provider/toggle';
+
     private const AJAX_NRLLM_CONFIG_TOGGLE = '/ajax/nrllm/config/toggle';
 
     private ConfigurationController $configController;
+
     private ProviderController $providerController;
+
     private ModelController $modelController;
+
     private LlmModuleController $llmModuleController;
+
     private ProviderRepository $providerRepository;
+
     private LlmConfigurationRepository $configurationRepository;
+
     private PersistenceManagerInterface $persistenceManager;
 
     protected function setUp(): void
@@ -340,10 +348,12 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
         // Toggle both configurations (demonstrates provider independence)
         $request1 = new ServerRequest('POST', self::AJAX_NRLLM_CONFIG_TOGGLE);
         $request1 = $request1->withParsedBody(['uid' => 1]);
+
         $response1 = $this->configController->toggleActiveAction($request1);
 
         $request2 = new ServerRequest('POST', self::AJAX_NRLLM_CONFIG_TOGGLE);
         $request2 = $request2->withParsedBody(['uid' => 2]);
+
         $response2 = $this->configController->toggleActiveAction($request2);
 
         // Both operations should succeed
@@ -365,6 +375,7 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
         // Set configuration 1 as default
         $request1 = new ServerRequest('POST', '/ajax/nrllm/config/setdefault');
         $request1 = $request1->withParsedBody(['uid' => 1]);
+
         $response1 = $this->configController->setDefaultAction($request1);
         self::assertSame(200, $response1->getStatusCode());
 
@@ -377,6 +388,7 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
         // Switch to configuration 2 as default
         $request2 = new ServerRequest('POST', '/ajax/nrllm/config/setdefault');
         $request2 = $request2->withParsedBody(['uid' => 2]);
+
         $response2 = $this->configController->setDefaultAction($request2);
         self::assertSame(200, $response2->getStatusCode());
 
@@ -401,11 +413,13 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
         // Toggle provider 1 to active
         $request1 = new ServerRequest('POST', self::AJAX_NRLLM_PROVIDER_TOGGLE);
         $request1 = $request1->withParsedBody(['uid' => 1]);
+
         $response1 = $this->providerController->toggleActiveAction($request1);
 
         // Toggle provider 2 to active
         $request2 = new ServerRequest('POST', self::AJAX_NRLLM_PROVIDER_TOGGLE);
         $request2 = $request2->withParsedBody(['uid' => 2]);
+
         $response2 = $this->providerController->toggleActiveAction($request2);
 
         self::assertSame(200, $response1->getStatusCode());
@@ -460,6 +474,7 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
         // Toggle config 1
         $request1 = new ServerRequest('POST', self::AJAX_NRLLM_CONFIG_TOGGLE);
         $request1 = $request1->withParsedBody(['uid' => 1]);
+
         $this->configController->toggleActiveAction($request1);
 
         // Config 2 should be unaffected
@@ -479,11 +494,13 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
         // Test connection for provider 1
         $request1 = new ServerRequest('POST', '/ajax/nrllm/provider/connection');
         $request1 = $request1->withParsedBody(['uid' => 1]);
+
         $response1 = $this->providerController->testConnectionAction($request1);
 
         // Test connection for provider 2
         $request2 = new ServerRequest('POST', '/ajax/nrllm/provider/connection');
         $request2 = $request2->withParsedBody(['uid' => 2]);
+
         $response2 = $this->providerController->testConnectionAction($request2);
 
         // Both should return valid responses
@@ -505,6 +522,7 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
         // Get models for provider 1
         $request1 = new ServerRequest('POST', self::AJAX_NRLLM_MODEL_GET_BY_PROVIDER);
         $request1 = $request1->withParsedBody(['providerUid' => 1]);
+
         $response1 = $this->modelController->getByProviderAction($request1);
 
         $body1 = json_decode((string)$response1->getBody(), true);
@@ -519,6 +537,7 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
         // Get models for provider 2
         $request2 = new ServerRequest('POST', self::AJAX_NRLLM_MODEL_GET_BY_PROVIDER);
         $request2 = $request2->withParsedBody(['providerUid' => 2]);
+
         $response2 = $this->modelController->getByProviderAction($request2);
 
         $body2 = json_decode((string)$response2->getBody(), true);
@@ -560,10 +579,12 @@ final class MultiProviderWorkflowTest extends AbstractFunctionalTestCase
         // Toggle both configurations
         $request1 = new ServerRequest('POST', self::AJAX_NRLLM_CONFIG_TOGGLE);
         $request1 = $request1->withParsedBody(['uid' => 1]);
+
         $this->configController->toggleActiveAction($request1);
 
         $request2 = new ServerRequest('POST', self::AJAX_NRLLM_CONFIG_TOGGLE);
         $request2 = $request2->withParsedBody(['uid' => 2]);
+
         $this->configController->toggleActiveAction($request2);
 
         // Toggle back

--- a/Tests/Functional/Controller/Backend/ProviderControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ProviderControllerTest.php
@@ -35,11 +35,15 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 final class ProviderControllerTest extends AbstractFunctionalTestCase
 {
     private const AJAX_NRLLM_PROVIDER_TOGGLE = '/ajax/nrllm/provider/toggle';
+
     private const NO_PROVIDER_UID_SPECIFIED = 'No provider UID specified';
+
     private const AJAX_NRLLM_PROVIDER_TEST = '/ajax/nrllm/provider/test';
 
     private ProviderController $controller;
+
     private ProviderRepository $providerRepository;
+
     private PersistenceManagerInterface $persistenceManager;
 
     protected function setUp(): void

--- a/Tests/Functional/Controller/Backend/SetupWizardControllerTest.php
+++ b/Tests/Functional/Controller/Backend/SetupWizardControllerTest.php
@@ -42,10 +42,15 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 final class SetupWizardControllerTest extends AbstractFunctionalTestCase
 {
     private const AJAX_NRLLM_WIZARD_GENERATE = '/ajax/nrllm/wizard/generate';
+
     private const AJAX_NRLLM_WIZARD_DETECT = '/ajax/nrllm/wizard/detect';
+
     private const HTTPS_API_OPENAI_COM_V1 = 'https://api.openai.com/v1';
+
     private const ENDPOINT_URL_IS_REQUIRED = 'Endpoint URL is required';
+
     private const AJAX_NRLLM_WIZARD_SAVE = '/ajax/nrllm/wizard/save';
+
     private const APPLICATION_JSON = 'application/json';
 
     private SetupWizardController $controller;

--- a/Tests/Functional/Controller/Backend/SkillSourceControllerTest.php
+++ b/Tests/Functional/Controller/Backend/SkillSourceControllerTest.php
@@ -81,6 +81,7 @@ final class SkillSourceControllerTest extends AbstractFunctionalTestCase
         $source->setTitle('Acme');
         $source->setType(SkillSourceType::SINGLE_FILE->value);
         $source->setUrl('https://github.com/acme/skills/blob/main/SKILL.md');
+
         $repository = $this->get(SkillSourceRepository::class);
         $repository->add($source);
         $this->get(PersistenceManagerInterface::class)->persistAll();

--- a/Tests/Functional/Controller/Backend/TaskExecutionAndRecordsControllerTest.php
+++ b/Tests/Functional/Controller/Backend/TaskExecutionAndRecordsControllerTest.php
@@ -45,14 +45,21 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 final class TaskExecutionAndRecordsControllerTest extends AbstractFunctionalTestCase
 {
     private const AJAX_NRLLM_TASK_LOAD_RECORD_DATA = '/ajax/nrllm/task/load-record-data';
+
     private const AJAX_NRLLM_TASK_FETCH_RECORDS = '/ajax/nrllm/task/fetch-records';
+
     private const AJAX_NRLLM_TASK_REFRESH_INPUT = '/ajax/nrllm/task/refresh-input';
+
     private const AJAX_NRLLM_TASK_EXECUTE = '/ajax/nrllm/task/execute';
+
     private const TASK_NOT_FOUND = 'Task not found';
+
     private const TEST_INPUT = 'test input';
 
     private TaskExecutionController $executionController;
+
     private TaskRecordsController $recordsController;
+
     private TaskRepository $taskRepository;
 
     protected function setUp(): void

--- a/Tests/Functional/Controller/Backend/TaskWizardControllerTest.php
+++ b/Tests/Functional/Controller/Backend/TaskWizardControllerTest.php
@@ -248,6 +248,7 @@ final class TaskWizardControllerTest extends AbstractFunctionalTestCase
         if ($parsedBody !== null) {
             $serverRequest = $serverRequest->withParsedBody($parsedBody);
         }
+
         $serverRequest = $serverRequest->withAttribute('normalizedParams', NormalizedParams::createFromRequest($serverRequest));
         $GLOBALS['TYPO3_REQUEST'] = $serverRequest;
 

--- a/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
@@ -83,6 +83,7 @@ use TYPO3\CMS\Extbase\Mvc\Request as ExtbaseRequest;
 final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
 {
     use LlmServiceManagerTestFactory;
+
     protected function tearDown(): void
     {
         unset($GLOBALS['BE_USER'], $GLOBALS['TYPO3_REQUEST'], $GLOBALS['LANG']);
@@ -255,6 +256,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
                 self::assertIsArray($step['messagesSent'] ?? null);
             }
         }
+
         self::assertSame(2, $llmSteps);
         // Each round's request precedes its response; the tool runs in between.
         self::assertSame(['request', 'llm', 'tool', 'request', 'llm'], $kinds);
@@ -571,6 +573,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
                 $stepKinds[] = $event['step']['kind'] ?? '';
             }
         }
+
         self::assertSame(['request', 'llm', 'tool', 'request', 'llm'], $stepKinds);
 
         $last = end($events);
@@ -589,6 +592,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
 
         $guardrail = new class implements GuardrailInterface {
             use GuardrailIdentityDoubleTrait;
+
             public function checkOutput(CompletionResponse $response): GuardrailResult
             {
                 return GuardrailResult::deny('blocked by test policy');
@@ -618,6 +622,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
 
         $guardrail = new class implements GuardrailInterface {
             use GuardrailIdentityDoubleTrait;
+
             public function checkOutput(CompletionResponse $response): GuardrailResult
             {
                 return GuardrailResult::requireApproval('needs a human');
@@ -645,6 +650,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
 
         $guardrail = new class implements GuardrailInterface {
             use GuardrailIdentityDoubleTrait;
+
             public function checkOutput(CompletionResponse $response): GuardrailResult
             {
                 return GuardrailResult::deny('blocked by test policy');
@@ -684,6 +690,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
                 $blocked = $event;
             }
         }
+
         self::assertIsArray($blocked);
         self::assertFalse($blocked['success']);
         self::assertSame($guardrail::class, $blocked['guardrail']);
@@ -705,11 +712,13 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
 
         $repo                = new RecordingAgentRunRepository();
         $repo->findResult    = $run;
-        $repo->claimsGranted = 1; // the next claim loses
+        $repo->claimsGranted = 1;
+        // the next claim loses
         $persister           = new AgentRunPersister($repo, FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL), new NullLogger());
 
         $config = new LlmConfiguration();
         $config->setIdentifier('cfg');
+
         $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
         $configurationRepository->method('findByUid')->willReturn($config);
 
@@ -749,10 +758,12 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
 
         $repo             = new RecordingAgentRunRepository();
         $repo->findResult = $run;
+
         $persister        = new AgentRunPersister($repo, FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL), new NullLogger());
 
         $config = new LlmConfiguration();
         $config->setIdentifier('cfg');
+
         $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
         $configurationRepository->method('findByUid')->willReturn($config);
 
@@ -795,11 +806,13 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
 
         $repo                     = new RecordingAgentRunRepository();
         $repo->findResult         = $run;
-        $repo->inputClaimsGranted = 1; // the next input claim loses
+        $repo->inputClaimsGranted = 1;
+        // the next input claim loses
         $persister                = new AgentRunPersister($repo, FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL), new NullLogger());
 
         $config = new LlmConfiguration();
         $config->setIdentifier('cfg');
+
         $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
         $configurationRepository->method('findByUid')->willReturn($config);
 

--- a/Tests/Functional/FunctionalTestsBootstrap.php
+++ b/Tests/Functional/FunctionalTestsBootstrap.php
@@ -23,6 +23,7 @@ if (!file_exists($autoloadFile)) {
         1730000001,
     );
 }
+
 require_once $autoloadFile;
 
 // Initialize testing framework

--- a/Tests/Functional/Provider/CircuitBreaker/CacheCircuitBreakerStoreTest.php
+++ b/Tests/Functional/Provider/CircuitBreaker/CacheCircuitBreakerStoreTest.php
@@ -63,7 +63,7 @@ final class CacheCircuitBreakerStoreTest extends AbstractFunctionalTestCase
     {
         // The ad-hoc scheme carries colons the cache frontend rejects; the store
         // must map them to distinct, valid entry identifiers.
-        $this->store->save('ad-hoc:chat:openai', new CircuitState(1, null), 300);
+        $this->store->save('ad-hoc:chat:openai', new CircuitState(1), 300);
         $this->store->save('ad-hoc:chat:groq', new CircuitState(7, 1_700_000_500), 300);
 
         self::assertSame(1, $this->store->load('ad-hoc:chat:openai')->consecutiveFailures);

--- a/Tests/Functional/Provider/Middleware/BudgetMiddlewarePipelineTest.php
+++ b/Tests/Functional/Provider/Middleware/BudgetMiddlewarePipelineTest.php
@@ -41,6 +41,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 final class BudgetMiddlewarePipelineTest extends AbstractFunctionalTestCase
 {
     private const TABLE_BUDGET = 'tx_nrllm_user_budget';
+
     private const TABLE_USAGE  = 'tx_nrllm_service_usage';
 
     private const BE_USER_UID = 42;
@@ -196,7 +197,7 @@ final class BudgetMiddlewarePipelineTest extends AbstractFunctionalTestCase
             },
         );
 
-        self::assertTrue($terminalRan, 'Another configuration\'s usage must not trip this configuration\'s cap.');
+        self::assertTrue($terminalRan, "Another configuration's usage must not trip this configuration's cap.");
     }
 
     /**
@@ -236,6 +237,7 @@ final class BudgetMiddlewarePipelineTest extends AbstractFunctionalTestCase
         if ($uid !== null) {
             $config->_setProperty('uid', $uid);
         }
+
         $config->setMaxCostPerDay($maxCostPerDay);
 
         return $config;

--- a/Tests/Functional/Provider/ProviderConnectionTest.php
+++ b/Tests/Functional/Provider/ProviderConnectionTest.php
@@ -155,6 +155,7 @@ final class ProviderConnectionTest extends AbstractFunctionalTestCase
             fclose($socket);
             return true;
         }
+
         return false;
     }
 }

--- a/Tests/Functional/Repository/BeGroupAccessControlTest.php
+++ b/Tests/Functional/Repository/BeGroupAccessControlTest.php
@@ -60,6 +60,7 @@ final class BeGroupAccessControlTest extends AbstractFunctionalTestCase
         foreach ($config->getBeGroups() as $group) {
             $uids[] = $group->getUid();
         }
+
         self::assertSame([5], $uids);
     }
 

--- a/Tests/Functional/Repository/LlmConfigurationFallbackChainTest.php
+++ b/Tests/Functional/Repository/LlmConfigurationFallbackChainTest.php
@@ -36,6 +36,7 @@ use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 class LlmConfigurationFallbackChainTest extends AbstractFunctionalTestCase
 {
     private LlmConfigurationRepository $subject;
+
     private PersistenceManager $persistenceManager;
 
     protected function setUp(): void

--- a/Tests/Functional/Repository/LlmConfigurationRepositoryTest.php
+++ b/Tests/Functional/Repository/LlmConfigurationRepositoryTest.php
@@ -25,6 +25,7 @@ use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 class LlmConfigurationRepositoryTest extends AbstractFunctionalTestCase
 {
     private LlmConfigurationRepository $subject;
+
     private PersistenceManager $persistenceManager;
 
     protected function setUp(): void

--- a/Tests/Functional/Repository/ModelRepositoryTest.php
+++ b/Tests/Functional/Repository/ModelRepositoryTest.php
@@ -31,7 +31,9 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 final class ModelRepositoryTest extends AbstractFunctionalTestCase
 {
     private ModelRepository $repository;
+
     private ProviderRepository $providerRepository;
+
     private PersistenceManagerInterface $persistenceManager;
 
     protected function setUp(): void
@@ -279,7 +281,7 @@ final class ModelRepositoryTest extends AbstractFunctionalTestCase
         self::assertGreaterThan(0, $models->count());
 
         // Verify we got the expected models by UID
-        $uids = array_map(fn($m) => $m->getUid(), $models->toArray());
+        $uids = array_map(fn(Model $m): ?int => $m->getUid(), $models->toArray());
         self::assertContains(1, $uids, 'Should find gpt-5 (uid=1) with chat capability');
         self::assertContains(3, $uids, 'Should find llama3 (uid=3) with chat capability');
 
@@ -298,7 +300,7 @@ final class ModelRepositoryTest extends AbstractFunctionalTestCase
         self::assertGreaterThan(0, $models->count());
 
         // Verify correct models returned by UID
-        $uids = array_map(fn($m) => $m->getUid(), $models->toArray());
+        $uids = array_map(fn(Model $m): ?int => $m->getUid(), $models->toArray());
         self::assertContains(1, $uids);
         self::assertContains(3, $uids);
     }
@@ -321,7 +323,7 @@ final class ModelRepositoryTest extends AbstractFunctionalTestCase
         self::assertGreaterThan(0, $models->count());
 
         // Verify correct model returned by UID
-        $uids = array_map(fn($m) => $m->getUid(), $models->toArray());
+        $uids = array_map(fn(Model $m): ?int => $m->getUid(), $models->toArray());
         self::assertContains(1, $uids, 'Should find gpt-5 with vision capability');
     }
 

--- a/Tests/Functional/Repository/ProviderRepositoryTest.php
+++ b/Tests/Functional/Repository/ProviderRepositoryTest.php
@@ -29,6 +29,7 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 final class ProviderRepositoryTest extends AbstractFunctionalTestCase
 {
     private ProviderRepository $repository;
+
     private PersistenceManagerInterface $persistenceManager;
 
     protected function setUp(): void
@@ -187,6 +188,7 @@ final class ProviderRepositoryTest extends AbstractFunctionalTestCase
             $provider->setIsActive(false);
             $this->repository->update($provider);
         }
+
         $this->persistenceManager->persistAll();
         $this->persistenceManager->clearState();
 

--- a/Tests/Functional/Repository/TaskRepositoryTest.php
+++ b/Tests/Functional/Repository/TaskRepositoryTest.php
@@ -28,6 +28,7 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 final class TaskRepositoryTest extends AbstractFunctionalTestCase
 {
     private TaskRepository $repository;
+
     private PersistenceManagerInterface $persistenceManager;
 
     protected function setUp(): void

--- a/Tests/Functional/Service/Evaluation/EvaluationResultRepositoryTest.php
+++ b/Tests/Functional/Service/Evaluation/EvaluationResultRepositoryTest.php
@@ -34,8 +34,11 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 final class EvaluationResultRepositoryTest extends AbstractFunctionalTestCase
 {
     private const SET = 'nr_llm.smoke';
+
     private const MODEL = 'gpt-test';
+
     private const GRADER = 'deterministic';
+
     private const TABLE = 'tx_nrllm_eval_result';
 
     private EvaluationResultRepository $repository;
@@ -168,6 +171,7 @@ final class EvaluationResultRepositoryTest extends AbstractFunctionalTestCase
     {
         self::assertNull($this->repository->meanQualityScoreForModel('unseen-model', self::GRADER));
     }
+
     #[Test]
     public function findLatestSegregatesByGrader(): void
     {

--- a/Tests/Functional/Service/Fixtures/ScriptedToolAdapter.php
+++ b/Tests/Functional/Service/Fixtures/ScriptedToolAdapter.php
@@ -63,7 +63,6 @@ final class ScriptedToolAdapter implements ProviderInterface, ToolCapableInterfa
             usage: new UsageStatistics(5, 4, 9),
             finishReason: 'stop',
             provider: 'scripted-fake',
-            toolCalls: null,
         );
     }
 

--- a/Tests/Functional/Service/Governance/GovernanceEventRepositoryTest.php
+++ b/Tests/Functional/Service/Governance/GovernanceEventRepositoryTest.php
@@ -23,6 +23,7 @@ final class GovernanceEventRepositoryTest extends AbstractFunctionalTestCase
     private const TABLE = 'tx_nrllm_governance_event';
 
     private GovernanceEventRepository $repository;
+
     private ConnectionPool $connectionPool;
 
     protected function setUp(): void

--- a/Tests/Functional/Service/Health/ProviderHealthRepositoryTest.php
+++ b/Tests/Functional/Service/Health/ProviderHealthRepositoryTest.php
@@ -23,6 +23,7 @@ final class ProviderHealthRepositoryTest extends AbstractFunctionalTestCase
     private const TABLE = 'tx_nrllm_telemetry';
 
     private ProviderHealthRepository $repository;
+
     private ConnectionPool $connectionPool;
 
     protected function setUp(): void

--- a/Tests/Functional/Service/LlmConfigurationServiceTest.php
+++ b/Tests/Functional/Service/LlmConfigurationServiceTest.php
@@ -27,6 +27,7 @@ use PHPUnit\Framework\Attributes\Test;
 class LlmConfigurationServiceTest extends AbstractFunctionalTestCase
 {
     private LlmConfigurationService $subject;
+
     private LlmConfigurationRepository $repository;
 
     protected function setUp(): void

--- a/Tests/Functional/Service/LlmServiceManagerToolsConfigurationTest.php
+++ b/Tests/Functional/Service/LlmServiceManagerToolsConfigurationTest.php
@@ -41,6 +41,7 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 final class LlmServiceManagerToolsConfigurationTest extends AbstractFunctionalTestCase
 {
     use LlmServiceManagerTestFactory;
+
     #[Test]
     public function chatWithToolsForConfigurationResolvesAdapterFromConfigurationAndReturnsToolCall(): void
     {

--- a/Tests/Functional/Service/Privacy/PrivacyPurgeTest.php
+++ b/Tests/Functional/Service/Privacy/PrivacyPurgeTest.php
@@ -31,6 +31,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 final class PrivacyPurgeTest extends AbstractFunctionalTestCase
 {
     private const EVAL_TABLE  = 'tx_nrllm_eval_result';
+
     private const AUDIT_TABLE = 'tx_nrllm_skill_audit';
 
     #[Test]

--- a/Tests/Functional/Service/Privacy/RetentionCoverageTest.php
+++ b/Tests/Functional/Service/Privacy/RetentionCoverageTest.php
@@ -240,6 +240,7 @@ final class RetentionCoverageTest extends AbstractFunctionalTestCase
 
         $runConnection = $connectionPool->getConnectionForTable('tx_nrllm_agentrun');
         $runConnection->insert('tx_nrllm_agentrun', $this->runRow('run-1', AgentRunStatus::COMPLETED, $timestamp));
+
         $runUid = (int)$runConnection->lastInsertId();
 
         $connectionPool->getConnectionForTable('tx_nrllm_agentrun_event')

--- a/Tests/Functional/Service/Retrieval/DatabaseSearchBackendTest.php
+++ b/Tests/Functional/Service/Retrieval/DatabaseSearchBackendTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Functional\Service\Retrieval;
 
 use Netresearch\NrLlm\Service\Retrieval\AccessContext;
 use Netresearch\NrLlm\Service\Retrieval\DatabaseSearchBackend;
+use Netresearch\NrLlm\Service\Retrieval\EvidenceSource;
 use Netresearch\NrLlm\Service\Retrieval\RetrievalQuery;
 use Netresearch\NrLlm\Service\Retrieval\SourceReference;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
@@ -174,7 +175,7 @@ final class DatabaseSearchBackendTest extends AbstractFunctionalTestCase
             AccessContext::publicOnly(),
         );
 
-        $ids = array_map(static fn($source): string => $source->sourceId, $result->sources);
+        $ids = array_map(static fn(EvidenceSource $source): string => $source->sourceId, $result->sources);
         self::assertContains('database:2:0', $ids);
 
         $migration = null;
@@ -183,6 +184,7 @@ final class DatabaseSearchBackendTest extends AbstractFunctionalTestCase
                 $migration = $source;
             }
         }
+
         self::assertNotNull($migration);
         self::assertSame('Aikido Migration Services', $migration->title);
         self::assertSame('http://localhost:59999/migration', $migration->url);
@@ -198,7 +200,7 @@ final class DatabaseSearchBackendTest extends AbstractFunctionalTestCase
             AccessContext::publicOnly(),
         );
 
-        $ids = array_map(static fn($source): string => $source->sourceId, $result->sources);
+        $ids = array_map(static fn(EvidenceSource $source): string => $source->sourceId, $result->sources);
         self::assertNotContains('database:3:0', $ids, 'hidden page leaked');
         self::assertNotContains('database:4:0', $ids, 'fe_group-protected page leaked');
         self::assertNotContains('database:5:0', $ids, 'no_search page leaked');
@@ -212,7 +214,7 @@ final class DatabaseSearchBackendTest extends AbstractFunctionalTestCase
             AccessContext::publicOnly(),
         );
 
-        $ids = array_map(static fn($source): string => $source->sourceId, $result->sources);
+        $ids = array_map(static fn(EvidenceSource $source): string => $source->sourceId, $result->sources);
         self::assertContains('database:2:1', $ids);
 
         foreach ($result->sources as $source) {
@@ -238,7 +240,7 @@ final class DatabaseSearchBackendTest extends AbstractFunctionalTestCase
             AccessContext::publicOnly(),
         );
 
-        $ids = array_map(static fn($source): string => $source->sourceId, $result->sources);
+        $ids = array_map(static fn(EvidenceSource $source): string => $source->sourceId, $result->sources);
         self::assertSame(['database:2:1'], $ids, 'untranslated page cited under a language-routed URL');
     }
 
@@ -250,7 +252,7 @@ final class DatabaseSearchBackendTest extends AbstractFunctionalTestCase
             AccessContext::publicOnly(),
         );
 
-        $ids = array_map(static fn($source): string => $source->sourceId, $result->sources);
+        $ids = array_map(static fn(EvidenceSource $source): string => $source->sourceId, $result->sources);
         self::assertNotContains('database:7:0', $ids, 'child of fe_group-restricted section leaked');
         self::assertNotContains('database:9:0', $ids, 'child of hidden section leaked');
 
@@ -300,7 +302,7 @@ final class DatabaseSearchBackendTest extends AbstractFunctionalTestCase
             AccessContext::publicOnly(),
         );
 
-        $ids = array_map(static fn($source): string => $source->sourceId, $result->sources);
+        $ids = array_map(static fn(EvidenceSource $source): string => $source->sourceId, $result->sources);
         self::assertContains('database:2:0', $ids);
     }
 
@@ -312,7 +314,7 @@ final class DatabaseSearchBackendTest extends AbstractFunctionalTestCase
             AccessContext::publicOnly(),
         );
 
-        $ids = array_map(static fn($source): string => $source->sourceId, $result->sources);
+        $ids = array_map(static fn(EvidenceSource $source): string => $source->sourceId, $result->sources);
         self::assertSame('database:2:0', $ids[0] ?? null, 'page covering all three words must rank first');
         self::assertContains('database:30:0', $ids, 'single-word match missing entirely');
     }
@@ -336,6 +338,7 @@ final class DatabaseSearchBackendTest extends AbstractFunctionalTestCase
                 return;
             }
         }
+
         self::fail('database:31:0 missing from the result');
     }
 

--- a/Tests/Functional/Service/Retrieval/IndexedSearchBackendTest.php
+++ b/Tests/Functional/Service/Retrieval/IndexedSearchBackendTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Functional\Service\Retrieval;
 
 use Netresearch\NrLlm\Service\Retrieval\AccessContext;
+use Netresearch\NrLlm\Service\Retrieval\EvidenceSource;
 use Netresearch\NrLlm\Service\Retrieval\IndexedSearchBackend;
 use Netresearch\NrLlm\Service\Retrieval\RetrievalQuery;
 use Netresearch\NrLlm\Service\Retrieval\SourceReference;
@@ -78,9 +79,9 @@ final class IndexedSearchBackendTest extends AbstractFunctionalTestCase
             'sorting' => 2, 'slug' => '/migration',
         ]);
 
-        $this->publicPhash = self::indexHash('public-doc');
-        $this->restrictedPhash = self::indexHash('restricted-doc');
-        $this->regainedPhash = self::indexHash('regained-doc');
+        $this->publicPhash = $this->indexHash('public-doc');
+        $this->restrictedPhash = $this->indexHash('restricted-doc');
+        $this->regainedPhash = $this->indexHash('regained-doc');
 
         $connection = $connectionPool->getConnectionForTable('index_phash');
         self::assertInstanceOf(Connection::class, $connection);
@@ -91,7 +92,7 @@ final class IndexedSearchBackendTest extends AbstractFunctionalTestCase
         // The "regained" document was ALSO rendered by an anonymous session.
         $connection->insert('index_grlist', [
             'phash' => $this->regainedPhash, 'phash_x' => $this->regainedPhash,
-            'hash_gr_list' => self::indexHash('0,-1'), 'gr_list' => '0,-1',
+            'hash_gr_list' => $this->indexHash('0,-1'), 'gr_list' => '0,-1',
         ]);
 
         $connection->insert('index_fulltext', [
@@ -108,8 +109,9 @@ final class IndexedSearchBackendTest extends AbstractFunctionalTestCase
         ]);
 
         foreach (['aikido', 'migration', 'insider', 'schedule'] as $word) {
-            $connection->insert('index_words', ['wid' => self::indexHash($word), 'baseword' => $word]);
+            $connection->insert('index_words', ['wid' => $this->indexHash($word), 'baseword' => $word]);
         }
+
         $this->relate($connection, $this->publicPhash, 'aikido', 4, 12);
         $this->relate($connection, $this->publicPhash, 'migration', 4, 8);
         $this->relate($connection, $this->restrictedPhash, 'aikido', 0, 5);
@@ -135,7 +137,7 @@ final class IndexedSearchBackendTest extends AbstractFunctionalTestCase
             AccessContext::publicOnly(),
         );
 
-        $ids = array_map(static fn($source): string => $source->sourceId, $result->sources);
+        $ids = array_map(static fn(EvidenceSource $source): string => $source->sourceId, $result->sources);
         self::assertContains('indexed_search:' . $this->publicPhash, $ids);
         self::assertContains('indexed_search:' . $this->regainedPhash, $ids, 'anonymous index_grlist row ignored');
         self::assertNotContains('indexed_search:' . $this->restrictedPhash, $ids, 'group-restricted document leaked');
@@ -154,7 +156,7 @@ final class IndexedSearchBackendTest extends AbstractFunctionalTestCase
             RetrievalQuery::create('aikido migration'),
             AccessContext::publicOnly(),
         );
-        $ids = array_map(static fn($source): string => $source->sourceId, $result->sources);
+        $ids = array_map(static fn(EvidenceSource $source): string => $source->sourceId, $result->sources);
         self::assertSame(['indexed_search:' . $this->publicPhash], $ids);
 
         $none = $this->backend->search(
@@ -171,20 +173,20 @@ final class IndexedSearchBackendTest extends AbstractFunctionalTestCase
         // Lexer produces) — it must be ignored, not required.
         $connection = $this->connectionPool->getConnectionForTable('index_words');
         self::assertInstanceOf(Connection::class, $connection);
-        $connection->insert('index_words', ['wid' => self::indexHash('the'), 'baseword' => 'the', 'is_stopword' => 1]);
+        $connection->insert('index_words', ['wid' => $this->indexHash('the'), 'baseword' => 'the', 'is_stopword' => 1]);
 
         $repeated = $this->backend->search(
             RetrievalQuery::create('aikido aikido migration'),
             AccessContext::publicOnly(),
         );
-        $ids = array_map(static fn($source): string => $source->sourceId, $repeated->sources);
+        $ids = array_map(static fn(EvidenceSource $source): string => $source->sourceId, $repeated->sources);
         self::assertSame(['indexed_search:' . $this->publicPhash], $ids, 'duplicate query word broke the required count');
 
         $withStopword = $this->backend->search(
             RetrievalQuery::create('the aikido migration'),
             AccessContext::publicOnly(),
         );
-        $ids = array_map(static fn($source): string => $source->sourceId, $withStopword->sources);
+        $ids = array_map(static fn(EvidenceSource $source): string => $source->sourceId, $withStopword->sources);
         self::assertSame(['indexed_search:' . $this->publicPhash], $ids, 'stopword was treated as a required word');
     }
 
@@ -201,7 +203,7 @@ final class IndexedSearchBackendTest extends AbstractFunctionalTestCase
             AccessContext::publicOnly(),
         );
 
-        $ids = array_map(static fn($source): string => $source->sourceId, $result->sources);
+        $ids = array_map(static fn(EvidenceSource $source): string => $source->sourceId, $result->sources);
         self::assertSame(['indexed_search:' . $this->publicPhash], $ids);
 
         // The gr_list guard must hold on the LIKE fallback path too: the
@@ -219,11 +221,11 @@ final class IndexedSearchBackendTest extends AbstractFunctionalTestCase
         $connection = $this->connectionPool->getConnectionForTable('index_phash');
         self::assertInstanceOf(Connection::class, $connection);
 
-        $filePhash = self::indexHash('file-doc');
+        $filePhash = $this->indexHash('file-doc');
         $connection->insert('index_phash', [
             'phash' => $filePhash,
             'phash_grouping' => $filePhash,
-            'contentHash' => self::indexHash('content-' . $filePhash),
+            'contentHash' => $this->indexHash('content-' . $filePhash),
             'data_page_id' => 2,
             'gr_list' => '0,-1',
             'item_type' => 'pdf',
@@ -240,7 +242,7 @@ final class IndexedSearchBackendTest extends AbstractFunctionalTestCase
             AccessContext::publicOnly(),
         );
 
-        $ids = array_map(static fn($source): string => $source->sourceId, $result->sources);
+        $ids = array_map(static fn(EvidenceSource $source): string => $source->sourceId, $result->sources);
         self::assertNotContains('indexed_search:' . $filePhash, $ids, 'non-page item_type leaked');
     }
 
@@ -288,7 +290,7 @@ final class IndexedSearchBackendTest extends AbstractFunctionalTestCase
         $connection->insert('index_phash', [
             'phash' => $phash,
             'phash_grouping' => $phash,
-            'contentHash' => self::indexHash('content-' . $phash),
+            'contentHash' => $this->indexHash('content-' . $phash),
             'data_page_id' => $pageUid,
             'gr_list' => $grList,
             'item_type' => '0',
@@ -301,7 +303,7 @@ final class IndexedSearchBackendTest extends AbstractFunctionalTestCase
     private function relate(Connection $connection, string $phash, string $word, int $flags, int $freq): void
     {
         $connection->insert('index_rel', [
-            'phash' => $phash, 'wid' => self::indexHash($word),
+            'phash' => $phash, 'wid' => $this->indexHash($word),
             'count' => 1, 'first' => 1, 'freq' => $freq, 'flags' => $flags,
         ]);
     }
@@ -311,7 +313,7 @@ final class IndexedSearchBackendTest extends AbstractFunctionalTestCase
      * the md5 of the lowercased word since TYPO3 13, #102975) — a storage
      * FORMAT, not a security control.
      */
-    private static function indexHash(string $value): string
+    private function indexHash(string $value): string
     {
         return md5($value); // NOSONAR php:S4790 — index table format, not cryptography
     }

--- a/Tests/Functional/Service/Retrieval/KeSearchBackendTest.php
+++ b/Tests/Functional/Service/Retrieval/KeSearchBackendTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Functional\Service\Retrieval;
 
 use Netresearch\NrLlm\Service\Retrieval\AccessContext;
+use Netresearch\NrLlm\Service\Retrieval\EvidenceSource;
 use Netresearch\NrLlm\Service\Retrieval\KeSearchBackend;
 use Netresearch\NrLlm\Service\Retrieval\RetrievalQuery;
 use Netresearch\NrLlm\Service\Retrieval\SourceReference;
@@ -154,7 +155,7 @@ final class KeSearchBackendTest extends AbstractFunctionalTestCase
             AccessContext::publicOnly(),
         );
 
-        $ids = array_map(static fn($source): string => $source->sourceId, $result->sources);
+        $ids = array_map(static fn(EvidenceSource $source): string => $source->sourceId, $result->sources);
         self::assertContains('ke_search:1', $ids, 'public page row missing');
         self::assertContains('ke_search:5', $ids, 'language=-1 external row missing');
 
@@ -165,6 +166,7 @@ final class KeSearchBackendTest extends AbstractFunctionalTestCase
                 self::assertSame(2, $source->pageUid);
                 self::assertStringContainsString('aikido', mb_strtolower($source->excerpt));
             }
+
             if ($source->sourceId === 'ke_search:5') {
                 self::assertSame('https://aikido.example.org/rules', $source->url);
                 self::assertNull($source->pageUid);
@@ -180,7 +182,7 @@ final class KeSearchBackendTest extends AbstractFunctionalTestCase
             AccessContext::publicOnly(),
         );
 
-        $ids = array_map(static fn($source): string => $source->sourceId, $result->sources);
+        $ids = array_map(static fn(EvidenceSource $source): string => $source->sourceId, $result->sources);
         self::assertNotContains('ke_search:2', $ids, 'fe_group-restricted row leaked');
         self::assertNotContains('ke_search:3', $ids, 'expired row leaked');
         self::assertNotContains('ke_search:4', $ids, 'foreign-language row leaked');
@@ -236,7 +238,7 @@ final class KeSearchBackendTest extends AbstractFunctionalTestCase
             AccessContext::publicOnly(),
         );
 
-        $ids = array_map(static fn($source): string => $source->sourceId, $result->sources);
+        $ids = array_map(static fn(EvidenceSource $source): string => $source->sourceId, $result->sources);
         self::assertContains('ke_search:1', $ids);
     }
 
@@ -253,7 +255,7 @@ final class KeSearchBackendTest extends AbstractFunctionalTestCase
             RetrievalQuery::create('aikido', 8, 'main'),
             AccessContext::publicOnly(),
         );
-        $ids = array_map(static fn($source): string => $source->sourceId, $result->sources);
+        $ids = array_map(static fn(EvidenceSource $source): string => $source->sourceId, $result->sources);
         self::assertContains('ke_search:1', $ids);
         self::assertNotContains('ke_search:5', $ids, 'external row not attributable to a site');
     }

--- a/Tests/Functional/Service/Skill/Fixtures/FakeGitHubClient.php
+++ b/Tests/Functional/Service/Skill/Fixtures/FakeGitHubClient.php
@@ -62,6 +62,7 @@ final readonly class FakeGitHubClient implements GitHubClientInterface
                 404,
             );
         }
+
         return $bodies[$path];
     }
 

--- a/Tests/Functional/Service/Skill/SkillSyncServiceTest.php
+++ b/Tests/Functional/Service/Skill/SkillSyncServiceTest.php
@@ -30,15 +30,25 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 final class SkillSyncServiceTest extends AbstractFunctionalTestCase
 {
     private const REPO_URL = 'https://github.com/acme/skills';
+
     private const SINGLE_FILE_URL = 'https://github.com/acme/skills/blob/main/SKILL.md';
+
     private const MARKET_URL = 'https://raw.githubusercontent.com/acme/market/main/marketplace.json';
+
     private const SKILL_A_PATH = 'skills/a/SKILL.md';
+
     private const SKILL_B_PATH = 'skills/b/SKILL.md';
+
     private const SKILL_A_ID = '10:skills/a/SKILL.md';
+
     private const SKILL_B_ID = '10:skills/b/SKILL.md';
+
     private const PLUGIN_A = 'p1/repoa';
+
     private const PLUGIN_B = 'p2/repob';
+
     private const MARKET_A_ID = '30:' . self::PLUGIN_A . '/' . self::SKILL_A_PATH;
+
     private const MARKET_B_ID = '30:' . self::PLUGIN_B . '/' . self::SKILL_A_PATH;
 
     private function service(FakeGitHubClient $gitHub, int $maxFiles = 500, int $maxSeconds = 120, int $heartbeatSeconds = 30): SkillSyncService
@@ -137,6 +147,7 @@ final class SkillSyncServiceTest extends AbstractFunctionalTestCase
                 'bodies' => [self::SKILL_A_PATH => $this->md('M' . $i, 'body ' . $i)],
             ];
         }
+
         return new FakeGitHubClient(
             repos: $repos,
             repoErrors: $repoErrors,
@@ -341,7 +352,8 @@ final class SkillSyncServiceTest extends AbstractFunctionalTestCase
     {
         $source = $this->repoSource();
         $source->setSyncStatus(SyncStatus::SYNCING->value);
-        $source->setLastSynced(time()); // fresh heartbeat → lock is considered active
+        $source->setLastSynced(time());
+        // fresh heartbeat → lock is considered active
         $result = $this->service(new FakeGitHubClient('sha1', [], []))->sync($source);
         self::assertSame(SyncStatus::SYNCING, $result->status);
         self::assertSame(['A sync is already running for this source.'], $result->errors);
@@ -352,7 +364,8 @@ final class SkillSyncServiceTest extends AbstractFunctionalTestCase
     {
         $source = $this->repoSource();
         $source->setSyncStatus(SyncStatus::SYNCING->value);
-        $source->setLastSynced(time() - 3600); // older than STALE_LOCK_SECONDS → stale, proceed
+        $source->setLastSynced(time() - 3600);
+        // older than STALE_LOCK_SECONDS → stale, proceed
         $gitHub = new FakeGitHubClient('sha1', [self::SKILL_A_PATH], [
             self::SKILL_A_PATH => $this->md('A', 'body'),
         ]);
@@ -454,6 +467,7 @@ final class SkillSyncServiceTest extends AbstractFunctionalTestCase
         $source->setType(SkillSourceType::REPO->value);
         $source->setUrl(self::REPO_URL);
         $source->setRef('main');
+
         $sourceRepository = $this->get(SkillSourceRepository::class);
         $sourceRepository->add($source);
         $this->get(PersistenceManagerInterface::class)->persistAll();

--- a/Tests/Functional/Service/Streaming/StreamingDispatcherTest.php
+++ b/Tests/Functional/Service/Streaming/StreamingDispatcherTest.php
@@ -37,9 +37,11 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 final class StreamingDispatcherTest extends AbstractFunctionalTestCase
 {
     private const USAGE_TABLE     = 'tx_nrllm_service_usage';
+
     private const TELEMETRY_TABLE = 'tx_nrllm_telemetry';
 
     private StreamingDispatcher $dispatcher;
+
     private ConnectionPool $connectionPool;
 
     protected function setUp(): void

--- a/Tests/Functional/Service/Task/DeprecationLogReaderTest.php
+++ b/Tests/Functional/Service/Task/DeprecationLogReaderTest.php
@@ -68,6 +68,7 @@ final class DeprecationLogReaderTest extends AbstractFunctionalTestCase
         for ($i = 1; $i <= 10; ++$i) {
             $lines[] = 'deprecation entry ' . $i;
         }
+
         $this->writeLog(implode("\n", $lines));
 
         $tail = $this->reader->readTail(3);

--- a/Tests/Functional/Service/Telemetry/TelemetryRepositoryTest.php
+++ b/Tests/Functional/Service/Telemetry/TelemetryRepositoryTest.php
@@ -23,6 +23,7 @@ final class TelemetryRepositoryTest extends AbstractFunctionalTestCase
     private const TABLE = 'tx_nrllm_telemetry';
 
     private TelemetryRepository $repository;
+
     private ConnectionPool $connectionPool;
 
     protected function setUp(): void

--- a/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
+++ b/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
@@ -12,6 +12,8 @@ namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
 use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
 use Netresearch\NrLlm\Domain\Enum\PrivacyLevel;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRunEvent;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
@@ -366,8 +368,8 @@ final class AgentRunPersisterTest extends AbstractFunctionalTestCase
 
         $events = $this->repository->findEvents($handle->runUid);
         self::assertCount(3, $events);
-        self::assertSame([0, 1, 2], array_map(static fn($e): int => $e->sequence, $events));
-        self::assertSame(['request', 'llm', 'tool'], array_map(static fn($e): string => $e->kind, $events));
+        self::assertSame([0, 1, 2], array_map(static fn(AgentRunEvent $e): int => $e->sequence, $events));
+        self::assertSame(['request', 'llm', 'tool'], array_map(static fn(AgentRunEvent $e): string => $e->kind, $events));
         // The full RunStep snapshot survives the round-trip.
         self::assertSame('answer', $events[1]->payload['content'] ?? null);
         self::assertSame('fetch_logs', $events[2]->payload['toolName'] ?? null);
@@ -554,6 +556,7 @@ final class AgentRunPersisterTest extends AbstractFunctionalTestCase
                 'crdate' => $old,
             ]);
         }
+
         $fresh = $this->persister->begin(null, 0);
         self::assertNotNull($fresh);
         $this->persister->settleCompleted($fresh, new ToolLoopResult('x', [], 1, false, UsageStatistics::fromTokens(0, 0)));
@@ -663,7 +666,7 @@ final class AgentRunPersisterTest extends AbstractFunctionalTestCase
 
         $found = $this->repository->findStaleRunning(time());
 
-        $uuids = array_map(static fn($r): string => $r->uuid, $found);
+        $uuids = array_map(static fn(AgentRun $r): string => $r->uuid, $found);
         self::assertContains($stale->uuid, $uuids);
         self::assertNotContains($fresh->uuid, $uuids);
         self::assertNotContains($interactive->uuid, $uuids);
@@ -748,7 +751,7 @@ final class AgentRunPersisterTest extends AbstractFunctionalTestCase
 
         $awaiting = $this->persister->findAwaitingRuns();
         self::assertNotNull($awaiting);
-        $uuids = array_map(static fn($run): string => $run->uuid, $awaiting);
+        $uuids = array_map(static fn(AgentRun $run): string => $run->uuid, $awaiting);
         self::assertContains($approval->uuid, $uuids);
         self::assertContains($input->uuid, $uuids);
         self::assertNotContains($running->uuid, $uuids);
@@ -785,7 +788,8 @@ final class AgentRunPersisterTest extends AbstractFunctionalTestCase
         foreach ($terminal as $run) {
             self::assertContains($run->status, ['completed', 'failed', 'cancelled']);
         }
-        $uuids = array_map(static fn($run): string => $run->uuid, $terminal);
+
+        $uuids = array_map(static fn(AgentRun $run): string => $run->uuid, $terminal);
         self::assertContains($done->uuid, $uuids);
         self::assertContains($failed->uuid, $uuids);
         self::assertContains($cancelled->uuid, $uuids);

--- a/Tests/Functional/Service/Tool/AgentRunRepositoryAggregatesTest.php
+++ b/Tests/Functional/Service/Tool/AgentRunRepositoryAggregatesTest.php
@@ -30,6 +30,7 @@ final class AgentRunRepositoryAggregatesTest extends AbstractFunctionalTestCase
     private const TABLE = 'tx_nrllm_agentrun';
 
     private AgentRunRepository $repository;
+
     private ConnectionPool $connectionPool;
 
     protected function setUp(): void

--- a/Tests/Functional/Service/Tool/FetchLogsToolTest.php
+++ b/Tests/Functional/Service/Tool/FetchLogsToolTest.php
@@ -29,7 +29,9 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 final class FetchLogsToolTest extends AbstractFunctionalTestCase
 {
     private const RAW_IP = '203.0.113.55';
+
     private const USER_ID = '4242';
+
     private const PAYLOAD_USERNAME = 'secretadmin';
 
     private FetchLogsTool $tool;

--- a/Tests/Functional/Service/Tool/GetLastExceptionToolFunctionalTest.php
+++ b/Tests/Functional/Service/Tool/GetLastExceptionToolFunctionalTest.php
@@ -95,6 +95,7 @@ final class GetLastExceptionToolFunctionalTest extends AbstractFunctionalTestCas
         if (is_file($seededLog)) {
             unlink($seededLog);
         }
+
         GeneralUtility::rmdir(Environment::getProjectPath() . '/probe-fixture', true);
         parent::tearDown();
     }

--- a/Tests/Functional/Service/Tool/ReadRecordsToolTest.php
+++ b/Tests/Functional/Service/Tool/ReadRecordsToolTest.php
@@ -141,8 +141,10 @@ final class ReadRecordsToolTest extends AbstractFunctionalTestCase
                 // Parity: no cell re-exposes a value absent from the text egress.
                 self::assertStringContainsString($cell, $result->content);
             }
+
             $headers[] = $row[2] ?? null;
         }
+
         self::assertContains('Alpha', $headers);
         self::assertContains('Beta', $headers);
     }

--- a/Tests/Functional/Service/Tool/SearchFalFilesToolTest.php
+++ b/Tests/Functional/Service/Tool/SearchFalFilesToolTest.php
@@ -125,6 +125,7 @@ final class SearchFalFilesToolTest extends AbstractFunctionalTestCase
             $this->tool->execute(['query' => 'brochure'], ToolExecutionContext::none())->content,
         );
     }
+
     #[Test]
     public function searchIsCaseInsensitive(): void
     {

--- a/Tests/Functional/Service/Tool/ToolAvailabilityServiceTest.php
+++ b/Tests/Functional/Service/Tool/ToolAvailabilityServiceTest.php
@@ -28,6 +28,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 final class ToolAvailabilityServiceTest extends AbstractFunctionalTestCase
 {
     private ToolStateRepository $stateRepository;
+
     private ToolGroupStateRepository $groupStateRepository;
 
     protected function setUp(): void

--- a/Tests/Functional/Service/Tool/ToolDataClassCoverageTest.php
+++ b/Tests/Functional/Service/Tool/ToolDataClassCoverageTest.php
@@ -42,7 +42,7 @@ final class ToolDataClassCoverageTest extends AbstractFunctionalTestCase
             $tool = $registry->get($name);
             self::assertNotNull($tool);
 
-            if (ToolDataClassResolver::defaultForGroup($tool->getGroup()) === null
+            if (!ToolDataClassResolver::defaultForGroup($tool->getGroup()) instanceof ToolDataClass
                 && !in_array($name, self::EXPLICITLY_DECLARED, true)
             ) {
                 $unclassed[] = sprintf('%s (group "%s")', $name, $tool->getGroup());

--- a/Tests/Functional/Service/Tool/ToolEffectCoverageTest.php
+++ b/Tests/Functional/Service/Tool/ToolEffectCoverageTest.php
@@ -58,6 +58,7 @@ final class ToolEffectCoverageTest extends AbstractFunctionalTestCase
                 $writers[] = $name;
             }
         }
+
         sort($writers);
 
         $expected = self::DECLARED_WRITERS;

--- a/Tests/Functional/Service/UsageAnalyticsServiceTest.php
+++ b/Tests/Functional/Service/UsageAnalyticsServiceTest.php
@@ -20,11 +20,13 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 final class UsageAnalyticsServiceTest extends AbstractFunctionalTestCase
 {
     private const LIT_2026_06_01 = '2026-06-01';
+
     private const LIT_2026_06_02 = '2026-06-02';
 
     private const TABLE = 'tx_nrllm_service_usage';
 
     private UsageAnalyticsService $service;
+
     private ConnectionPool $connectionPool;
 
     protected function setUp(): void

--- a/Tests/Functional/Service/UsageTrackerServiceTest.php
+++ b/Tests/Functional/Service/UsageTrackerServiceTest.php
@@ -25,6 +25,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 final class UsageTrackerServiceTest extends AbstractFunctionalTestCase
 {
     private UsageTrackerService $service;
+
     private ConnectionPool $connectionPool;
 
     private const TABLE = 'tx_nrllm_service_usage';

--- a/Tests/Functional/Updates/DataClassEnforcementDefaultUpdateWizardTest.php
+++ b/Tests/Functional/Updates/DataClassEnforcementDefaultUpdateWizardTest.php
@@ -120,10 +120,12 @@ final class DataClassEnforcementDefaultUpdateWizardTest extends AbstractFunction
         if (!is_array($confVars)) {
             $confVars = [];
         }
+
         $extensions = $confVars['EXTENSIONS'] ?? [];
         if (!is_array($extensions)) {
             $extensions = [];
         }
+
         $extensions['nr_llm']   = $nrLlm;
         $confVars['EXTENSIONS'] = $extensions;
         $GLOBALS['TYPO3_CONF_VARS'] = $confVars;

--- a/Tests/Integration/AbstractIntegrationTestCase.php
+++ b/Tests/Integration/AbstractIntegrationTestCase.php
@@ -29,6 +29,7 @@ use Psr\Log\NullLogger;
 abstract class AbstractIntegrationTestCase extends AbstractUnitTestCase
 {
     protected RequestFactoryInterface $requestFactory;
+
     protected StreamFactoryInterface $streamFactory;
 
     protected function setUp(): void
@@ -92,7 +93,7 @@ abstract class AbstractIntegrationTestCase extends AbstractUnitTestCase
         $requests = [];
         $client = self::createStub(ClientInterface::class);
         $client->method('sendRequest')
-            ->willReturnCallback(function (RequestInterface $request) use ($response, &$requests) {
+            ->willReturnCallback(function (RequestInterface $request) use ($response, &$requests): ResponseInterface {
                 $requests[] = $request;
                 return $response;
             });
@@ -207,7 +208,7 @@ abstract class AbstractIntegrationTestCase extends AbstractUnitTestCase
                     'object' => 'embedding',
                     'index' => 0,
                     'embedding' => array_map(
-                        fn() => $this->faker->randomFloat(8, -1, 1),
+                        fn(): float => $this->faker->randomFloat(8, -1, 1),
                         range(1, $dimensions),
                     ),
                 ],

--- a/Tests/Integration/Service/LlmServiceManagerIntegrationTest.php
+++ b/Tests/Integration/Service/LlmServiceManagerIntegrationTest.php
@@ -37,8 +37,11 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 class LlmServiceManagerIntegrationTest extends AbstractIntegrationTestCase
 {
     use LlmServiceManagerTestFactory;
+
     private LlmServiceManager $subject;
+
     private ExtensionConfiguration&MockObject $extensionConfigStub;
+
     private ProviderAdapterRegistryInterface&Stub $adapterRegistryStub;
 
     protected function setUp(): void
@@ -272,7 +275,7 @@ class LlmServiceManagerIntegrationTest extends AbstractIntegrationTestCase
 
         $this->subject->chat(
             [['role' => 'user', 'content' => 'Hello']],
-            new ChatOptions(provider: 'openai', temperature: 0.5, maxTokens: 100),
+            new ChatOptions(temperature: 0.5, maxTokens: 100, provider: 'openai'),
         );
 
         self::assertCount(1, $clientSetup['requests']);

--- a/Tests/Unit/AbstractUnitTestCase.php
+++ b/Tests/Unit/AbstractUnitTestCase.php
@@ -94,9 +94,9 @@ abstract class AbstractUnitTestCase extends TestCase
         $request = self::createStub(RequestInterface::class);
 
         // Use callback to return the same stub for chaining methods
-        $request->method('withHeader')->willReturnCallback(fn() => $request);
-        $request->method('withBody')->willReturnCallback(fn() => $request);
-        $request->method('withoutHeader')->willReturnCallback(fn() => $request);
+        $request->method('withHeader')->willReturnCallback(fn(): Stub => $request);
+        $request->method('withBody')->willReturnCallback(fn(): Stub => $request);
+        $request->method('withoutHeader')->willReturnCallback(fn(): Stub => $request);
         $request->method('getMethod')->willReturn($method);
         $request->method('getUri')->willReturn($uriStub);
 
@@ -110,7 +110,7 @@ abstract class AbstractUnitTestCase extends TestCase
     {
         $stub = self::createStub(StreamFactoryInterface::class);
         $stub->method('createStream')
-            ->willReturnCallback(function (string $content) {
+            ->willReturnCallback(function (string $content): Stub {
                 $stream = $this->createStub(StreamInterface::class);
                 $stream->method('__toString')->willReturn($content);
                 $stream->method('getContents')->willReturn($content);
@@ -153,7 +153,7 @@ abstract class AbstractUnitTestCase extends TestCase
         $vaultHttpClient->method('withAuthentication')->willReturn($vaultHttpClient);
         $vaultHttpClient->method('withReason')->willReturn($vaultHttpClient);
         $vaultHttpClient->method('withTimeout')->willReturn($vaultHttpClient);
-        $vaultHttpClient->method('sendRequest')->willReturnCallback(fn() => $this->createHttpResponseMock(200, '{}'));
+        $vaultHttpClient->method('sendRequest')->willReturnCallback(fn(): ResponseInterface => $this->createHttpResponseMock(200, '{}'));
 
         $stub = self::createStub(VaultServiceInterface::class);
         $stub->method('retrieve')->willReturnCallback(fn(string $id) => $secrets[$id] ?? 'test-secret');
@@ -163,7 +163,7 @@ abstract class AbstractUnitTestCase extends TestCase
         if ($secrets === null) {
             $stub->method('exists')->willReturn(true);
         } else {
-            $stub->method('exists')->willReturnCallback(fn(string $id) => isset($secrets[$id]));
+            $stub->method('exists')->willReturnCallback(fn(string $id): bool => isset($secrets[$id]));
         }
 
         $stub->method('http')->willReturn($vaultHttpClient);
@@ -204,7 +204,7 @@ abstract class AbstractUnitTestCase extends TestCase
             fn(string $name) => $headers[$name] ?? [],
         );
         $response->method('hasHeader')->willReturnCallback(
-            fn(string $name) => isset($headers[$name]),
+            fn(string $name): bool => isset($headers[$name]),
         );
 
         return $response;

--- a/Tests/Unit/Command/Fixture/InMemoryAgentRunRepository.php
+++ b/Tests/Unit/Command/Fixture/InMemoryAgentRunRepository.php
@@ -132,6 +132,7 @@ final class InMemoryAgentRunRepository implements AgentRunRepositoryInterface
         if ($this->refuseRequeueStale) {
             return false;
         }
+
         $this->staleRequeues[] = ['runUid' => $runUid, 'now' => $now];
 
         return true;
@@ -148,6 +149,7 @@ final class InMemoryAgentRunRepository implements AgentRunRepositoryInterface
         if ($this->refuseDeadLetterStale) {
             return false;
         }
+
         $this->staleDeadLetters[] = ['runUid' => $runUid, 'now' => $now, 'reason' => $terminationReason];
 
         return true;

--- a/Tests/Unit/Command/Fixture/InMemoryEvaluationResultRepository.php
+++ b/Tests/Unit/Command/Fixture/InMemoryEvaluationResultRepository.php
@@ -51,7 +51,7 @@ final class InMemoryEvaluationResultRepository implements EvaluationResultReposi
     {
         $latest = $this->findLatest($setIdentifier, $model, $grader);
 
-        return $latest === null ? [] : [$latest];
+        return $latest instanceof EvaluationResultSummary ? [$latest] : [];
     }
 
     public function meanQualityScoreForModel(string $model, string $grader): ?float

--- a/Tests/Unit/Command/PurgePrivacyDataCommandTest.php
+++ b/Tests/Unit/Command/PurgePrivacyDataCommandTest.php
@@ -59,6 +59,7 @@ final class PurgePrivacyDataCommandTest extends TestCase
         $this->sessions->purgeReturns            = 7;
         $this->agentRuns->purgeReturns           = 11;
         $this->agentRuns->purgeUnfinishedReturns = 1;
+
         $this->governance->purgeReturns          = 4;
 
         $tester = new CommandTester($this->command(['retentionDays' => '45']));

--- a/Tests/Unit/Command/ReapStaleAgentRunsCommandTest.php
+++ b/Tests/Unit/Command/ReapStaleAgentRunsCommandTest.php
@@ -138,7 +138,7 @@ final class ReapStaleAgentRunsCommandTest extends TestCase
     public function failsWhenNoMessageBusIsAvailable(): void
     {
         $persister = new AgentRunPersister($this->repository, FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL));
-        $tester    = new CommandTester(new ReapStaleAgentRunsCommand($persister, null));
+        $tester    = new CommandTester(new ReapStaleAgentRunsCommand($persister));
 
         $exit = $tester->execute([]);
 
@@ -216,7 +216,6 @@ final class ReapStaleAgentRunsCommandTest extends TestCase
             startedAt: 0,
             finishedAt: 0,
             crdate: 0,
-            suspendedState: null,
             queuedRequest: '{"messages":[]}',
             claimedBy: 'dead-worker:1',
             leaseExpires: 1,

--- a/Tests/Unit/Command/RetrievalEvalRunCommandTest.php
+++ b/Tests/Unit/Command/RetrievalEvalRunCommandTest.php
@@ -147,6 +147,7 @@ final class RetrievalEvalRunCommandTest extends TestCase
     {
         $repository = new InMemoryEvaluationResultRepository();
         $repository->seed($this->perfectBaseline());
+
         $tester = new CommandTester($this->command(new StaticRetriever(), $repository));
 
         $exitCode = $tester->execute(['set' => self::SET_IDENTIFIER, 'retriever' => self::RETRIEVER_IDENTIFIER]);
@@ -160,6 +161,7 @@ final class RetrievalEvalRunCommandTest extends TestCase
     {
         $repository = new InMemoryEvaluationResultRepository();
         $repository->seed($this->perfectBaseline());
+
         $tester = new CommandTester($this->command(new StaticRetriever(), $repository));
 
         $exitCode = $tester->execute([

--- a/Tests/Unit/Configuration/PrivacyRetentionConfigurationTest.php
+++ b/Tests/Unit/Configuration/PrivacyRetentionConfigurationTest.php
@@ -100,7 +100,11 @@ final class PrivacyRetentionConfigurationTest extends AbstractUnitTestCase
 
         foreach (explode("\n", $contents) as $number => $line) {
             $position = strpos($line, 'label=');
-            if (!str_starts_with($line, '# cat=') || $position === false) {
+            if (!str_starts_with($line, '# cat=')) {
+                continue;
+            }
+
+            if ($position === false) {
                 continue;
             }
 

--- a/Tests/Unit/Controller/Backend/ConfigurationControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ConfigurationControllerTest.php
@@ -44,13 +44,21 @@ use TYPO3\CMS\Core\Http\ServerRequest;
 final class ConfigurationControllerTest extends TestCase
 {
     private LlmConfigurationRepository&MockObject $configurationRepository;
+
     private LlmConfigurationServiceInterface&MockObject $configurationService;
+
     private LlmServiceManagerInterface&MockObject $llmServiceManager;
+
     private ProviderAdapterRegistryInterface&MockObject $providerAdapterRegistry;
+
     private ModelRepository&MockObject $modelRepository;
+
     private ModelSelectionServiceInterface&MockObject $modelSelectionService;
+
     private TestPromptResolverInterface&MockObject $testPromptResolver;
+
     private ConfigurationController $subject;
+
     private mixed $previousBeUser;
 
     protected function setUp(): void
@@ -89,6 +97,7 @@ final class ConfigurationControllerTest extends TestCase
         } else {
             $GLOBALS['BE_USER'] = $this->previousBeUser;
         }
+
         parent::tearDown();
     }
 
@@ -155,6 +164,7 @@ final class ConfigurationControllerTest extends TestCase
         $reflection = new ReflectionClass($configuration);
         $uidProperty = $reflection->getProperty('uid');
         $uidProperty->setValue($configuration, $uid);
+
         $configuration->setIsActive($isActive);
         $configuration->setIsDefault($isDefault);
         return $configuration;
@@ -1208,6 +1218,7 @@ final class ConfigurationControllerTest extends TestCase
 
         $provider = new Provider();
         $provider->setName('OpenAI');
+
         $resolved = new Model();
         $resolved->setName('gpt-4o');
         $resolved->setProvider($provider);

--- a/Tests/Unit/Controller/Backend/ModelControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ModelControllerTest.php
@@ -38,9 +38,13 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 final class ModelControllerTest extends TestCase
 {
     private ModelRepository&MockObject $modelRepository;
+
     private ProviderRepository&Stub $providerRepository;
+
     private PersistenceManagerInterface&MockObject $persistenceManager;
+
     private ModelController $subject;
+
     private mixed $previousBeUser;
 
     protected function setUp(): void
@@ -69,6 +73,7 @@ final class ModelControllerTest extends TestCase
         } else {
             $GLOBALS['BE_USER'] = $this->previousBeUser;
         }
+
         parent::tearDown();
     }
 
@@ -115,6 +120,7 @@ final class ModelControllerTest extends TestCase
         $reflection = new ReflectionClass($model);
         $uidProperty = $reflection->getProperty('uid');
         $uidProperty->setValue($model, $uid);
+
         $model->setIsActive($isActive);
         $model->setIsDefault($isDefault);
         return $model;
@@ -370,6 +376,7 @@ final class ModelControllerTest extends TestCase
         $queryResult = new class ([$model1, $model2]) implements QueryResultInterface {
             /** @var array<int, object> */
             private array $items;
+
             /**
              * @param array<int, object> $items
              */
@@ -377,68 +384,83 @@ final class ModelControllerTest extends TestCase
             {
                 $this->items = array_values($items);
             }
+
             public function setQuery(QueryInterface $query): void
             {
                 // Intentionally empty: this in-memory stub ignores the query object.
             }
+
             public function getFirst(): ?object
             {
                 return $this->items[0] ?? null;
             }
+
             /**
              * @return list<object>
              */
             public function toArray(): array
             {
-                /** @var list<object> */
-                return $this->items;
+                // offsetSet()/offsetUnset() can leave gaps, so re-index rather
+                // than asserting listness of the stored array.
+                return array_values($this->items);
             }
+
             public function count(): int
             {
                 return count($this->items);
             }
+
             public function getQuery(): QueryInterface
             {
                 throw new LogicException('Not implemented', 7771386589);
             }
+
             public function offsetExists($offset): bool
             {
                 return is_int($offset) && isset($this->items[$offset]);
             }
+
             public function offsetGet($offset): mixed
             {
                 return is_int($offset) ? ($this->items[$offset] ?? null) : null;
             }
+
             public function offsetSet($offset, $value): void
             {
                 if (is_object($value) && is_int($offset)) {
                     $this->items[$offset] = $value;
                 }
             }
+
             public function offsetUnset($offset): void
             {
                 if (is_int($offset)) {
                     unset($this->items[$offset]);
                 }
             }
+
             public function current(): object
             {
                 $current = current($this->items);
                 assert($current !== false);
                 return $current;
             }
+
             public function next(): void
             {
                 next($this->items);
             }
+
             public function key(): int
             {
                 return (int)key($this->items);
             }
+
             public function valid(): bool
             {
                 return key($this->items) !== null;
             }
+
             public function rewind(): void
             {
                 reset($this->items);

--- a/Tests/Unit/Controller/Backend/ModelDiscoveryControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ModelDiscoveryControllerTest.php
@@ -35,8 +35,11 @@ use TYPO3\CMS\Core\Http\ServerRequest;
 final class ModelDiscoveryControllerTest extends TestCase
 {
     private ProviderRepository&MockObject $providerRepository;
+
     private ModelDiscoveryInterface&MockObject $modelDiscovery;
+
     private ModelDiscoveryController $subject;
+
     private mixed $previousBeUser;
 
     protected function setUp(): void
@@ -68,6 +71,7 @@ final class ModelDiscoveryControllerTest extends TestCase
         } else {
             $GLOBALS['BE_USER'] = $this->previousBeUser;
         }
+
         parent::tearDown();
     }
 
@@ -433,6 +437,7 @@ final class ModelDiscoveryControllerTest extends TestCase
         $reflection = new ReflectionClass($provider);
         $uidProperty = $reflection->getProperty('uid');
         $uidProperty->setValue($provider, $uid);
+
         $provider->setName('Test Provider');
         $provider->setAdapterType('openai');
         $provider->setApiKey('0190a5e0-7a1c-7b2d-8f3e-4a5b6c7d8e9f');

--- a/Tests/Unit/Controller/Backend/ModelTestControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ModelTestControllerTest.php
@@ -41,9 +41,13 @@ use TYPO3\CMS\Core\Http\ServerRequest;
 final class ModelTestControllerTest extends TestCase
 {
     private ModelRepository&MockObject $modelRepository;
+
     private ProviderAdapterRegistryInterface&MockObject $providerAdapterRegistry;
+
     private TestPromptResolverInterface&MockObject $testPromptResolver;
+
     private ModelTestController $subject;
+
     private mixed $previousBeUser;
 
     protected function setUp(): void
@@ -78,6 +82,7 @@ final class ModelTestControllerTest extends TestCase
         } else {
             $GLOBALS['BE_USER'] = $this->previousBeUser;
         }
+
         parent::tearDown();
     }
 
@@ -180,8 +185,10 @@ final class ModelTestControllerTest extends TestCase
         $providerReflection = new ReflectionClass($provider);
         $providerUidProp = $providerReflection->getProperty('uid');
         $providerUidProp->setValue($provider, 1);
+
         $provider->setName('OpenAI');
         $provider->setAdapterType('openai');
+
         $model->setProvider($provider);
 
         $this->modelRepository
@@ -232,8 +239,10 @@ final class ModelTestControllerTest extends TestCase
         $providerReflection = new ReflectionClass($provider);
         $providerUidProp = $providerReflection->getProperty('uid');
         $providerUidProp->setValue($provider, 1);
+
         $provider->setName('OpenAI');
         $provider->setAdapterType('openai');
+
         $model->setProvider($provider);
 
         $this->modelRepository
@@ -428,6 +437,7 @@ final class ModelTestControllerTest extends TestCase
         $reflection = new ReflectionClass($model);
         $uidProperty = $reflection->getProperty('uid');
         $uidProperty->setValue($model, $uid);
+
         $model->setIsActive($isActive);
         $model->setIsDefault($isDefault);
         return $model;

--- a/Tests/Unit/Controller/Backend/PresetControllerTest.php
+++ b/Tests/Unit/Controller/Backend/PresetControllerTest.php
@@ -63,10 +63,11 @@ final class PresetControllerTest extends TestCase
         } else {
             $GLOBALS['BE_USER'] = $this->previousBeUser;
         }
+
         parent::tearDown();
     }
 
-    private static function preset(): ConfigurationPreset
+    private function preset(): ConfigurationPreset
     {
         return new ConfigurationPreset(
             identifier: 'ext.chat',
@@ -122,7 +123,7 @@ final class PresetControllerTest extends TestCase
      * checksum differs from the current declaration — i.e. drifted. Its name
      * differs so an update produces a non-empty diff.
      */
-    private static function driftedRecord(): LlmConfiguration
+    private function driftedRecord(): LlmConfiguration
     {
         $record = new LlmConfiguration();
         $record->setIdentifier('ext.chat');
@@ -137,7 +138,7 @@ final class PresetControllerTest extends TestCase
     /**
      * @return array<string, mixed>
      */
-    private static function decode(ResponseInterface $response): array
+    private function decode(ResponseInterface $response): array
     {
         $decoded = json_decode((string)$response->getBody(), true);
         self::assertIsArray($decoded);
@@ -172,12 +173,13 @@ final class PresetControllerTest extends TestCase
     {
         $model = new Model();
         $model->setName('Claude Sonnet');
-        $controller = $this->createController([self::preset()], existing: null, matchedModel: $model);
+
+        $controller = $this->createController([$this->preset()], matchedModel: $model);
 
         $response = $controller->listPresetsAction(new ServerRequest());
 
         self::assertSame(200, $response->getStatusCode());
-        $body = self::decode($response);
+        $body = $this->decode($response);
         self::assertTrue($body['success']);
         assert(isset($body['presets']) && is_array($body['presets']));
         self::assertCount(1, $body['presets']);
@@ -194,9 +196,9 @@ final class PresetControllerTest extends TestCase
     #[Test]
     public function listPresetsOmitsAlreadyImportedPresets(): void
     {
-        $controller = $this->createController([self::preset()], existing: new LlmConfiguration());
+        $controller = $this->createController([$this->preset()], existing: new LlmConfiguration());
 
-        $body = self::decode($controller->listPresetsAction(new ServerRequest()));
+        $body = $this->decode($controller->listPresetsAction(new ServerRequest()));
 
         self::assertSame([], $body['presets']);
     }
@@ -209,9 +211,10 @@ final class PresetControllerTest extends TestCase
         $configuration = new LlmConfiguration();
         $configuration->_setProperty('uid', 7);
         $configuration->setPresetChecksum('0000000000000000000000000000000000000000000000000000000000000000');
-        $controller = $this->createController([self::preset()], existing: $configuration);
 
-        $body = self::decode($controller->listPresetsAction(new ServerRequest()));
+        $controller = $this->createController([$this->preset()], existing: $configuration);
+
+        $body = $this->decode($controller->listPresetsAction(new ServerRequest()));
 
         self::assertSame([], $body['presets']);
         assert(isset($body['drifted']) && is_array($body['drifted']));
@@ -227,10 +230,11 @@ final class PresetControllerTest extends TestCase
     public function listPresetsOmitsImportedPresetWithUnchangedChecksumFromDrifted(): void
     {
         $configuration = new LlmConfiguration();
-        $configuration->setPresetChecksum(self::preset()->checksum());
-        $controller = $this->createController([self::preset()], existing: $configuration);
+        $configuration->setPresetChecksum($this->preset()->checksum());
 
-        $body = self::decode($controller->listPresetsAction(new ServerRequest()));
+        $controller = $this->createController([$this->preset()], existing: $configuration);
+
+        $body = $this->decode($controller->listPresetsAction(new ServerRequest()));
 
         self::assertSame([], $body['presets']);
         self::assertSame([], $body['drifted']);
@@ -242,13 +246,13 @@ final class PresetControllerTest extends TestCase
         // The registry must see the identifier as pending while the import
         // service checks for duplicates against the same repository — a null
         // answer serves both.
-        $controller = $this->createController([self::preset()], existing: null, matchedModel: new Model());
+        $controller = $this->createController([$this->preset()], matchedModel: new Model());
         $request = (new ServerRequest())->withParsedBody(['identifier' => 'ext.chat']);
 
         $response = $controller->importAction($request);
 
         self::assertSame(200, $response->getStatusCode());
-        $body = self::decode($response);
+        $body = $this->decode($response);
         self::assertTrue($body['success']);
         self::assertSame('ext.chat', $body['identifier']);
     }
@@ -256,26 +260,26 @@ final class PresetControllerTest extends TestCase
     #[Test]
     public function importReturns404ForUnknownIdentifier(): void
     {
-        $controller = $this->createController([self::preset()]);
+        $controller = $this->createController([$this->preset()]);
         $request = (new ServerRequest())->withParsedBody(['identifier' => 'ext.unknown']);
 
         $response = $controller->importAction($request);
 
         self::assertSame(404, $response->getStatusCode());
-        self::assertFalse(self::decode($response)['success']);
+        self::assertFalse($this->decode($response)['success']);
     }
 
     #[Test]
     public function importReturns422WhenPresetIsUnsatisfiable(): void
     {
         // No matched model and no candidates: preflight is unsatisfiable.
-        $controller = $this->createController([self::preset()], existing: null, matchedModel: null);
+        $controller = $this->createController([$this->preset()]);
         $request = (new ServerRequest())->withParsedBody(['identifier' => 'ext.chat']);
 
         $response = $controller->importAction($request);
 
         self::assertSame(422, $response->getStatusCode());
-        $body = self::decode($response);
+        $body = $this->decode($response);
         self::assertFalse($body['success']);
         assert(isset($body['error']) && is_string($body['error']));
         self::assertStringContainsString('capabilities: chat', $body['error']);
@@ -284,11 +288,12 @@ final class PresetControllerTest extends TestCase
     #[Test]
     public function listPresetsSummarisesDriftedChangedFields(): void
     {
-        $configuration = self::driftedRecord();
+        $configuration = $this->driftedRecord();
         $configuration->_setProperty('uid', 7);
-        $controller = $this->createController([self::preset()], existing: $configuration);
 
-        $body = self::decode($controller->listPresetsAction(new ServerRequest()));
+        $controller = $this->createController([$this->preset()], existing: $configuration);
+
+        $body = $this->decode($controller->listPresetsAction(new ServerRequest()));
 
         assert(isset($body['drifted']) && is_array($body['drifted']));
         $entry = $body['drifted'][0];
@@ -317,7 +322,7 @@ final class PresetControllerTest extends TestCase
     #[Test]
     public function diffReturns404ForUnknownIdentifier(): void
     {
-        $controller = $this->createController([self::preset()]);
+        $controller = $this->createController([$this->preset()]);
         $request = (new ServerRequest())->withQueryParams(['identifier' => 'ext.unknown']);
 
         self::assertSame(404, $controller->diffAction($request)->getStatusCode());
@@ -326,7 +331,7 @@ final class PresetControllerTest extends TestCase
     #[Test]
     public function diffReturns422WhenNothingImported(): void
     {
-        $controller = $this->createController([self::preset()], existing: null);
+        $controller = $this->createController([$this->preset()]);
         $request = (new ServerRequest())->withQueryParams(['identifier' => 'ext.chat']);
 
         self::assertSame(422, $controller->diffAction($request)->getStatusCode());
@@ -335,13 +340,13 @@ final class PresetControllerTest extends TestCase
     #[Test]
     public function diffReturnsChangesForDriftedRecord(): void
     {
-        $controller = $this->createController([self::preset()], existing: self::driftedRecord(), matchedModel: new Model());
+        $controller = $this->createController([$this->preset()], existing: $this->driftedRecord(), matchedModel: new Model());
         $request = (new ServerRequest())->withQueryParams(['identifier' => 'ext.chat']);
 
         $response = $controller->diffAction($request);
 
         self::assertSame(200, $response->getStatusCode());
-        $body = self::decode($response);
+        $body = $this->decode($response);
         self::assertTrue($body['success']);
         self::assertSame('ext.chat', $body['identifier']);
         assert(isset($body['changes']) && is_array($body['changes']));
@@ -350,19 +355,20 @@ final class PresetControllerTest extends TestCase
             assert(is_array($change) && isset($change['field']) && is_string($change['field']));
             $fields[] = $change['field'];
         }
+
         self::assertContains('name', $fields);
     }
 
     #[Test]
     public function updateAppliesDriftedRecordAndReturnsChangedFields(): void
     {
-        $controller = $this->createController([self::preset()], existing: self::driftedRecord(), matchedModel: new Model());
+        $controller = $this->createController([$this->preset()], existing: $this->driftedRecord(), matchedModel: new Model());
         $request = (new ServerRequest())->withParsedBody(['identifier' => 'ext.chat']);
 
         $response = $controller->updateAction($request);
 
         self::assertSame(200, $response->getStatusCode());
-        $body = self::decode($response);
+        $body = $this->decode($response);
         self::assertTrue($body['success']);
         self::assertSame('ext.chat', $body['identifier']);
         assert(isset($body['changedFields']) && is_array($body['changedFields']));
@@ -372,23 +378,25 @@ final class PresetControllerTest extends TestCase
     #[Test]
     public function updateReturns422WhenModeSwitchedToFixed(): void
     {
-        $record = self::driftedRecord();
+        $record = $this->driftedRecord();
         $record->setModelSelectionMode(ModelSelectionMode::FIXED->value);
-        $controller = $this->createController([self::preset()], existing: $record, matchedModel: new Model());
+
+        $controller = $this->createController([$this->preset()], existing: $record, matchedModel: new Model());
         $request = (new ServerRequest())->withParsedBody(['identifier' => 'ext.chat']);
 
         $response = $controller->updateAction($request);
 
         self::assertSame(422, $response->getStatusCode());
-        self::assertFalse(self::decode($response)['success']);
+        self::assertFalse($this->decode($response)['success']);
     }
 
     #[Test]
     public function updateReturns422WhenRecordNotDrifted(): void
     {
-        $record = self::driftedRecord();
-        $record->setPresetChecksum(self::preset()->checksum());
-        $controller = $this->createController([self::preset()], existing: $record, matchedModel: new Model());
+        $record = $this->driftedRecord();
+        $record->setPresetChecksum($this->preset()->checksum());
+
+        $controller = $this->createController([$this->preset()], existing: $record, matchedModel: new Model());
         $request = (new ServerRequest())->withParsedBody(['identifier' => 'ext.chat']);
 
         self::assertSame(422, $controller->updateAction($request)->getStatusCode());
@@ -397,7 +405,7 @@ final class PresetControllerTest extends TestCase
     #[Test]
     public function updateReturns404ForUnknownIdentifier(): void
     {
-        $controller = $this->createController([self::preset()]);
+        $controller = $this->createController([$this->preset()]);
         $request = (new ServerRequest())->withParsedBody(['identifier' => 'ext.unknown']);
 
         self::assertSame(404, $controller->updateAction($request)->getStatusCode());

--- a/Tests/Unit/Controller/Backend/ProviderControllerTest.php
+++ b/Tests/Unit/Controller/Backend/ProviderControllerTest.php
@@ -35,9 +35,13 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 final class ProviderControllerTest extends TestCase
 {
     private ProviderRepository&MockObject $providerRepository;
+
     private PersistenceManagerInterface&MockObject $persistenceManager;
+
     private ProviderAdapterRegistryInterface&MockObject $providerAdapterRegistry;
+
     private ProviderController $subject;
+
     private mixed $previousBeUser;
 
     protected function setUp(): void
@@ -66,6 +70,7 @@ final class ProviderControllerTest extends TestCase
         } else {
             $GLOBALS['BE_USER'] = $this->previousBeUser;
         }
+
         parent::tearDown();
     }
 
@@ -126,6 +131,7 @@ final class ProviderControllerTest extends TestCase
         $reflection = new ReflectionClass($provider);
         $uidProperty = $reflection->getProperty('uid');
         $uidProperty->setValue($provider, $uid);
+
         $provider->setIsActive($isActive);
         return $provider;
     }

--- a/Tests/Unit/Controller/Backend/RequiresBackendAdminTraitTest.php
+++ b/Tests/Unit/Controller/Backend/RequiresBackendAdminTraitTest.php
@@ -41,6 +41,7 @@ final class RequiresBackendAdminTraitTest extends TestCase
         } else {
             $GLOBALS['BE_USER'] = $this->previousBeUser;
         }
+
         parent::tearDown();
     }
 

--- a/Tests/Unit/Controller/Backend/SpecializedTestControllerTest.php
+++ b/Tests/Unit/Controller/Backend/SpecializedTestControllerTest.php
@@ -67,6 +67,7 @@ final class SpecializedTestControllerTest extends TestCase
         } else {
             $GLOBALS['BE_USER'] = $this->previousBeUser;
         }
+
         parent::tearDown();
     }
 

--- a/Tests/Unit/Controller/Backend/TaskWizardControllerTest.php
+++ b/Tests/Unit/Controller/Backend/TaskWizardControllerTest.php
@@ -30,7 +30,9 @@ use stdClass;
 final class TaskWizardControllerTest extends TestCase
 {
     private ReflectionMethod $toStr;
+
     private ReflectionMethod $toInt;
+
     private ReflectionMethod $toFloat;
 
     protected function setUp(): void

--- a/Tests/Unit/DependencyInjection/ProviderCompilerPassTest.php
+++ b/Tests/Unit/DependencyInjection/ProviderCompilerPassTest.php
@@ -264,6 +264,7 @@ class ProviderCompilerPassTest extends AbstractUnitTestCase
         // public — doing so would drift the public-service set locked by ADR-028.
         $container = new ContainerBuilder();
         $container->setDefinition(LlmServiceManager::class, new Definition(LlmServiceManager::class));
+
         $definition = $container->setDefinition('provider.attr', new Definition(AttributeTaggedProvider::class));
         self::assertFalse($definition->isPublic());
 
@@ -294,6 +295,7 @@ class ProviderCompilerPassTest extends AbstractUnitTestCase
 
         $definition = new Definition(AttributeTaggedProvider::class);
         $definition->addTag(AsLlmProvider::TAG_NAME, ['priority' => 999]);
+
         $container->setDefinition('provider.attr', $definition);
 
         (new ProviderCompilerPass())->process($container);

--- a/Tests/Unit/DependencyInjection/TranslatorCompilerPassTest.php
+++ b/Tests/Unit/DependencyInjection/TranslatorCompilerPassTest.php
@@ -50,6 +50,7 @@ class TranslatorCompilerPassTest extends AbstractUnitTestCase
         $container = new ContainerBuilder();
         $definition = new Definition(AttributeTaggedTranslator::class);
         $definition->addTag(AsTranslator::TAG_NAME);
+
         $container->setDefinition('translator.preexisting', $definition);
 
         (new TranslatorCompilerPass(self::TEST_SCAN_PREFIX))->process($container);
@@ -100,6 +101,7 @@ class TranslatorCompilerPassTest extends AbstractUnitTestCase
         $container = new ContainerBuilder();
         $definition = new Definition(AttributeTaggedTranslator::class);
         $definition->setPublic(false);
+
         $container->setDefinition('translator.private', $definition);
 
         (new TranslatorCompilerPass(self::TEST_SCAN_PREFIX))->process($container);

--- a/Tests/Unit/Domain/Model/CompletionResponseTest.php
+++ b/Tests/Unit/Domain/Model/CompletionResponseTest.php
@@ -169,7 +169,6 @@ class CompletionResponseTest extends AbstractUnitTestCase
             content: 'content',
             model: 'gpt-4',
             usage: new UsageStatistics(10, 20, 30),
-            toolCalls: null,
         );
 
         self::assertFalse($response->hasToolCalls());
@@ -250,7 +249,6 @@ class CompletionResponseTest extends AbstractUnitTestCase
             content: 'result',
             model: 'gpt-4',
             usage: new UsageStatistics(10, 20, 30),
-            thinking: null,
         );
 
         self::assertFalse($response->hasThinking());

--- a/Tests/Unit/Domain/Model/EmbeddingResponseTest.php
+++ b/Tests/Unit/Domain/Model/EmbeddingResponseTest.php
@@ -24,7 +24,7 @@ class EmbeddingResponseTest extends AbstractUnitTestCase
      */
     private function createSampleEmbedding(int $dimensions = 1536): array
     {
-        return array_map(fn() => random_int(-1_000_000, 1_000_000) / 1_000_000, range(1, $dimensions));
+        return array_map(fn(): int|float => random_int(-1_000_000, 1_000_000) / 1_000_000, range(1, $dimensions));
     }
 
     #[Test]
@@ -167,7 +167,7 @@ class EmbeddingResponseTest extends AbstractUnitTestCase
         self::assertEqualsWithDelta(0.8, $normalized[1], 0.0001);
 
         // Verify magnitude is 1
-        $magnitude = sqrt(array_sum(array_map(fn($x) => $x * $x, $normalized)));
+        $magnitude = sqrt(array_sum(array_map(fn(float $x): float => $x * $x, $normalized)));
         self::assertEqualsWithDelta(1.0, $magnitude, 0.0001);
     }
 
@@ -295,7 +295,7 @@ class EmbeddingResponseTest extends AbstractUnitTestCase
     public function batchEmbeddingsAreStoredCorrectly(): void
     {
         $texts = ['text1', 'text2', 'text3', 'text4', 'text5'];
-        $embeddings = array_map(fn() => $this->createSampleEmbedding(256), $texts);
+        $embeddings = array_map(fn(): array => $this->createSampleEmbedding(256), $texts);
 
         $response = new EmbeddingResponse(
             embeddings: $embeddings,

--- a/Tests/Unit/Domain/Model/LlmConfigurationTest.php
+++ b/Tests/Unit/Domain/Model/LlmConfigurationTest.php
@@ -704,6 +704,7 @@ final class LlmConfigurationTest extends AbstractUnitTestCase
     {
         $groups = new ObjectStorage();
         $groups->attach(new BackendUserGroup());
+
         $this->subject->setBeGroups($groups);
 
         self::assertTrue($this->subject->hasAccessRestrictions());

--- a/Tests/Unit/Domain/Model/ModelTest.php
+++ b/Tests/Unit/Domain/Model/ModelTest.php
@@ -128,6 +128,7 @@ final class ModelTest extends TestCase
 
         $provider = $this->createProviderWithUid(1);
         $provider->setName('OpenAI');
+
         $model->setProvider($provider);
 
         self::assertSame('GPT-4o (OpenAI)', $model->getDisplayName());

--- a/Tests/Unit/Domain/Model/TranslationResultTest.php
+++ b/Tests/Unit/Domain/Model/TranslationResultTest.php
@@ -273,7 +273,6 @@ final class TranslationResultTest extends AbstractUnitTestCase
             targetLanguage: 'de',
             confidence: 0.9,
             usage: $this->defaultUsage,
-            alternatives: null,
         );
 
         self::assertSame([], $result->getAlternatives());

--- a/Tests/Unit/Domain/Model/VisionResponseTest.php
+++ b/Tests/Unit/Domain/Model/VisionResponseTest.php
@@ -175,7 +175,6 @@ final class VisionResponseTest extends AbstractUnitTestCase
             description: 'No confidence',
             model: 'gpt-4o',
             usage: $this->defaultUsage,
-            confidence: null,
         );
 
         self::assertFalse($response->meetsConfidence(0.5));

--- a/Tests/Unit/Domain/ValueObject/ToolResultTest.php
+++ b/Tests/Unit/Domain/ValueObject/ToolResultTest.php
@@ -72,6 +72,7 @@ final class ToolResultTest extends TestCase
                 $stringProps[] = $property->getName();
             }
         }
+
         self::assertSame(['content'], $stringProps);
     }
 }

--- a/Tests/Unit/Exception/NrLlmExceptionInterfaceTest.php
+++ b/Tests/Unit/Exception/NrLlmExceptionInterfaceTest.php
@@ -46,7 +46,11 @@ final class NrLlmExceptionInterfaceTest extends TestCase
             $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir));
 
             foreach ($iterator as $file) {
-                if (!$file instanceof SplFileInfo || $file->getExtension() !== 'php') {
+                if (!$file instanceof SplFileInfo) {
+                    continue;
+                }
+
+                if ($file->getExtension() !== 'php') {
                     continue;
                 }
 

--- a/Tests/Unit/Fixture/InMemoryTelemetryRepository.php
+++ b/Tests/Unit/Fixture/InMemoryTelemetryRepository.php
@@ -35,7 +35,7 @@ final class InMemoryTelemetryRepository implements TelemetryRepositoryInterface
 
     public function record(TelemetryRecord $record): void
     {
-        if ($this->failOnRecord !== null) {
+        if ($this->failOnRecord instanceof Throwable) {
             throw $this->failOnRecord;
         }
 

--- a/Tests/Unit/Form/Tca/ToolGroupItemsTest.php
+++ b/Tests/Unit/Form/Tca/ToolGroupItemsTest.php
@@ -112,6 +112,7 @@ final class ToolGroupItemsTest extends AbstractUnitTestCase
         foreach ($groups as $i => $group) {
             $tools[] = new FakeTool('tool_' . $i . '_' . $group, group: $group);
         }
+
         GeneralUtility::addInstance(ToolRegistry::class, new ToolRegistry($tools));
     }
 }

--- a/Tests/Unit/Provider/AbstractProviderMutationTest.php
+++ b/Tests/Unit/Provider/AbstractProviderMutationTest.php
@@ -26,6 +26,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use ReflectionClass;
 use ReflectionException;
 use Throwable;
@@ -68,9 +69,10 @@ class AbstractProviderMutationTest extends AbstractUnitTestCase
         try {
             return $method->invoke($object, ...$args);
         } catch (ReflectionException $e) {
-            if ($e->getPrevious() !== null) {
+            if ($e->getPrevious() instanceof Throwable) {
                 throw $e->getPrevious();
             }
+
             throw $e;
         }
     }
@@ -242,7 +244,7 @@ class AbstractProviderMutationTest extends AbstractUnitTestCase
         $httpClient = self::createStub(ClientInterface::class);
         $httpClient
             ->method('sendRequest')
-            ->willReturnCallback(function (RequestInterface $request) use (&$capturedUrl) {
+            ->willReturnCallback(function (RequestInterface $request) use (&$capturedUrl): ResponseInterface {
                 $capturedUrl = (string)$request->getUri();
 
                 return $this->createJsonResponseMock(['ok' => true]);
@@ -277,7 +279,7 @@ class AbstractProviderMutationTest extends AbstractUnitTestCase
         $httpClient = self::createStub(ClientInterface::class);
         $httpClient
             ->method('sendRequest')
-            ->willReturnCallback(function (RequestInterface $request) use (&$capturedUrl) {
+            ->willReturnCallback(function (RequestInterface $request) use (&$capturedUrl): ResponseInterface {
                 $capturedUrl = (string)$request->getUri();
 
                 return $this->createJsonResponseMock(['ok' => true]);
@@ -313,7 +315,7 @@ class AbstractProviderMutationTest extends AbstractUnitTestCase
         $httpClient = self::createStub(ClientInterface::class);
         $httpClient
             ->method('sendRequest')
-            ->willReturnCallback(function () use (&$attempts) {
+            ->willReturnCallback(function () use (&$attempts): ResponseInterface {
                 $attempts++;
                 if ($attempts < 3) {
                     throw new class ('Connection failed', 6712573549) extends Exception implements ClientExceptionInterface {};
@@ -386,7 +388,7 @@ class AbstractProviderMutationTest extends AbstractUnitTestCase
         $httpClient = self::createStub(ClientInterface::class);
         $httpClient
             ->method('sendRequest')
-            ->willReturnCallback(function () use (&$attempts) {
+            ->willReturnCallback(function () use (&$attempts): ResponseInterface {
                 $attempts++;
 
                 return $this->createJsonResponseMock(['error' => ['message' => 'Bad request']], 400);
@@ -636,7 +638,7 @@ class AbstractProviderMutationTest extends AbstractUnitTestCase
         $httpClient = self::createStub(ClientInterface::class);
         $httpClient
             ->method('sendRequest')
-            ->willReturnCallback(function (RequestInterface $request) use (&$capturedBody) {
+            ->willReturnCallback(function (RequestInterface $request) use (&$capturedBody): ResponseInterface {
                 $capturedBody = (string)$request->getBody();
 
                 return $this->createJsonResponseMock(['ok' => true]);
@@ -671,7 +673,7 @@ class AbstractProviderMutationTest extends AbstractUnitTestCase
         $httpClient = self::createStub(ClientInterface::class);
         $httpClient
             ->method('sendRequest')
-            ->willReturnCallback(function (RequestInterface $request) use (&$capturedBody) {
+            ->willReturnCallback(function (RequestInterface $request) use (&$capturedBody): ResponseInterface {
                 $capturedBody = (string)$request->getBody();
 
                 return $this->createJsonResponseMock(['ok' => true]);
@@ -706,7 +708,7 @@ class AbstractProviderMutationTest extends AbstractUnitTestCase
         $httpClient = self::createStub(ClientInterface::class);
         $httpClient
             ->method('sendRequest')
-            ->willReturnCallback(function (RequestInterface $request) use (&$capturedBody) {
+            ->willReturnCallback(function (RequestInterface $request) use (&$capturedBody): ResponseInterface {
                 $capturedBody = (string)$request->getBody();
 
                 return $this->createJsonResponseMock(['ok' => true]);
@@ -743,7 +745,7 @@ class AbstractProviderMutationTest extends AbstractUnitTestCase
         $httpClient = self::createStub(ClientInterface::class);
         $httpClient
             ->method('sendRequest')
-            ->willReturnCallback(function (RequestInterface $request) use (&$capturedRequest) {
+            ->willReturnCallback(function (RequestInterface $request) use (&$capturedRequest): ResponseInterface {
                 $capturedRequest = $request;
 
                 return $this->createJsonResponseMock(['ok' => true]);
@@ -809,7 +811,7 @@ class AbstractProviderMutationTest extends AbstractUnitTestCase
         $httpClient = self::createStub(ClientInterface::class);
         $httpClient
             ->method('sendRequest')
-            ->willReturnCallback(function () use (&$attempts) {
+            ->willReturnCallback(function () use (&$attempts): ResponseInterface {
                 $attempts++;
                 // Return a server error that causes retry
                 return $this->createJsonResponseMock(['error' => 'Server error'], 500);
@@ -880,7 +882,7 @@ class AbstractProviderMutationTest extends AbstractUnitTestCase
         $httpClient = self::createStub(ClientInterface::class);
         $httpClient
             ->method('sendRequest')
-            ->willReturnCallback(function () use (&$attempts) {
+            ->willReturnCallback(function () use (&$attempts): ResponseInterface {
                 $attempts++;
 
                 return $this->createJsonResponseMock(['success' => true]);

--- a/Tests/Unit/Provider/CircuitBreaker/CircuitStateTest.php
+++ b/Tests/Unit/Provider/CircuitBreaker/CircuitStateTest.php
@@ -32,7 +32,7 @@ final class CircuitStateTest extends AbstractUnitTestCase
     #[Test]
     public function statusIsClosedWhenNeverOpened(): void
     {
-        $state = new CircuitState(3, null);
+        $state = new CircuitState(3);
 
         self::assertSame(CircuitStatus::Closed, $state->status(1_000, 30));
         // A failure streak without an open timestamp is still "closed" — it is
@@ -63,7 +63,7 @@ final class CircuitStateTest extends AbstractUnitTestCase
         self::assertSame(0, $state->secondsUntilHalfOpen($openedAt + 30, 30));
         self::assertSame(0, $state->secondsUntilHalfOpen($openedAt + 999, 30));
         // Not open → no wait.
-        self::assertSame(0, (new CircuitState(0, null))->secondsUntilHalfOpen(1_000, 30));
+        self::assertSame(0, (new CircuitState(0))->secondsUntilHalfOpen(1_000, 30));
     }
 
     #[Test]

--- a/Tests/Unit/Provider/ClaudeProviderTest.php
+++ b/Tests/Unit/Provider/ClaudeProviderTest.php
@@ -36,6 +36,7 @@ use Psr\Http\Message\StreamInterface;
 class ClaudeProviderTest extends AbstractUnitTestCase
 {
     private ClaudeProvider $subject;
+
     private ClientInterface&Stub $httpClientStub;
 
     protected function setUp(): void
@@ -668,7 +669,7 @@ class ClaudeProviderTest extends AbstractUnitTestCase
 
         $stream = self::createStub(StreamInterface::class);
         $eofCallCount = 0;
-        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount) {
+        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount): bool {
             return ++$eofCallCount > 1;
         });
         $stream->method('read')->willReturn($streamData);
@@ -702,7 +703,7 @@ class ClaudeProviderTest extends AbstractUnitTestCase
 
         $stream = self::createStub(StreamInterface::class);
         $eofCallCount = 0;
-        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount) {
+        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount): bool {
             return ++$eofCallCount > 1;
         });
         $stream->method('read')->willReturn($streamData);
@@ -729,7 +730,7 @@ class ClaudeProviderTest extends AbstractUnitTestCase
 
         $stream = self::createStub(StreamInterface::class);
         $eofCallCount = 0;
-        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount) {
+        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount): bool {
             return ++$eofCallCount > 1;
         });
         $stream->method('read')->willReturn($streamData);

--- a/Tests/Unit/Provider/GeminiProviderTest.php
+++ b/Tests/Unit/Provider/GeminiProviderTest.php
@@ -35,6 +35,7 @@ use Psr\Http\Message\StreamInterface;
 class GeminiProviderTest extends AbstractUnitTestCase
 {
     private GeminiProvider $subject;
+
     private ClientInterface&Stub $httpClientStub;
 
     protected function setUp(): void
@@ -1040,10 +1041,10 @@ class GeminiProviderTest extends AbstractUnitTestCase
 
         $streamStub = self::createStub(StreamInterface::class);
         $readCount = 0;
-        $streamStub->method('eof')->willReturnCallback(function () use (&$readCount) {
+        $streamStub->method('eof')->willReturnCallback(function () use (&$readCount): bool {
             return $readCount >= 1; // @phpstan-ignore greaterOrEqual.alwaysFalse
         });
-        $streamStub->method('read')->willReturnCallback(function () use (&$readCount, $sseData) {
+        $streamStub->method('read')->willReturnCallback(function () use (&$readCount, $sseData): string {
             $readCount++;
             return $sseData;
         });
@@ -1074,10 +1075,10 @@ class GeminiProviderTest extends AbstractUnitTestCase
 
         $streamStub = self::createStub(StreamInterface::class);
         $readCount = 0;
-        $streamStub->method('eof')->willReturnCallback(function () use (&$readCount) {
+        $streamStub->method('eof')->willReturnCallback(function () use (&$readCount): bool {
             return $readCount >= 1; // @phpstan-ignore greaterOrEqual.alwaysFalse
         });
-        $streamStub->method('read')->willReturnCallback(function () use (&$readCount, $sseData) {
+        $streamStub->method('read')->willReturnCallback(function () use (&$readCount, $sseData): string {
             $readCount++;
             return $sseData;
         });
@@ -1114,10 +1115,10 @@ class GeminiProviderTest extends AbstractUnitTestCase
 
         $streamStub = self::createStub(StreamInterface::class);
         $readCount = 0;
-        $streamStub->method('eof')->willReturnCallback(function () use (&$readCount) {
+        $streamStub->method('eof')->willReturnCallback(function () use (&$readCount): bool {
             return $readCount >= 1; // @phpstan-ignore greaterOrEqual.alwaysFalse
         });
-        $streamStub->method('read')->willReturnCallback(function () use (&$readCount, $sseData) {
+        $streamStub->method('read')->willReturnCallback(function () use (&$readCount, $sseData): string {
             $readCount++;
             return $sseData;
         });
@@ -1149,10 +1150,10 @@ class GeminiProviderTest extends AbstractUnitTestCase
 
         $streamStub = self::createStub(StreamInterface::class);
         $readCount = 0;
-        $streamStub->method('eof')->willReturnCallback(function () use (&$readCount) {
+        $streamStub->method('eof')->willReturnCallback(function () use (&$readCount): bool {
             return $readCount >= 1; // @phpstan-ignore greaterOrEqual.alwaysFalse
         });
-        $streamStub->method('read')->willReturnCallback(function () use (&$readCount, $sseData) {
+        $streamStub->method('read')->willReturnCallback(function () use (&$readCount, $sseData): string {
             $readCount++;
             return $sseData;
         });
@@ -1688,10 +1689,10 @@ class GeminiProviderTest extends AbstractUnitTestCase
     {
         $streamStub = self::createStub(StreamInterface::class);
         $readCount = 0;
-        $streamStub->method('eof')->willReturnCallback(function () use (&$readCount) {
+        $streamStub->method('eof')->willReturnCallback(function () use (&$readCount): bool {
             return $readCount >= 1; // @phpstan-ignore greaterOrEqual.alwaysFalse
         });
-        $streamStub->method('read')->willReturnCallback(function () use (&$readCount, $sseData) {
+        $streamStub->method('read')->willReturnCallback(function () use (&$readCount, $sseData): string {
             $readCount++;
             return $sseData;
         });
@@ -1743,7 +1744,7 @@ class GeminiProviderTest extends AbstractUnitTestCase
      *
      * @return array<string, mixed>
      */
-    private static function okCandidateResponse(): array
+    private function okCandidateResponse(): array
     {
         return [
             'candidates' => [[
@@ -2152,7 +2153,7 @@ class GeminiProviderTest extends AbstractUnitTestCase
         $capturedBody   = null;
 
         $subject = $this->createCapturingSubject(
-            self::okCandidateResponse(),
+            $this->okCandidateResponse(),
             $capturedMethod,
             $capturedUri,
             $capturedBody,
@@ -2181,7 +2182,7 @@ class GeminiProviderTest extends AbstractUnitTestCase
         $capturedBody   = null;
 
         $subject = $this->createCapturingSubject(
-            self::okCandidateResponse(),
+            $this->okCandidateResponse(),
             $capturedMethod,
             $capturedUri,
             $capturedBody,
@@ -2207,7 +2208,7 @@ class GeminiProviderTest extends AbstractUnitTestCase
         $capturedBody   = null;
 
         $subject = $this->createCapturingSubject(
-            self::okCandidateResponse(),
+            $this->okCandidateResponse(),
             $capturedMethod,
             $capturedUri,
             $capturedBody,
@@ -2239,7 +2240,7 @@ class GeminiProviderTest extends AbstractUnitTestCase
         $capturedBody   = null;
 
         $subject = $this->createCapturingSubject(
-            self::okCandidateResponse(),
+            $this->okCandidateResponse(),
             $capturedMethod,
             $capturedUri,
             $capturedBody,
@@ -2266,7 +2267,7 @@ class GeminiProviderTest extends AbstractUnitTestCase
         $capturedBody   = null;
 
         $subject = $this->createCapturingSubject(
-            self::okCandidateResponse(),
+            $this->okCandidateResponse(),
             $capturedMethod,
             $capturedUri,
             $capturedBody,
@@ -2299,7 +2300,7 @@ class GeminiProviderTest extends AbstractUnitTestCase
         $capturedBody   = null;
 
         $subject = $this->createCapturingSubject(
-            self::okCandidateResponse(),
+            $this->okCandidateResponse(),
             $capturedMethod,
             $capturedUri,
             $capturedBody,
@@ -2366,7 +2367,7 @@ class GeminiProviderTest extends AbstractUnitTestCase
         $capturedBody   = null;
 
         $subject = $this->createCapturingSubject(
-            self::okCandidateResponse(),
+            $this->okCandidateResponse(),
             $capturedMethod,
             $capturedUri,
             $capturedBody,
@@ -2403,7 +2404,7 @@ class GeminiProviderTest extends AbstractUnitTestCase
         $capturedBody   = null;
 
         $subject = $this->createCapturingSubject(
-            self::okCandidateResponse(),
+            $this->okCandidateResponse(),
             $capturedMethod,
             $capturedUri,
             $capturedBody,
@@ -2449,7 +2450,7 @@ class GeminiProviderTest extends AbstractUnitTestCase
         $capturedBody   = null;
 
         $subject = $this->createCapturingSubject(
-            self::okCandidateResponse(),
+            $this->okCandidateResponse(),
             $capturedMethod,
             $capturedUri,
             $capturedBody,
@@ -2636,10 +2637,10 @@ class GeminiProviderTest extends AbstractUnitTestCase
 
         $streamStub = self::createStub(StreamInterface::class);
         $readCount = 0;
-        $streamStub->method('eof')->willReturnCallback(function () use (&$readCount) {
+        $streamStub->method('eof')->willReturnCallback(function () use (&$readCount): bool {
             return $readCount >= 2; // @phpstan-ignore greaterOrEqual.alwaysFalse
         });
-        $streamStub->method('read')->willReturnCallback(function () use (&$readCount, $chunkOne, $chunkTwo) {
+        $streamStub->method('read')->willReturnCallback(function () use (&$readCount, $chunkOne, $chunkTwo): string {
             $readCount++;
             return $readCount === 1 ? $chunkOne : $chunkTwo;
         });

--- a/Tests/Unit/Provider/GroqProviderTest.php
+++ b/Tests/Unit/Provider/GroqProviderTest.php
@@ -31,6 +31,7 @@ use Psr\Http\Message\StreamInterface;
 class GroqProviderTest extends AbstractUnitTestCase
 {
     private GroqProvider $subject;
+
     private ClientInterface&Stub $httpClientStub;
 
     protected function setUp(): void

--- a/Tests/Unit/Provider/Middleware/CacheMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/CacheMiddlewareTest.php
@@ -281,6 +281,7 @@ final class CacheMiddlewareTest extends AbstractUnitTestCase
         if ($ttl !== null) {
             $metadata[CacheMiddleware::METADATA_CACHE_TTL] = $ttl;
         }
+
         if ($tags !== null) {
             $metadata[CacheMiddleware::METADATA_CACHE_TAGS] = $tags;
         }

--- a/Tests/Unit/Provider/Middleware/CircuitBreakerMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/CircuitBreakerMiddlewareTest.php
@@ -167,7 +167,8 @@ final class CircuitBreakerMiddlewareTest extends AbstractUnitTestCase
     public function openCircuitFailsFastWithoutCallingProvider(): void
     {
         $store = new InMemoryCircuitBreakerStore();
-        $store->seed(self::PROVIDER, new CircuitState(5, time())); // opened just now
+        $store->seed(self::PROVIDER, new CircuitState(5, time()));
+        // opened just now
         $called = false;
 
         try {
@@ -194,6 +195,7 @@ final class CircuitBreakerMiddlewareTest extends AbstractUnitTestCase
         $store = new InMemoryCircuitBreakerStore();
         // Opened long enough ago that the cooldown has elapsed → half-open.
         $store->seed(self::PROVIDER, new CircuitState(5, time() - 31));
+
         $called = false;
 
         $result = $this->middleware($store, cooldown: 30)->handle(
@@ -266,7 +268,7 @@ final class CircuitBreakerMiddlewareTest extends AbstractUnitTestCase
     public function successResetsAFailureStreak(): void
     {
         $store = new InMemoryCircuitBreakerStore();
-        $store->seed(self::PROVIDER, new CircuitState(2, null)); // closed, counting
+        $store->seed(self::PROVIDER, new CircuitState(2)); // closed, counting
 
         $this->middleware($store)->handle(
             $this->context()->withConfiguration($this->config(self::PROVIDER)),
@@ -282,7 +284,7 @@ final class CircuitBreakerMiddlewareTest extends AbstractUnitTestCase
     public function nonTrippingFailureLeavesStateUntouchedAndRethrows(): void
     {
         $store = new InMemoryCircuitBreakerStore();
-        $store->seed(self::PROVIDER, new CircuitState(2, null));
+        $store->seed(self::PROVIDER, new CircuitState(2));
 
         try {
             $this->middleware($store)->handle(

--- a/Tests/Unit/Provider/Middleware/FallbackMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/FallbackMiddlewareTest.php
@@ -59,7 +59,7 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
             ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
             function (ProviderCallContext $ctx) use (&$calls): string {
                 $config = $ctx->configuration;
-                assert($config !== null);
+                assert($config instanceof LlmConfiguration);
                 $calls[] = $config->getIdentifier();
 
                 return 'ok';
@@ -79,7 +79,7 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
 
         $caught = $this->captureException(
             ProviderConnectionException::class,
-            fn() => $pipeline->run(
+            fn(): mixed => $pipeline->run(
                 ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
                 static function () use ($err): never {
                     throw $err;
@@ -105,7 +105,7 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
             ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
             function (ProviderCallContext $ctx) use (&$calls): string {
                 $config = $ctx->configuration;
-                assert($config !== null);
+                assert($config instanceof LlmConfiguration);
                 $calls[] = $config->getIdentifier();
                 if ($config->getIdentifier() === 'primary') {
                     throw new ProviderConnectionException('down', 0);
@@ -136,7 +136,7 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
             ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
             function (ProviderCallContext $ctx) use (&$calls): string {
                 $config = $ctx->configuration;
-                assert($config !== null);
+                assert($config instanceof LlmConfiguration);
                 $calls[] = $config->getIdentifier();
                 if ($config->getIdentifier() === 'primary') {
                     throw new CircuitOpenException('openai', 12);
@@ -171,7 +171,7 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
             $context,
             static function (ProviderCallContext $ctx): string {
                 $config = $ctx->configuration;
-                assert($config !== null);
+                assert($config instanceof LlmConfiguration);
                 if ($config->getIdentifier() !== 'alt2') {
                     throw new ProviderConnectionException('down', 0);
                 }
@@ -214,7 +214,7 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
             ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
             static function (ProviderCallContext $ctx): string {
                 $config = $ctx->configuration;
-                assert($config !== null);
+                assert($config instanceof LlmConfiguration);
                 if ($config->getIdentifier() === 'primary') {
                     throw new ProviderResponseException('rate limited', 429);
                 }
@@ -239,7 +239,7 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
             ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
             static function (ProviderCallContext $ctx): string {
                 $config = $ctx->configuration;
-                assert($config !== null);
+                assert($config instanceof LlmConfiguration);
                 if ($config->getIdentifier() === 'primary') {
                     throw new ProviderResponseException('internal error', 500);
                 }
@@ -269,7 +269,7 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
                     ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
                     static function (ProviderCallContext $ctx) use (&$calls, $err): never {
                         $config = $ctx->configuration;
-                        assert($config !== null);
+                        assert($config instanceof LlmConfiguration);
                         $calls[] = $config->getIdentifier();
 
                         throw $err;
@@ -297,7 +297,7 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
                     ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
                     static function (ProviderCallContext $ctx) use (&$calls, $err): never {
                         $config = $ctx->configuration;
-                        assert($config !== null);
+                        assert($config instanceof LlmConfiguration);
                         $calls[] = $config->getIdentifier();
 
                         throw $err;
@@ -325,7 +325,7 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
                     ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
                     static function (ProviderCallContext $ctx) use (&$calls, $err): never {
                         $config = $ctx->configuration;
-                        assert($config !== null);
+                        assert($config instanceof LlmConfiguration);
                         $calls[] = $config->getIdentifier();
 
                         throw $err;
@@ -360,7 +360,7 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
             ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
             function (ProviderCallContext $ctx) use (&$calls): string {
                 $config = $ctx->configuration;
-                assert($config !== null);
+                assert($config instanceof LlmConfiguration);
                 $calls[] = $config->getIdentifier();
                 if (\in_array($config->getIdentifier(), ['p', 'a', 'b'], true)) {
                     throw new ProviderConnectionException('down', 0);
@@ -391,7 +391,7 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
 
         $exhausted = $this->captureException(
             FallbackChainExhaustedException::class,
-            fn() => $pipeline->run(
+            fn(): mixed => $pipeline->run(
                 ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
                 static function (): never {
                     throw new ProviderConnectionException('down', 0);
@@ -423,7 +423,7 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
             ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
             function (ProviderCallContext $ctx) use (&$calls): string {
                 $config = $ctx->configuration;
-                assert($config !== null);
+                assert($config instanceof LlmConfiguration);
                 $calls[] = $config->getIdentifier();
                 if ($config->getIdentifier() === 'p') {
                     throw new ProviderConnectionException('down', 0);
@@ -457,7 +457,7 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
             ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
             function (ProviderCallContext $ctx) use (&$calls): string {
                 $config = $ctx->configuration;
-                assert($config !== null);
+                assert($config instanceof LlmConfiguration);
                 $calls[] = $config->getIdentifier();
                 if ($config->getIdentifier() === 'p') {
                     throw new ProviderConnectionException('down', 0);
@@ -486,7 +486,7 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
                     ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
                     static function (ProviderCallContext $ctx) use (&$calls, $err): never {
                         $config = $ctx->configuration;
-                        assert($config !== null);
+                        assert($config instanceof LlmConfiguration);
                         $calls[] = $config->getIdentifier();
 
                         throw $err;
@@ -518,7 +518,7 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
             ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
             function (ProviderCallContext $ctx) use (&$calls): string {
                 $config = $ctx->configuration;
-                assert($config !== null);
+                assert($config instanceof LlmConfiguration);
                 $calls[] = $config->getIdentifier();
                 if ($config->getIdentifier() === 'p') {
                     throw new ProviderConnectionException('down', 0);
@@ -547,7 +547,7 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
                     ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
                     static function (ProviderCallContext $ctx) use (&$calls, $err): never {
                         $config = $ctx->configuration;
-                        assert($config !== null);
+                        assert($config instanceof LlmConfiguration);
                         $calls[] = $config->getIdentifier();
 
                         throw $err;
@@ -587,7 +587,7 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
         $config = new LlmConfiguration();
         $config->setIdentifier($identifier);
         $config->setIsActive($active);
-        if ($chain !== null) {
+        if ($chain instanceof FallbackChain) {
             $config->setFallbackChainDTO($chain);
         }
 

--- a/Tests/Unit/Provider/Middleware/GuardrailMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/GuardrailMiddlewareTest.php
@@ -49,6 +49,7 @@ final class GuardrailMiddlewareTest extends TestCase
             // A second guardrail sees the redacted content and allows it.
             new class implements GuardrailInterface {
                 use GuardrailIdentityDoubleTrait;
+
                 public function checkOutput(CompletionResponse $response): GuardrailResult
                 {
                     return $response->content === '[redacted]'
@@ -122,6 +123,7 @@ final class GuardrailMiddlewareTest extends TestCase
         // Retry while the content is 'first'; allow the fresh 'second'.
         $guardrail = new class implements GuardrailInterface {
             use GuardrailIdentityDoubleTrait;
+
             public function checkOutput(CompletionResponse $response): GuardrailResult
             {
                 return $response->content === 'first'
@@ -216,6 +218,7 @@ final class GuardrailMiddlewareTest extends TestCase
 
         $config = new LlmConfiguration();
         $config->setAllowedGuardrails('some-other-guardrail');
+
         $context = ProviderCallContext::forConfiguration(ProviderOperation::Chat, $config);
 
         $result = $middleware->handle($context, fn(): CompletionResponse => $this->response('hello'));
@@ -314,6 +317,7 @@ final class GuardrailMiddlewareTest extends TestCase
     {
         return new class ($result) implements GuardrailInterface {
             use GuardrailIdentityDoubleTrait;
+
             public function __construct(private readonly GuardrailResult $result) {}
 
             public function checkOutput(CompletionResponse $response): GuardrailResult

--- a/Tests/Unit/Provider/Middleware/MiddlewarePipelineTest.php
+++ b/Tests/Unit/Provider/Middleware/MiddlewarePipelineTest.php
@@ -32,7 +32,7 @@ final class MiddlewarePipelineTest extends TestCase
             context: ProviderCallContext::forConfiguration(ProviderOperation::Chat, $config),
             terminal: static function (ProviderCallContext $ctx): string {
                 $config = $ctx->configuration;
-                \assert($config !== null);
+                \assert($config instanceof LlmConfiguration);
 
                 return 'terminal:' . $config->getIdentifier();
             },
@@ -51,7 +51,7 @@ final class MiddlewarePipelineTest extends TestCase
             context: ProviderCallContext::forConfiguration(ProviderOperation::Embedding, $this->configuration('primary')),
             terminal: static function (ProviderCallContext $ctx): string {
                 $config = $ctx->configuration;
-                \assert($config !== null);
+                \assert($config instanceof LlmConfiguration);
 
                 return 'terminal:' . $config->getIdentifier();
             },
@@ -73,7 +73,7 @@ final class MiddlewarePipelineTest extends TestCase
             context: ProviderCallContext::forConfiguration(ProviderOperation::Chat, $this->configuration('primary')),
             terminal: static function (ProviderCallContext $ctx): string {
                 $config = $ctx->configuration;
-                \assert($config !== null);
+                \assert($config instanceof LlmConfiguration);
 
                 return 'T(' . $config->getIdentifier() . ')';
             },
@@ -131,7 +131,7 @@ final class MiddlewarePipelineTest extends TestCase
             context: ProviderCallContext::forConfiguration(ProviderOperation::Chat, $this->configuration('primary')),
             terminal: static function (ProviderCallContext $ctx): string {
                 $config = $ctx->configuration;
-                \assert($config !== null);
+                \assert($config instanceof LlmConfiguration);
 
                 return $config->getIdentifier();
             },

--- a/Tests/Unit/Provider/Middleware/ProviderCallContextTest.php
+++ b/Tests/Unit/Provider/Middleware/ProviderCallContextTest.php
@@ -107,6 +107,7 @@ final class ProviderCallContextTest extends TestCase
     {
         $primary  = (new LlmConfiguration());
         $primary->setIdentifier('primary');
+
         $fallback = (new LlmConfiguration());
         $fallback->setIdentifier('fallback');
 

--- a/Tests/Unit/Provider/MistralProviderTest.php
+++ b/Tests/Unit/Provider/MistralProviderTest.php
@@ -31,6 +31,7 @@ use Psr\Http\Message\StreamInterface;
 class MistralProviderTest extends AbstractUnitTestCase
 {
     private MistralProvider $subject;
+
     private ClientInterface&Stub $httpClientStub;
 
     protected function setUp(): void

--- a/Tests/Unit/Provider/OllamaProviderTest.php
+++ b/Tests/Unit/Provider/OllamaProviderTest.php
@@ -36,6 +36,7 @@ use RuntimeException;
 class OllamaProviderTest extends AbstractUnitTestCase
 {
     private OllamaProvider $subject;
+
     private ClientInterface&Stub $httpClientStub;
 
     protected function setUp(): void

--- a/Tests/Unit/Provider/OllamaProviderToolsTest.php
+++ b/Tests/Unit/Provider/OllamaProviderToolsTest.php
@@ -270,6 +270,7 @@ class OllamaProviderToolsTest extends AbstractUnitTestCase
         // Explicitly OFF: the top-level `think` field carries `false`.
         $subject = $this->buildSubject($this->plainAssistantResponse('done'));
         $subject->chatCompletionWithTools($messages, [$tool], ['think' => false]);
+
         $payload = $this->capturedRequest();
         self::assertArrayHasKey('think', $payload);
         self::assertFalse($payload['think']);

--- a/Tests/Unit/Provider/OpenAiProviderTest.php
+++ b/Tests/Unit/Provider/OpenAiProviderTest.php
@@ -39,6 +39,7 @@ use Psr\Http\Message\StreamInterface;
 class OpenAiProviderTest extends AbstractUnitTestCase
 {
     private OpenAiProvider $subject;
+
     private ClientInterface&Stub $httpClientStub;
 
     protected function setUp(): void
@@ -797,7 +798,7 @@ class OpenAiProviderTest extends AbstractUnitTestCase
 
         $stream = self::createStub(StreamInterface::class);
         $eofCallCount = 0;
-        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount) {
+        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount): bool {
             return ++$eofCallCount > 1;
         });
         $stream->method('read')->willReturn($streamData);
@@ -827,7 +828,7 @@ class OpenAiProviderTest extends AbstractUnitTestCase
 
         $stream = self::createStub(StreamInterface::class);
         $eofCallCount = 0;
-        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount) {
+        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount): bool {
             return ++$eofCallCount > 1;
         });
         $stream->method('read')->willReturn($streamData);
@@ -858,7 +859,7 @@ class OpenAiProviderTest extends AbstractUnitTestCase
 
         $stream = self::createStub(StreamInterface::class);
         $eofCallCount = 0;
-        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount) {
+        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount): bool {
             return ++$eofCallCount > 1;
         });
         $stream->method('read')->willReturn($streamData);
@@ -1272,7 +1273,7 @@ class OpenAiProviderTest extends AbstractUnitTestCase
 
         $stream = self::createStub(StreamInterface::class);
         $eofCallCount = 0;
-        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount) {
+        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount): bool {
             return ++$eofCallCount > 1;
         });
         $stream->method('read')->willReturn($streamData);
@@ -1305,7 +1306,7 @@ class OpenAiProviderTest extends AbstractUnitTestCase
 
         $stream = self::createStub(StreamInterface::class);
         $eofCallCount = 0;
-        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount) {
+        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount): bool {
             return ++$eofCallCount > 1;
         });
         $stream->method('read')->willReturn($streamData);

--- a/Tests/Unit/Provider/OpenRouterProviderTest.php
+++ b/Tests/Unit/Provider/OpenRouterProviderTest.php
@@ -111,11 +111,12 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
     ): OpenRouterProvider {
         $httpClientMock = self::createStub(ClientInterface::class);
         $httpClientMock->method('sendRequest')
-            ->willReturnCallback(function (RequestInterface $request) use ($modelsResponse, $chatResponse) {
+            ->willReturnCallback(function (RequestInterface $request) use ($modelsResponse, $chatResponse): ResponseInterface {
                 $uri = (string)$request->getUri();
                 if (str_contains($uri, '/models')) {
                     return $this->createJsonResponseMock($modelsResponse);
                 }
+
                 return $this->createJsonResponseMock($chatResponse);
             });
 
@@ -301,7 +302,7 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         // OpenRouter models have provider prefixes in keys (e.g., "anthropic/claude-3.5-sonnet")
         $modelKeys = array_keys($models);
         self::assertTrue(
-            count(array_filter($modelKeys, fn($m) => str_contains((string)$m, '/'))) > 0,
+            count(array_filter($modelKeys, fn(string $m): bool => str_contains($m, '/'))) > 0,
             'OpenRouter models should have provider prefixes in keys',
         );
     }
@@ -1237,7 +1238,7 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
 
         $stream = self::createStub(StreamInterface::class);
         $eofCallCount = 0;
-        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount) {
+        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount): bool {
             return ++$eofCallCount > 1;
         });
         $stream->method('read')->willReturn($streamData);
@@ -1270,7 +1271,7 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
 
         $stream = self::createStub(StreamInterface::class);
         $eofCallCount = 0;
-        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount) {
+        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount): bool {
             return ++$eofCallCount > 1;
         });
         $stream->method('read')->willReturn($streamData);
@@ -1299,7 +1300,7 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
 
         $stream = self::createStub(StreamInterface::class);
         $eofCallCount = 0;
-        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount) {
+        $stream->method('eof')->willReturnCallback(function () use (&$eofCallCount): bool {
             return ++$eofCallCount > 1;
         });
         $stream->method('read')->willReturn($streamData);
@@ -1684,7 +1685,7 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
      *
      * @return array<string, mixed>
      */
-    private static function modelEntry(string $id, float $prompt, float $completion, array $overrides = []): array
+    private function modelEntry(string $id, float $prompt, float $completion, array $overrides = []): array
     {
         return $overrides + [
             'id' => $id,
@@ -2611,9 +2612,9 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         $model = $this->capturedRoutedModel(
             ['routingStrategy' => 'cost_optimized'],
             [
-                self::modelEntry('prompt-heavy/model', 0.05, 0.001),
-                self::modelEntry('completion-heavy/model', 0.001, 0.04),
-                self::modelEntry('mid/model', 0.02, 0.02),
+                $this->modelEntry('prompt-heavy/model', 0.05, 0.001),
+                $this->modelEntry('completion-heavy/model', 0.001, 0.04),
+                $this->modelEntry('mid/model', 0.02, 0.02),
             ],
         );
 
@@ -2626,8 +2627,8 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         $model = $this->capturedRoutedModel(
             ['routingStrategy' => 'cost_optimized'],
             [
-                self::modelEntry('first/model', 0.01, 0.01),
-                self::modelEntry('second/model', 0.01, 0.01),
+                $this->modelEntry('first/model', 0.01, 0.01),
+                $this->modelEntry('second/model', 0.01, 0.01),
             ],
         );
 
@@ -2640,8 +2641,8 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         $model = $this->capturedRoutedModel(
             ['routingStrategy' => 'performance'],
             [
-                self::modelEntry('slow/opus', 0.01, 0.03),
-                self::modelEntry('quick/flash', 0.001, 0.002),
+                $this->modelEntry('slow/opus', 0.01, 0.03),
+                $this->modelEntry('quick/flash', 0.001, 0.002),
             ],
         );
 
@@ -2654,8 +2655,8 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         $model = $this->capturedRoutedModel(
             ['routingStrategy' => 'balanced'],
             [
-                self::modelEntry('fast/haiku', 0.0001, 0.0001),
-                self::modelEntry('steady/sonnet', 0.003, 0.015),
+                $this->modelEntry('fast/haiku', 0.0001, 0.0001),
+                $this->modelEntry('steady/sonnet', 0.003, 0.015),
             ],
         );
 
@@ -2668,7 +2669,7 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         $captured = [];
         $provider = $this->createCapturingRoutingProvider(
             ['routingStrategy' => 'explicit'],
-            ['data' => [self::modelEntry('steady/sonnet', 0.003, 0.015)]],
+            ['data' => [$this->modelEntry('steady/sonnet', 0.003, 0.015)]],
             $this->chatResponse(),
             $captured,
         );
@@ -2689,9 +2690,9 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         $model = $this->capturedRoutedModel(
             ['routingStrategy' => 'cost_optimized'],
             [
-                self::modelEntry('tiny/context', 0.00001, 0.00001, ['context_length' => 4000]),
-                self::modelEntry('exact/context', 0.0001, 0.0001, ['context_length' => 100000]),
-                self::modelEntry('huge/context', 0.01, 0.01, ['context_length' => 128000]),
+                $this->modelEntry('tiny/context', 0.00001, 0.00001, ['context_length' => 4000]),
+                $this->modelEntry('exact/context', 0.0001, 0.0001, ['context_length' => 100000]),
+                $this->modelEntry('huge/context', 0.01, 0.01, ['context_length' => 128000]),
             ],
             ['min_context' => 100000],
         );
@@ -2707,8 +2708,8 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         $model = $this->capturedRoutedModel(
             ['routingStrategy' => 'cost_optimized'],
             [
-                self::modelEntry('plain/cheap', 0.0001, 0.0001),
-                self::modelEntry('able/model', 0.01, 0.01, [
+                $this->modelEntry('plain/cheap', 0.0001, 0.0001),
+                $this->modelEntry('able/model', 0.01, 0.01, [
                     'architecture' => ['modality' => 'multimodal'],
                     'supports_function_calling' => true,
                 ]),
@@ -2724,8 +2725,8 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         $model = $this->capturedRoutedModel(
             ['routingStrategy' => 'cost_optimized'],
             [
-                self::modelEntry('text/cheap', 0.0001, 0.0001),
-                self::modelEntry('vision/pricier', 0.01, 0.01, [
+                $this->modelEntry('text/cheap', 0.0001, 0.0001),
+                $this->modelEntry('vision/pricier', 0.01, 0.01, [
                     'architecture' => ['modality' => 'multimodal'],
                 ]),
             ],
@@ -2741,8 +2742,8 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         $model = $this->capturedRoutedModel(
             ['routingStrategy' => 'cost_optimized'],
             [
-                self::modelEntry('plain/cheap', 0.0001, 0.0001),
-                self::modelEntry('tools/pricier', 0.01, 0.01, [
+                $this->modelEntry('plain/cheap', 0.0001, 0.0001),
+                $this->modelEntry('tools/pricier', 0.01, 0.01, [
                     'supports_function_calling' => true,
                 ]),
             ],
@@ -2761,7 +2762,7 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
     {
         $model = $this->capturedVisionModel(
             [],
-            [self::modelEntry('anthropic/claude-3.5-sonnet', 0.003, 0.015, [
+            [$this->modelEntry('anthropic/claude-3.5-sonnet', 0.003, 0.015, [
                 'architecture' => ['modality' => 'multimodal'],
             ])],
         );
@@ -2776,7 +2777,7 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         // the curated vision-model list that is available must be selected.
         $model = $this->capturedVisionModel(
             [],
-            [self::modelEntry('anthropic/claude-sonnet-4-5', 0.003, 0.015)],
+            [$this->modelEntry('anthropic/claude-sonnet-4-5', 0.003, 0.015)],
         );
 
         self::assertSame('anthropic/claude-sonnet-4-5', $model);
@@ -2789,7 +2790,7 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         // hardcoded 'openai/gpt-5.2' fallback and over unavailable entries.
         $model = $this->capturedVisionModel(
             [],
-            [self::modelEntry('google/gemini-3-flash', 0.001, 0.002)],
+            [$this->modelEntry('google/gemini-3-flash', 0.001, 0.002)],
         );
 
         self::assertSame('google/gemini-3-flash', $model);

--- a/Tests/Unit/Provider/ProviderAdapterRegistryTest.php
+++ b/Tests/Unit/Provider/ProviderAdapterRegistryTest.php
@@ -34,6 +34,7 @@ use stdClass;
 class ProviderAdapterRegistryTest extends AbstractUnitTestCase
 {
     private ProviderAdapterRegistry $subject;
+
     private LoggerInterface&Stub $loggerStub;
 
     protected function setUp(): void

--- a/Tests/Unit/Provider/ResponseParserTraitMutationTest.php
+++ b/Tests/Unit/Provider/ResponseParserTraitMutationTest.php
@@ -39,6 +39,7 @@ class ResponseParserTraitMutationTest extends AbstractUnitTestCase
             $this->createSecureHttpClientFactoryMock(),
         );
         $provider->setHttpClient($this->createHttpClientMock());
+
         $this->traitObject = $provider;
     }
 

--- a/Tests/Unit/Service/Agent/AgentRuntimeTest.php
+++ b/Tests/Unit/Service/Agent/AgentRuntimeTest.php
@@ -296,7 +296,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         );
 
         $runtime = $this->runtime($loop);
-        $result  = $runtime->run($this->request(), static function (): void {
+        $result  = $runtime->run($this->request(), static function (): never {
             throw new RuntimeException('client gone', 1784700002);
         });
 
@@ -333,6 +333,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
     {
         $this->repository->findResult  = $this->suspendedRun();
         $this->repository->maxSequence = 4;
+
         $loopResult = $this->loopResult('continued');
 
         $seenBeUser = null;
@@ -559,11 +560,11 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         $uuid       = $runtime0->enqueue(new AgentRunRequest(
             configuration: new LlmConfiguration(),
             messages: [ChatMessage::user('do the queued thing')],
+            actor: AiActorContext::backendUser(9),
             allowedToolNames: ['fetch_logs'],
             options: (new ToolOptions(temperature: 0.5, plannedCost: 1.25))->withIdempotencyKey('idem-1'),
             maxIterations: 50,
             captureRaw: true,
-            actor: AiActorContext::backendUser(9),
         ));
 
         $this->repository->findResult = $this->queuedRun($uuid, $this->repository->enqueuedRuns[0]['requestJson']);
@@ -1207,7 +1208,6 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
             startedAt: 0,
             finishedAt: 0,
             crdate: 0,
-            suspendedState: null,
             queuedRequest: $requestJson,
             requeueCount: $requeueCount,
             pendingEffect: $pendingEffect,
@@ -1355,8 +1355,8 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         return new AgentRunRequest(
             configuration: new LlmConfiguration(),
             messages: [ChatMessage::user('go')],
-            maxIterations: $maxIterations,
             actor: AiActorContext::backendUser(9),
+            maxIterations: $maxIterations,
         );
     }
 

--- a/Tests/Unit/Service/Budget/BackendUserContextResolverTest.php
+++ b/Tests/Unit/Service/Budget/BackendUserContextResolverTest.php
@@ -34,6 +34,7 @@ final class BackendUserContextResolverTest extends AbstractUnitTestCase
         } else {
             $GLOBALS['BE_USER'] = $this->previousBeUser;
         }
+
         parent::tearDown();
     }
 

--- a/Tests/Unit/Service/BudgetServiceTest.php
+++ b/Tests/Unit/Service/BudgetServiceTest.php
@@ -432,6 +432,7 @@ class BudgetServiceTest extends AbstractUnitTestCase
         if ($uid !== null) {
             $config->_setProperty('uid', $uid);
         }
+
         $config->setIdentifier('capped');
         $config->setMaxRequestsPerDay($dailyRequests);
         $config->setMaxTokensPerDay($dailyTokens);

--- a/Tests/Unit/Service/CacheManagerMutationTest.php
+++ b/Tests/Unit/Service/CacheManagerMutationTest.php
@@ -117,7 +117,7 @@ class CacheManagerMutationTest extends AbstractUnitTestCase
             ->with(
                 self::anything(),
                 self::anything(),
-                self::callback(fn(array $tags) => in_array('nrllm', $tags, true)
+                self::callback(fn(array $tags): bool => in_array('nrllm', $tags, true)
                         && in_array('nrllm_response', $tags, true)),
                 self::anything(),
             );
@@ -137,7 +137,7 @@ class CacheManagerMutationTest extends AbstractUnitTestCase
             ->with(
                 self::anything(),
                 self::anything(),
-                self::callback(fn(array $tags) => in_array('nrllm', $tags, true)
+                self::callback(fn(array $tags): bool => in_array('nrllm', $tags, true)
                         && in_array('nrllm_response', $tags, true)
                         && in_array('custom_tag', $tags, true)),
                 self::anything(),
@@ -161,7 +161,7 @@ class CacheManagerMutationTest extends AbstractUnitTestCase
                 self::callback(
                     // 'nrllm' should appear only once even if passed as custom tag
 
-                    fn(array $tags) => count(array_keys($tags, 'nrllm', true)) === 1,
+                    fn(array $tags): bool => count(array_keys($tags, 'nrllm', true)) === 1,
                 ),
                 self::anything(),
             );
@@ -252,7 +252,7 @@ class CacheManagerMutationTest extends AbstractUnitTestCase
                 self::callback(
                     // Model 'gpt-4.0-turbo' should become 'nrllm_model_gpt_4_0_turbo'
 
-                    fn(array $tags) => in_array('nrllm_model_gpt_4_0_turbo', $tags, true),
+                    fn(array $tags): bool => in_array('nrllm_model_gpt_4_0_turbo', $tags, true),
                 ),
                 self::anything(),
             );
@@ -280,6 +280,7 @@ class CacheManagerMutationTest extends AbstractUnitTestCase
                             return !str_contains($tag, '.') && !str_contains($tag, '-');
                         }
                     }
+
                     return false;
                 }),
                 self::anything(),
@@ -478,7 +479,7 @@ class CacheManagerMutationTest extends AbstractUnitTestCase
             ->with(
                 self::anything(),
                 self::anything(),
-                self::callback(fn(array $tags) => in_array('nrllm_provider_claude', $tags, true)),
+                self::callback(fn(array $tags): bool => in_array('nrllm_provider_claude', $tags, true)),
                 self::anything(),
             );
 
@@ -498,7 +499,7 @@ class CacheManagerMutationTest extends AbstractUnitTestCase
             ->with(
                 self::anything(),
                 self::anything(),
-                self::callback(fn(array $tags) => in_array('nrllm_provider_openai', $tags, true)),
+                self::callback(fn(array $tags): bool => in_array('nrllm_provider_openai', $tags, true)),
                 self::anything(),
             );
 
@@ -517,7 +518,7 @@ class CacheManagerMutationTest extends AbstractUnitTestCase
             ->with(
                 self::anything(),
                 self::anything(),
-                self::callback(fn(array $tags) => in_array('nrllm_embeddings', $tags, true)),
+                self::callback(fn(array $tags): bool => in_array('nrllm_embeddings', $tags, true)),
                 self::anything(),
             );
 
@@ -536,7 +537,7 @@ class CacheManagerMutationTest extends AbstractUnitTestCase
             ->with(
                 self::anything(),
                 self::anything(),
-                self::callback(fn(array $tags) => in_array('nrllm_completion', $tags, true)),
+                self::callback(fn(array $tags): bool => in_array('nrllm_completion', $tags, true)),
                 self::anything(),
             );
 

--- a/Tests/Unit/Service/CacheManagerTest.php
+++ b/Tests/Unit/Service/CacheManagerTest.php
@@ -248,7 +248,7 @@ class CacheManagerTest extends AbstractUnitTestCase
                 'test_key',
                 $data,
                 self::callback(
-                    fn(array $tags)
+                    fn(array $tags): bool
                     => in_array('nrllm', $tags, true)
                     && in_array('nrllm_response', $tags, true),
                 ),
@@ -276,7 +276,7 @@ class CacheManagerTest extends AbstractUnitTestCase
                 'test_key',
                 $data,
                 self::callback(
-                    fn(array $tags)
+                    fn(array $tags): bool
                     => in_array('nrllm', $tags, true)
                     && in_array('nrllm_response', $tags, true)
                     && in_array('custom_tag', $tags, true),
@@ -386,7 +386,7 @@ class CacheManagerTest extends AbstractUnitTestCase
                 self::isString(),
                 $response,
                 self::callback(
-                    fn(array $tags)
+                    fn(array $tags): bool
                     => in_array('nrllm_completion', $tags, true)
                     && in_array('nrllm_provider_openai', $tags, true),
                 ),
@@ -417,7 +417,7 @@ class CacheManagerTest extends AbstractUnitTestCase
                 self::anything(),
                 self::anything(),
                 self::callback(
-                    fn(array $tags)
+                    fn(array $tags): bool
                     => in_array('nrllm_model_gpt_4o', $tags, true),
                 ),
                 self::anything(),

--- a/Tests/Unit/Service/Context/ContextWindowManagerTest.php
+++ b/Tests/Unit/Service/Context/ContextWindowManagerTest.php
@@ -158,7 +158,7 @@ final class ContextWindowManagerTest extends TestCase
     private function turn(string $callId, string $result): array
     {
         return [
-            ChatMessage::assistantToolCalls([new ToolCall($callId, 'fetch', ['q' => 'x'])], null),
+            ChatMessage::assistantToolCalls([new ToolCall($callId, 'fetch', ['q' => 'x'])]),
             ChatMessage::toolResult($callId, $result),
         ];
     }

--- a/Tests/Unit/Service/Context/TranscriptEstimatorTest.php
+++ b/Tests/Unit/Service/Context/TranscriptEstimatorTest.php
@@ -75,7 +75,7 @@ final class TranscriptEstimatorTest extends TestCase
     public function toolCallArgumentsAreCountedAsDense(): void
     {
         $call     = new ToolCall('call_1', 'fetch', ['q' => str_repeat('x', 400)]);
-        $estimate = $this->estimator->estimate([ChatMessage::assistantToolCalls([$call], null)], [], 1.0);
+        $estimate = $this->estimator->estimate([ChatMessage::assistantToolCalls([$call])], [], 1.0);
 
         self::assertGreaterThan(100, $estimate);
     }

--- a/Tests/Unit/Service/Feature/CompletionServiceMutationTest.php
+++ b/Tests/Unit/Service/Feature/CompletionServiceMutationTest.php
@@ -52,7 +52,7 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
             ->willReturn($this->createMockResponse('Response'));
 
         $service = new CompletionService($llmManagerMock);
-        $result = $service->complete('Test prompt', null);
+        $result = $service->complete('Test prompt');
 
         self::assertInstanceOf(CompletionResponse::class, $result);
     }
@@ -66,7 +66,7 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
             ->method('chat')
             ->with(
                 self::anything(),
-                self::callback(fn(ChatOptions $opts) => $opts->getTemperature() === 0.2),
+                self::callback(fn(ChatOptions $opts): bool => $opts->getTemperature() === 0.2),
             )
             ->willReturn($this->createMockResponse('Factual response'));
 
@@ -83,7 +83,7 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
             ->method('chat')
             ->with(
                 self::anything(),
-                self::callback(fn(ChatOptions $opts) => $opts->getTopP() === 0.9),
+                self::callback(fn(ChatOptions $opts): bool => $opts->getTopP() === 0.9),
             )
             ->willReturn($this->createMockResponse('Factual response'));
 
@@ -100,7 +100,7 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
             ->method('chat')
             ->with(
                 self::anything(),
-                self::callback(fn(ChatOptions $opts) => $opts->getTemperature() === 0.5),
+                self::callback(fn(ChatOptions $opts): bool => $opts->getTemperature() === 0.5),
             )
             ->willReturn($this->createMockResponse('Response'));
 
@@ -118,7 +118,7 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
             ->method('chat')
             ->with(
                 self::anything(),
-                self::callback(fn(ChatOptions $opts) => $opts->getTemperature() === 1.2),
+                self::callback(fn(ChatOptions $opts): bool => $opts->getTemperature() === 1.2),
             )
             ->willReturn($this->createMockResponse('Creative response'));
 
@@ -135,7 +135,7 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
             ->method('chat')
             ->with(
                 self::anything(),
-                self::callback(fn(ChatOptions $opts) => $opts->getTopP() === 1.0),
+                self::callback(fn(ChatOptions $opts): bool => $opts->getTopP() === 1.0),
             )
             ->willReturn($this->createMockResponse('Creative response'));
 
@@ -152,7 +152,7 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
             ->method('chat')
             ->with(
                 self::anything(),
-                self::callback(fn(ChatOptions $opts) => $opts->getPresencePenalty() === 0.6),
+                self::callback(fn(ChatOptions $opts): bool => $opts->getPresencePenalty() === 0.6),
             )
             ->willReturn($this->createMockResponse('Creative response'));
 
@@ -169,7 +169,7 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
             ->method('chat')
             ->with(
                 self::anything(),
-                self::callback(fn(ChatOptions $opts) => $opts->getPresencePenalty() === 0.3),
+                self::callback(fn(ChatOptions $opts): bool => $opts->getPresencePenalty() === 0.3),
             )
             ->willReturn($this->createMockResponse('Response'));
 
@@ -188,7 +188,7 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
             ->willReturn($this->createMockResponse('{"key": "value"}'));
 
         $service = new CompletionService($llmManagerMock);
-        $result = $service->completeJson('Generate JSON', null);
+        $result = $service->completeJson('Generate JSON');
 
         self::assertEquals(['key' => 'value'], $result);
     }
@@ -203,7 +203,7 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
             ->willReturn($this->createMockResponse('# Heading'));
 
         $service = new CompletionService($llmManagerMock);
-        $result = $service->completeMarkdown('Generate markdown', null);
+        $result = $service->completeMarkdown('Generate markdown');
 
         self::assertEquals('# Heading', $result);
     }
@@ -475,6 +475,7 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
                     if (count($messages) !== 2) {
                         return false;
                     }
+
                     $msg0 = $messages[0];
                     $msg1 = $messages[1];
                     return $msg0 instanceof ChatMessage
@@ -505,6 +506,7 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
                     if (count($messages) !== 1) {
                         return false;
                     }
+
                     $msg = $messages[0];
                     return $msg instanceof ChatMessage
                         && $msg->isUser()
@@ -541,7 +543,7 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
             ->willReturn($this->createMockResponse('Response'));
 
         $service = new CompletionService($llmManagerMock);
-        $result = $service->completeFactual('Question', null);
+        $result = $service->completeFactual('Question');
 
         self::assertInstanceOf(CompletionResponse::class, $result);
     }
@@ -555,7 +557,7 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
             ->willReturn($this->createMockResponse('Response'));
 
         $service = new CompletionService($llmManagerMock);
-        $result = $service->completeCreative('Prompt', null);
+        $result = $service->completeCreative('Prompt');
 
         self::assertInstanceOf(CompletionResponse::class, $result);
     }
@@ -569,7 +571,7 @@ class CompletionServiceMutationTest extends AbstractUnitTestCase
             ->method('chat')
             ->with(
                 self::anything(),
-                self::callback(fn(ChatOptions $opts) => $opts->getResponseFormat() === 'json'),
+                self::callback(fn(ChatOptions $opts): bool => $opts->getResponseFormat() === 'json'),
             )
             ->willReturn($this->createMockResponse('{"key": "value"}'));
 

--- a/Tests/Unit/Service/Feature/CompletionServiceTest.php
+++ b/Tests/Unit/Service/Feature/CompletionServiceTest.php
@@ -27,6 +27,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 class CompletionServiceTest extends AbstractUnitTestCase
 {
     private CompletionService $subject;
+
     private LlmServiceManagerInterface $llmManagerStub;
 
     protected function setUp(): void
@@ -99,6 +100,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
                     if (count($messages) !== 2) {
                         return false;
                     }
+
                     $msg0 = $messages[0];
                     $msg1 = $messages[1];
                     return $msg0 instanceof ChatMessage
@@ -181,7 +183,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
             ->method('chat')
             ->with(
                 self::anything(),
-                self::callback(fn(ChatOptions $options) => $options->getTemperature() === 0.2
+                self::callback(fn(ChatOptions $options): bool => $options->getTemperature() === 0.2
                         && $options->getTopP() === 0.9),
             )
             ->willReturn($mockResponse);
@@ -201,7 +203,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
             ->method('chat')
             ->with(
                 self::anything(),
-                self::callback(fn(ChatOptions $options) => $options->getTemperature() === 1.2
+                self::callback(fn(ChatOptions $options): bool => $options->getTemperature() === 1.2
                         && $options->getPresencePenalty() === 0.6),
             )
             ->willReturn($mockResponse);
@@ -377,7 +379,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
             ->method('chat')
             ->with(
                 self::anything(),
-                self::callback(fn(ChatOptions $opts) => $opts->getTemperature() === 0.5),
+                self::callback(fn(ChatOptions $opts): bool => $opts->getTemperature() === 0.5),
             )
             ->willReturn($mockResponse);
 
@@ -398,7 +400,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
             ->method('chat')
             ->with(
                 self::anything(),
-                self::callback(fn(ChatOptions $opts) => $opts->getTopP() === 0.5),
+                self::callback(fn(ChatOptions $opts): bool => $opts->getTopP() === 0.5),
             )
             ->willReturn($mockResponse);
 
@@ -419,7 +421,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
             ->method('chat')
             ->with(
                 self::anything(),
-                self::callback(fn(ChatOptions $opts) => $opts->getTemperature() === 0.8),
+                self::callback(fn(ChatOptions $opts): bool => $opts->getTemperature() === 0.8),
             )
             ->willReturn($mockResponse);
 
@@ -440,7 +442,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
             ->method('chat')
             ->with(
                 self::anything(),
-                self::callback(fn(ChatOptions $opts) => $opts->getTopP() === 0.8 && $opts->getPresencePenalty() === 0.3),
+                self::callback(fn(ChatOptions $opts): bool => $opts->getTopP() === 0.8 && $opts->getPresencePenalty() === 0.3),
             )
             ->willReturn($mockResponse);
 
@@ -622,7 +624,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
             ->method('chat')
             ->willReturn($mockResponse);
 
-        $result = $subject->complete('Test prompt', null);
+        $result = $subject->complete('Test prompt');
 
         self::assertInstanceOf(CompletionResponse::class, $result);
     }
@@ -691,7 +693,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
             ->method('chat')
             ->willReturn($mockResponse);
 
-        $result = $subject->completeJson('Test', null);
+        $result = $subject->completeJson('Test');
 
         self::assertTrue($result['answer']);
     }
@@ -715,7 +717,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
             )
             ->willReturn($mockResponse);
 
-        $result = $subject->completeMarkdown('Test', null);
+        $result = $subject->completeMarkdown('Test');
 
         self::assertEquals('# Title', $result);
     }

--- a/Tests/Unit/Service/Feature/ConversationServiceTest.php
+++ b/Tests/Unit/Service/Feature/ConversationServiceTest.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
+use Netresearch\NrLlm\Domain\ValueObject\AiSessionMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ContextFitResult;
 use Netresearch\NrLlm\Exception\AccessDeniedException;
@@ -317,10 +318,11 @@ final class ConversationServiceTest extends TestCase
         } catch (Throwable) {
             // The first provider call fails; the user turn is already recorded.
         }
+
         $service->send($actor, $session->uuid, 'second');
 
         // No two turns share a sequence number, even across the failed attempt.
-        $sequences = array_map(static fn($m): int => $m->sequence, $repository->findMessages($session->uid));
+        $sequences = array_map(static fn(AiSessionMessage $m): int => $m->sequence, $repository->findMessages($session->uid));
         self::assertSame($sequences, array_values(array_unique($sequences)));
     }
 

--- a/Tests/Unit/Service/Feature/EmbeddingServiceMutationTest.php
+++ b/Tests/Unit/Service/Feature/EmbeddingServiceMutationTest.php
@@ -154,7 +154,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
         $result = $service->normalize($vector);
 
         // Calculate magnitude of result
-        $magnitude = sqrt(array_sum(array_map(fn($x) => $x * $x, $result)));
+        $magnitude = sqrt(array_sum(array_map(fn(float $x): float => $x * $x, $result)));
 
         self::assertEqualsWithDelta(1.0, $magnitude, 0.0001);
     }
@@ -190,7 +190,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
         $service = new EmbeddingService($llmManagerMock);
 
         // Pass null options
-        $result = $service->embedFull('test text', null);
+        $result = $service->embedFull('test text');
 
         self::assertInstanceOf(EmbeddingResponse::class, $result);
     }
@@ -219,7 +219,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
 
         $service = new EmbeddingService($llmManagerMock);
 
-        $result = $service->embedBatch(['text1', 'text2'], null);
+        $result = $service->embedBatch(['text1', 'text2']);
 
         self::assertCount(2, $result);
     }
@@ -362,7 +362,7 @@ class EmbeddingServiceMutationTest extends AbstractUnitTestCase
         $result = $service->normalize($vector);
 
         // Magnitude of result should still be 1.0
-        $magnitude = sqrt(array_sum(array_map(fn($x) => $x * $x, $result)));
+        $magnitude = sqrt(array_sum(array_map(fn(float $x): float => $x * $x, $result)));
         self::assertEqualsWithDelta(1.0, $magnitude, 0.0001);
 
         // Signs should be preserved

--- a/Tests/Unit/Service/Feature/EmbeddingServiceTest.php
+++ b/Tests/Unit/Service/Feature/EmbeddingServiceTest.php
@@ -25,6 +25,7 @@ use PHPUnit\Framework\Attributes\Test;
 class EmbeddingServiceTest extends AbstractUnitTestCase
 {
     private EmbeddingService $subject;
+
     private LlmServiceManagerInterface $llmManagerStub;
 
     protected function setUp(): void

--- a/Tests/Unit/Service/Feature/TranslationServiceTest.php
+++ b/Tests/Unit/Service/Feature/TranslationServiceTest.php
@@ -40,8 +40,11 @@ use ReflectionClass;
 class TranslationServiceTest extends AbstractUnitTestCase
 {
     private LlmServiceManagerInterface&Stub $llmManagerStub;
+
     private TranslatorRegistryInterface&MockObject $translatorRegistryMock;
+
     private LlmConfigurationServiceInterface&Stub $configServiceStub;
+
     private TranslationService $subject;
 
     protected function setUp(): void
@@ -1056,7 +1059,7 @@ class TranslationServiceTest extends AbstractUnitTestCase
             ->method('get')
             ->willReturn($translatorStub);
 
-        $result = $this->subject->translateBatchWithTranslator(['Hello', 'World'], 'de', null);
+        $result = $this->subject->translateBatchWithTranslator(['Hello', 'World'], 'de');
 
         self::assertCount(2, $result);
     }

--- a/Tests/Unit/Service/Feature/VisionServiceMutationTest.php
+++ b/Tests/Unit/Service/Feature/VisionServiceMutationTest.php
@@ -47,7 +47,7 @@ class VisionServiceMutationTest extends AbstractUnitTestCase
             ->method('vision')
             ->with(
                 self::anything(),
-                self::callback(fn(VisionOptions $opts) => $opts->getMaxTokens() === 100),
+                self::callback(fn(VisionOptions $opts): bool => $opts->getMaxTokens() === 100),
             )
             ->willReturn($this->createMockVisionResponse('Alt text'));
 
@@ -64,7 +64,7 @@ class VisionServiceMutationTest extends AbstractUnitTestCase
             ->method('vision')
             ->with(
                 self::anything(),
-                self::callback(fn(VisionOptions $opts) => $opts->getMaxTokens() === 200),
+                self::callback(fn(VisionOptions $opts): bool => $opts->getMaxTokens() === 200),
             )
             ->willReturn($this->createMockVisionResponse('Alt text'));
 
@@ -82,7 +82,7 @@ class VisionServiceMutationTest extends AbstractUnitTestCase
             ->method('vision')
             ->with(
                 self::anything(),
-                self::callback(fn(VisionOptions $opts) => $opts->getTemperature() === 0.5),
+                self::callback(fn(VisionOptions $opts): bool => $opts->getTemperature() === 0.5),
             )
             ->willReturn($this->createMockVisionResponse('Alt text'));
 
@@ -99,7 +99,7 @@ class VisionServiceMutationTest extends AbstractUnitTestCase
             ->method('vision')
             ->with(
                 self::anything(),
-                self::callback(fn(VisionOptions $opts) => $opts->getTemperature() === 0.8),
+                self::callback(fn(VisionOptions $opts): bool => $opts->getTemperature() === 0.8),
             )
             ->willReturn($this->createMockVisionResponse('Alt text'));
 
@@ -117,7 +117,7 @@ class VisionServiceMutationTest extends AbstractUnitTestCase
             ->method('vision')
             ->with(
                 self::anything(),
-                self::callback(fn(VisionOptions $opts) => $opts->getMaxTokens() === 50),
+                self::callback(fn(VisionOptions $opts): bool => $opts->getMaxTokens() === 50),
             )
             ->willReturn($this->createMockVisionResponse('Title'));
 
@@ -134,7 +134,7 @@ class VisionServiceMutationTest extends AbstractUnitTestCase
             ->method('vision')
             ->with(
                 self::anything(),
-                self::callback(fn(VisionOptions $opts) => $opts->getMaxTokens() === 75),
+                self::callback(fn(VisionOptions $opts): bool => $opts->getMaxTokens() === 75),
             )
             ->willReturn($this->createMockVisionResponse('Title'));
 
@@ -152,7 +152,7 @@ class VisionServiceMutationTest extends AbstractUnitTestCase
             ->method('vision')
             ->with(
                 self::anything(),
-                self::callback(fn(VisionOptions $opts) => $opts->getTemperature() === 0.7),
+                self::callback(fn(VisionOptions $opts): bool => $opts->getTemperature() === 0.7),
             )
             ->willReturn($this->createMockVisionResponse('Title'));
 
@@ -169,7 +169,7 @@ class VisionServiceMutationTest extends AbstractUnitTestCase
             ->method('vision')
             ->with(
                 self::anything(),
-                self::callback(fn(VisionOptions $opts) => $opts->getMaxTokens() === 500),
+                self::callback(fn(VisionOptions $opts): bool => $opts->getMaxTokens() === 500),
             )
             ->willReturn($this->createMockVisionResponse('Description'));
 
@@ -186,7 +186,7 @@ class VisionServiceMutationTest extends AbstractUnitTestCase
             ->method('vision')
             ->with(
                 self::anything(),
-                self::callback(fn(VisionOptions $opts) => $opts->getTemperature() === 0.7),
+                self::callback(fn(VisionOptions $opts): bool => $opts->getTemperature() === 0.7),
             )
             ->willReturn($this->createMockVisionResponse('Description'));
 
@@ -489,7 +489,7 @@ class VisionServiceMutationTest extends AbstractUnitTestCase
         $service = new VisionService($llmManagerMock);
 
         // Pass null explicitly
-        $result = $service->generateAltText('https://example.com/image.jpg', null);
+        $result = $service->generateAltText('https://example.com/image.jpg');
 
         self::assertEquals('Alt text', $result);
     }
@@ -506,7 +506,7 @@ class VisionServiceMutationTest extends AbstractUnitTestCase
         $service = new VisionService($llmManagerMock);
 
         // Pass null explicitly
-        $result = $service->generateTitle('https://example.com/image.jpg', null);
+        $result = $service->generateTitle('https://example.com/image.jpg');
 
         self::assertEquals('Title', $result);
     }
@@ -523,7 +523,7 @@ class VisionServiceMutationTest extends AbstractUnitTestCase
         $service = new VisionService($llmManagerMock);
 
         // Pass null explicitly
-        $result = $service->generateDescription('https://example.com/image.jpg', null);
+        $result = $service->generateDescription('https://example.com/image.jpg');
 
         self::assertEquals('Description', $result);
     }
@@ -540,7 +540,7 @@ class VisionServiceMutationTest extends AbstractUnitTestCase
         $service = new VisionService($llmManagerMock);
 
         // Pass null explicitly
-        $result = $service->analyzeImage('https://example.com/image.jpg', 'Prompt', null);
+        $result = $service->analyzeImage('https://example.com/image.jpg', 'Prompt');
 
         self::assertEquals('Analysis', $result);
     }
@@ -557,7 +557,7 @@ class VisionServiceMutationTest extends AbstractUnitTestCase
         $service = new VisionService($llmManagerMock);
 
         // Pass null explicitly
-        $result = $service->analyzeImageFull('https://example.com/image.jpg', 'Prompt', null);
+        $result = $service->analyzeImageFull('https://example.com/image.jpg', 'Prompt');
 
         self::assertInstanceOf(VisionResponse::class, $result);
     }

--- a/Tests/Unit/Service/Feature/VisionServiceTest.php
+++ b/Tests/Unit/Service/Feature/VisionServiceTest.php
@@ -25,6 +25,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 class VisionServiceTest extends AbstractUnitTestCase
 {
     private VisionService $subject;
+
     private LlmServiceManagerInterface $llmManagerStub;
 
     protected function setUp(): void

--- a/Tests/Unit/Service/Guardrail/InputGuardrailScreenerTest.php
+++ b/Tests/Unit/Service/Guardrail/InputGuardrailScreenerTest.php
@@ -177,6 +177,7 @@ final class InputGuardrailScreenerTest extends TestCase
     {
         return new class implements InputGuardrailInterface {
             use GuardrailIdentityDoubleTrait;
+
             public function checkInput(string $text): GuardrailResult
             {
                 return GuardrailResult::allow();
@@ -188,6 +189,7 @@ final class InputGuardrailScreenerTest extends TestCase
     {
         return new class ($needle, $replacement) implements InputGuardrailInterface {
             use GuardrailIdentityDoubleTrait;
+
             public function __construct(private readonly string $needle, private readonly string $replacement) {}
 
             public function checkInput(string $text): GuardrailResult
@@ -205,6 +207,7 @@ final class InputGuardrailScreenerTest extends TestCase
     {
         return new class ($reason) implements InputGuardrailInterface {
             use GuardrailIdentityDoubleTrait;
+
             public function __construct(private readonly string $reason) {}
 
             public function checkInput(string $text): GuardrailResult
@@ -218,6 +221,7 @@ final class InputGuardrailScreenerTest extends TestCase
     {
         return new class ($reason) implements InputGuardrailInterface {
             use GuardrailIdentityDoubleTrait;
+
             public function __construct(private readonly string $reason) {}
 
             public function checkInput(string $text): GuardrailResult
@@ -231,6 +235,7 @@ final class InputGuardrailScreenerTest extends TestCase
     {
         return new class implements InputGuardrailInterface {
             use GuardrailIdentityDoubleTrait;
+
             public function checkInput(string $text): GuardrailResult
             {
                 return GuardrailResult::retry('later');

--- a/Tests/Unit/Service/Health/ProviderHealthServiceTest.php
+++ b/Tests/Unit/Service/Health/ProviderHealthServiceTest.php
@@ -191,6 +191,7 @@ final class ProviderHealthServiceTest extends AbstractUnitTestCase
                 if (!\array_key_exists($identifier, $identifierToProvider)) {
                     return null;
                 }
+
                 $provider = $identifierToProvider[$identifier];
                 if ($provider === null) {
                     return null;

--- a/Tests/Unit/Service/LlmConfigurationServiceTest.php
+++ b/Tests/Unit/Service/LlmConfigurationServiceTest.php
@@ -33,10 +33,15 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 class LlmConfigurationServiceTest extends AbstractUnitTestCase
 {
     private LlmConfigurationRepository&MockObject $repositoryMock;
+
     private PersistenceManagerInterface&Stub $persistenceManagerStub;
+
     private Context&MockObject $contextMock;
+
     private bool $isAdmin = false;
+
     private bool $isLoggedIn = true;
+
     /** @var array<int> */
     private array $groupIds = [];
 
@@ -84,6 +89,7 @@ class LlmConfigurationServiceTest extends AbstractUnitTestCase
                 $group->method('getUid')->willReturn($id);
                 $groups->attach($group);
             }
+
             $config->method('getBeGroups')->willReturn($groups);
         } else {
             // getBeGroups() never returns null — an unrestricted configuration

--- a/Tests/Unit/Service/LlmServiceManagerMutationTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerMutationTest.php
@@ -28,6 +28,7 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 class LlmServiceManagerMutationTest extends AbstractUnitTestCase
 {
     use LlmServiceManagerTestFactory;
+
     /**
      * @param array<string, mixed> $config
      */

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -71,10 +71,15 @@ use TYPO3\CMS\Core\Context\Context;
 class LlmServiceManagerTest extends AbstractUnitTestCase
 {
     use LlmServiceManagerTestFactory;
+
     private LlmServiceManager $subject;
+
     private ExtensionConfiguration $extensionConfigStub;
+
     private LoggerInterface $loggerStub;
+
     private ProviderAdapterRegistryInterface $adapterRegistryStub;
+
     private TestableProvider $provider;
 
     protected function setUp(): void
@@ -889,7 +894,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         // screened too (ADR-089), not only the user turns.
         $manager->chat(
             [['role' => 'user', 'content' => 'hello']],
-            new ChatOptions(provider: 'openai', systemPrompt: 'You hold key sk-abcdef0123456789ABCDEF now'),
+            new ChatOptions(systemPrompt: 'You hold key sk-abcdef0123456789ABCDEF now', provider: 'openai'),
         );
 
         $joined = $this->joinContents($provider->capturedMessages);
@@ -1005,6 +1010,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         return new InputGuardrailScreener([
             new class ($reason) implements InputGuardrailInterface {
                 use GuardrailIdentityDoubleTrait;
+
                 public function __construct(private readonly string $reason) {}
 
                 public function checkInput(string $text): GuardrailResult
@@ -2683,6 +2689,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
                 provider: $testProvider->getIdentifier(),
             ));
         }
+
         $manager->registerProvider($testProvider);
 
         return $manager;
@@ -2703,7 +2710,7 @@ final class RecordingMiddleware implements ProviderMiddlewareInterface
         callable $next,
     ): mixed {
         $configuration = $context->configuration;
-        assert($configuration !== null);
+        assert($configuration instanceof LlmConfiguration);
 
         $this->calls[] = [
             'operation'          => $context->operation,
@@ -2723,11 +2730,15 @@ final class RecordingMiddleware implements ProviderMiddlewareInterface
 class TestableProvider extends AbstractProvider
 {
     private ?CompletionResponse $nextResponse = null;
+
     private ?EmbeddingResponse $nextEmbeddingResponse = null;
+
     /** @var array<string, mixed> */
     private array $lastOptions = [];
+
     /** @var array<string, mixed> */
     private array $lastConfiguration = [];
+
     /**
      * Messages the provider last received (for asserting input screening on the
      * ad-hoc provider-key path, ADR-087).
@@ -2853,7 +2864,7 @@ class TestableVisionProvider extends TestableProvider implements VisionCapableIn
 
     public function __construct()
     {
-        parent::__construct('openai-vision', 'OpenAI Vision', true);
+        parent::__construct('openai-vision', 'OpenAI Vision');
     }
 
     public function setNextVisionResponse(VisionResponse $response): void
@@ -2896,7 +2907,7 @@ class TestableStreamingProvider extends TestableProvider implements StreamingCap
 {
     public function __construct()
     {
-        parent::__construct('openai-stream', 'OpenAI Stream', true);
+        parent::__construct('openai-stream', 'OpenAI Stream');
     }
 
     public function streamChatCompletion(array $messages, array $options = []): Generator
@@ -2925,7 +2936,7 @@ class StubStreamingProvider extends TestableProvider implements StreamingCapable
 
     public function __construct()
     {
-        parent::__construct('mock', 'Mock', true);
+        parent::__construct('mock', 'Mock');
     }
 
     public function streamChatCompletion(array $messages, array $options = []): Generator
@@ -2952,7 +2963,7 @@ class TestableToolProvider extends TestableProvider implements ToolCapableInterf
 
     public function __construct()
     {
-        parent::__construct('openai-tools', 'OpenAI Tools', true);
+        parent::__construct('openai-tools', 'OpenAI Tools');
     }
 
     public function chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse
@@ -2976,14 +2987,14 @@ class TestableNoEmbeddingsProvider extends TestableProvider
 {
     public function __construct()
     {
-        parent::__construct('limited', 'Limited Provider', true);
+        parent::__construct('limited', 'Limited Provider');
     }
 
     public function supportsFeature(string|ModelCapability $feature): bool
     {
         $featureValue = $feature instanceof ModelCapability ? $feature->value : $feature;
         // Does NOT support embeddings
-        return in_array($featureValue, ['chat'], true);
+        return $featureValue === 'chat';
     }
 
     public function embeddings(string|array $input, array $options = []): EmbeddingResponse

--- a/Tests/Unit/Service/ModelSelectionServiceTest.php
+++ b/Tests/Unit/Service/ModelSelectionServiceTest.php
@@ -30,6 +30,7 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 final class ModelSelectionServiceTest extends TestCase
 {
     private ModelRepository&Stub $modelRepository;
+
     private ModelSelectionService $subject;
 
     protected function setUp(): void
@@ -55,6 +56,7 @@ final class ModelSelectionServiceTest extends TestCase
         $providerReflection = new ReflectionClass($provider);
         $providerUid = $providerReflection->getProperty('uid');
         $providerUid->setValue($provider, $uid);
+
         $provider->setAdapterType($adapterType);
         $provider->setPriority($providerPriority);
 
@@ -62,6 +64,7 @@ final class ModelSelectionServiceTest extends TestCase
         $reflection = new ReflectionClass($model);
         $uidProperty = $reflection->getProperty('uid');
         $uidProperty->setValue($model, $uid);
+
         $model->setIdentifier('model-' . $uid);
         $model->setName('Model ' . $uid);
         $model->setCapabilities($capabilities);
@@ -95,6 +98,7 @@ final class ModelSelectionServiceTest extends TestCase
         return new class ($items) implements QueryResultInterface {
             /** @var array<int, object> */
             private array $items;
+
             /**
              * @param array<int, object> $items
              */
@@ -102,74 +106,91 @@ final class ModelSelectionServiceTest extends TestCase
             {
                 $this->items = array_values($items);
             }
+
             public function setQuery(QueryInterface $query): void
             {
                 // Intentionally empty: this in-memory test double has no backing query to bind.
             }
+
             public function getFirst(): ?object
             {
                 return $this->items[0] ?? null;
             }
+
             /**
              * @return list<object>
              */
             public function toArray(): array
             {
-                /** @var list<object> */
-                return $this->items;
+                // offsetSet()/offsetUnset() can leave gaps, so re-index rather
+                // than asserting listness of the stored array.
+                return array_values($this->items);
             }
+
             public function count(): int
             {
                 return count($this->items);
             }
+
             public function getQuery(): QueryInterface
             {
                 throw new LogicException('Not implemented', 7771386590);
             }
+
             public function offsetExists($offset): bool
             {
                 if (!is_int($offset)) {
                     return false;
                 }
+
                 return isset($this->items[$offset]);
             }
+
             public function offsetGet($offset): mixed
             {
                 if (!is_int($offset)) {
                     return null;
                 }
+
                 return $this->items[$offset];
             }
+
             public function offsetSet($offset, $value): void
             {
                 if (is_object($value) && is_int($offset)) {
                     $this->items[$offset] = $value;
                 }
             }
+
             public function offsetUnset($offset): void
             {
                 if (is_int($offset)) {
                     unset($this->items[$offset]);
                 }
             }
+
             public function current(): object
             {
                 $current = current($this->items);
                 assert($current !== false);
                 return $current;
             }
+
             public function next(): void
             {
                 next($this->items);
             }
+
             public function key(): int
             {
                 return (int)key($this->items);
             }
+
             public function valid(): bool
             {
                 return key($this->items) !== null;
             }
+
             public function rewind(): void
             {
                 reset($this->items);
@@ -444,6 +465,7 @@ final class ModelSelectionServiceTest extends TestCase
         $reflection = new ReflectionClass($model);
         $uidProperty = $reflection->getProperty('uid');
         $uidProperty->setValue($model, 1);
+
         $model->setCapabilities('chat');
         // No provider set
 

--- a/Tests/Unit/Service/Preset/ConfigurationPresetDiffServiceTest.php
+++ b/Tests/Unit/Service/Preset/ConfigurationPresetDiffServiceTest.php
@@ -33,7 +33,7 @@ final class ConfigurationPresetDiffServiceTest extends TestCase
     /**
      * A record whose values match {@see baselinePreset()} field for field.
      */
-    private static function baselineRecord(): LlmConfiguration
+    private function baselineRecord(): LlmConfiguration
     {
         $record = new LlmConfiguration();
         $record->setIdentifier('ext.chat');
@@ -49,7 +49,7 @@ final class ConfigurationPresetDiffServiceTest extends TestCase
         return $record;
     }
 
-    private static function baselinePreset(): ConfigurationPreset
+    private function baselinePreset(): ConfigurationPreset
     {
         return new ConfigurationPreset(
             identifier: 'ext.chat',
@@ -66,20 +66,21 @@ final class ConfigurationPresetDiffServiceTest extends TestCase
     /**
      * @param list<PresetFieldDiff> $changes
      */
-    private static function change(array $changes, string $field): PresetFieldDiff
+    private function change(array $changes, string $field): PresetFieldDiff
     {
         foreach ($changes as $change) {
             if ($change->field === $field) {
                 return $change;
             }
         }
+
         self::fail(sprintf('No diff entry for field "%s".', $field));
     }
 
     #[Test]
     public function reportsNoChangeWhenDeclarationMatchesRecord(): void
     {
-        $diff = $this->subject->diff(self::baselinePreset(), self::baselineRecord());
+        $diff = $this->subject->diff($this->baselinePreset(), $this->baselineRecord());
 
         self::assertFalse($diff->hasChanges());
         self::assertSame([], $diff->changedFields());
@@ -100,11 +101,11 @@ final class ConfigurationPresetDiffServiceTest extends TestCase
             allowedToolGroups: ['rag', 'content'],
         );
 
-        $changes = $this->subject->diff($preset, self::baselineRecord())->changes;
+        $changes = $this->subject->diff($preset, $this->baselineRecord())->changes;
 
-        self::assertSame('Chat', self::change($changes, 'name')->current);
-        self::assertSame('Chat v2', self::change($changes, 'name')->declared);
-        self::assertSame('Updated.', self::change($changes, 'description')->declared);
+        self::assertSame('Chat', $this->change($changes, 'name')->current);
+        self::assertSame('Chat v2', $this->change($changes, 'name')->declared);
+        self::assertSame('Updated.', $this->change($changes, 'description')->declared);
     }
 
     #[Test]
@@ -121,7 +122,7 @@ final class ConfigurationPresetDiffServiceTest extends TestCase
             allowedToolGroups: ['rag', 'content'],
         );
 
-        $change = self::change($this->subject->diff($preset, self::baselineRecord())->changes, 'temperature');
+        $change = $this->change($this->subject->diff($preset, $this->baselineRecord())->changes, 'temperature');
 
         self::assertSame('0.20', $change->current);
         self::assertSame('0.90', $change->declared);
@@ -142,7 +143,7 @@ final class ConfigurationPresetDiffServiceTest extends TestCase
             allowedToolGroups: ['rag', 'content'],
         );
 
-        $diff = $this->subject->diff($preset, self::baselineRecord());
+        $diff = $this->subject->diff($preset, $this->baselineRecord());
 
         self::assertNotContains('temperature', $diff->changedFields());
     }
@@ -165,14 +166,14 @@ final class ConfigurationPresetDiffServiceTest extends TestCase
             allowedToolGroups: ['rag', 'content'],
         );
 
-        $changes = $this->subject->diff($preset, self::baselineRecord())->changes;
+        $changes = $this->subject->diff($preset, $this->baselineRecord())->changes;
 
-        self::assertSame('chat', self::change($changes, 'criteria.capabilities')->current);
-        self::assertSame('chat, vision', self::change($changes, 'criteria.capabilities')->declared);
-        self::assertSame('0', self::change($changes, 'criteria.minContextLength')->current);
-        self::assertSame('8000', self::change($changes, 'criteria.minContextLength')->declared);
-        self::assertSame('false', self::change($changes, 'criteria.preferLowestCost')->current);
-        self::assertSame('true', self::change($changes, 'criteria.preferLowestCost')->declared);
+        self::assertSame('chat', $this->change($changes, 'criteria.capabilities')->current);
+        self::assertSame('chat, vision', $this->change($changes, 'criteria.capabilities')->declared);
+        self::assertSame('0', $this->change($changes, 'criteria.minContextLength')->current);
+        self::assertSame('8000', $this->change($changes, 'criteria.minContextLength')->declared);
+        self::assertSame('false', $this->change($changes, 'criteria.preferLowestCost')->current);
+        self::assertSame('true', $this->change($changes, 'criteria.preferLowestCost')->declared);
     }
 
     #[Test]
@@ -180,10 +181,10 @@ final class ConfigurationPresetDiffServiceTest extends TestCase
     {
         // Declared list order differs from the record's CSV order, but the
         // sets are equal, so it is not a change.
-        $record = self::baselineRecord();
+        $record = $this->baselineRecord();
         $record->setAllowedToolGroups('content,rag');
 
-        $diff = $this->subject->diff(self::baselinePreset(), $record);
+        $diff = $this->subject->diff($this->baselinePreset(), $record);
 
         self::assertNotContains('allowedToolGroups', $diff->changedFields());
     }
@@ -202,7 +203,7 @@ final class ConfigurationPresetDiffServiceTest extends TestCase
             allowedToolGroups: ['rag'],
         );
 
-        $diff = $this->subject->diff($preset, self::baselineRecord());
+        $diff = $this->subject->diff($preset, $this->baselineRecord());
 
         self::assertContains('allowedToolGroups', $diff->changedFields());
     }
@@ -218,12 +219,11 @@ final class ConfigurationPresetDiffServiceTest extends TestCase
             description: 'A chat preset.',
             criteria: new ModelSelectionCriteria(capabilities: ['chat']),
             systemPrompt: 'You are helpful.',
-            temperature: null,
             maxTokens: 2000,
             allowedToolGroups: ['rag', 'content'],
         );
 
-        $diff = $this->subject->diff($preset, self::baselineRecord());
+        $diff = $this->subject->diff($preset, $this->baselineRecord());
 
         self::assertNotContains('temperature', $diff->changedFields());
     }
@@ -233,11 +233,11 @@ final class ConfigurationPresetDiffServiceTest extends TestCase
     {
         // Flipping the record's activation / default flags produces no diff
         // entry: those fields are structurally absent from a preset.
-        $record = self::baselineRecord();
+        $record = $this->baselineRecord();
         $record->setIsActive(true);
         $record->setIsDefault(true);
 
-        $diff = $this->subject->diff(self::baselinePreset(), $record);
+        $diff = $this->subject->diff($this->baselinePreset(), $record);
 
         self::assertFalse($diff->hasChanges());
     }

--- a/Tests/Unit/Service/Preset/ConfigurationPresetImportServiceTest.php
+++ b/Tests/Unit/Service/Preset/ConfigurationPresetImportServiceTest.php
@@ -36,10 +36,15 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 final class ConfigurationPresetImportServiceTest extends TestCase
 {
     private ModelSelectionServiceInterface&MockObject $modelSelectionService;
+
     private LlmConfigurationRepository&MockObject $configurationRepository;
+
     private PersistenceManagerInterface&MockObject $persistenceManager;
+
     private ModelRepository&MockObject $modelRepository;
+
     private ProviderRepository&MockObject $providerRepository;
+
     private ConfigurationPresetImportService $subject;
 
     protected function setUp(): void
@@ -68,7 +73,7 @@ final class ConfigurationPresetImportServiceTest extends TestCase
         );
     }
 
-    private static function preset(): ConfigurationPreset
+    private function preset(): ConfigurationPreset
     {
         return new ConfigurationPreset(
             identifier: 'ext.chat',
@@ -92,7 +97,7 @@ final class ConfigurationPresetImportServiceTest extends TestCase
         $model->setName('Claude Sonnet');
         $this->modelSelectionService->method('findMatchingModel')->willReturn($model);
 
-        $result = $this->subject->preflight(self::preset());
+        $result = $this->subject->preflight($this->preset());
 
         self::assertTrue($result->satisfiable);
         self::assertSame('Claude Sonnet', $result->matchedModelLabel);
@@ -106,7 +111,7 @@ final class ConfigurationPresetImportServiceTest extends TestCase
         $model->setModelId('claude-sonnet-4-5');
         $this->modelSelectionService->method('findMatchingModel')->willReturn($model);
 
-        $result = $this->subject->preflight(self::preset());
+        $result = $this->subject->preflight($this->preset());
 
         self::assertSame('claude-sonnet-4-5', $result->matchedModelLabel);
     }
@@ -117,7 +122,7 @@ final class ConfigurationPresetImportServiceTest extends TestCase
         $this->modelSelectionService->method('findMatchingModel')->willReturn(null);
         $this->modelSelectionService->method('findCandidates')->willReturn([]);
 
-        $result = $this->subject->preflight(self::preset());
+        $result = $this->subject->preflight($this->preset());
 
         self::assertFalse($result->satisfiable);
         self::assertSame('capabilities: chat, tools', $result->missingRequirement);
@@ -132,7 +137,7 @@ final class ConfigurationPresetImportServiceTest extends TestCase
             static fn(array $criteria): array => isset($criteria['minContextLength']) ? [] : [new Model()],
         );
 
-        $result = $this->subject->preflight(self::preset());
+        $result = $this->subject->preflight($this->preset());
 
         self::assertFalse($result->satisfiable);
         self::assertSame('minimum context length: 8000', $result->missingRequirement);
@@ -141,7 +146,7 @@ final class ConfigurationPresetImportServiceTest extends TestCase
     #[Test]
     public function importCreatesActiveCriteriaModeRecordWithChecksum(): void
     {
-        $preset = self::preset();
+        $preset = $this->preset();
         $model = new Model();
         $model->setName('Claude Sonnet');
         $this->modelSelectionService->method('findMatchingModel')->willReturn($model);
@@ -208,7 +213,7 @@ final class ConfigurationPresetImportServiceTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionCode(1789347005);
 
-        $this->subject->import(self::preset());
+        $this->subject->import($this->preset());
     }
 
     #[Test]
@@ -222,14 +227,14 @@ final class ConfigurationPresetImportServiceTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionCode(1789347006);
 
-        $this->subject->import(self::preset());
+        $this->subject->import($this->preset());
     }
 
     /**
      * A changed declaration for the same identifier: name, description,
      * temperature and criteria all differ from {@see preset()}.
      */
-    private static function changedPreset(): ConfigurationPreset
+    private function changedPreset(): ConfigurationPreset
     {
         return new ConfigurationPreset(
             identifier: 'ext.chat',
@@ -251,7 +256,7 @@ final class ConfigurationPresetImportServiceTest extends TestCase
      * checksum is that declaration's, so passing a *different* declaration to
      * update() makes it drifted.
      */
-    private static function recordImportedFrom(ConfigurationPreset $importedFrom): LlmConfiguration
+    private function recordImportedFrom(ConfigurationPreset $importedFrom): LlmConfiguration
     {
         $record = new LlmConfiguration();
         $record->setIdentifier($importedFrom->identifier);
@@ -262,24 +267,31 @@ final class ConfigurationPresetImportServiceTest extends TestCase
         if ($importedFrom->systemPrompt !== null) {
             $record->setSystemPrompt($importedFrom->systemPrompt);
         }
+
         if ($importedFrom->temperature !== null) {
             $record->setTemperature($importedFrom->temperature);
         }
+
         if ($importedFrom->maxTokens !== null) {
             $record->setMaxTokens($importedFrom->maxTokens);
         }
+
         if ($importedFrom->maxRequestsPerDay !== null) {
             $record->setMaxRequestsPerDay($importedFrom->maxRequestsPerDay);
         }
+
         if ($importedFrom->maxTokensPerDay !== null) {
             $record->setMaxTokensPerDay($importedFrom->maxTokensPerDay);
         }
+
         if ($importedFrom->maxCostPerDay !== null) {
             $record->setMaxCostPerDay($importedFrom->maxCostPerDay);
         }
+
         if ($importedFrom->allowedToolGroups !== []) {
             $record->setAllowedToolGroups(implode(',', $importedFrom->allowedToolGroups));
         }
+
         $record->setPresetChecksum($importedFrom->checksum());
 
         return $record;
@@ -288,8 +300,8 @@ final class ConfigurationPresetImportServiceTest extends TestCase
     #[Test]
     public function updateAppliesDeclaredFieldsAndRestampsChecksum(): void
     {
-        $preset = self::changedPreset();
-        $record = self::recordImportedFrom(self::preset());
+        $preset = $this->changedPreset();
+        $record = $this->recordImportedFrom($this->preset());
         $this->modelSelectionService->method('findMatchingModel')->willReturn(new Model());
         $this->configurationRepository->expects(self::once())->method('update')->with($record);
         $this->persistenceManager->expects(self::once())->method('persistAll');
@@ -310,8 +322,8 @@ final class ConfigurationPresetImportServiceTest extends TestCase
     #[Test]
     public function updateLeavesAdminOwnedFieldsUntouched(): void
     {
-        $preset = self::changedPreset();
-        $record = self::recordImportedFrom(self::preset());
+        $preset = $this->changedPreset();
+        $record = $this->recordImportedFrom($this->preset());
         $record->setIsActive(true);
         $record->setIsDefault(true);
         $this->modelSelectionService->method('findMatchingModel')->willReturn(new Model());
@@ -334,10 +346,9 @@ final class ConfigurationPresetImportServiceTest extends TestCase
             description: 'A chat preset.',
             criteria: new ModelSelectionCriteria(capabilities: ['chat', 'tools'], minContextLength: 8000),
             systemPrompt: 'You are helpful.',
-            temperature: null,
             maxTokens: 2000,
         );
-        $record = self::recordImportedFrom(self::preset());
+        $record = $this->recordImportedFrom($this->preset());
         $this->modelSelectionService->method('findMatchingModel')->willReturn(new Model());
 
         $diff = $this->subject->update($preset, $record);
@@ -350,8 +361,8 @@ final class ConfigurationPresetImportServiceTest extends TestCase
     #[Test]
     public function updateRefusesWhenRecordIsNotDrifted(): void
     {
-        $preset = self::changedPreset();
-        $record = self::recordImportedFrom($preset); // stored checksum equals current declaration
+        $preset = $this->changedPreset();
+        $record = $this->recordImportedFrom($preset); // stored checksum equals current declaration
         $this->configurationRepository->expects(self::never())->method('update');
 
         $this->expectException(InvalidArgumentException::class);
@@ -363,8 +374,8 @@ final class ConfigurationPresetImportServiceTest extends TestCase
     #[Test]
     public function updateRefusesWhenRecordCarriesNoStoredChecksum(): void
     {
-        $preset = self::changedPreset();
-        $record = self::recordImportedFrom(self::preset());
+        $preset = $this->changedPreset();
+        $record = $this->recordImportedFrom($this->preset());
         $record->setPresetChecksum('');
         $this->configurationRepository->expects(self::never())->method('update');
 
@@ -377,8 +388,8 @@ final class ConfigurationPresetImportServiceTest extends TestCase
     #[Test]
     public function updateRefusesWhenModeSwitchedToFixed(): void
     {
-        $preset = self::changedPreset();
-        $record = self::recordImportedFrom(self::preset());
+        $preset = $this->changedPreset();
+        $record = $this->recordImportedFrom($this->preset());
         $record->setModelSelectionMode(ModelSelectionMode::FIXED->value);
         $this->configurationRepository->expects(self::never())->method('update');
 
@@ -391,8 +402,8 @@ final class ConfigurationPresetImportServiceTest extends TestCase
     #[Test]
     public function updateRefusesWhenUpdatedCriteriaUnsatisfiable(): void
     {
-        $preset = self::changedPreset();
-        $record = self::recordImportedFrom(self::preset());
+        $preset = $this->changedPreset();
+        $record = $this->recordImportedFrom($this->preset());
         $this->modelSelectionService->method('findMatchingModel')->willReturn(null);
         $this->modelSelectionService->method('findCandidates')->willReturn([]);
         $this->configurationRepository->expects(self::never())->method('update');
@@ -406,8 +417,8 @@ final class ConfigurationPresetImportServiceTest extends TestCase
     #[Test]
     public function updateRefusesWhenRecordBelongsToAnotherIdentifier(): void
     {
-        $preset = self::changedPreset();
-        $record = self::recordImportedFrom(self::preset());
+        $preset = $this->changedPreset();
+        $record = $this->recordImportedFrom($this->preset());
         $record->setIdentifier('ext.other');
         $this->configurationRepository->expects(self::never())->method('update');
 
@@ -420,8 +431,8 @@ final class ConfigurationPresetImportServiceTest extends TestCase
     #[Test]
     public function previewUpdateReturnsDiffWithoutPersisting(): void
     {
-        $preset = self::changedPreset();
-        $record = self::recordImportedFrom(self::preset());
+        $preset = $this->changedPreset();
+        $record = $this->recordImportedFrom($this->preset());
         $this->modelSelectionService->method('findMatchingModel')->willReturn(new Model());
         $this->configurationRepository->expects(self::never())->method('update');
         $this->persistenceManager->expects(self::never())->method('persistAll');
@@ -466,7 +477,7 @@ final class ConfigurationPresetImportServiceTest extends TestCase
         $this->modelSelectionService->method('findMatchingModel')->willReturn(null);
         $this->modelSelectionService->method('findCandidates')->willReturn([]);
 
-        $result = $subject->preflight(self::preset());
+        $result = $subject->preflight($this->preset());
 
         self::assertSame(PresetRemedy::AddProvider, $result->remedy);
         self::assertNull($result->remedySubject);
@@ -499,7 +510,7 @@ final class ConfigurationPresetImportServiceTest extends TestCase
         $this->modelSelectionService->method('findCandidates')->willReturn([]);
         $this->modelSelectionService->method('modelMatchesCriteria')->willReturn(true);
 
-        $result = $subject->preflight(self::preset());
+        $result = $subject->preflight($this->preset());
 
         self::assertSame(PresetRemedy::ActivateModel, $result->remedy);
         self::assertSame('gpt-4o (OpenAI)', $result->remedySubject);
@@ -528,7 +539,7 @@ final class ConfigurationPresetImportServiceTest extends TestCase
         $this->modelSelectionService->method('findCandidates')->willReturn([]);
         $this->modelSelectionService->method('modelMatchesCriteria')->willReturn(true);
 
-        $result = $subject->preflight(self::preset());
+        $result = $subject->preflight($this->preset());
 
         self::assertSame(PresetRemedy::AddModel, $result->remedy);
     }
@@ -538,6 +549,7 @@ final class ConfigurationPresetImportServiceTest extends TestCase
     {
         $openAi = new Provider();
         $openAi->setName('OpenAI');
+
         $ollama = new Provider();
         $ollama->setName('Ollama');
 
@@ -556,7 +568,7 @@ final class ConfigurationPresetImportServiceTest extends TestCase
         $this->modelSelectionService->method('findMatchingModel')->willReturn(null);
         $this->modelSelectionService->method('findCandidates')->willReturn([]);
 
-        $result = $subject->preflight(self::preset());
+        $result = $subject->preflight($this->preset());
 
         self::assertSame(PresetRemedy::AddModel, $result->remedy);
         self::assertSame('OpenAI, Ollama', $result->remedySubject);
@@ -571,7 +583,7 @@ final class ConfigurationPresetImportServiceTest extends TestCase
             static fn(array $criteria): array => isset($criteria['minContextLength']) ? [] : [new Model()],
         );
 
-        $result = $this->subject->preflight(self::preset());
+        $result = $this->subject->preflight($this->preset());
 
         self::assertSame(PresetRemedy::AdjustSetup, $result->remedy);
         self::assertNull($result->remedySubject);
@@ -584,7 +596,7 @@ final class ConfigurationPresetImportServiceTest extends TestCase
         $model->setName('gpt-4o');
         $this->modelSelectionService->method('findMatchingModel')->willReturn($model);
 
-        $result = $this->subject->preflight(self::preset());
+        $result = $this->subject->preflight($this->preset());
 
         self::assertTrue($result->satisfiable);
         self::assertNull($result->remedy);
@@ -612,7 +624,7 @@ final class ConfigurationPresetImportServiceTest extends TestCase
         $this->modelSelectionService->method('findMatchingModel')->willReturn(null);
         $this->modelSelectionService->method('findCandidates')->willReturn([]);
 
-        $result = $subject->preflight(self::preset());
+        $result = $subject->preflight($this->preset());
 
         self::assertSame(PresetRemedy::AddProvider, $result->remedy);
     }

--- a/Tests/Unit/Service/Preset/ConfigurationPresetRegistryTest.php
+++ b/Tests/Unit/Service/Preset/ConfigurationPresetRegistryTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(ConfigurationPresetRegistry::class)]
 final class ConfigurationPresetRegistryTest extends TestCase
 {
-    private static function preset(string $identifier): ConfigurationPreset
+    private function preset(string $identifier): ConfigurationPreset
     {
         return new ConfigurationPreset(
             identifier: $identifier,
@@ -38,8 +38,8 @@ final class ConfigurationPresetRegistryTest extends TestCase
     #[Test]
     public function collectsPresetsAcrossProvidersAndLooksUpByIdentifier(): void
     {
-        $alpha = self::preset('ext_a.alpha');
-        $beta = self::preset('ext_b.beta');
+        $alpha = $this->preset('ext_a.alpha');
+        $beta = $this->preset('ext_b.beta');
         $registry = new ConfigurationPresetRegistry(
             [new FixturePresetProvider([$alpha]), new FixturePresetProvider([$beta])],
             self::createStub(LlmConfigurationRepository::class),
@@ -58,8 +58,8 @@ final class ConfigurationPresetRegistryTest extends TestCase
 
         new ConfigurationPresetRegistry(
             [
-                new FixturePresetProvider([self::preset('ext.dup')]),
-                new FixturePresetProvider([self::preset('ext.dup')]),
+                new FixturePresetProvider([$this->preset('ext.dup')]),
+                new FixturePresetProvider([$this->preset('ext.dup')]),
             ],
             self::createStub(LlmConfigurationRepository::class),
         );
@@ -68,8 +68,8 @@ final class ConfigurationPresetRegistryTest extends TestCase
     #[Test]
     public function pendingReturnsOnlyPresetsWithoutConfigurationRecord(): void
     {
-        $imported = self::preset('ext.imported');
-        $pending = self::preset('ext.pending');
+        $imported = $this->preset('ext.imported');
+        $pending = $this->preset('ext.pending');
         $repository = $this->createMock(LlmConfigurationRepository::class);
         $repository->method('findOneByIdentifier')->willReturnCallback(
             static fn(string $identifier): ?LlmConfiguration => $identifier === 'ext.imported' ? new LlmConfiguration() : null,
@@ -86,9 +86,10 @@ final class ConfigurationPresetRegistryTest extends TestCase
     #[Test]
     public function driftedReturnsImportedPresetWhoseDeclarationChanged(): void
     {
-        $preset = self::preset('ext.imported');
+        $preset = $this->preset('ext.imported');
         $configuration = new LlmConfiguration();
         $configuration->setPresetChecksum('0000000000000000000000000000000000000000000000000000000000000000');
+
         $repository = $this->createMock(LlmConfigurationRepository::class);
         $repository->method('findOneByIdentifier')->willReturn($configuration);
 
@@ -106,9 +107,10 @@ final class ConfigurationPresetRegistryTest extends TestCase
     #[Test]
     public function driftedOmitsImportedPresetWithUnchangedChecksum(): void
     {
-        $preset = self::preset('ext.imported');
+        $preset = $this->preset('ext.imported');
         $configuration = new LlmConfiguration();
         $configuration->setPresetChecksum($preset->checksum());
+
         $repository = $this->createMock(LlmConfigurationRepository::class);
         $repository->method('findOneByIdentifier')->willReturn($configuration);
 
@@ -125,8 +127,8 @@ final class ConfigurationPresetRegistryTest extends TestCase
     {
         // A pending preset has no record; a hand-created record sharing a
         // declared identifier carries no stored checksum. Neither is drift.
-        $pending = self::preset('ext.pending');
-        $handCreated = self::preset('ext.hand_created');
+        $pending = $this->preset('ext.pending');
+        $handCreated = $this->preset('ext.hand_created');
         $record = new LlmConfiguration();
         $repository = $this->createMock(LlmConfigurationRepository::class);
         $repository->method('findOneByIdentifier')->willReturnCallback(

--- a/Tests/Unit/Service/Preset/ConfigurationPresetTest.php
+++ b/Tests/Unit/Service/Preset/ConfigurationPresetTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(ConfigurationPreset::class)]
 final class ConfigurationPresetTest extends TestCase
 {
-    private static function chatCriteria(): ModelSelectionCriteria
+    private function chatCriteria(): ModelSelectionCriteria
     {
         return new ModelSelectionCriteria(capabilities: ['chat']);
     }
@@ -32,7 +32,7 @@ final class ConfigurationPresetTest extends TestCase
             identifier: 'nr_ai_search.chat',
             name: 'AI Search Chat',
             description: 'Answers site-search questions.',
-            criteria: self::chatCriteria(),
+            criteria: $this->chatCriteria(),
         );
 
         self::assertSame('nr_ai_search.chat', $preset->identifier);
@@ -68,7 +68,7 @@ final class ConfigurationPresetTest extends TestCase
             identifier: $identifier,
             name: 'Name',
             description: '',
-            criteria: self::chatCriteria(),
+            criteria: $this->chatCriteria(),
         );
     }
 
@@ -82,7 +82,7 @@ final class ConfigurationPresetTest extends TestCase
             identifier: str_repeat('a', 101),
             name: 'Name',
             description: '',
-            criteria: self::chatCriteria(),
+            criteria: $this->chatCriteria(),
         );
     }
 
@@ -110,7 +110,7 @@ final class ConfigurationPresetTest extends TestCase
             identifier: 'ext.chat',
             name: str_repeat('n', 256),
             description: '',
-            criteria: self::chatCriteria(),
+            criteria: $this->chatCriteria(),
         );
     }
 
@@ -146,7 +146,7 @@ final class ConfigurationPresetTest extends TestCase
             'identifier' => 'ext.chat',
             'name' => 'Name',
             'description' => '',
-            'criteria' => self::chatCriteria(),
+            'criteria' => $this->chatCriteria(),
         ] + $seed)));
     }
 
@@ -159,7 +159,7 @@ final class ConfigurationPresetTest extends TestCase
             identifier: 'ext.chat',
             name: str_repeat('ä', 255),
             description: '',
-            criteria: self::chatCriteria(),
+            criteria: $this->chatCriteria(),
         );
 
         self::assertSame(255, mb_strlen($preset->name));
@@ -175,7 +175,7 @@ final class ConfigurationPresetTest extends TestCase
             identifier: 'ext.chat',
             name: '',
             description: '',
-            criteria: self::chatCriteria(),
+            criteria: $this->chatCriteria(),
         );
     }
 
@@ -220,13 +220,13 @@ final class ConfigurationPresetTest extends TestCase
             identifier: 'ext.chat',
             name: 'Chat',
             description: 'A chat preset.',
-            criteria: self::chatCriteria(),
+            criteria: $this->chatCriteria(),
         );
         $changedDescription = new ConfigurationPreset(
             identifier: 'ext.chat',
             name: 'Chat',
             description: 'A different description.',
-            criteria: self::chatCriteria(),
+            criteria: $this->chatCriteria(),
         );
         $changedCriteria = new ConfigurationPreset(
             identifier: 'ext.chat',
@@ -238,7 +238,7 @@ final class ConfigurationPresetTest extends TestCase
             identifier: 'ext.chat',
             name: 'Chat',
             description: 'A chat preset.',
-            criteria: self::chatCriteria(),
+            criteria: $this->chatCriteria(),
             temperature: 0.5,
         );
 

--- a/Tests/Unit/Service/Session/Fixtures/RecordingAiSessionRepository.php
+++ b/Tests/Unit/Service/Session/Fixtures/RecordingAiSessionRepository.php
@@ -103,6 +103,7 @@ final class RecordingAiSessionRepository implements AiSessionRepositoryInterface
             $this->sessions[$sessionUid]['messageCount'] = max($this->sessions[$sessionUid]['messageCount'], $messageCount);
             $this->sessions[$sessionUid]['lastActivity'] = 1;
         }
+
         $this->touchCalls[] = ['session' => $sessionUid, 'messageCount' => $messageCount];
     }
 
@@ -145,6 +146,7 @@ final class RecordingAiSessionRepository implements AiSessionRepositoryInterface
                 );
             }
         }
+
         usort($out, static fn(AiSessionMessage $a, AiSessionMessage $b): int => $a->sequence <=> $b->sequence);
 
         return $out;

--- a/Tests/Unit/Service/SetupWizard/ConfigurationGeneratorTest.php
+++ b/Tests/Unit/Service/SetupWizard/ConfigurationGeneratorTest.php
@@ -33,10 +33,15 @@ use RuntimeException;
 class ConfigurationGeneratorTest extends AbstractUnitTestCase
 {
     private ClientInterface&Stub $httpClientStub;
+
     private RequestFactoryInterface&Stub $requestFactoryStub;
+
     private StreamFactoryInterface&Stub $streamFactoryStub;
+
     private VaultServiceInterface $vaultStub;
+
     private LoggerInterface&Stub $loggerStub;
+
     private ConfigurationGenerator $subject;
 
     protected function setUp(): void
@@ -78,8 +83,8 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
     {
         return new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
     }
 
@@ -87,8 +92,8 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
     {
         return new DetectedProvider(
             adapterType: 'anthropic',
-            endpoint: 'https://api.anthropic.com',
             suggestedName: 'Anthropic',
+            endpoint: 'https://api.anthropic.com',
         );
     }
 
@@ -96,8 +101,8 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
     {
         return new DetectedProvider(
             adapterType: 'gemini',
-            endpoint: 'https://generativelanguage.googleapis.com',
             suggestedName: 'Google Gemini',
+            endpoint: 'https://generativelanguage.googleapis.com',
         );
     }
 
@@ -154,8 +159,8 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
 
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://169.254.169.254/v1',
             suggestedName: 'Metadata SSRF',
+            endpoint: 'https://169.254.169.254/v1',
         );
 
         $result = $subject->generate($provider, 'test-key', $this->createTestModels());
@@ -187,7 +192,7 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
 
         self::assertNotEmpty($result);
         // Should return fallback configurations
-        self::assertContains('content-assistant', array_map(fn($c) => $c->identifier, $result));
+        self::assertContains('content-assistant', array_map(fn(SuggestedConfiguration $c): string => $c->identifier, $result));
     }
 
     #[Test]
@@ -591,7 +596,7 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
 
         // Should return fallback configurations
         self::assertNotEmpty($result);
-        self::assertContains('content-assistant', array_map(fn($c) => $c->identifier, $result));
+        self::assertContains('content-assistant', array_map(fn(SuggestedConfiguration $c): string => $c->identifier, $result));
     }
 
     #[Test]
@@ -652,7 +657,7 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
 
         // Should return fallback configurations
         self::assertNotEmpty($result);
-        self::assertContains('content-assistant', array_map(fn($c) => $c->identifier, $result));
+        self::assertContains('content-assistant', array_map(fn(SuggestedConfiguration $c): string => $c->identifier, $result));
     }
 
     // ==================== SuggestedConfiguration tests ====================
@@ -709,7 +714,7 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
 
         $result = $this->subject->generate($provider, 'test-key', []);
 
-        $identifiers = array_map(fn($c) => $c->identifier, $result);
+        $identifiers = array_map(fn(SuggestedConfiguration $c): string => $c->identifier, $result);
 
         self::assertContains('content-assistant', $identifiers);
         self::assertContains('content-summarizer', $identifiers);
@@ -768,7 +773,7 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
         $result = $this->subject->generate($provider, 'test-key', $models);
 
         self::assertNotEmpty($result);
-        self::assertContains('content-assistant', array_map(fn($c) => $c->identifier, $result));
+        self::assertContains('content-assistant', array_map(fn(SuggestedConfiguration $c): string => $c->identifier, $result));
     }
 
     // ==================== extractAnthropicContent edge cases ====================
@@ -808,7 +813,7 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
 
         // Empty content → empty string → parse fails → fallback
         self::assertNotEmpty($result);
-        self::assertContains('content-assistant', array_map(fn($c) => $c->identifier, $result));
+        self::assertContains('content-assistant', array_map(fn(SuggestedConfiguration $c): string => $c->identifier, $result));
     }
 
     #[Test]
@@ -845,7 +850,7 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
         $result = $this->subject->generate($provider, 'test-key', $models);
 
         self::assertNotEmpty($result);
-        self::assertContains('content-assistant', array_map(fn($c) => $c->identifier, $result));
+        self::assertContains('content-assistant', array_map(fn(SuggestedConfiguration $c): string => $c->identifier, $result));
     }
 
     #[Test]
@@ -882,7 +887,7 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
         $result = $this->subject->generate($provider, 'test-key', $models);
 
         self::assertNotEmpty($result);
-        self::assertContains('content-assistant', array_map(fn($c) => $c->identifier, $result));
+        self::assertContains('content-assistant', array_map(fn(SuggestedConfiguration $c): string => $c->identifier, $result));
     }
 
     // ==================== extractGeminiContent edge cases ====================
@@ -920,7 +925,7 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
         $result = $this->subject->generate($provider, 'test-key', $models);
 
         self::assertNotEmpty($result);
-        self::assertContains('content-assistant', array_map(fn($c) => $c->identifier, $result));
+        self::assertContains('content-assistant', array_map(fn(SuggestedConfiguration $c): string => $c->identifier, $result));
     }
 
     #[Test]
@@ -956,7 +961,7 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
         $result = $this->subject->generate($provider, 'test-key', $models);
 
         self::assertNotEmpty($result);
-        self::assertContains('content-assistant', array_map(fn($c) => $c->identifier, $result));
+        self::assertContains('content-assistant', array_map(fn(SuggestedConfiguration $c): string => $c->identifier, $result));
     }
 
     #[Test]
@@ -992,7 +997,7 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
         $result = $this->subject->generate($provider, 'test-key', $models);
 
         self::assertNotEmpty($result);
-        self::assertContains('content-assistant', array_map(fn($c) => $c->identifier, $result));
+        self::assertContains('content-assistant', array_map(fn(SuggestedConfiguration $c): string => $c->identifier, $result));
     }
 
     #[Test]
@@ -1028,7 +1033,7 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
         $result = $this->subject->generate($provider, 'test-key', $models);
 
         self::assertNotEmpty($result);
-        self::assertContains('content-assistant', array_map(fn($c) => $c->identifier, $result));
+        self::assertContains('content-assistant', array_map(fn(SuggestedConfiguration $c): string => $c->identifier, $result));
     }
 
     #[Test]
@@ -1066,7 +1071,7 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
         $result = $this->subject->generate($provider, 'test-key', $models);
 
         self::assertNotEmpty($result);
-        self::assertContains('content-assistant', array_map(fn($c) => $c->identifier, $result));
+        self::assertContains('content-assistant', array_map(fn(SuggestedConfiguration $c): string => $c->identifier, $result));
     }
 
     #[Test]
@@ -1104,7 +1109,7 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
         $result = $this->subject->generate($provider, 'test-key', $models);
 
         self::assertNotEmpty($result);
-        self::assertContains('content-assistant', array_map(fn($c) => $c->identifier, $result));
+        self::assertContains('content-assistant', array_map(fn(SuggestedConfiguration $c): string => $c->identifier, $result));
     }
 
     // ==================== extractOpenAIContent edge cases ====================
@@ -1133,7 +1138,7 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
         $result = $this->subject->generate($provider, 'test-key', $models);
 
         self::assertNotEmpty($result);
-        self::assertContains('content-assistant', array_map(fn($c) => $c->identifier, $result));
+        self::assertContains('content-assistant', array_map(fn(SuggestedConfiguration $c): string => $c->identifier, $result));
     }
 
     #[Test]
@@ -1160,7 +1165,7 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
         $result = $this->subject->generate($provider, 'test-key', $models);
 
         self::assertNotEmpty($result);
-        self::assertContains('content-assistant', array_map(fn($c) => $c->identifier, $result));
+        self::assertContains('content-assistant', array_map(fn(SuggestedConfiguration $c): string => $c->identifier, $result));
     }
 
     #[Test]
@@ -1187,7 +1192,7 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
         $result = $this->subject->generate($provider, 'test-key', $models);
 
         self::assertNotEmpty($result);
-        self::assertContains('content-assistant', array_map(fn($c) => $c->identifier, $result));
+        self::assertContains('content-assistant', array_map(fn(SuggestedConfiguration $c): string => $c->identifier, $result));
     }
 
     #[Test]
@@ -1214,7 +1219,7 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
         $result = $this->subject->generate($provider, 'test-key', $models);
 
         self::assertNotEmpty($result);
-        self::assertContains('content-assistant', array_map(fn($c) => $c->identifier, $result));
+        self::assertContains('content-assistant', array_map(fn(SuggestedConfiguration $c): string => $c->identifier, $result));
     }
 
     // ==================== parseResponse edge cases ====================
@@ -1528,8 +1533,8 @@ class ConfigurationGeneratorTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com/',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com/',
         );
         $models = $this->createTestModels();
 

--- a/Tests/Unit/Service/SetupWizard/ModelDiscoveryTest.php
+++ b/Tests/Unit/Service/SetupWizard/ModelDiscoveryTest.php
@@ -35,11 +35,17 @@ use RuntimeException;
 class ModelDiscoveryTest extends AbstractUnitTestCase
 {
     private ClientInterface&Stub $httpClientStub;
+
     private RequestFactoryInterface&Stub $requestFactoryStub;
+
     private StreamFactoryInterface&Stub $streamFactoryStub;
+
     private VaultServiceInterface $vaultStub;
+
     private SecureHttpClientFactory $httpClientFactory;
+
     private LoggerInterface&Stub $loggerStub;
+
     private ModelDiscovery $subject;
 
     protected function setUp(): void
@@ -86,8 +92,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -109,8 +115,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'anthropic',
-            endpoint: 'https://api.anthropic.com',
             suggestedName: 'Anthropic',
+            endpoint: 'https://api.anthropic.com',
         );
 
         $this->requestFactoryStub
@@ -131,8 +137,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'gemini',
-            endpoint: 'https://generativelanguage.googleapis.com',
             suggestedName: 'Google Gemini',
+            endpoint: 'https://generativelanguage.googleapis.com',
         );
 
         $this->requestFactoryStub
@@ -153,8 +159,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'ollama',
-            endpoint: 'http://localhost:11434',
             suggestedName: 'Ollama',
+            endpoint: 'http://localhost:11434',
         );
 
         $this->requestFactoryStub
@@ -175,8 +181,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -198,8 +204,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -221,8 +227,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -259,8 +265,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
 
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://169.254.169.254/latest/meta-data',
             suggestedName: 'Metadata SSRF',
+            endpoint: 'https://169.254.169.254/latest/meta-data',
         );
 
         $result = $subject->testConnection($provider, 'test-key');
@@ -282,8 +288,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
 
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'http://127.0.0.1:8080/v1',
             suggestedName: 'Loopback SSRF',
+            endpoint: 'http://127.0.0.1:8080/v1',
         );
 
         // The host gate rejects the loopback target before any request is sent;
@@ -302,8 +308,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -332,8 +338,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -355,14 +361,14 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'anthropic',
-            endpoint: 'https://api.anthropic.com',
             suggestedName: 'Anthropic',
+            endpoint: 'https://api.anthropic.com',
         );
 
         $models = $this->subject->discover($provider, 'test-key');
 
         self::assertNotEmpty($models);
-        $modelIds = array_map(fn(DiscoveredModel $m) => $m->modelId, $models);
+        $modelIds = array_map(fn(DiscoveredModel $m): string => $m->modelId, $models);
         self::assertContains('claude-opus-4-5-20251101', $modelIds);
         self::assertContains('claude-sonnet-4-5-20250929', $modelIds);
         self::assertContains('claude-haiku-4-5-20251001', $modelIds);
@@ -373,8 +379,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'gemini',
-            endpoint: 'https://generativelanguage.googleapis.com',
             suggestedName: 'Google Gemini',
+            endpoint: 'https://generativelanguage.googleapis.com',
         );
 
         $this->requestFactoryStub
@@ -407,7 +413,7 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $models = $this->subject->discover($provider, 'test-key');
 
         self::assertNotEmpty($models);
-        $modelIds = array_map(fn(DiscoveredModel $m) => $m->modelId, $models);
+        $modelIds = array_map(fn(DiscoveredModel $m): string => $m->modelId, $models);
         self::assertContains('gemini-3-flash', $modelIds);
     }
 
@@ -419,8 +425,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // proxy and referrer logs). Capture the URL the request was built with.
         $provider = new DetectedProvider(
             adapterType: 'gemini',
-            endpoint: 'https://generativelanguage.googleapis.com/v1beta',
             suggestedName: 'Google Gemini',
+            endpoint: 'https://generativelanguage.googleapis.com/v1beta',
         );
 
         $capturedUri = null;
@@ -448,8 +454,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'gemini',
-            endpoint: 'https://generativelanguage.googleapis.com',
             suggestedName: 'Google Gemini',
+            endpoint: 'https://generativelanguage.googleapis.com',
         );
 
         $this->requestFactoryStub
@@ -470,8 +476,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'ollama',
-            endpoint: 'http://localhost:11434',
             suggestedName: 'Ollama',
+            endpoint: 'http://localhost:11434',
         );
 
         $this->requestFactoryStub
@@ -509,7 +515,7 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $models = $this->subject->discover($provider, '');
 
         self::assertNotEmpty($models);
-        $modelIds = array_map(fn(DiscoveredModel $m) => $m->modelId, $models);
+        $modelIds = array_map(fn(DiscoveredModel $m): string => $m->modelId, $models);
         self::assertContains('llama3:latest', $modelIds);
     }
 
@@ -518,8 +524,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'ollama',
-            endpoint: 'http://localhost:11434',
             suggestedName: 'Ollama',
+            endpoint: 'http://localhost:11434',
         );
 
         $this->requestFactoryStub
@@ -540,8 +546,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'openrouter',
-            endpoint: 'https://openrouter.ai/api',
             suggestedName: 'OpenRouter',
+            endpoint: 'https://openrouter.ai/api',
         );
 
         $this->requestFactoryStub
@@ -578,8 +584,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'mistral',
-            endpoint: 'https://api.mistral.ai',
             suggestedName: 'Mistral AI',
+            endpoint: 'https://api.mistral.ai',
         );
 
         $this->requestFactoryStub
@@ -607,8 +613,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'mistral',
-            endpoint: 'https://api.mistral.ai',
             suggestedName: 'Mistral AI',
+            endpoint: 'https://api.mistral.ai',
         );
 
         $this->requestFactoryStub
@@ -622,7 +628,7 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $models = $this->subject->discover($provider, 'test-key');
 
         self::assertNotEmpty($models);
-        $modelIds = array_map(fn(DiscoveredModel $m) => $m->modelId, $models);
+        $modelIds = array_map(fn(DiscoveredModel $m): string => $m->modelId, $models);
         self::assertContains('mistral-large-latest', $modelIds);
     }
 
@@ -631,8 +637,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'groq',
-            endpoint: 'https://api.groq.com',
             suggestedName: 'Groq',
+            endpoint: 'https://api.groq.com',
         );
 
         $this->requestFactoryStub
@@ -663,8 +669,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'groq',
-            endpoint: 'https://api.groq.com',
             suggestedName: 'Groq',
+            endpoint: 'https://api.groq.com',
         );
 
         $this->requestFactoryStub
@@ -685,8 +691,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'unknown-provider',
-            endpoint: 'https://example.com',
             suggestedName: 'Unknown',
+            endpoint: 'https://example.com',
         );
 
         $models = $this->subject->discover($provider, 'test-key');
@@ -703,8 +709,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -727,7 +733,7 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
 
         $models = $this->subject->discover($provider, 'test-key');
 
-        $modelIds = array_map(fn(DiscoveredModel $m) => $m->modelId, $models);
+        $modelIds = array_map(fn(DiscoveredModel $m): string => $m->modelId, $models);
         self::assertContains('gpt-5.2', $modelIds);
         self::assertContains('gpt-image-1', $modelIds);
         self::assertNotContains('text-davinci-003', $modelIds);
@@ -740,8 +746,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -791,8 +797,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -829,8 +835,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -860,8 +866,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -889,8 +895,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'ollama',
-            endpoint: 'http://localhost:11434',
             suggestedName: 'Ollama',
+            endpoint: 'http://localhost:11434',
         );
 
         $this->requestFactoryStub
@@ -931,8 +937,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'ollama',
-            endpoint: 'http://localhost:11434',
             suggestedName: 'Ollama',
+            endpoint: 'http://localhost:11434',
         );
 
         $this->requestFactoryStub
@@ -1023,8 +1029,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         self::assertEquals('openai', $provider->adapterType);
@@ -1039,8 +1045,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -1062,8 +1068,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -1084,8 +1090,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -1099,7 +1105,7 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $models = $this->subject->discover($provider, 'test-key');
 
         self::assertNotEmpty($models);
-        $modelIds = array_map(fn(DiscoveredModel $m) => $m->modelId, $models);
+        $modelIds = array_map(fn(DiscoveredModel $m): string => $m->modelId, $models);
         // Fallback models should include current GPT models
         self::assertContains('gpt-5.3', $modelIds);
     }
@@ -1109,8 +1115,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -1132,7 +1138,7 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $models = $this->subject->discover($provider, 'test-key');
 
         self::assertNotEmpty($models);
-        $modelIds = array_map(fn(DiscoveredModel $m) => $m->modelId, $models);
+        $modelIds = array_map(fn(DiscoveredModel $m): string => $m->modelId, $models);
         self::assertContains('gpt-5.3', $modelIds);
     }
 
@@ -1143,8 +1149,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'anthropic',
-            endpoint: 'https://api.anthropic.com/v1',
             suggestedName: 'Anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
         );
 
         $this->requestFactoryStub
@@ -1173,7 +1179,7 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $models = $this->subject->discover($provider, 'test-key');
 
         self::assertNotEmpty($models);
-        $modelIds = array_map(fn(DiscoveredModel $m) => $m->modelId, $models);
+        $modelIds = array_map(fn(DiscoveredModel $m): string => $m->modelId, $models);
         self::assertContains('claude-opus-4-5-20251101', $modelIds);
         self::assertContains('claude-sonnet-4-5-20250929', $modelIds);
     }
@@ -1183,8 +1189,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'anthropic',
-            endpoint: 'https://api.anthropic.com/v1',
             suggestedName: 'Anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
         );
 
         $this->requestFactoryStub
@@ -1198,7 +1204,7 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $models = $this->subject->discover($provider, 'bad-key');
 
         self::assertNotEmpty($models);
-        $modelIds = array_map(fn(DiscoveredModel $m) => $m->modelId, $models);
+        $modelIds = array_map(fn(DiscoveredModel $m): string => $m->modelId, $models);
         self::assertContains('claude-opus-4-5-20251101', $modelIds);
     }
 
@@ -1207,8 +1213,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'anthropic',
-            endpoint: 'https://api.anthropic.com/v1',
             suggestedName: 'Anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
         );
 
         $this->requestFactoryStub
@@ -1222,7 +1228,7 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $models = $this->subject->discover($provider, 'test-key');
 
         self::assertNotEmpty($models);
-        $modelIds = array_map(fn(DiscoveredModel $m) => $m->modelId, $models);
+        $modelIds = array_map(fn(DiscoveredModel $m): string => $m->modelId, $models);
         self::assertContains('claude-opus-4-5-20251101', $modelIds);
     }
 
@@ -1231,8 +1237,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'anthropic',
-            endpoint: 'https://api.anthropic.com/v1',
             suggestedName: 'Anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
         );
 
         $this->requestFactoryStub
@@ -1246,7 +1252,7 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $models = $this->subject->discover($provider, 'test-key');
 
         self::assertNotEmpty($models);
-        $modelIds = array_map(fn(DiscoveredModel $m) => $m->modelId, $models);
+        $modelIds = array_map(fn(DiscoveredModel $m): string => $m->modelId, $models);
         self::assertContains('claude-opus-4-5-20251101', $modelIds);
     }
 
@@ -1255,8 +1261,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'anthropic',
-            endpoint: 'https://api.anthropic.com/v1',
             suggestedName: 'Anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
         );
 
         $this->requestFactoryStub
@@ -1277,8 +1283,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'anthropic',
-            endpoint: 'https://api.anthropic.com/v1',
             suggestedName: 'Anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
         );
 
         $this->requestFactoryStub
@@ -1304,7 +1310,7 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // if the loop had stopped early, the result would be the fallback
         // catalog (which contains the same id), so pin the fallback flag.
         self::assertFalse($this->subject->wasLastDiscoveryFromFallback());
-        $modelIds = array_map(fn(DiscoveredModel $m) => $m->modelId, $models);
+        $modelIds = array_map(fn(DiscoveredModel $m): string => $m->modelId, $models);
         self::assertContains('claude-opus-4-5-20251101', $modelIds);
     }
 
@@ -1313,8 +1319,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'anthropic',
-            endpoint: 'https://api.anthropic.com/v1',
             suggestedName: 'Anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
         );
 
         $this->requestFactoryStub
@@ -1328,7 +1334,7 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $models = $this->subject->discover($provider, 'test-key');
 
         self::assertNotEmpty($models);
-        $modelIds = array_map(fn(DiscoveredModel $m) => $m->modelId, $models);
+        $modelIds = array_map(fn(DiscoveredModel $m): string => $m->modelId, $models);
         self::assertContains('claude-opus-4-5-20251101', $modelIds);
     }
 
@@ -1338,8 +1344,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // Dated model IDs like 'claude-opus-4-5-20251101' should match 'claude-opus-4-5' prefix
         $provider = new DetectedProvider(
             adapterType: 'anthropic',
-            endpoint: 'https://api.anthropic.com/v1',
             suggestedName: 'Anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
         );
 
         $this->requestFactoryStub
@@ -1371,8 +1377,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'anthropic',
-            endpoint: 'https://api.anthropic.com/v1',
             suggestedName: 'Anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
         );
 
         $this->requestFactoryStub
@@ -1403,8 +1409,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'anthropic',
-            endpoint: 'https://api.anthropic.com/v1',
             suggestedName: 'Anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
         );
 
         $this->requestFactoryStub
@@ -1438,8 +1444,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'gemini',
-            endpoint: 'https://generativelanguage.googleapis.com/v1beta',
             suggestedName: 'Google Gemini',
+            endpoint: 'https://generativelanguage.googleapis.com/v1beta',
         );
 
         $this->requestFactoryStub
@@ -1453,7 +1459,7 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $models = $this->subject->discover($provider, 'test-key');
 
         self::assertNotEmpty($models);
-        $modelIds = array_map(fn(DiscoveredModel $m) => $m->modelId, $models);
+        $modelIds = array_map(fn(DiscoveredModel $m): string => $m->modelId, $models);
         self::assertContains('gemini-3-flash', $modelIds);
     }
 
@@ -1462,8 +1468,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'gemini',
-            endpoint: 'https://generativelanguage.googleapis.com/v1beta',
             suggestedName: 'Google Gemini',
+            endpoint: 'https://generativelanguage.googleapis.com/v1beta',
         );
 
         $this->requestFactoryStub
@@ -1477,7 +1483,7 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $models = $this->subject->discover($provider, 'test-key');
 
         self::assertNotEmpty($models);
-        $modelIds = array_map(fn(DiscoveredModel $m) => $m->modelId, $models);
+        $modelIds = array_map(fn(DiscoveredModel $m): string => $m->modelId, $models);
         self::assertContains('gemini-3-flash', $modelIds);
     }
 
@@ -1486,8 +1492,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'gemini',
-            endpoint: 'https://generativelanguage.googleapis.com/v1beta',
             suggestedName: 'Google Gemini',
+            endpoint: 'https://generativelanguage.googleapis.com/v1beta',
         );
 
         $this->requestFactoryStub
@@ -1501,7 +1507,7 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $models = $this->subject->discover($provider, 'test-key');
 
         self::assertNotEmpty($models);
-        $modelIds = array_map(fn(DiscoveredModel $m) => $m->modelId, $models);
+        $modelIds = array_map(fn(DiscoveredModel $m): string => $m->modelId, $models);
         self::assertContains('gemini-3-flash', $modelIds);
     }
 
@@ -1510,8 +1516,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'gemini',
-            endpoint: 'https://generativelanguage.googleapis.com/v1beta',
             suggestedName: 'Google Gemini',
+            endpoint: 'https://generativelanguage.googleapis.com/v1beta',
         );
 
         $this->requestFactoryStub
@@ -1532,7 +1538,7 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $models = $this->subject->discover($provider, 'test-key');
 
         self::assertNotEmpty($models);
-        $modelIds = array_map(fn(DiscoveredModel $m) => $m->modelId, $models);
+        $modelIds = array_map(fn(DiscoveredModel $m): string => $m->modelId, $models);
         self::assertContains('gemini-3-flash', $modelIds);
     }
 
@@ -1541,8 +1547,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'gemini',
-            endpoint: 'https://generativelanguage.googleapis.com/v1beta',
             suggestedName: 'Google Gemini',
+            endpoint: 'https://generativelanguage.googleapis.com/v1beta',
         );
 
         $this->requestFactoryStub
@@ -1563,7 +1569,7 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $models = $this->subject->discover($provider, 'test-key');
 
         self::assertNotEmpty($models);
-        $modelIds = array_map(fn(DiscoveredModel $m) => $m->modelId, $models);
+        $modelIds = array_map(fn(DiscoveredModel $m): string => $m->modelId, $models);
         self::assertContains('gemini-3-flash', $modelIds);
     }
 
@@ -1572,8 +1578,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'gemini',
-            endpoint: 'https://generativelanguage.googleapis.com/v1beta',
             suggestedName: 'Google Gemini',
+            endpoint: 'https://generativelanguage.googleapis.com/v1beta',
         );
 
         $this->requestFactoryStub
@@ -1606,8 +1612,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'gemini',
-            endpoint: 'https://generativelanguage.googleapis.com/v1beta',
             suggestedName: 'Google Gemini',
+            endpoint: 'https://generativelanguage.googleapis.com/v1beta',
         );
 
         $this->requestFactoryStub
@@ -1647,8 +1653,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'gemini',
-            endpoint: 'https://generativelanguage.googleapis.com/v1beta',
             suggestedName: 'Google Gemini',
+            endpoint: 'https://generativelanguage.googleapis.com/v1beta',
         );
 
         $this->requestFactoryStub
@@ -1689,8 +1695,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'ollama',
-            endpoint: 'http://localhost:11434',
             suggestedName: 'Ollama',
+            endpoint: 'http://localhost:11434',
         );
 
         $this->requestFactoryStub
@@ -1712,8 +1718,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'ollama',
-            endpoint: 'http://localhost:11434',
             suggestedName: 'Ollama',
+            endpoint: 'http://localhost:11434',
         );
 
         $this->requestFactoryStub
@@ -1734,8 +1740,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'ollama',
-            endpoint: 'http://localhost:11434',
             suggestedName: 'Ollama',
+            endpoint: 'http://localhost:11434',
         );
 
         $this->requestFactoryStub
@@ -1779,8 +1785,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'ollama',
-            endpoint: 'http://localhost:11434',
             suggestedName: 'Ollama',
+            endpoint: 'http://localhost:11434',
         );
 
         $this->requestFactoryStub
@@ -1817,8 +1823,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'ollama',
-            endpoint: 'http://localhost:11434',
             suggestedName: 'Ollama',
+            endpoint: 'http://localhost:11434',
         );
 
         $this->requestFactoryStub
@@ -1852,8 +1858,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'ollama',
-            endpoint: 'http://localhost:11434',
             suggestedName: 'Ollama',
+            endpoint: 'http://localhost:11434',
         );
 
         $this->requestFactoryStub
@@ -1895,8 +1901,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'ollama',
-            endpoint: 'http://localhost:11434',
             suggestedName: 'Ollama',
+            endpoint: 'http://localhost:11434',
         );
 
         $this->requestFactoryStub
@@ -1961,8 +1967,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
 
         $provider = new DetectedProvider(
             adapterType: 'ollama',
-            endpoint: 'http://localhost:11434',
             suggestedName: 'Ollama',
+            endpoint: 'http://localhost:11434',
         );
 
         $subject = new ModelDiscovery(
@@ -1973,6 +1979,7 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
             $this->loggerStub,
         );
         $subject->setHttpClient($httpClient);
+
         $models = $subject->discover($provider, '');
 
         // Model is still added with fallback details (contextLength = 0)
@@ -1988,8 +1995,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'ollama',
-            endpoint: 'http://localhost:11434',
             suggestedName: 'Ollama',
+            endpoint: 'http://localhost:11434',
         );
 
         $this->requestFactoryStub
@@ -2055,8 +2062,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'ollama',
-            endpoint: 'http://localhost:11434',
             suggestedName: 'Ollama',
+            endpoint: 'http://localhost:11434',
         );
 
         $this->requestFactoryStub
@@ -2098,8 +2105,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'ollama',
-            endpoint: 'http://localhost:11434',
             suggestedName: 'Ollama',
+            endpoint: 'http://localhost:11434',
         );
 
         $this->requestFactoryStub
@@ -2141,8 +2148,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'ollama',
-            endpoint: 'http://localhost:11434',
             suggestedName: 'Ollama',
+            endpoint: 'http://localhost:11434',
         );
 
         $this->requestFactoryStub
@@ -2190,8 +2197,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'openrouter',
-            endpoint: 'https://openrouter.ai/api',
             suggestedName: 'OpenRouter',
+            endpoint: 'https://openrouter.ai/api',
         );
 
         $this->requestFactoryStub
@@ -2212,8 +2219,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'openrouter',
-            endpoint: 'https://openrouter.ai/api',
             suggestedName: 'OpenRouter',
+            endpoint: 'https://openrouter.ai/api',
         );
 
         $this->requestFactoryStub
@@ -2252,8 +2259,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'openrouter',
-            endpoint: 'https://openrouter.ai/api',
             suggestedName: 'OpenRouter',
+            endpoint: 'https://openrouter.ai/api',
         );
 
         $this->requestFactoryStub
@@ -2283,8 +2290,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'mistral',
-            endpoint: 'https://api.mistral.ai',
             suggestedName: 'Mistral AI',
+            endpoint: 'https://api.mistral.ai',
         );
 
         $this->requestFactoryStub
@@ -2313,8 +2320,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'mistral',
-            endpoint: 'https://api.mistral.ai',
             suggestedName: 'Mistral AI',
+            endpoint: 'https://api.mistral.ai',
         );
 
         $this->requestFactoryStub
@@ -2328,7 +2335,7 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $models = $this->subject->discover($provider, 'test-key');
 
         self::assertNotEmpty($models);
-        $modelIds = array_map(fn(DiscoveredModel $m) => $m->modelId, $models);
+        $modelIds = array_map(fn(DiscoveredModel $m): string => $m->modelId, $models);
         self::assertContains('mistral-large-latest', $modelIds);
     }
 
@@ -2337,8 +2344,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'mistral',
-            endpoint: 'https://api.mistral.ai',
             suggestedName: 'Mistral AI',
+            endpoint: 'https://api.mistral.ai',
         );
 
         $this->requestFactoryStub
@@ -2370,8 +2377,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'groq',
-            endpoint: 'https://api.groq.com',
             suggestedName: 'Groq',
+            endpoint: 'https://api.groq.com',
         );
 
         $this->requestFactoryStub
@@ -2400,8 +2407,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'groq',
-            endpoint: 'https://api.groq.com',
             suggestedName: 'Groq',
+            endpoint: 'https://api.groq.com',
         );
 
         $this->requestFactoryStub
@@ -2430,8 +2437,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'groq',
-            endpoint: 'https://api.groq.com',
             suggestedName: 'Groq',
+            endpoint: 'https://api.groq.com',
         );
 
         $this->requestFactoryStub
@@ -2457,6 +2464,7 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         foreach ($models as $m) {
             $byId[$m->modelId] = $m;
         }
+
         self::assertSame(131072, $byId['model-with-ctx']->contextLength);
         self::assertSame(0, $byId['model-without-ctx']->contextLength);
     }
@@ -2466,8 +2474,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'groq',
-            endpoint: 'https://api.groq.com',
             suggestedName: 'Groq',
+            endpoint: 'https://api.groq.com',
         );
 
         $this->requestFactoryStub
@@ -2491,8 +2499,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // Covers line 420: continue when model['id'] is not a non-empty string
         $provider = new DetectedProvider(
             adapterType: 'anthropic',
-            endpoint: 'https://api.anthropic.com/v1',
             suggestedName: 'Anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
         );
 
         $this->requestFactoryStub
@@ -2517,7 +2525,7 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // The invalid ids must be SKIPPED (not break the loop, not blow up
         // with a TypeError that degrades to the fallback catalog).
         self::assertFalse($this->subject->wasLastDiscoveryFromFallback());
-        $modelIds = array_map(fn(DiscoveredModel $m) => $m->modelId, $models);
+        $modelIds = array_map(fn(DiscoveredModel $m): string => $m->modelId, $models);
         self::assertContains('claude-opus-4-5-20251101', $modelIds);
         // None of the invalid entries should appear
         self::assertNotContains('', $modelIds);
@@ -2531,8 +2539,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // Covers line 638: return false when gemini-* model contains 'embedding'
         $provider = new DetectedProvider(
             adapterType: 'gemini',
-            endpoint: 'https://generativelanguage.googleapis.com/v1beta',
             suggestedName: 'Google Gemini',
+            endpoint: 'https://generativelanguage.googleapis.com/v1beta',
         );
 
         $this->requestFactoryStub
@@ -2553,7 +2561,7 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
 
         $models = $this->subject->discover($provider, 'test-key');
 
-        $modelIds = array_map(fn(DiscoveredModel $m) => $m->modelId, $models);
+        $modelIds = array_map(fn(DiscoveredModel $m): string => $m->modelId, $models);
         // Embedding models (gemini-* prefix with 'embedding') must be excluded
         self::assertNotContains('gemini-embedding-exp-03-07', $modelIds);
         self::assertNotContains('gemini-1.5-embedding', $modelIds);
@@ -2568,8 +2576,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // Covers line 789: continue when model item in /api/tags is not an array
         $provider = new DetectedProvider(
             adapterType: 'ollama',
-            endpoint: 'http://localhost:11434',
             suggestedName: 'Ollama',
+            endpoint: 'http://localhost:11434',
         );
 
         $this->requestFactoryStub
@@ -2616,8 +2624,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // Covers lines 855 and 861: fallback values when model_info and parameters keys are missing
         $provider = new DetectedProvider(
             adapterType: 'ollama',
-            endpoint: 'http://localhost:11434',
             suggestedName: 'Ollama',
+            endpoint: 'http://localhost:11434',
         );
 
         $this->requestFactoryStub
@@ -2662,8 +2670,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // Covers line 962: return [] when response status is not 200
         $provider = new DetectedProvider(
             adapterType: 'openrouter',
-            endpoint: 'https://openrouter.ai/api',
             suggestedName: 'OpenRouter',
+            endpoint: 'https://openrouter.ai/api',
         );
 
         $this->requestFactoryStub
@@ -2687,8 +2695,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // Covers line 970: modelList = [] when $data has no 'data' key
         $provider = new DetectedProvider(
             adapterType: 'openrouter',
-            endpoint: 'https://openrouter.ai/api',
             suggestedName: 'OpenRouter',
+            endpoint: 'https://openrouter.ai/api',
         );
 
         $this->requestFactoryStub
@@ -2717,8 +2725,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // Covers line 1037: modelList = [] when $data has no 'data' key
         $provider = new DetectedProvider(
             adapterType: 'mistral',
-            endpoint: 'https://api.mistral.ai',
             suggestedName: 'Mistral AI',
+            endpoint: 'https://api.mistral.ai',
         );
 
         $this->requestFactoryStub
@@ -2740,7 +2748,7 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // No 'data' key → modelList is [] → no API models found
         // Mistral falls back to static models on empty discovery
         self::assertNotEmpty($models);
-        $modelIds = array_map(fn(DiscoveredModel $m) => $m->modelId, $models);
+        $modelIds = array_map(fn(DiscoveredModel $m): string => $m->modelId, $models);
         self::assertContains('mistral-large-latest', $modelIds);
     }
 
@@ -2752,8 +2760,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // Covers line 1122: modelList = [] when $data has no 'data' key
         $provider = new DetectedProvider(
             adapterType: 'groq',
-            endpoint: 'https://api.groq.com',
             suggestedName: 'Groq',
+            endpoint: 'https://api.groq.com',
         );
 
         $this->requestFactoryStub
@@ -2814,8 +2822,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $captured = [];
@@ -2837,8 +2845,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // A user-entered trailing slash must not produce "https://…//models".
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com/',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com/',
         );
 
         $captured = [];
@@ -2857,8 +2865,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'anthropic',
-            endpoint: 'https://api.anthropic.com',
             suggestedName: 'Anthropic',
+            endpoint: 'https://api.anthropic.com',
         );
 
         $captured = [];
@@ -2881,8 +2889,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'gemini',
-            endpoint: 'https://generativelanguage.googleapis.com',
             suggestedName: 'Google Gemini',
+            endpoint: 'https://generativelanguage.googleapis.com',
         );
 
         $captured = [];
@@ -2903,8 +2911,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'ollama',
-            endpoint: 'http://localhost:11434',
             suggestedName: 'Ollama',
+            endpoint: 'http://localhost:11434',
         );
 
         $captured = [];
@@ -2927,8 +2935,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // does not become ".../api/api/tags".
         $provider = new DetectedProvider(
             adapterType: 'ollama',
-            endpoint: 'http://localhost:11434/api',
             suggestedName: 'Ollama',
+            endpoint: 'http://localhost:11434/api',
         );
 
         $captured = [];
@@ -2948,8 +2956,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // The success window is 200–299; 300 must be reported as a failure.
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -2973,8 +2981,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // single ".../models", never ".../…//models".
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com/',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com/',
         );
 
         $captured = [];
@@ -3001,8 +3009,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // absent from the fallback list.
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -3032,8 +3040,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // flipped-comparison mutants.
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -3061,8 +3069,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // going after the bad entry.
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -3113,8 +3121,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
 
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -3157,8 +3165,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // a generic description, chat capability and zeroed numeric fields.
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -3193,8 +3201,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // (defaultOpenAICapabilities): image / text_to_speech / transcription.
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -3263,8 +3271,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $subject = $this->makeSubjectWithLogger($logger);
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $subject->discover($provider, 'test-key');
@@ -3293,8 +3301,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $subject = $this->makeSubjectWithLogger($logger);
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $subject->discover($provider, 'test-key');
@@ -3322,8 +3330,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $subject = $this->makeSubjectWithLogger($logger);
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $subject->testConnection($provider, 'test-key');
@@ -3357,8 +3365,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $subject = $this->makeSubjectWithLogger($logger);
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $subject->discover($provider, 'test-key');
@@ -3380,8 +3388,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
 
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -3410,8 +3418,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
 
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -3440,8 +3448,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // (failOnWarning turns that into a failure).
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -3467,8 +3475,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // no gpt-4.1).
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -3497,8 +3505,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // '-search' arm.
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -3526,8 +3534,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // defaultOpenAICapabilities().
         $provider = new DetectedProvider(
             adapterType: 'openai',
-            endpoint: 'https://api.openai.com',
             suggestedName: 'OpenAI',
+            endpoint: 'https://api.openai.com',
         );
 
         $this->requestFactoryStub
@@ -3553,8 +3561,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
     {
         $provider = new DetectedProvider(
             adapterType: 'anthropic',
-            endpoint: 'https://api.anthropic.com/v1',
             suggestedName: 'Anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
         );
 
         $captured = [];
@@ -3581,8 +3589,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // is absent from the fallback list.
         $provider = new DetectedProvider(
             adapterType: 'anthropic',
-            endpoint: 'https://api.anthropic.com/v1',
             suggestedName: 'Anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
         );
 
         $this->requestFactoryStub
@@ -3611,8 +3619,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // OpenAI test for the warning rationale).
         $provider = new DetectedProvider(
             adapterType: 'anthropic',
-            endpoint: 'https://api.anthropic.com/v1',
             suggestedName: 'Anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
         );
 
         $this->requestFactoryStub
@@ -3637,8 +3645,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // and the flipped-comparison mutants.
         $provider = new DetectedProvider(
             adapterType: 'anthropic',
-            endpoint: 'https://api.anthropic.com/v1',
             suggestedName: 'Anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
         );
 
         $this->requestFactoryStub
@@ -3680,8 +3688,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
 
         $provider = new DetectedProvider(
             adapterType: 'anthropic',
-            endpoint: 'https://api.anthropic.com/v1',
             suggestedName: 'Anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
         );
 
         $this->requestFactoryStub
@@ -3739,8 +3747,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $subject = $this->makeSubjectWithLogger($logger);
         $provider = new DetectedProvider(
             adapterType: 'anthropic',
-            endpoint: 'https://api.anthropic.com/v1',
             suggestedName: 'Anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
         );
 
         $subject->discover($provider, 'test-key');
@@ -3769,8 +3777,8 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         $subject = $this->makeSubjectWithLogger($logger);
         $provider = new DetectedProvider(
             adapterType: 'anthropic',
-            endpoint: 'https://api.anthropic.com/v1',
             suggestedName: 'Anthropic',
+            endpoint: 'https://api.anthropic.com/v1',
         );
 
         $subject->discover($provider, 'test-key');

--- a/Tests/Unit/Service/Skill/GitHubClientTest.php
+++ b/Tests/Unit/Service/Skill/GitHubClientTest.php
@@ -74,14 +74,14 @@ final class GitHubClientTest extends TestCase
     #[Test]
     public function resolveShaReadsCommitSha(): void
     {
-        $client = $this->clientReturning(fn(RequestInterface $r) => $this->json(['sha' => 'abc123sha']));
+        $client = $this->clientReturning(fn(RequestInterface $r): ResponseInterface => $this->json(['sha' => 'abc123sha']));
         self::assertSame('abc123sha', $client->resolveSha('o', 'r', 'main', null));
     }
 
     #[Test]
     public function listTreeReturnsBlobPaths(): void
     {
-        $client = $this->clientReturning(fn(RequestInterface $r) => $this->json([
+        $client = $this->clientReturning(fn(RequestInterface $r): ResponseInterface => $this->json([
             'tree' => [
                 ['path' => 'SKILL.md', 'type' => 'blob'],
                 ['path' => 'skills', 'type' => 'tree'],
@@ -96,7 +96,7 @@ final class GitHubClientTest extends TestCase
     {
         // A 200 with a missing/non-array `tree` must NOT return [] — that would
         // make the sync orphan (delete) every previously-synced skill.
-        $client = $this->clientReturning(fn(RequestInterface $r) => $this->json(['message' => 'ok but no tree']));
+        $client = $this->clientReturning(fn(RequestInterface $r): ResponseInterface => $this->json(['message' => 'ok but no tree']));
         $this->expectException(GitHubApiException::class);
         $client->listTree('o', 'r', 'sha', null);
     }
@@ -104,7 +104,7 @@ final class GitHubClientTest extends TestCase
     #[Test]
     public function fetchAllowedUrlRejectsNonGitHubHost(): void
     {
-        $client = $this->clientReturning(fn(RequestInterface $r) => $this->json([]));
+        $client = $this->clientReturning(fn(RequestInterface $r): ResponseInterface => $this->json([]));
         $this->expectException(HostNotAllowedException::class);
         $client->fetchAllowedUrl('https://evil.example.com/marketplace.json', null);
     }
@@ -112,7 +112,7 @@ final class GitHubClientTest extends TestCase
     #[Test]
     public function fetchAllowedUrlRejectsNonHttpsScheme(): void
     {
-        $client = $this->clientReturning(fn(RequestInterface $r) => $this->json([]));
+        $client = $this->clientReturning(fn(RequestInterface $r): ResponseInterface => $this->json([]));
         $this->expectException(HostNotAllowedException::class);
         $client->fetchAllowedUrl('http://raw.githubusercontent.com/o/r/sha/SKILL.md', null);
     }
@@ -121,7 +121,7 @@ final class GitHubClientTest extends TestCase
     public function exhaustedPrimaryBudgetOn403IsFlaggedAsRateLimit(): void
     {
         $client = $this->clientReturning(
-            fn(RequestInterface $r) => $this->httpResponse(403, ['X-RateLimit-Remaining' => '0', 'X-RateLimit-Reset' => '4711']),
+            fn(RequestInterface $r): ResponseInterface => $this->httpResponse(403, ['X-RateLimit-Remaining' => '0', 'X-RateLimit-Reset' => '4711']),
         );
         $e = $this->captureFailure($client);
         self::assertTrue($e->isRateLimit, '403 with X-RateLimit-Remaining: 0 must be a rate-limit failure');
@@ -130,7 +130,7 @@ final class GitHubClientTest extends TestCase
     #[Test]
     public function http429IsFlaggedAsRateLimit(): void
     {
-        $client = $this->clientReturning(fn(RequestInterface $r) => $this->httpResponse(429));
+        $client = $this->clientReturning(fn(RequestInterface $r): ResponseInterface => $this->httpResponse(429));
         $e = $this->captureFailure($client);
         self::assertTrue($e->isRateLimit, 'HTTP 429 must be a rate-limit failure');
     }
@@ -138,7 +138,7 @@ final class GitHubClientTest extends TestCase
     #[Test]
     public function http500IsNotARateLimit(): void
     {
-        $client = $this->clientReturning(fn(RequestInterface $r) => $this->httpResponse(500));
+        $client = $this->clientReturning(fn(RequestInterface $r): ResponseInterface => $this->httpResponse(500));
         $e = $this->captureFailure($client);
         self::assertFalse($e->isRateLimit, 'a server error must stay a generic (non-rate-limit) failure');
         self::assertSame(500, $e->status);
@@ -148,7 +148,7 @@ final class GitHubClientTest extends TestCase
     public function redirectIsRejectedAndNeverSilentlyConsumed(): void
     {
         // 3xx must be treated as an error: a followed redirect could escape the host allowlist.
-        $client = $this->clientReturning(fn(RequestInterface $r) => $this->httpResponse(302, ['Location' => 'https://evil.example.com/']));
+        $client = $this->clientReturning(fn(RequestInterface $r): ResponseInterface => $this->httpResponse(302, ['Location' => 'https://evil.example.com/']));
         $e = $this->captureFailure($client);
         self::assertFalse($e->isRateLimit);
         self::assertSame(302, $e->status);
@@ -163,6 +163,7 @@ final class GitHubClientTest extends TestCase
         foreach ($headers as $name => $value) {
             $response = $response->withHeader($name, $value);
         }
+
         return $response;
     }
 
@@ -173,6 +174,7 @@ final class GitHubClientTest extends TestCase
         } catch (GitHubApiException $e) {
             return $e;
         }
+
         self::fail('expected a GitHubApiException to be thrown');
     }
 }

--- a/Tests/Unit/Service/SkillConfigInjectionTest.php
+++ b/Tests/Unit/Service/SkillConfigInjectionTest.php
@@ -46,6 +46,7 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 final class SkillConfigInjectionTest extends AbstractUnitTestCase
 {
     use LlmServiceManagerTestFactory;
+
     private const SKILL_NEEDLE = '### Skill: Config Skill';
 
     private const SYSTEM_PROMPT = 'You are a translator.';
@@ -234,6 +235,7 @@ final class SkillConfigInjectionTest extends AbstractUnitTestCase
         $skill->setSupportStatus(SupportStatus::FULL->value);
         $skill->setEnabled(true);
         $skill->setOrphaned(false);
+
         $configuration->addSkill($skill);
 
         return $configuration;

--- a/Tests/Unit/Service/Streaming/StreamRedactionWindowTest.php
+++ b/Tests/Unit/Service/Streaming/StreamRedactionWindowTest.php
@@ -65,6 +65,7 @@ final class StreamRedactionWindowTest extends TestCase
                 $out .= $d;
             }
         }
+
         foreach ($w->flush() as $d) {
             $out .= $d;
         }
@@ -169,6 +170,7 @@ final class StreamRedactionWindowTest extends TestCase
             $w->push('some benign words here and there ');
             $max = max($max, $w->currentWindowBytes());
         }
+
         $w->flush();
 
         self::assertLessThan(20000, $max, 'window is pruned well below the ~165 KB raw stream');
@@ -185,9 +187,11 @@ final class StreamRedactionWindowTest extends TestCase
         foreach ($w->push($raw) as $d) {
             $out .= $d;
         }
+
         foreach ($w->push(' done') as $d) {
             $out .= $d;
         }
+
         foreach ($w->flush() as $d) {
             $out .= $d;
         }
@@ -207,6 +211,7 @@ final class StreamRedactionWindowTest extends TestCase
         foreach ($w->push($blob) as $d) {
             $out .= $d;
         }
+
         foreach ($w->flush() as $d) {
             $out .= $d;
         }
@@ -227,6 +232,7 @@ final class StreamRedactionWindowTest extends TestCase
                 self::assertTrue(mb_check_encoding($out, 'UTF-8'), 'no delta boundary splits a codepoint');
             }
         }
+
         foreach ($w->flush() as $d) {
             $out .= $d;
         }

--- a/Tests/Unit/Service/Streaming/StreamingDispatcherTest.php
+++ b/Tests/Unit/Service/Streaming/StreamingDispatcherTest.php
@@ -76,6 +76,7 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
     {
         $guardrail = new class implements GuardrailInterface {
             use GuardrailIdentityDoubleTrait;
+
             public function checkOutput(CompletionResponse $response): GuardrailResult
             {
                 return str_contains($response->content, 'sk-secret')
@@ -108,6 +109,7 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
     {
         $guardrail = new class implements GuardrailInterface {
             use GuardrailIdentityDoubleTrait;
+
             public function checkOutput(CompletionResponse $response): GuardrailResult
             {
                 return GuardrailResult::allow();
@@ -329,6 +331,7 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
         foreach ($chunks as $chunk) {
             self::assertTrue(mb_check_encoding($chunk, 'UTF-8'), 'each yielded chunk must be valid UTF-8');
         }
+
         self::assertSame($text, implode('', $chunks));
     }
 
@@ -339,6 +342,7 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
         // onto the buffered path — chunks pass through 1:1, no re-chunking.
         $guardrail = new class implements GuardrailInterface {
             use GuardrailIdentityDoubleTrait;
+
             public function checkOutput(CompletionResponse $response): GuardrailResult
             {
                 return GuardrailResult::deny('policy');
@@ -512,6 +516,7 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
             $seen[] = $chunk;
             break; // abandon after the first chunk
         }
+
         // Destroying the suspended generator runs its finally (settlement).
         unset($generator);
 
@@ -694,9 +699,10 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
             $surfaced = $e;
         }
 
-        if ($surfaced === null) {
+        if (!$surfaced instanceof ProviderConnectionException) {
             self::fail('An exhausted streaming fallback chain must surface the last error.');
         }
+
         // The LAST retryable exception is surfaced (the ?? fallback default is
         // never reached because $lastRetryable is set) — code/message prove the
         // actual candidate error propagated, not a freshly built default.

--- a/Tests/Unit/Service/Task/TaskExecutionServiceTest.php
+++ b/Tests/Unit/Service/Task/TaskExecutionServiceTest.php
@@ -31,6 +31,7 @@ use ReflectionProperty;
 final class TaskExecutionServiceTest extends AbstractUnitTestCase
 {
     private LlmServiceManagerInterface&MockObject $llmServiceManager;
+
     private TaskExecutionService $subject;
 
     protected function setUp(): void

--- a/Tests/Unit/Service/Task/TaskInputResolverTest.php
+++ b/Tests/Unit/Service/Task/TaskInputResolverTest.php
@@ -32,9 +32,13 @@ use RuntimeException;
 final class TaskInputResolverTest extends AbstractUnitTestCase
 {
     private SystemLogReaderInterface&MockObject $systemLogReader;
+
     private DeprecationLogReaderInterface&MockObject $deprecationLogReader;
+
     private RecordTableReaderInterface&MockObject $recordTableReader;
+
     private LoggerInterface&MockObject $logger;
+
     private TaskInputResolver $subject;
 
     protected function setUp(): void
@@ -53,7 +57,7 @@ final class TaskInputResolverTest extends AbstractUnitTestCase
         );
     }
 
-    private static function makeTask(string $inputType, string $inputSourceJson = ''): Task
+    private function makeTask(string $inputType, string $inputSourceJson = ''): Task
     {
         $task = new Task();
         $task->setInputType($inputType);
@@ -70,7 +74,7 @@ final class TaskInputResolverTest extends AbstractUnitTestCase
         $this->recordTableReader->expects(self::never())->method('fetchAll');
         $this->logger->expects(self::never())->method(self::anything());
 
-        self::assertSame('', $this->subject->resolve(self::makeTask('unknown')));
+        self::assertSame('', $this->subject->resolve($this->makeTask('unknown')));
     }
 
     #[Test]
@@ -84,7 +88,7 @@ final class TaskInputResolverTest extends AbstractUnitTestCase
 
         self::assertSame(
             'deprecation-log-content',
-            $this->subject->resolve(self::makeTask(Task::INPUT_DEPRECATION_LOG)),
+            $this->subject->resolve($this->makeTask(Task::INPUT_DEPRECATION_LOG)),
         );
     }
 
@@ -101,7 +105,7 @@ final class TaskInputResolverTest extends AbstractUnitTestCase
             ]);
         $this->logger->expects(self::never())->method(self::anything());
 
-        $output = $this->subject->resolve(self::makeTask(Task::INPUT_SYSLOG));
+        $output = $this->subject->resolve($this->makeTask(Task::INPUT_SYSLOG));
 
         // Exact rendering pins the timestamp formatting, the type-label
         // lookup (1 -> DB, 5 -> ERROR), the error marker threshold
@@ -128,7 +132,7 @@ final class TaskInputResolverTest extends AbstractUnitTestCase
             ->willReturn([[]]);
         $this->logger->expects(self::never())->method(self::anything());
 
-        $output = $this->subject->resolve(self::makeTask(Task::INPUT_SYSLOG));
+        $output = $this->subject->resolve($this->makeTask(Task::INPUT_SYSLOG));
 
         self::assertSame('[' . date('Y-m-d H:i:s', 0) . '] [OTHER]  ', $output);
     }
@@ -148,7 +152,7 @@ final class TaskInputResolverTest extends AbstractUnitTestCase
             ]);
         $this->logger->expects(self::never())->method(self::anything());
 
-        $output = $this->subject->resolve(self::makeTask(Task::INPUT_SYSLOG));
+        $output = $this->subject->resolve($this->makeTask(Task::INPUT_SYSLOG));
 
         self::assertSame('[' . date('Y-m-d H:i:s', 1714521600) . '] [FILE]  x', $output);
     }
@@ -175,7 +179,7 @@ final class TaskInputResolverTest extends AbstractUnitTestCase
             ]);
         $this->logger->expects(self::never())->method(self::anything());
 
-        $output = $this->subject->resolve(self::makeTask(Task::INPUT_SYSLOG));
+        $output = $this->subject->resolve($this->makeTask(Task::INPUT_SYSLOG));
 
         $time  = date('Y-m-d H:i:s', 0);
         $lines = [
@@ -202,10 +206,7 @@ final class TaskInputResolverTest extends AbstractUnitTestCase
             ->with(25, false)
             ->willReturn([]);
 
-        $output = $this->subject->resolve(self::makeTask(
-            Task::INPUT_SYSLOG,
-            '{"limit":25,"error_only":false}',
-        ));
+        $output = $this->subject->resolve($this->makeTask(Task::INPUT_SYSLOG, '{"limit":25,"error_only":false}'));
 
         self::assertSame('', $output);
     }
@@ -225,10 +226,7 @@ final class TaskInputResolverTest extends AbstractUnitTestCase
             ->with(25, true)
             ->willReturn([]);
 
-        $output = $this->subject->resolve(self::makeTask(
-            Task::INPUT_SYSLOG,
-            '{"limit":"25","error_only":1}',
-        ));
+        $output = $this->subject->resolve($this->makeTask(Task::INPUT_SYSLOG, '{"limit":"25","error_only":1}'));
 
         self::assertSame('', $output);
     }
@@ -268,7 +266,7 @@ final class TaskInputResolverTest extends AbstractUnitTestCase
                 }),
             );
 
-        $output = $this->subject->resolve(self::makeTask(Task::INPUT_SYSLOG));
+        $output = $this->subject->resolve($this->makeTask(Task::INPUT_SYSLOG));
 
         self::assertStringNotContainsString('SQLSTATE', $output);
         self::assertStringNotContainsString('sys_log_secret', $output);
@@ -282,7 +280,7 @@ final class TaskInputResolverTest extends AbstractUnitTestCase
         $this->recordTableReader->expects(self::never())->method('fetchAll');
         $this->logger->expects(self::never())->method(self::anything());
 
-        $output = $this->subject->resolve(self::makeTask(Task::INPUT_TABLE, '{"limit":10}'));
+        $output = $this->subject->resolve($this->makeTask(Task::INPUT_TABLE, '{"limit":10}'));
 
         self::assertSame('No table configured.', $output);
     }
@@ -300,10 +298,7 @@ final class TaskInputResolverTest extends AbstractUnitTestCase
             ]);
         $this->logger->expects(self::never())->method(self::anything());
 
-        $output = $this->subject->resolve(self::makeTask(
-            Task::INPUT_TABLE,
-            '{"table":"be_users","limit":5}',
-        ));
+        $output = $this->subject->resolve($this->makeTask(Task::INPUT_TABLE, '{"table":"be_users","limit":5}'));
 
         self::assertJson($output);
         $decoded = json_decode($output, true);
@@ -326,10 +321,7 @@ final class TaskInputResolverTest extends AbstractUnitTestCase
             ->willReturn([['uid' => 1, 'username' => 'admin']]);
         $this->logger->expects(self::never())->method(self::anything());
 
-        $output = $this->subject->resolve(self::makeTask(
-            Task::INPUT_TABLE,
-            '{"table":"be_users","limit":"7"}',
-        ));
+        $output = $this->subject->resolve($this->makeTask(Task::INPUT_TABLE, '{"table":"be_users","limit":"7"}'));
 
         self::assertSame(
             json_encode([['uid' => 1, 'username' => 'admin']], JSON_PRETTY_PRINT),
@@ -351,10 +343,7 @@ final class TaskInputResolverTest extends AbstractUnitTestCase
             ->willReturn([['uid' => 1]]);
         $this->logger->expects(self::never())->method(self::anything());
 
-        $output = $this->subject->resolve(self::makeTask(
-            Task::INPUT_TABLE,
-            '{"table":123,"limit":5}',
-        ));
+        $output = $this->subject->resolve($this->makeTask(Task::INPUT_TABLE, '{"table":123,"limit":5}'));
 
         self::assertSame(
             json_encode([['uid' => 1]], JSON_PRETTY_PRINT),
@@ -395,10 +384,7 @@ final class TaskInputResolverTest extends AbstractUnitTestCase
                 }),
             );
 
-        $output = $this->subject->resolve(self::makeTask(
-            Task::INPUT_TABLE,
-            '{"table":"be_users"}',
-        ));
+        $output = $this->subject->resolve($this->makeTask(Task::INPUT_TABLE, '{"table":"be_users"}'));
 
         self::assertStringNotContainsString('SQLSTATE', $output);
         self::assertStringNotContainsString('secret_table', $output);
@@ -435,10 +421,7 @@ final class TaskInputResolverTest extends AbstractUnitTestCase
                 }),
             );
 
-        $output = $this->subject->resolve(self::makeTask(
-            Task::INPUT_TABLE,
-            '{"table":"be_groups"}',
-        ));
+        $output = $this->subject->resolve($this->makeTask(Task::INPUT_TABLE, '{"table":"be_groups"}'));
 
         self::assertSame('Error reading table. See system log for details.', $output);
     }

--- a/Tests/Unit/Service/TestPromptResolverServiceTest.php
+++ b/Tests/Unit/Service/TestPromptResolverServiceTest.php
@@ -36,6 +36,7 @@ final class TestPromptResolverServiceTest extends AbstractUnitTestCase
         } else {
             $GLOBALS['BE_USER'] = $this->previousBeUser;
         }
+
         parent::tearDown();
     }
 

--- a/Tests/Unit/Service/Tool/AgentRunPersisterTest.php
+++ b/Tests/Unit/Service/Tool/AgentRunPersisterTest.php
@@ -36,6 +36,7 @@ final class AgentRunPersisterTest extends TestCase
     {
         $repository = new RecordingAgentRunRepository();
         $repository->nextUid = 42;
+
         $persister = new AgentRunPersister($repository, FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL));
 
         $config = new LlmConfiguration();
@@ -151,6 +152,7 @@ final class AgentRunPersisterTest extends TestCase
     {
         $repository               = new RecordingAgentRunRepository();
         $repository->throwOnClaim = true;
+
         $persister                = new AgentRunPersister($repository, FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL));
         $run                      = new AgentRun(1, 'uuid', 'waiting_for_approval', 0, '', 0, 0, false, 0, 0, 0, 0.0, '', '', 0, 0, 0, '{}');
 
@@ -164,6 +166,7 @@ final class AgentRunPersisterTest extends TestCase
     {
         $repository               = new RecordingAgentRunRepository();
         $repository->throwOnStart = true;
+
         $persister                = new AgentRunPersister($repository, FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL));
 
         self::assertNull($persister->begin(null, 0));
@@ -174,6 +177,7 @@ final class AgentRunPersisterTest extends TestCase
     {
         $repository                = new RecordingAgentRunRepository();
         $repository->throwOnRecord = true;
+
         $persister                 = new AgentRunPersister($repository, FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL));
         $handle                    = new AgentRunHandle(1, 'uuid');
 
@@ -244,6 +248,7 @@ final class AgentRunPersisterTest extends TestCase
     {
         $repository               = new RecordingAgentRunRepository();
         $repository->refuseFinish = true;
+
         $logger                   = $this->createMock(LoggerInterface::class);
         $logger->expects(self::once())->method('notice')->with(self::stringContains('was not settled by this call'), self::anything());
 
@@ -259,6 +264,7 @@ final class AgentRunPersisterTest extends TestCase
     {
         $repository                 = new RecordingAgentRunRepository();
         $repository->throwOnSuspend = true;
+
         $persister                  = new AgentRunPersister($repository, FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL));
 
         // An approval-gated tool is side-effecting: telling the caller "awaiting
@@ -280,6 +286,7 @@ final class AgentRunPersisterTest extends TestCase
     {
         $repository                = new RecordingAgentRunRepository();
         $repository->throwOnFinish = true;
+
         $persister                 = new AgentRunPersister($repository, FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL));
         $handle                    = new AgentRunHandle(1, 'uuid');
 

--- a/Tests/Unit/Service/Tool/Builtin/ContentToolsSpecTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/ContentToolsSpecTest.php
@@ -64,6 +64,7 @@ final class ContentToolsSpecTest extends TestCase
         } else {
             unset($GLOBALS['BE_USER']);
         }
+
         parent::tearDown();
     }
 

--- a/Tests/Unit/Service/Tool/Builtin/DiagnosticsToolsSpecTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/DiagnosticsToolsSpecTest.php
@@ -38,7 +38,7 @@ final class DiagnosticsToolsSpecTest extends TestCase
     /**
      * @return list<class-string<ToolInterface>>
      */
-    private static function toolClasses(): array
+    private function toolClasses(): array
     {
         return [
             ListExtensionsTool::class,
@@ -53,7 +53,7 @@ final class DiagnosticsToolsSpecTest extends TestCase
     /**
      * @param class-string<ToolInterface> $class
      */
-    private static function bare(string $class): ToolInterface
+    private function bare(string $class): ToolInterface
     {
         $tool = (new ReflectionClass($class))->newInstanceWithoutConstructor();
         self::assertInstanceOf(ToolInterface::class, $tool);
@@ -74,7 +74,7 @@ final class DiagnosticsToolsSpecTest extends TestCase
         ];
 
         foreach ($expected as $class => $name) {
-            $spec = self::bare($class)->getSpec();
+            $spec = $this->bare($class)->getSpec();
             self::assertSame($name, $spec->name);
             // All arguments are optional across the whole wave.
             self::assertArrayNotHasKey('required', $spec->parameters);
@@ -84,8 +84,8 @@ final class DiagnosticsToolsSpecTest extends TestCase
     #[Test]
     public function allAreAdminOnlyAndEnabledByDefault(): void
     {
-        foreach (self::toolClasses() as $class) {
-            $tool = self::bare($class);
+        foreach ($this->toolClasses() as $class) {
+            $tool = $this->bare($class);
             self::assertTrue($tool->requiresAdmin(), $class);
             self::assertTrue($tool->isEnabledByDefault(), $class);
         }
@@ -94,8 +94,8 @@ final class DiagnosticsToolsSpecTest extends TestCase
     #[Test]
     public function groupsFollowTheTaxonomy(): void
     {
-        foreach (self::toolClasses() as $class) {
-            $tool     = self::bare($class);
+        foreach ($this->toolClasses() as $class) {
+            $tool     = $this->bare($class);
             $expected = $class === GetSiteConfigTool::class ? 'configuration' : 'system';
             self::assertSame($expected, $tool->getGroup(), $class);
         }

--- a/Tests/Unit/Service/Tool/Builtin/ExcerptTagSpacingTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/ExcerptTagSpacingTest.php
@@ -36,7 +36,7 @@ final class ExcerptTagSpacingTest extends TestCase
      * @param class-string $class
      * @param list<mixed>  $arguments
      */
-    private static function invokeExcerptHelper(string $class, string $method, array $arguments): string
+    private function invokeExcerptHelper(string $class, string $method, array $arguments): string
     {
         $reflection = new ReflectionClass($class);
         $instance   = $reflection->newInstanceWithoutConstructor();
@@ -56,11 +56,7 @@ final class ExcerptTagSpacingTest extends TestCase
     #[Test]
     public function probeUrlBodyExcerptSeparatesAdjacentTableCells(): void
     {
-        $excerpt = self::invokeExcerptHelper(
-            ProbeUrlTool::class,
-            'bodyExcerpt',
-            ['<table><tr><td>Price</td><td>100</td></tr></table>'],
-        );
+        $excerpt = $this->invokeExcerptHelper(ProbeUrlTool::class, 'bodyExcerpt', ['<table><tr><td>Price</td><td>100</td></tr></table>']);
 
         self::assertSame('Price 100', $excerpt);
     }
@@ -68,11 +64,7 @@ final class ExcerptTagSpacingTest extends TestCase
     #[Test]
     public function probeUrlBodyExcerptSeparatesAdjacentBlockElementsWithoutDoubleSpaces(): void
     {
-        $excerpt = self::invokeExcerptHelper(
-            ProbeUrlTool::class,
-            'bodyExcerpt',
-            ["<h1>Title</h1>\n<p>Intro <b>text</b></p><p>Next</p>"],
-        );
+        $excerpt = $this->invokeExcerptHelper(ProbeUrlTool::class, 'bodyExcerpt', ["<h1>Title</h1>\n<p>Intro <b>text</b></p><p>Next</p>"]);
 
         self::assertSame('Title Intro text Next', $excerpt);
         self::assertStringNotContainsString('  ', $excerpt);
@@ -81,11 +73,7 @@ final class ExcerptTagSpacingTest extends TestCase
     #[Test]
     public function probeUrlBodyExcerptKeepsInlineJoinedWordsIntact(): void
     {
-        $excerpt = self::invokeExcerptHelper(
-            ProbeUrlTool::class,
-            'bodyExcerpt',
-            ['<p>cyber<b>security</b> report</p>'],
-        );
+        $excerpt = $this->invokeExcerptHelper(ProbeUrlTool::class, 'bodyExcerpt', ['<p>cyber<b>security</b> report</p>']);
 
         self::assertSame('cybersecurity report', $excerpt);
     }
@@ -93,11 +81,7 @@ final class ExcerptTagSpacingTest extends TestCase
     #[Test]
     public function probeUrlBodyExcerptKeepsTheByteCap(): void
     {
-        $excerpt = self::invokeExcerptHelper(
-            ProbeUrlTool::class,
-            'bodyExcerpt',
-            ['<td>' . str_repeat('a', 3000) . '</td>'],
-        );
+        $excerpt = $this->invokeExcerptHelper(ProbeUrlTool::class, 'bodyExcerpt', ['<td>' . str_repeat('a', 3000) . '</td>']);
 
         // 2048 capped bytes plus the appended ellipsis.
         self::assertSame(2048 + strlen('…'), strlen($excerpt));
@@ -107,11 +91,7 @@ final class ExcerptTagSpacingTest extends TestCase
     #[Test]
     public function pageContentExcerptSeparatesAdjacentTableCells(): void
     {
-        $excerpt = self::invokeExcerptHelper(
-            GetPageContentTool::class,
-            'excerpt',
-            ['<tr><td>Price</td><td>100</td></tr><tr><td>Total</td><td>200</td></tr>'],
-        );
+        $excerpt = $this->invokeExcerptHelper(GetPageContentTool::class, 'excerpt', ['<tr><td>Price</td><td>100</td></tr><tr><td>Total</td><td>200</td></tr>']);
 
         self::assertSame('Price 100 Total 200', $excerpt);
     }
@@ -119,11 +99,7 @@ final class ExcerptTagSpacingTest extends TestCase
     #[Test]
     public function pageContentExcerptKeepsInlineJoinedWordsIntact(): void
     {
-        $excerpt = self::invokeExcerptHelper(
-            GetPageContentTool::class,
-            'excerpt',
-            ['<p>cyber<b>security</b> report</p>'],
-        );
+        $excerpt = $this->invokeExcerptHelper(GetPageContentTool::class, 'excerpt', ['<p>cyber<b>security</b> report</p>']);
 
         self::assertSame('cybersecurity report', $excerpt);
     }
@@ -131,11 +107,7 @@ final class ExcerptTagSpacingTest extends TestCase
     #[Test]
     public function pageContentExcerptKeepsTheLengthCap(): void
     {
-        $excerpt = self::invokeExcerptHelper(
-            GetPageContentTool::class,
-            'excerpt',
-            ['<p>' . str_repeat('a', 250) . '</p>'],
-        );
+        $excerpt = $this->invokeExcerptHelper(GetPageContentTool::class, 'excerpt', ['<p>' . str_repeat('a', 250) . '</p>']);
 
         // 200 capped characters plus the appended ellipsis.
         self::assertSame(201, mb_strlen($excerpt));
@@ -145,16 +117,12 @@ final class ExcerptTagSpacingTest extends TestCase
     #[Test]
     public function searchRecordsMatchExcerptSeparatesAdjacentTableCells(): void
     {
-        $hit = self::invokeExcerptHelper(
-            SearchRecordsTool::class,
-            'formatHit',
-            [
-                'tt_content',
-                ['uid' => 7, 'pid' => 1, 'bodytext' => '<tr><td>Price</td><td>100</td></tr>'],
-                ['bodytext'],
-                'Price 100',
-            ],
-        );
+        $hit = $this->invokeExcerptHelper(SearchRecordsTool::class, 'formatHit', [
+            'tt_content',
+            ['uid' => 7, 'pid' => 1, 'bodytext' => '<tr><td>Price</td><td>100</td></tr>'],
+            ['bodytext'],
+            'Price 100',
+        ]);
 
         // Before the fix the plain text was 'Price100', so a query spanning
         // the cell boundary produced no match excerpt at all.
@@ -165,16 +133,12 @@ final class ExcerptTagSpacingTest extends TestCase
     #[Test]
     public function searchRecordsMatchExcerptKeepsInlineJoinedWordsIntact(): void
     {
-        $hit = self::invokeExcerptHelper(
-            SearchRecordsTool::class,
-            'formatHit',
-            [
-                'tt_content',
-                ['uid' => 7, 'pid' => 1, 'bodytext' => '<p>cyber<b>security</b> report</p>'],
-                ['bodytext'],
-                'cybersecurity',
-            ],
-        );
+        $hit = $this->invokeExcerptHelper(SearchRecordsTool::class, 'formatHit', [
+            'tt_content',
+            ['uid' => 7, 'pid' => 1, 'bodytext' => '<p>cyber<b>security</b> report</p>'],
+            ['bodytext'],
+            'cybersecurity',
+        ]);
 
         // A word joined by an inline element must stay searchable as one word.
         self::assertStringContainsString('match(bodytext): cybersecurity report', $hit);

--- a/Tests/Unit/Service/Tool/Builtin/FalToolsSpecTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/FalToolsSpecTest.php
@@ -37,7 +37,7 @@ final class FalToolsSpecTest extends TestCase
     /**
      * @return list<class-string<ToolInterface>>
      */
-    private static function toolClasses(): array
+    private function toolClasses(): array
     {
         return [
             ListFalStoragesTool::class,
@@ -51,7 +51,7 @@ final class FalToolsSpecTest extends TestCase
     /**
      * @param class-string<ToolInterface> $class
      */
-    private static function bare(string $class): ToolInterface
+    private function bare(string $class): ToolInterface
     {
         $tool = (new ReflectionClass($class))->newInstanceWithoutConstructor();
         self::assertInstanceOf(ToolInterface::class, $tool);
@@ -62,23 +62,23 @@ final class FalToolsSpecTest extends TestCase
     #[Test]
     public function specsExposeNamesAndRequiredParameters(): void
     {
-        $storages = self::bare(ListFalStoragesTool::class)->getSpec();
+        $storages = $this->bare(ListFalStoragesTool::class)->getSpec();
         self::assertSame('list_fal_storages', $storages->name);
         self::assertArrayNotHasKey('required', $storages->parameters);
 
-        $browse = self::bare(BrowseFalFolderTool::class)->getSpec();
+        $browse = $this->bare(BrowseFalFolderTool::class)->getSpec();
         self::assertSame('browse_fal_folder', $browse->name);
         self::assertArrayNotHasKey('required', $browse->parameters);
 
-        $search = self::bare(SearchFalFilesTool::class)->getSpec();
+        $search = $this->bare(SearchFalFilesTool::class)->getSpec();
         self::assertSame('search_fal_files', $search->name);
         self::assertSame(['query'], $search->parameters['required'] ?? []);
 
-        $references = self::bare(GetFalReferencesTool::class)->getSpec();
+        $references = $this->bare(GetFalReferencesTool::class)->getSpec();
         self::assertSame('get_fal_references', $references->name);
         self::assertSame(['uid'], $references->parameters['required'] ?? []);
 
-        $missing = self::bare(FindMissingFilesTool::class)->getSpec();
+        $missing = $this->bare(FindMissingFilesTool::class)->getSpec();
         self::assertSame('find_missing_files', $missing->name);
         self::assertArrayNotHasKey('required', $missing->parameters);
     }
@@ -86,8 +86,8 @@ final class FalToolsSpecTest extends TestCase
     #[Test]
     public function allToolsAreNonAdminEnabledByDefaultAndInTheFilesGroup(): void
     {
-        foreach (self::toolClasses() as $class) {
-            $tool = self::bare($class);
+        foreach ($this->toolClasses() as $class) {
+            $tool = $this->bare($class);
             self::assertFalse($tool->requiresAdmin(), $class);
             self::assertTrue($tool->isEnabledByDefault(), $class);
             self::assertSame('files', $tool->getGroup(), $class);
@@ -101,11 +101,11 @@ final class FalToolsSpecTest extends TestCase
         // no storages and every tool answers with its neutral denial.
         self::assertSame(
             'Asset not found or not permitted.',
-            self::bare(GetFalReferencesTool::class)->execute(['uid' => 0], ToolExecutionContext::none())->content,
+            $this->bare(GetFalReferencesTool::class)->execute(['uid' => 0], ToolExecutionContext::none())->content,
         );
         self::assertSame(
             'Error: "query" is required.',
-            self::bare(SearchFalFilesTool::class)->execute([], ToolExecutionContext::none())->content,
+            $this->bare(SearchFalFilesTool::class)->execute([], ToolExecutionContext::none())->content,
         );
     }
 }

--- a/Tests/Unit/Service/Tool/Builtin/GetEnvRawToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/GetEnvRawToolTest.php
@@ -25,6 +25,7 @@ use PHPUnit\Framework\TestCase;
 final class GetEnvRawToolTest extends TestCase
 {
     private const SECRET_KEY = 'NRLLM_TEST_RAW_SECRET_KEY';
+
     private const SECRET_VALUE = 'raw-unmasked-value';
 
     protected function setUp(): void

--- a/Tests/Unit/Service/Tool/Builtin/GetEnvToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/GetEnvToolTest.php
@@ -27,28 +27,43 @@ use PHPUnit\Framework\TestCase;
 final class GetEnvToolTest extends TestCase
 {
     private const PLAIN_KEY = 'NRLLM_TEST_PLAIN_HOST';
+
     private const PLAIN_VALUE = 'web-01.example.test';
+
     private const SECRET_KEY = 'NRLLM_TEST_DB_PASSWORD';
+
     private const SECRET_VALUE = 'sup3r-s3cr3t-value';
+
     // Name uses PWD (not PASS), matched by the secret-name pattern.
     private const PWD_KEY = 'NRLLM_TEST_MYSQL_PWD';
+
     private const PWD_VALUE = 'dbpass123';
+
     // Non-secret NAME whose VALUE embeds credentials in a connection URL.
     private const URL_KEY = 'NRLLM_TEST_REDIS_URL';
+
     private const URL_VALUE = 'redis://cacheuser:s3cr3turl@cache-01:6379/0';
+
     // Same, but with an EMPTY username (redis://:password@host).
     private const NOUSER_URL_KEY = 'NRLLM_TEST_NOUSER_URL';
+
     private const NOUSER_URL_VALUE = 'redis://:s3cr3tnouser@cache-02:6379/0';
+
     // Names that give NOTHING away — no PASS/KEY/SECRET/TOKEN substring — whose
     // values are unmistakable secrets. Matching on names alone egressed both
     // verbatim to the provider (ADR-123).
     private const SHAPED_PAT_KEY = 'NRLLM_TEST_GITHUB_PAT';
+
     private const SHAPED_PAT_VALUE = 'ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
     private const SHAPED_STRIPE_KEY = 'NRLLM_TEST_STRIPE_LIVE';
+
     // Assembled rather than written out: a complete Stripe-shaped literal in a
     // committed file trips GitHub's push protection, even as an obvious fixture.
     private const SHAPED_STRIPE_VALUE = 'sk_live_' . '999999999999999999999999';
+
     private const SHAPED_JWT_KEY = 'NRLLM_TEST_SESSION_BLOB';
+
     private const SHAPED_JWT_VALUE = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abcDEF123';
 
     protected function setUp(): void
@@ -66,6 +81,7 @@ final class GetEnvToolTest extends TestCase
             putenv($name);
             unset($_ENV[$name]);
         }
+
         parent::tearDown();
     }
 

--- a/Tests/Unit/Service/Tool/Builtin/GetTcaToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/GetTcaToolTest.php
@@ -75,6 +75,7 @@ final class GetTcaToolTest extends TestCase
         } else {
             $GLOBALS['BE_USER'] = $this->beUserBackup;
         }
+
         parent::tearDown();
     }
 

--- a/Tests/Unit/Service/Tool/Builtin/HistoryValidationToolsSpecTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/HistoryValidationToolsSpecTest.php
@@ -35,7 +35,7 @@ final class HistoryValidationToolsSpecTest extends TestCase
     /**
      * @param class-string<ToolInterface> $class
      */
-    private static function bare(string $class): ToolInterface
+    private function bare(string $class): ToolInterface
     {
         $tool = (new ReflectionClass($class))->newInstanceWithoutConstructor();
         self::assertInstanceOf(ToolInterface::class, $tool);
@@ -46,19 +46,19 @@ final class HistoryValidationToolsSpecTest extends TestCase
     #[Test]
     public function specsExposeNamesAndRequiredParameters(): void
     {
-        $history = self::bare(GetRecordHistoryTool::class)->getSpec();
+        $history = $this->bare(GetRecordHistoryTool::class)->getSpec();
         self::assertSame('get_record_history', $history->name);
         self::assertSame(['table', 'uid'], $history->parameters['required'] ?? []);
 
-        $resolve = self::bare(ResolveUrlTool::class)->getSpec();
+        $resolve = $this->bare(ResolveUrlTool::class)->getSpec();
         self::assertSame('resolve_url', $resolve->name);
         self::assertSame(['url'], $resolve->parameters['required'] ?? []);
 
-        $validate = self::bare(ValidateTcaTool::class)->getSpec();
+        $validate = $this->bare(ValidateTcaTool::class)->getSpec();
         self::assertSame('validate_tca', $validate->name);
         self::assertArrayNotHasKey('required', $validate->parameters);
 
-        $check = self::bare(CheckTypoScriptTool::class)->getSpec();
+        $check = $this->bare(CheckTypoScriptTool::class)->getSpec();
         self::assertSame('check_typoscript', $check->name);
         self::assertSame(['pageUid'], $check->parameters['required'] ?? []);
     }
@@ -66,16 +66,16 @@ final class HistoryValidationToolsSpecTest extends TestCase
     #[Test]
     public function adminAndDefaultFlagsArePinned(): void
     {
-        self::assertFalse(self::bare(GetRecordHistoryTool::class)->requiresAdmin());
-        self::assertFalse(self::bare(ResolveUrlTool::class)->requiresAdmin());
-        self::assertFalse(self::bare(ValidateTcaTool::class)->requiresAdmin());
+        self::assertFalse($this->bare(GetRecordHistoryTool::class)->requiresAdmin());
+        self::assertFalse($this->bare(ResolveUrlTool::class)->requiresAdmin());
+        self::assertFalse($this->bare(ValidateTcaTool::class)->requiresAdmin());
         // check_typoscript scans configuration — admin-only like get_typoscript.
-        self::assertTrue(self::bare(CheckTypoScriptTool::class)->requiresAdmin());
+        self::assertTrue($this->bare(CheckTypoScriptTool::class)->requiresAdmin());
 
-        self::assertTrue(self::bare(GetRecordHistoryTool::class)->isEnabledByDefault());
-        self::assertTrue(self::bare(ResolveUrlTool::class)->isEnabledByDefault());
-        self::assertTrue(self::bare(ValidateTcaTool::class)->isEnabledByDefault());
-        self::assertTrue(self::bare(CheckTypoScriptTool::class)->isEnabledByDefault());
+        self::assertTrue($this->bare(GetRecordHistoryTool::class)->isEnabledByDefault());
+        self::assertTrue($this->bare(ResolveUrlTool::class)->isEnabledByDefault());
+        self::assertTrue($this->bare(ValidateTcaTool::class)->isEnabledByDefault());
+        self::assertTrue($this->bare(CheckTypoScriptTool::class)->isEnabledByDefault());
     }
 
     #[Test]
@@ -84,19 +84,19 @@ final class HistoryValidationToolsSpecTest extends TestCase
         // No $GLOBALS['BE_USER'] in unit context → fail-closed paths.
         self::assertSame(
             'Table not found or not permitted.',
-            self::bare(GetRecordHistoryTool::class)->execute(['table' => '', 'uid' => 0], ToolExecutionContext::none())->content,
+            $this->bare(GetRecordHistoryTool::class)->execute(['table' => '', 'uid' => 0], ToolExecutionContext::none())->content,
         );
         self::assertSame(
             'Page not found or no TypoScript template.',
-            self::bare(CheckTypoScriptTool::class)->execute(['pageUid' => 0], ToolExecutionContext::none())->content,
+            $this->bare(CheckTypoScriptTool::class)->execute(['pageUid' => 0], ToolExecutionContext::none())->content,
         );
         self::assertSame(
             'Error: "url" is required.',
-            self::bare(ResolveUrlTool::class)->execute([], ToolExecutionContext::none())->content,
+            $this->bare(ResolveUrlTool::class)->execute([], ToolExecutionContext::none())->content,
         );
         self::assertSame(
             'Page not found or not permitted.',
-            self::bare(ResolveUrlTool::class)->execute(['url' => '/x'], ToolExecutionContext::none())->content,
+            $this->bare(ResolveUrlTool::class)->execute(['url' => '/x'], ToolExecutionContext::none())->content,
         );
     }
 }

--- a/Tests/Unit/Service/Tool/Builtin/ReadRecordsToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/ReadRecordsToolTest.php
@@ -108,6 +108,7 @@ final class ReadRecordsToolTest extends TestCase
         } else {
             unset($GLOBALS['BE_USER']);
         }
+
         parent::tearDown();
     }
 

--- a/Tests/Unit/Service/Tool/Builtin/SearchCodeToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/SearchCodeToolTest.php
@@ -32,6 +32,7 @@ final class SearchCodeToolTest extends TestCase
         foreach (['Classes', 'vendor/acme', '.git', 'var/log', 'Resources'] as $dir) {
             mkdir($this->root . '/' . $dir, 0o777, true);
         }
+
         file_put_contents($this->root . '/Classes/Alpha.php', "<?php\nfunction findMeHere() {}\n\$apiKey = 'topsecret-findMeHere';\n");
         file_put_contents($this->root . '/Resources/notes.md', "findMeHere in docs\n");
         file_put_contents($this->root . '/Classes/binary.png', 'findMeHere-in-binary');

--- a/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
+++ b/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
@@ -44,6 +44,7 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         if ($this->throwOnStart) {
             throw new RuntimeException('startRun failed', 5383517209);
         }
+
         $this->startedRuns[] = [
             'uuid'                     => $uuid,
             'configurationUid'         => $configurationUid,
@@ -59,6 +60,7 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         if ($this->throwOnRecord) {
             throw new RuntimeException('recordEvent failed', 9973913396);
         }
+
         $this->events[] = [
             'runUid'      => $runUid,
             'sequence'    => $sequence,
@@ -85,9 +87,11 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         if ($this->throwOnFinish) {
             throw new RuntimeException('finishRun failed', 7543565687);
         }
+
         if ($this->refuseFinish) {
             return false;
         }
+
         $this->finished = [
             'runUid'           => $runUid,
             'status'           => $status,
@@ -121,9 +125,11 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         if ($this->throwOnSuspend) {
             throw new RuntimeException('suspendRun failed', 1784600401);
         }
+
         if ($this->refuseSuspend) {
             return false;
         }
+
         $this->suspended = ['runUid' => $runUid, 'stateJson' => $stateJson];
 
         return true;
@@ -142,9 +148,11 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         if ($this->throwOnSuspendForInput) {
             throw new RuntimeException('suspendRunForInput failed', 1784600402);
         }
+
         if ($this->refuseSuspendForInput) {
             return false;
         }
+
         $this->suspendedForInput = ['runUid' => $runUid, 'stateJson' => $stateJson];
 
         return true;
@@ -160,6 +168,7 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         if ($this->throwOnEnqueue) {
             throw new RuntimeException('enqueueRun failed', 1784700010);
         }
+
         $this->enqueuedRuns[] = [
             'uuid'                    => $uuid,
             'configurationUid'        => $configurationUid,
@@ -184,9 +193,11 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         if ($this->throwOnClaimQueued) {
             throw new RuntimeException('claimQueued failed', 1784700011);
         }
+
         if ($this->refuseClaimQueued) {
             return false;
         }
+
         $this->queuedClaim = ['runUid' => $runUid, 'claimedBy' => $claimedBy, 'leaseExpires' => $leaseExpires];
 
         return true;
@@ -202,10 +213,12 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         if ($this->throwOnClaim) {
             throw new RuntimeException('claimForResume failed', 1784600400);
         }
+
         // First claim wins; a second concurrent claim on the same run loses.
         if ($this->claimsGranted > 0) {
             return false;
         }
+
         ++$this->claimsGranted;
 
         return true;
@@ -221,9 +234,11 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         if ($this->throwOnClaimInput) {
             throw new RuntimeException('claimForResumeFromInput failed', 1784600403);
         }
+
         if ($this->inputClaimsGranted > 0) {
             return false;
         }
+
         ++$this->inputClaimsGranted;
 
         return true;
@@ -268,6 +283,7 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         if ($this->throwOnMaxSequence) {
             throw new RuntimeException('maxEventSequence failed', 1784600403);
         }
+
         if ($this->maxSequenceReturns !== []) {
             return array_shift($this->maxSequenceReturns);
         }
@@ -288,9 +304,11 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         if ($this->throwOnRenewLease) {
             throw new RuntimeException('renewLease failed', 1784700020);
         }
+
         if ($this->refuseRenewLease) {
             return false;
         }
+
         $this->leaseRenewals[] = ['runUid' => $runUid, 'claimedBy' => $claimedBy, 'leaseExpires' => $leaseExpires];
 
         return true;
@@ -304,9 +322,11 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         if ($this->throwOnRenewLease) {
             throw new RuntimeException('markPendingEffect failed', 1785000020);
         }
+
         if ($this->refuseRenewLease) {
             return false;
         }
+
         $this->pendingEffects[] = ['runUid' => $runUid, 'claimedBy' => $claimedBy, 'effect' => $effect, 'leaseExpires' => $leaseExpires];
 
         return true;
@@ -325,9 +345,11 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         if ($this->throwOnRequeue) {
             throw new RuntimeException('requeue failed', 1784700021);
         }
+
         if ($this->refuseRequeue) {
             return false;
         }
+
         $this->requeues[] = ['runUid' => $runUid, 'claimedBy' => $claimedBy];
 
         return true;
@@ -368,6 +390,7 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         if ($this->refuseRequeueStale) {
             return false;
         }
+
         $this->staleRequeues[] = ['runUid' => $runUid, 'now' => $now];
 
         return true;
@@ -383,6 +406,7 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         if ($this->refuseDeadLetterStale) {
             return false;
         }
+
         $this->staleDeadLetters[] = ['runUid' => $runUid, 'now' => $now, 'reason' => $terminationReason];
 
         return true;

--- a/Tests/Unit/Service/Tool/LogExceptionReaderTest.php
+++ b/Tests/Unit/Service/Tool/LogExceptionReaderTest.php
@@ -91,7 +91,7 @@ final class LogExceptionReaderTest extends TestCase
     #[Test]
     public function timeWindowFilters(): void
     {
-        $probe = (int)strtotime('Mon, 06 Jul 2026 01:13:20 +0200');
+        $probe = strtotime('Mon, 06 Jul 2026 01:13:20 +0200');
 
         $entries = $this->reader->read(10, null, $probe - 30, $probe + 30);
 

--- a/Tests/Unit/Service/Tool/Mcp/McpSchemaNormalizerTest.php
+++ b/Tests/Unit/Service/Tool/Mcp/McpSchemaNormalizerTest.php
@@ -128,7 +128,7 @@ final class McpSchemaNormalizerTest extends TestCase
     #[Test]
     public function aSchemaAtTheDepthCapIsAccepted(): void
     {
-        $schema = self::nestedObjectSchema(self::acceptableNestingLevels());
+        $schema = $this->nestedObjectSchema($this->acceptableNestingLevels());
 
         self::assertSame($schema, $this->normalizer->normalise($schema));
     }
@@ -137,7 +137,7 @@ final class McpSchemaNormalizerTest extends TestCase
     public function aSchemaBeyondTheDepthCapIsRejected(): void
     {
         self::assertNull(
-            $this->normalizer->normalise(self::nestedObjectSchema(self::acceptableNestingLevels() + 1)),
+            $this->normalizer->normalise($this->nestedObjectSchema($this->acceptableNestingLevels() + 1)),
         );
     }
 
@@ -216,7 +216,7 @@ final class McpSchemaNormalizerTest extends TestCase
      * sub-schema. Derived from the constant so a changed cap does not silently
      * turn these two tests into assertions about the same side of the boundary.
      */
-    private static function acceptableNestingLevels(): int
+    private function acceptableNestingLevels(): int
     {
         return intdiv(McpSchemaNormalizer::MAX_DEPTH - 1, 2);
     }
@@ -224,7 +224,7 @@ final class McpSchemaNormalizerTest extends TestCase
     /**
      * @return array<string, mixed>
      */
-    private static function nestedObjectSchema(int $levels): array
+    private function nestedObjectSchema(int $levels): array
     {
         $schema = ['type' => 'object', 'properties' => ['leaf' => ['type' => 'string']]];
 

--- a/Tests/Unit/Service/Tool/ToolCallPolicyTest.php
+++ b/Tests/Unit/Service/Tool/ToolCallPolicyTest.php
@@ -133,6 +133,7 @@ final class ToolCallPolicyTest extends TestCase
                 sprintf('enforcement="%s" should observe (tool still offered)', $value),
             );
         }
+
         foreach ($enforceValues as $value) {
             self::assertFalse(
                 $this->policy($registry, enforcement: $value)->decide('system_tool', $config, $this->admin())->allowed,

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -162,7 +162,7 @@ final class ToolLoopServiceTest extends TestCase
         // invalid byte is gone (the exact substitute char is an mbstring detail).
         self::assertTrue(mb_check_encoding($artifact->label, 'UTF-8'));
         self::assertStringNotContainsString("\xFF", $artifact->label);
-        $leaf = self::str($artifact->data['text'] ?? null);
+        $leaf = $this->str($artifact->data['text'] ?? null);
         self::assertTrue(mb_check_encoding($leaf, 'UTF-8'));
         self::assertStringNotContainsString("\xFF", $leaf);
     }
@@ -185,7 +185,7 @@ final class ToolLoopServiceTest extends TestCase
         self::assertCount(1, $artifacts);
         self::assertSame(ArtifactType::TEXT, $artifacts[0]->type);
         self::assertSame('Artifacts omitted', $artifacts[0]->label);
-        self::assertStringContainsString('exceeded', self::str($artifacts[0]->data['text'] ?? ''));
+        self::assertStringContainsString('exceeded', $this->str($artifacts[0]->data['text'] ?? ''));
     }
 
     #[Test]
@@ -207,7 +207,7 @@ final class ToolLoopServiceTest extends TestCase
 
         self::assertCount(1, $artifacts);
         self::assertSame('Artifacts omitted', $artifacts[0]->label);
-        self::assertStringContainsString('could not be encoded', self::str($artifacts[0]->data['text'] ?? ''));
+        self::assertStringContainsString('could not be encoded', $this->str($artifacts[0]->data['text'] ?? ''));
     }
 
     #[Test]
@@ -385,16 +385,16 @@ final class ToolLoopServiceTest extends TestCase
 
         // The second round must carry the appended assistant + tool turns as
         // typed ChatMessage VOs whose wire form stays OpenAI-compatible.
-        $round2    = self::arr($captured[1] ?? null);
+        $round2    = $this->arr($captured[1] ?? null);
         $assistant = $round2[1] ?? null;
         self::assertInstanceOf(ChatMessage::class, $assistant);
         self::assertSame('assistant', $assistant->role);
 
         $wire     = $assistant->toArray();
-        $calls    = self::arr($wire['tool_calls'] ?? null);
-        $function = self::arr(self::arr($calls[0] ?? null)['function'] ?? null);
-        self::assertSame('call_1', self::arr($calls[0] ?? null)['id'] ?? null);
-        self::assertSame('function', self::arr($calls[0] ?? null)['type'] ?? null);
+        $calls    = $this->arr($wire['tool_calls'] ?? null);
+        $function = $this->arr($this->arr($calls[0] ?? null)['function'] ?? null);
+        self::assertSame('call_1', $this->arr($calls[0] ?? null)['id'] ?? null);
+        self::assertSame('function', $this->arr($calls[0] ?? null)['type'] ?? null);
         // Empty arguments MUST serialise to an object, not an array.
         self::assertSame('{}', $function['arguments'] ?? null);
 
@@ -478,7 +478,7 @@ final class ToolLoopServiceTest extends TestCase
         $service  = $this->service($mgr, $registry);
         $service->runLoop([$this->userTurn('hi')], $this->localConfiguration(), ToolExecutionContext::none(), ['fetch_logs']);
 
-        $specs = self::arr($capturedTools[0] ?? null);
+        $specs = $this->arr($capturedTools[0] ?? null);
         $names = array_map(
             static fn(mixed $s): string => $s instanceof ToolSpec ? $s->name : '<not-a-spec>',
             array_values($specs),
@@ -743,7 +743,7 @@ final class ToolLoopServiceTest extends TestCase
         // null ⇒ "no per-run restriction" ⇒ collapses to the enabled set only.
         $service->runLoop([$this->userTurn('hi')], $this->localConfiguration(), ToolExecutionContext::none(), null);
 
-        $specs = self::arr($capturedTools[0] ?? null);
+        $specs = $this->arr($capturedTools[0] ?? null);
         $names = array_map(
             static fn(mixed $s): string => $s instanceof ToolSpec ? $s->name : '<not-a-spec>',
             array_values($specs),
@@ -982,6 +982,7 @@ final class ToolLoopServiceTest extends TestCase
         } catch (ToolApprovalRequiredException $e) {
             return $e->state;
         }
+
         self::fail('Expected the run to suspend for approval.');
     }
 
@@ -1052,7 +1053,7 @@ final class ToolLoopServiceTest extends TestCase
         // The caller explicitly asks for both, and both are globally enabled.
         $service->runLoop([$this->userTurn('go')], $configuration, ToolExecutionContext::none(), ['content_tool', 'system_tool']);
 
-        self::assertSame(['content_tool'], $captured, 'A tool outside the configuration\'s groups must never be offered.');
+        self::assertSame(['content_tool'], $captured, "A tool outside the configuration's groups must never be offered.");
     }
 
     #[Test]
@@ -1407,7 +1408,7 @@ final class ToolLoopServiceTest extends TestCase
      *
      * @return array<array-key, mixed>
      */
-    private static function arr(mixed $value): array
+    private function arr(mixed $value): array
     {
         self::assertIsArray($value);
 
@@ -1418,7 +1419,7 @@ final class ToolLoopServiceTest extends TestCase
      * Assert a mixed value is a string and return it narrowed (PHPStan-clean
      * access into artifact `data` leaves).
      */
-    private static function str(mixed $value): string
+    private function str(mixed $value): string
     {
         self::assertIsString($value);
 
@@ -1660,7 +1661,7 @@ final class ToolLoopServiceTest extends TestCase
 
         $messages = $assembled->messagesSent;
         self::assertIsArray($messages);
-        $first = self::arr($messages[0] ?? null);
+        $first = $this->arr($messages[0] ?? null);
         self::assertSame('system', $first['role'] ?? null);
         self::assertSame('OVERRIDE_SYS', $first['content'] ?? null);
     }

--- a/Tests/Unit/Service/UsageTrackerServiceTest.php
+++ b/Tests/Unit/Service/UsageTrackerServiceTest.php
@@ -33,10 +33,15 @@ use TYPO3\CMS\Core\SingletonInterface;
 class UsageTrackerServiceTest extends AbstractUnitTestCase
 {
     private ConnectionPool&Stub $connectionPoolStub;
+
     private Context&MockObject $contextMock;
+
     private QueryBuilder&Stub $queryBuilderStub;
+
     private Connection&Stub $connectionStub;
+
     private ExpressionBuilder&Stub $exprStub;
+
     private Result&Stub $resultStub;
 
     protected function setUp(): void
@@ -130,7 +135,7 @@ class UsageTrackerServiceTest extends AbstractUnitTestCase
             ->method('insert')
             ->with(
                 'tx_nrllm_service_usage',
-                self::callback(fn(array $data) => $data['service_type'] === 'translation'
+                self::callback(fn(array $data): bool => $data['service_type'] === 'translation'
                         && $data['service_provider'] === 'deepl'
                         && $data['request_count'] === 1
                         && $data['characters_used'] === 1000
@@ -169,7 +174,7 @@ class UsageTrackerServiceTest extends AbstractUnitTestCase
             ->method('executeStatement')
             ->with(
                 self::stringContains('UPDATE tx_nrllm_service_usage SET'),
-                self::callback(fn(array $params) => $params['tokens'] === 500
+                self::callback(fn(array $params): bool => $params['tokens'] === 500
                         && $params['promptTokens'] === 25
                         && $params['completionTokens'] === 75
                         && $params['characters'] === 300
@@ -219,7 +224,7 @@ class UsageTrackerServiceTest extends AbstractUnitTestCase
             ->method('insert')
             ->with(
                 'tx_nrllm_service_usage',
-                self::callback(fn(array $data) => $data['configuration_uid'] === 42),
+                self::callback(fn(array $data): bool => $data['configuration_uid'] === 42),
             );
 
         $connectionPoolStub = self::createStub(ConnectionPool::class);
@@ -264,7 +269,7 @@ class UsageTrackerServiceTest extends AbstractUnitTestCase
             ->method('insert')
             ->with(
                 'tx_nrllm_service_usage',
-                self::callback(fn(array $data) => $data['tokens_used'] === $metrics['tokens']
+                self::callback(fn(array $data): bool => $data['tokens_used'] === $metrics['tokens']
                         && $data['prompt_tokens'] === $metrics['promptTokens']
                         && $data['completion_tokens'] === $metrics['completionTokens']
                         && $data['characters_used'] === $metrics['characters']
@@ -309,7 +314,7 @@ class UsageTrackerServiceTest extends AbstractUnitTestCase
             ->method('insert')
             ->with(
                 'tx_nrllm_service_usage',
-                self::callback(fn(array $data) => $data['service_type'] === 'image'
+                self::callback(fn(array $data): bool => $data['service_type'] === 'image'
                         && $data['service_provider'] === 'dall-e'
                         && $data['model_id'] === 'gpt-image-2'
                         && $data['model_uid'] === 0
@@ -356,7 +361,7 @@ class UsageTrackerServiceTest extends AbstractUnitTestCase
             ->method('insert')
             ->with(
                 'tx_nrllm_service_usage',
-                self::callback(fn(array $data) => $data['be_user'] === 0
+                self::callback(fn(array $data): bool => $data['be_user'] === 0
                         && array_key_exists('pid', $data)
                         && $data['pid'] === 0
                         && $data['configuration_uid'] === 0
@@ -408,7 +413,7 @@ class UsageTrackerServiceTest extends AbstractUnitTestCase
             ->method('executeStatement')
             ->with(
                 self::stringContains('UPDATE tx_nrllm_service_usage SET'),
-                self::callback(fn(array $params) => $params['tokens'] === 0
+                self::callback(fn(array $params): bool => $params['tokens'] === 0
                         && $params['promptTokens'] === 0
                         && $params['completionTokens'] === 0
                         && $params['characters'] === 0
@@ -510,7 +515,7 @@ class UsageTrackerServiceTest extends AbstractUnitTestCase
             ->method('insert')
             ->with(
                 'tx_nrllm_service_usage',
-                self::callback(fn(array $data) => $data['be_user'] === 99),
+                self::callback(fn(array $data): bool => $data['be_user'] === 99),
             );
 
         $connectionPoolStub = self::createStub(ConnectionPool::class);

--- a/Tests/Unit/Service/WizardGeneratorServiceTest.php
+++ b/Tests/Unit/Service/WizardGeneratorServiceTest.php
@@ -35,8 +35,11 @@ use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 class WizardGeneratorServiceTest extends AbstractUnitTestCase
 {
     private LlmServiceManagerInterface&MockObject $llmServiceManager;
+
     private LlmConfigurationRepository&MockObject $configurationRepository;
+
     private ModelRepository&MockObject $modelRepository;
+
     private WizardGeneratorService $subject;
 
     protected function setUp(): void
@@ -123,11 +126,11 @@ class WizardGeneratorServiceTest extends AbstractUnitTestCase
     {
         $iterator = new ArrayIterator($items);
         $stub = self::createStub(QueryResultInterface::class);
-        $stub->method('current')->willReturnCallback(fn() => $iterator->current());
-        $stub->method('key')->willReturnCallback(fn() => $iterator->key());
-        $stub->method('next')->willReturnCallback(fn() => $iterator->next());
-        $stub->method('rewind')->willReturnCallback(fn() => $iterator->rewind());
-        $stub->method('valid')->willReturnCallback(fn() => $iterator->valid());
+        $stub->method('current')->willReturnCallback(fn(): object => $iterator->current());
+        $stub->method('key')->willReturnCallback(fn(): int|string => $iterator->key());
+        $stub->method('next')->willReturnCallback(fn(): null => $iterator->next());
+        $stub->method('rewind')->willReturnCallback(fn(): null => $iterator->rewind());
+        $stub->method('valid')->willReturnCallback(fn(): bool => $iterator->valid());
         $stub->method('count')->willReturn(count($items));
         $stub->method('toArray')->willReturn($items);
         $stub->method('getFirst')->willReturn($items[0] ?? null);
@@ -174,7 +177,7 @@ class WizardGeneratorServiceTest extends AbstractUnitTestCase
         $defaultConfig = $this->createConfigurationWithModel();
         $this->stubDefaultConfig($defaultConfig);
 
-        $result = $this->subject->resolveConfiguration(null);
+        $result = $this->subject->resolveConfiguration();
 
         self::assertSame($defaultConfig, $result);
     }
@@ -202,7 +205,7 @@ class WizardGeneratorServiceTest extends AbstractUnitTestCase
     {
         $this->stubNoDefaultConfig();
 
-        $result = $this->subject->resolveConfiguration(null);
+        $result = $this->subject->resolveConfiguration();
 
         self::assertNull($result);
     }
@@ -1780,6 +1783,7 @@ class WizardGeneratorServiceTest extends AbstractUnitTestCase
             $m->setDescription('Description ' . $i);
             $models[] = $m;
         }
+
         $this->modelRepository->method('findActive')->willReturn($this->createQueryResultStub($models));
 
         // Non-LlmConfiguration item FIRST: with `continue` the valid one is still collected;
@@ -2320,6 +2324,7 @@ class WizardGeneratorServiceTest extends AbstractUnitTestCase
         } catch (JsonException $e) {
             $expectedError = $e->getMessage();
         }
+
         self::assertNotSame('', $expectedError);
 
         $config = $this->createConfigurationWithModel();
@@ -2707,6 +2712,7 @@ class WizardGeneratorServiceTest extends AbstractUnitTestCase
             $m->setDescription('Desc ' . $i);
             $models[] = $m;
         }
+
         $this->modelRepository->method('findActive')->willReturn($this->createQueryResultStub($models));
 
         $existingConfig = new LlmConfiguration();

--- a/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
+++ b/Tests/Unit/Specialized/AbstractSpecializedServiceTest.php
@@ -44,6 +44,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
@@ -134,7 +135,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
         // does not run.
         $budget->expects(self::once())->method('check')->willReturn(BudgetCheckResult::allowed());
 
-        $this->createSubject(budgetService: $budget)->callEnforceBudget(42, 0.5, null);
+        $this->createSubject(budgetService: $budget)->callEnforceBudget(42, 0.5);
     }
 
     #[Test]
@@ -150,7 +151,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
 
         $this->expectException(BudgetExceededException::class);
 
-        $subject->callEnforceBudget(42, 0.5, null);
+        $subject->callEnforceBudget(42, 0.5);
     }
 
     #[Test]
@@ -164,7 +165,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
 
         $subject = $this->createSubject(budgetService: $budget);
 
-        $subject->callEnforceBudget(7, 0.25, null);
+        $subject->callEnforceBudget(7, 0.25);
 
         $this->addToAssertionCount(1);
     }
@@ -180,7 +181,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
 
         $subject = $this->createSubject(budgetService: $budget);
 
-        $subject->callEnforceBudget(null, null, null);
+        $subject->callEnforceBudget(null, null);
 
         $this->addToAssertionCount(1);
     }
@@ -243,7 +244,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
         $httpClient = $this->createMock(ClientInterface::class);
         $httpClient->expects(self::once())
             ->method('sendRequest')
-            ->willReturnCallback(function (RequestInterface $request) use (&$captured) {
+            ->willReturnCallback(function (RequestInterface $request) use (&$captured): ResponseInterface {
                 $captured = $request;
 
                 return $this->createJsonResponseMock(['result' => 'ok'], 200);
@@ -286,7 +287,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
         $httpClient = $this->createMock(ClientInterface::class);
         $httpClient->expects(self::once())
             ->method('sendRequest')
-            ->willReturnCallback(function (RequestInterface $request) use (&$captured) {
+            ->willReturnCallback(function (RequestInterface $request) use (&$captured): ResponseInterface {
                 $captured = $request;
                 return $this->createJsonResponseMock([], 200);
             });
@@ -333,7 +334,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
                 return $vaultHttpClient;
             },
         );
-        $vaultHttpClient->method('sendRequest')->willReturnCallback(fn() => $this->createJsonResponseMock([], 200));
+        $vaultHttpClient->method('sendRequest')->willReturnCallback(fn(): ResponseInterface => $this->createJsonResponseMock([], 200));
 
         $vault = self::createStub(VaultServiceInterface::class);
         $vault->method('exists')->willReturn(true);
@@ -412,7 +413,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
         $client->expects(self::never())->method('withTimeout');
         $client->method('withAuthentication')->willReturn($client);
         $client->method('withReason')->willReturn($client);
-        $client->method('sendRequest')->willReturnCallback(fn() => $this->createJsonResponseMock([], 200));
+        $client->method('sendRequest')->willReturnCallback(fn(): ResponseInterface => $this->createJsonResponseMock([], 200));
 
         $subject = $this->createSubjectWithVaultClient(
             $client,
@@ -637,7 +638,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
         $httpClient = $this->createMock(ClientInterface::class);
         $httpClient->expects(self::once())
             ->method('sendRequest')
-            ->willReturnCallback(function (RequestInterface $request) use (&$captured) {
+            ->willReturnCallback(function (RequestInterface $request) use (&$captured): ResponseInterface {
                 $captured = $request;
                 return $this->createJsonResponseMock([], 200);
             });
@@ -754,6 +755,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
         // record precedes it in the result.
         $lowerSorting = new Model();
         $lowerSorting->setModelId('gpt-image-1');
+
         $default = new Model();
         $default->setModelId('gpt-image-2');
         $default->setIsDefault(true);
@@ -776,6 +778,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
         // first usable one wins when no record is flagged as default.
         $first = new Model();
         $first->setModelId('tts-1-hd');
+
         $second = new Model();
         $second->setModelId('tts-1');
 
@@ -927,6 +930,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
 
         $registryDefault = new Model();
         $registryDefault->setModelId('gpt-image-1');
+
         $modelRepository = self::createStub(ModelRepository::class);
         $modelRepository->method('findByCapability')
             ->willReturn(new InMemoryQueryResult([$registryDefault]));
@@ -950,6 +954,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
 
         $registryDefault = new Model();
         $registryDefault->setModelId('gpt-image-1');
+
         $modelRepository = self::createStub(ModelRepository::class);
         $modelRepository->method('findByCapability')
             ->willReturn(new InMemoryQueryResult([$registryDefault]));
@@ -1047,7 +1052,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
     {
         $configurationRepository = self::createStub(LlmConfigurationRepository::class);
         $configurationRepository->method('findOneByIdentifier')
-            ->willReturn($this->createConfiguration(systemPrompt: 'Hidden prompt.', active: false));
+            ->willReturn($this->createConfiguration(active: false, systemPrompt: 'Hidden prompt.'));
 
         $subject = $this->createSubject(configurationRepository: $configurationRepository);
 
@@ -1232,7 +1237,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
                 return $client;
             },
         );
-        $client->method('sendRequest')->willReturnCallback(fn() => $this->createJsonResponseMock([], 200));
+        $client->method('sendRequest')->willReturnCallback(fn(): ResponseInterface => $this->createJsonResponseMock([], 200));
 
         return $client;
     }
@@ -1282,6 +1287,7 @@ final class AbstractSpecializedServiceTest extends AbstractUnitTestCase
                 } else {
                     $uriString = '';
                 }
+
                 return new TestableRequest($method, $uriString);
             });
         return $stub;
@@ -1505,9 +1511,10 @@ final class TestableRequest implements RequestInterface
 
     public function getBody(): StreamInterface
     {
-        if ($this->body === null) {
+        if (!$this->body instanceof StreamInterface) {
             throw new LogicException('No body set', 3134810639);
         }
+
         return $this->body;
     }
 
@@ -1515,32 +1522,39 @@ final class TestableRequest implements RequestInterface
     {
         return '1.1';
     }
+
     public function withProtocolVersion(string $version): static
     {
         return $this;
     }
+
     public function withAddedHeader(string $name, $value): static
     {
         return $this->withHeader($name, $value);
     }
+
     public function withoutHeader(string $name): static
     {
         $clone = clone $this;
         unset($clone->headers[$name]);
         return $clone;
     }
+
     public function withRequestTarget(string $requestTarget): static
     {
         return $this;
     }
+
     public function withMethod(string $method): static
     {
         return $this;
     }
+
     public function getUri(): UriInterface
     {
         throw new LogicException('Not implemented', 4146456712);
     }
+
     public function withUri(UriInterface $uri, bool $preserveHost = false): static
     {
         return $this;

--- a/Tests/Unit/Specialized/Document/DocumentAnalysisServiceTest.php
+++ b/Tests/Unit/Specialized/Document/DocumentAnalysisServiceTest.php
@@ -35,11 +35,15 @@ use PHPUnit\Framework\MockObject\MockObject;
 class DocumentAnalysisServiceTest extends AbstractUnitTestCase
 {
     private const PDF = "%PDF-1.7\nfake-document-bytes";
+
     private const PROMPT = 'Summarize this document.';
 
     private LlmServiceManagerInterface&MockObject $llmManager;
+
     private VisionServiceInterface&MockObject $visionService;
+
     private PdfRasterizerInterface&MockObject $rasterizer;
+
     private DocumentAnalysisService $subject;
 
     protected function setUp(): void

--- a/Tests/Unit/Specialized/Exception/SpecializedServiceExceptionTest.php
+++ b/Tests/Unit/Specialized/Exception/SpecializedServiceExceptionTest.php
@@ -75,7 +75,7 @@ class SpecializedServiceExceptionTest extends AbstractUnitTestCase
     #[Test]
     public function getDetailedMessageExcludesNullContext(): void
     {
-        $exception = new TranslatorException('Error', 'translation', null);
+        $exception = new TranslatorException('Error', 'translation');
 
         self::assertEquals('[translation] Error', $exception->getDetailedMessage());
         self::assertStringNotContainsString('Context:', $exception->getDetailedMessage());

--- a/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/DallEImageServiceTest.php
@@ -59,13 +59,21 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 class DallEImageServiceTest extends AbstractUnitTestCase
 {
     private ClientInterface&Stub $httpClientStub;
+
     private RequestFactoryInterface&Stub $requestFactoryStub;
+
     private StreamFactoryInterface&Stub $streamFactoryStub;
+
     private ExtensionConfiguration&MockObject $extensionConfigMock;
+
     private UsageTrackerServiceInterface&Stub $usageTrackerStub;
+
     private LoggerInterface&Stub $loggerStub;
+
     private VaultServiceInterface $vaultStub;
+
     private SpecializedCostCalculatorInterface $costCalculator;
+
     private ?string $tempFile = null;
 
     protected function setUp(): void
@@ -177,6 +185,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         if ($this->tempFile !== null && file_exists($this->tempFile)) {
             unlink($this->tempFile);
         }
+
         parent::tearDown();
     }
 
@@ -638,6 +647,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
     {
         $regular = new Model();
         $regular->setModelId('gpt-image-1');
+
         $default = new Model();
         $default->setModelId('gpt-image-2');
         $default->setIsDefault(true);
@@ -661,6 +671,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         $foreignDefault = new Model();
         $foreignDefault->setModelId('flux-schnell');
         $foreignDefault->setIsDefault(true);
+
         $acceptable = new Model();
         $acceptable->setModelId('gpt-image-2');
 
@@ -885,9 +896,7 @@ class DallEImageServiceTest extends AbstractUnitTestCase
         $requestStub->method('withHeader')->willReturnSelf();
         $requestStub->method('withBody')->willReturnSelf();
         $this->requestFactoryStub->method('createRequest')->willReturnCallback(
-            function () use (&$capturedUrl, $requestStub): RequestInterface {
-                // createRequest($method, $url) — capture the URL (the second positional argument).
-                $args = func_get_args();
+            function (...$args) use (&$capturedUrl, $requestStub): RequestInterface {
                 $capturedUrl = is_string($args[1] ?? null) ? $args[1] : '';
                 return $requestStub;
             },

--- a/Tests/Unit/Specialized/Image/FalImageServiceTest.php
+++ b/Tests/Unit/Specialized/Image/FalImageServiceTest.php
@@ -57,11 +57,17 @@ class FalImageServiceTest extends AbstractUnitTestCase
     use PipelineRoutingAssertionTrait;
 
     private ClientInterface&Stub $httpClientStub;
+
     private RequestFactoryInterface&Stub $requestFactoryStub;
+
     private StreamFactoryInterface&Stub $streamFactoryStub;
+
     private ExtensionConfiguration&MockObject $extensionConfigMock;
+
     private UsageTrackerServiceInterface&Stub $usageTrackerStub;
+
     private LoggerInterface&Stub $loggerStub;
+
     private VaultServiceInterface $vaultStub;
 
     /** @var list<array{method: string, uri: string}> */

--- a/Tests/Unit/Specialized/Option/ImageGenerationOptionsTest.php
+++ b/Tests/Unit/Specialized/Option/ImageGenerationOptionsTest.php
@@ -579,6 +579,7 @@ class ImageGenerationOptionsTest extends AbstractUnitTestCase
         self::assertIsString($options->style);
         self::assertIsString($options->format);
     }
+
     // ============ Budget / attribution fields (ADR-057) ============
 
     #[Test]

--- a/Tests/Unit/Specialized/Option/SpeechSynthesisOptionsTest.php
+++ b/Tests/Unit/Specialized/Option/SpeechSynthesisOptionsTest.php
@@ -360,6 +360,7 @@ class SpeechSynthesisOptionsTest extends AbstractUnitTestCase
         self::assertContains('nova', $voices);
         self::assertContains('shimmer', $voices);
     }
+
     // ============ Budget / attribution fields (ADR-057) ============
 
     #[Test]

--- a/Tests/Unit/Specialized/Option/TranscriptionOptionsTest.php
+++ b/Tests/Unit/Specialized/Option/TranscriptionOptionsTest.php
@@ -111,10 +111,7 @@ class TranscriptionOptionsTest extends AbstractUnitTestCase
     {
         $options = new TranscriptionOptions(
             model: null,
-            language: null,
             format: null,
-            prompt: null,
-            temperature: null,
         );
 
         self::assertNull($options->model);
@@ -149,10 +146,7 @@ class TranscriptionOptionsTest extends AbstractUnitTestCase
     {
         $options = new TranscriptionOptions(
             model: 'whisper-1',
-            language: null,
             format: 'json',
-            prompt: null,
-            temperature: null,
         );
 
         $array = $options->toArray();

--- a/Tests/Unit/Specialized/Speech/SegmentMutationTest.php
+++ b/Tests/Unit/Specialized/Speech/SegmentMutationTest.php
@@ -41,7 +41,7 @@ class SegmentMutationTest extends AbstractUnitTestCase
     #[Test]
     public function hasWordsReturnsFalseForNull(): void
     {
-        $segment = new Segment('Test', 0.0, 1.0, words: null);
+        $segment = new Segment('Test', 0.0, 1.0);
 
         self::assertFalse($segment->hasWords());
     }

--- a/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/TextToSpeechServiceTest.php
@@ -57,12 +57,19 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
     use PipelineRoutingAssertionTrait;
 
     private ClientInterface&Stub $httpClientStub;
+
     private RequestFactoryInterface&Stub $requestFactoryStub;
+
     private StreamFactoryInterface&Stub $streamFactoryStub;
+
     private ExtensionConfiguration&MockObject $extensionConfigMock;
+
     private UsageTrackerServiceInterface&Stub $usageTrackerStub;
+
     private LoggerInterface&Stub $loggerStub;
+
     private VaultServiceInterface $vaultStub;
+
     private SpecializedCostCalculatorInterface $costCalculator;
 
     protected function setUp(): void
@@ -578,6 +585,7 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
     {
         $regular = new Model();
         $regular->setModelId('tts-1');
+
         $default = new Model();
         $default->setModelId('tts-1-hd');
         $default->setIsDefault(true);
@@ -741,8 +749,8 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         $this->setupSuccessfulRequest();
 
         $options = new SpeechSynthesisOptions(
-            voice: 'nova',
             model: 'tts-1-hd',
+            voice: 'nova',
             format: 'opus',
             speed: 1.5,
         );
@@ -1184,8 +1192,8 @@ class TextToSpeechServiceTest extends AbstractUnitTestCase
         $this->setupSuccessfulRequest();
 
         $options = new SpeechSynthesisOptions(
-            voice: 'nova',
             model: 'tts-1-hd',
+            voice: 'nova',
             format: 'opus',
             speed: 1.5,
         );

--- a/Tests/Unit/Specialized/Speech/TranscriptionResultMutationTest.php
+++ b/Tests/Unit/Specialized/Speech/TranscriptionResultMutationTest.php
@@ -25,7 +25,7 @@ class TranscriptionResultMutationTest extends AbstractUnitTestCase
     #[Test]
     public function hasSegmentsReturnsFalseForNull(): void
     {
-        $result = new TranscriptionResult('Test', 'en', segments: null);
+        $result = new TranscriptionResult('Test', 'en');
 
         self::assertFalse($result->hasSegments());
     }
@@ -50,7 +50,7 @@ class TranscriptionResultMutationTest extends AbstractUnitTestCase
     #[Test]
     public function getFormattedDurationReturnsNullWhenDurationIsNull(): void
     {
-        $result = new TranscriptionResult('Test', 'en', duration: null);
+        $result = new TranscriptionResult('Test', 'en');
 
         self::assertNull($result->getFormattedDuration());
     }
@@ -85,7 +85,7 @@ class TranscriptionResultMutationTest extends AbstractUnitTestCase
     #[Test]
     public function getConfidencePercentReturnsNullWhenConfidenceIsNull(): void
     {
-        $result = new TranscriptionResult('Test', 'en', confidence: null);
+        $result = new TranscriptionResult('Test', 'en');
 
         self::assertNull($result->getConfidencePercent());
     }
@@ -139,7 +139,7 @@ class TranscriptionResultMutationTest extends AbstractUnitTestCase
     #[Test]
     public function toSrtReturnsNullWithoutSegments(): void
     {
-        $result = new TranscriptionResult('Test', 'en', segments: null);
+        $result = new TranscriptionResult('Test', 'en');
 
         self::assertNull($result->toSrt());
     }
@@ -203,7 +203,7 @@ class TranscriptionResultMutationTest extends AbstractUnitTestCase
     #[Test]
     public function toVttReturnsNullWithoutSegments(): void
     {
-        $result = new TranscriptionResult('Test', 'en', segments: null);
+        $result = new TranscriptionResult('Test', 'en');
 
         self::assertNull($result->toVtt());
     }

--- a/Tests/Unit/Specialized/Speech/TranscriptionResultTest.php
+++ b/Tests/Unit/Specialized/Speech/TranscriptionResultTest.php
@@ -79,7 +79,6 @@ class TranscriptionResultTest extends AbstractUnitTestCase
         $result = new TranscriptionResult(
             text: 'Hello',
             language: 'en',
-            segments: null,
         );
 
         self::assertFalse($result->hasSegments());
@@ -130,7 +129,6 @@ class TranscriptionResultTest extends AbstractUnitTestCase
         $result = new TranscriptionResult(
             text: 'test',
             language: 'en',
-            duration: null,
         );
 
         self::assertNull($result->getFormattedDuration());
@@ -171,7 +169,6 @@ class TranscriptionResultTest extends AbstractUnitTestCase
         $result = new TranscriptionResult(
             text: 'test',
             language: 'en',
-            confidence: null,
         );
 
         self::assertNull($result->getConfidencePercent());
@@ -205,7 +202,6 @@ class TranscriptionResultTest extends AbstractUnitTestCase
         $result = new TranscriptionResult(
             text: 'Hello world',
             language: 'en',
-            segments: null,
         );
 
         self::assertNull($result->toSrt());
@@ -254,7 +250,6 @@ class TranscriptionResultTest extends AbstractUnitTestCase
         $result = new TranscriptionResult(
             text: 'Hello',
             language: 'en',
-            segments: null,
         );
 
         self::assertNull($result->toVtt());

--- a/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
+++ b/Tests/Unit/Specialized/Speech/WhisperTranscriptionServiceTest.php
@@ -57,13 +57,21 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
     use PipelineRoutingAssertionTrait;
 
     private ClientInterface&Stub $httpClientStub;
+
     private RequestFactoryInterface&Stub $requestFactoryStub;
+
     private StreamFactoryInterface&Stub $streamFactoryStub;
+
     private ExtensionConfiguration&MockObject $extensionConfigMock;
+
     private UsageTrackerServiceInterface&Stub $usageTrackerStub;
+
     private LoggerInterface&Stub $loggerStub;
+
     private VaultServiceInterface $vaultStub;
+
     private SpecializedCostCalculatorInterface $costCalculator;
+
     private ?string $tempFile = null;
 
     /**
@@ -154,6 +162,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         if ($this->tempFile !== null && file_exists($this->tempFile)) {
             unlink($this->tempFile);
         }
+
         parent::tearDown();
     }
 
@@ -363,6 +372,7 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
     {
         $regular = new Model();
         $regular->setModelId('whisper-1');
+
         $default = new Model();
         $default->setModelId('gpt-4o-transcribe');
         $default->setIsDefault(true);
@@ -1179,11 +1189,11 @@ class WhisperTranscriptionServiceTest extends AbstractUnitTestCase
         $this->setupSuccessfulRequest((string)json_encode(['text' => 'Full options test']));
 
         $options = new TranscriptionOptions(
+            model: 'whisper-1',
             language: 'en',
             format: 'json',
             prompt: 'Technical content',
             temperature: 0.3,
-            model: 'whisper-1',
         );
 
         $result = $subject->transcribeFromContent('fake audio content', 'test.wav', $options);

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorBudgetTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorBudgetTest.php
@@ -95,7 +95,7 @@ final class DeepLTranslatorBudgetTest extends TestCase
         bool $allowed = true,
         ?BudgetServiceInterface $budgetService = null,
     ): DeepLTranslator {
-        if ($budgetService === null) {
+        if (!$budgetService instanceof BudgetServiceInterface) {
             $budgetService = $this->createMock(BudgetServiceInterface::class);
             $budgetService->method('check')->willReturn(
                 $allowed

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorMutationTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorMutationTest.php
@@ -40,6 +40,7 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
 {
     /** @var array<string, array<string, array<string, int|string>>> */
     private array $defaultConfig;
+
     private UsageTrackerServiceInterface $usageTrackerStub;
 
     protected function setUp(): void
@@ -347,8 +348,8 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
 
         $options = new DeepLOptions(
             formality: 'more',
-            preserveFormatting: true,
             glossaryId: 'gls_123',
+            preserveFormatting: true,
         );
 
         $result = $translator->translate('Hello', 'de', null, ['deepl' => $options]);
@@ -478,7 +479,7 @@ class DeepLTranslatorMutationTest extends AbstractUnitTestCase
             ->with(
                 'translation',
                 'deepl',
-                self::callback(fn(array $data) => $data['batch_size'] === 2 && $data['characters'] === 10),
+                self::callback(fn(array $data): bool => $data['batch_size'] === 2 && $data['characters'] === 10),
             );
 
         $translator = new DeepLTranslator(

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorOptionsTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorOptionsTest.php
@@ -515,7 +515,7 @@ class DeepLTranslatorOptionsTest extends AbstractUnitTestCase
             ->with(
                 'translation',
                 'deepl',
-                self::callback(fn(array $data) => $data['characters'] === $expectedTotalChars && $data['batch_size'] === 3),
+                self::callback(fn(array $data): bool => $data['characters'] === $expectedTotalChars && $data['batch_size'] === 3),
             );
 
         $httpClientMock = self::createStub(ClientInterface::class);

--- a/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/DeepLTranslatorTest.php
@@ -35,6 +35,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
@@ -49,6 +50,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
     use PipelineRoutingAssertionTrait;
 
     private DeepLTranslator $subject;
+
     private UsageTrackerServiceInterface $usageTrackerStub;
 
     /** @var array{translators: array{deepl: array{apiKeyIdentifier: string, timeout: int}}} */
@@ -189,8 +191,8 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
                 $uriStub->method('getPath')->willReturn(parse_url($uri, PHP_URL_PATH) ?? '');
 
                 $request = self::createStub(RequestInterface::class);
-                $request->method('withHeader')->willReturnCallback(fn() => $request);
-                $request->method('withoutHeader')->willReturnCallback(fn() => $request);
+                $request->method('withHeader')->willReturnCallback(fn(): Stub => $request);
+                $request->method('withoutHeader')->willReturnCallback(fn(): Stub => $request);
                 $request->method('withBody')->willReturnCallback(
                     function (StreamInterface $body) use (&$captured, &$request): RequestInterface {
                         $captured['body'] = (string)$body;
@@ -313,6 +315,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
         } catch (LogicException $e) {
             self::assertSame('vault unavailable', $e->getMessage());
         }
+
         self::assertFalse($reflection->getProperty('baseUrlResolved')->getValue($translator));
 
         // Second attempt retries retrieve() and succeeds (Free key → free host).
@@ -533,7 +536,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             ->with(
                 'translation',
                 'deepl',
-                self::callback(fn(array $data) => $data['characters'] === mb_strlen($text)),
+                self::callback(fn(array $data): bool => $data['characters'] === mb_strlen($text)),
                 null,
                 0,
                 '',
@@ -1013,7 +1016,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
             ->with(
                 'translation',
                 'deepl',
-                self::callback(fn(array $data) => $data['characters'] === mb_strlen($text)),
+                self::callback(fn(array $data): bool => $data['characters'] === mb_strlen($text)),
                 null,
                 0,
                 '',
@@ -1192,7 +1195,7 @@ class DeepLTranslatorTest extends AbstractUnitTestCase
                 'translation',
                 'deepl',
                 self::callback(
-                    fn(array $data) => $data['characters'] === $expectedCharacters && $data['batch_size'] === 2,
+                    fn(array $data): bool => $data['characters'] === $expectedCharacters && $data['batch_size'] === 2,
                 ),
                 null,
                 0,

--- a/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
+++ b/Tests/Unit/Specialized/Translation/LlmTranslatorTest.php
@@ -38,9 +38,13 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 class LlmTranslatorTest extends AbstractUnitTestCase
 {
     use LlmServiceManagerTestFactory;
+
     private LlmServiceManager $llmManager;
+
     private UsageTrackerServiceInterface&Stub $usageTrackerStub;
+
     private LlmTranslator $subject;
+
     private TranslatorTestProvider $provider;
 
     protected function setUp(): void
@@ -937,6 +941,7 @@ class LlmTranslatorTest extends AbstractUnitTestCase
         $captured = new class {
             /** @var list<mixed> */
             public array $messages = [];
+
             /** @var array<int, ChatOptions> */
             public array $options = [];
         };
@@ -1276,6 +1281,7 @@ class LlmTranslatorTest extends AbstractUnitTestCase
 class TranslatorTestProvider extends AbstractProvider
 {
     public ?CompletionResponse $nextResponse = null;
+
     /** @var array<CompletionResponse> */
     public array $responseQueue = [];
 

--- a/Tests/Unit/Testing/FakeCompletionServiceTest.php
+++ b/Tests/Unit/Testing/FakeCompletionServiceTest.php
@@ -32,8 +32,8 @@ final class FakeCompletionServiceTest extends TestCase
     #[Test]
     public function returnsQueuedResponsesInFifoOrderAcrossTheResponseMethods(): void
     {
-        $first  = self::response('first');
-        $second = self::response('second');
+        $first  = $this->response('first');
+        $second = $this->response('second');
 
         $subject = new FakeCompletionService();
         $subject->responses = [$first, $second];
@@ -45,8 +45,8 @@ final class FakeCompletionServiceTest extends TestCase
     #[Test]
     public function factualAndCreativeAlsoDrawFromTheResponseQueue(): void
     {
-        $first  = self::response('factual');
-        $second = self::response('creative');
+        $first  = $this->response('factual');
+        $second = $this->response('creative');
 
         $subject = new FakeCompletionService();
         $subject->responses = [$first, $second];
@@ -79,7 +79,7 @@ final class FakeCompletionServiceTest extends TestCase
     public function recordsPromptAndOptionsPerMethod(): void
     {
         $subject = new FakeCompletionService();
-        $subject->responses = [self::response('ok')];
+        $subject->responses = [$this->response('ok')];
 
         $subject->complete('the prompt');
 
@@ -94,7 +94,7 @@ final class FakeCompletionServiceTest extends TestCase
         $configuration = new LlmConfiguration();
 
         $subject = new FakeCompletionService();
-        $subject->responses = [self::response('ok')];
+        $subject->responses = [$this->response('ok')];
 
         $subject->completeForConfiguration('p', $configuration);
 
@@ -106,7 +106,7 @@ final class FakeCompletionServiceTest extends TestCase
     public function throwsConfiguredThrowableInsteadOfReturning(): void
     {
         $subject = new FakeCompletionService();
-        $subject->responses = [self::response('unused')];
+        $subject->responses = [$this->response('unused')];
         $subject->throwable = new RuntimeException('boom');
 
         $this->expectException(RuntimeException::class);
@@ -144,7 +144,7 @@ final class FakeCompletionServiceTest extends TestCase
         $subject->complete('a');
     }
 
-    private static function response(string $content): CompletionResponse
+    private function response(string $content): CompletionResponse
     {
         return new CompletionResponse($content, 'fake-model', new UsageStatistics(0, 0, 0));
     }

--- a/Tests/Unit/Testing/FakeToolCallingServiceTest.php
+++ b/Tests/Unit/Testing/FakeToolCallingServiceTest.php
@@ -33,8 +33,8 @@ final class FakeToolCallingServiceTest extends TestCase
     #[Test]
     public function returnsQueuedResponsesInFifoOrderAcrossBothMethods(): void
     {
-        $first = self::response('first');
-        $second = self::response('second');
+        $first = $this->response('first');
+        $second = $this->response('second');
 
         $subject = new FakeToolCallingService();
         $subject->responses = [$first, $second];
@@ -51,7 +51,7 @@ final class FakeToolCallingServiceTest extends TestCase
         $options  = new ToolOptions();
 
         $subject = new FakeToolCallingService();
-        $subject->responses = [self::response('ok')];
+        $subject->responses = [$this->response('ok')];
 
         $subject->chatWithTools($messages, $tools, $options);
 
@@ -68,7 +68,7 @@ final class FakeToolCallingServiceTest extends TestCase
         $configuration = new LlmConfiguration();
 
         $subject = new FakeToolCallingService();
-        $subject->responses = [self::response('ok')];
+        $subject->responses = [$this->response('ok')];
 
         $subject->chatWithToolsForConfiguration([], [], $configuration);
 
@@ -80,7 +80,7 @@ final class FakeToolCallingServiceTest extends TestCase
     public function throwsConfiguredThrowableInsteadOfReturning(): void
     {
         $subject = new FakeToolCallingService();
-        $subject->responses = [self::response('unused')];
+        $subject->responses = [$this->response('unused')];
         $subject->throwable = new RuntimeException('boom');
 
         $this->expectException(RuntimeException::class);
@@ -92,7 +92,7 @@ final class FakeToolCallingServiceTest extends TestCase
     #[Test]
     public function throwableIsOneShotAndNextCallReturnsAQueuedResponseAgain(): void
     {
-        $queued = self::response('after');
+        $queued = $this->response('after');
 
         $subject = new FakeToolCallingService();
         $subject->responses = [$queued];
@@ -120,7 +120,7 @@ final class FakeToolCallingServiceTest extends TestCase
         $subject->chatWithTools([], []);
     }
 
-    private static function response(string $content): CompletionResponse
+    private function response(string $content): CompletionResponse
     {
         return new CompletionResponse($content, 'fake-model', new UsageStatistics(0, 0, 0));
     }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -12,7 +12,7 @@ use Netresearch\NrLlm\Form\FieldWizard\ModelConstraintsWizard;
 use Netresearch\NrLlm\Hook\ProviderEndpointNormalizationHook;
 use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
 
-defined('TYPO3') or die();
+defined('TYPO3') || die();
 
 (static function (): void {
     // Cache configuration (also in Configuration/Caching.php for TYPO3 v14+)


### PR DESCRIPTION
## Why

`Build/rector/rector.php` assembled its own rule baseline from scratch. That is what made the Rector 2.6.0 release on 2026-08-03 an org-wide outage rather than a one-line fix: `SetList::STRICT_BOOLEANS` was removed upstream and every repo carrying its own set list had to be repaired individually. The org policy is that [netresearch/typo3-ci-workflows](https://github.com/netresearch/typo3-ci-workflows) owns the Rector rule baseline, so the next upstream change is absorbed once, centrally. This adopts [v1.3.4](https://github.com/netresearch/typo3-ci-workflows/releases/tag/v1.3.4) of that shared config, following [netresearch/t3x-nr-image-optimize#150](https://github.com/netresearch/t3x-nr-image-optimize/pull/150).

## What the shared config now provides

The PHP sets and `phpVersion`, the code-quality sets (`CODE_QUALITY`, `CODING_STYLE`, `DEAD_CODE`, `EARLY_RETURN`, `INSTANCEOF`, `PRIVATIZATION`, `TYPE_DECLARATION`, `UP_TO_PHP_82`), the common rule skips, `importNames()`/`removeUnusedImports()`, and the Rector-specific PHPStan neon that the package ships for exactly this purpose. All of that is deleted from the local config.

## What stays local

The `Tests/` path override, because the shared `$projectRoot` default does not include `Tests/` and `paths()` replaces rather than merges; `PHPUnitSetList::PHPUNIT_110`; `Typo3SetList::CODE_QUALITY` and `Typo3SetList::GENERAL`; `Typo3LevelSetList::UP_TO_TYPO3_13` (the v14 set pulls in ComponentFactory/cache migrations this extension does not need yet); `AddVoidReturnTypeWhereNoReturnRector`, which is not part of the shared `TYPE_DECLARATION` set; and the three reasoned skips — `ReadOnlyPropertyRector` on the OpenAI integration test, `AddErrorCodeToExceptionRector` on the three exceptions whose constructor takes `($context, ?Throwable $previous)` instead of the standard `\Throwable` signature, and `Tests/Fuzzy/` where Eris' namespace functions collide with auto-imports.

## One deliberate removal: ExtEmConfRector

The `ExtEmConfRector` configuration is gone, because under the shared base it could not fire: the shared config skips `ext_emconf.php` whenever `$projectRoot` is passed. That is verified rather than assumed — perturbing the `php` constraint in `ext_emconf.php` and re-running Rector shows the rule correcting the line under a bare config and staying silent under this one. Treating `ext_emconf.php` as off-limits to tooling is consistent across the org (php-cs-fixer `notPath`, PHPStan `excludePaths`, and this repo's own `.php-cs-fixer.dist.php`), and no converted repo in the fleet keeps the rule. The constraints the rule enforced — `typo3: 13.4.0-14.99.99`, `php: 8.2.0-8.99.99` — are already exactly what `ext_emconf.php` declares, and that file carries a hand-written comment explaining the intentional TER range which is better left untouched.

## Source changes

The source diff comes from the sets the shared baseline adds and the previous config did not have. These are Rector's own output, applied to a fixpoint, not hand edits.

## Verification

Verified against the toolchain the Rector job actually runs. `Build/rector/rector.php` is judged on PHP 8.2 in CI (`rector-php-version: '8.2'` in `.github/workflows/ci.yml`), so this used `composer config platform.php 8.2.33` with a cold `composer install` — which resolves phpunit 11.5.56, meaning only the PHPUnit rules CI can see were applied. The pin was removed again before committing and `composer.lock` is gitignored.

Checks run: Rector to a fixpoint (`--dry-run` exit 0), `composer ci:test:php:cgl` clean with Rector still at its fixpoint afterwards, PHPStan clean at `--memory-limit=1G`, and the unit suite green.

One deviation from `AGENTS.md` worth flagging: it prescribes `Build/Scripts/runTests.sh`, which needs Docker, and Docker is not available in the environment this was prepared in. The verification therefore called `.Build/bin/*` directly under the platform pin, the same way the reference PRs in this campaign were prepared. CI remains the authoritative gate.
