### PR TITLE
test(service): pin every branch of the actor entitlement check

### DIFF
--- a/Tests/Unit/Service/ConfigurationResolverTest.php
+++ b/Tests/Unit/Service/ConfigurationResolverTest.php
@@ -9,9 +9,11 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service;
 
+use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
 use Netresearch\NrLlm\Exception\AccessDeniedException;
 use Netresearch\NrLlm\Exception\ConfigurationInactiveException;
 use Netresearch\NrLlm\Exception\ConfigurationNotFoundException;
@@ -19,6 +21,8 @@ use Netresearch\NrLlm\Service\ConfigurationResolver;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 
 #[CoversClass(ConfigurationResolver::class)]
 class ConfigurationResolverTest extends AbstractUnitTestCase
@@ -220,5 +224,168 @@ class ConfigurationResolverTest extends AbstractUnitTestCase
         $this->expectExceptionCode(1784211003);
 
         $subject->getActiveByIdentifier('restricted');
+    }
+
+    // ---- getActiveByIdentifierForActor(): the actorMayUse() decision ----
+    //
+    // An authorisation decision (ADR-070/083/110): who may drive a call
+    // through a group-restricted configuration. Every branch is pinned here
+    // because the check runs against the passed actor, not the ambient
+    // BE_USER — precisely so a queue worker authorises identically to a
+    // synchronous request, which also means no functional-test fixture ever
+    // exercises it by accident.
+
+    /**
+     * @param list<int|null> $groupUids
+     */
+    private function restrictedConfiguration(array $groupUids): LlmConfiguration
+    {
+        $groups = new ObjectStorage();
+        foreach ($groupUids as $uid) {
+            $group = self::createStub(AbstractEntity::class);
+            $group->method('getUid')->willReturn($uid);
+            $groups->attach($group);
+        }
+
+        $configuration = self::createStub(LlmConfiguration::class);
+        $configuration->method('isActive')->willReturn(true);
+        $configuration->method('hasAccessRestrictions')->willReturn($groupUids !== []);
+        $configuration->method('getBeGroups')->willReturn($groups);
+
+        return $configuration;
+    }
+
+    private function resolverFor(LlmConfiguration $configuration): ConfigurationResolver
+    {
+        $repository = self::createStub(LlmConfigurationRepository::class);
+        $repository->method('findOneByIdentifier')->willReturn($configuration);
+
+        return new ConfigurationResolver($repository);
+    }
+
+    #[Test]
+    public function anUnrestrictedConfigurationResolvesForAnyActorIncludingAnonymous(): void
+    {
+        $configuration = $this->restrictedConfiguration([]);
+
+        $resolved = $this->resolverFor($configuration)
+            ->getActiveByIdentifierForActor('open', AiActorContext::anonymous());
+
+        self::assertSame($configuration, $resolved);
+    }
+
+    #[Test]
+    public function anAdminResolvesARestrictedConfigurationWithoutGroupMembership(): void
+    {
+        $configuration = $this->restrictedConfiguration([7]);
+
+        $resolved = $this->resolverFor($configuration)
+            ->getActiveByIdentifierForActor('restricted', AiActorContext::backendUser(3, isAdmin: true));
+
+        self::assertSame($configuration, $resolved);
+    }
+
+    #[Test]
+    public function aGroupMemberResolvesARestrictedConfiguration(): void
+    {
+        $configuration = $this->restrictedConfiguration([7, 9]);
+
+        $resolved = $this->resolverFor($configuration)
+            ->getActiveByIdentifierForActor('restricted', AiActorContext::backendUser(3, backendGroupIds: [2, 9]));
+
+        self::assertSame($configuration, $resolved);
+    }
+
+    #[Test]
+    public function aNonMemberIsDeniedARestrictedConfiguration(): void
+    {
+        $configuration = $this->restrictedConfiguration([7]);
+
+        $this->expectException(AccessDeniedException::class);
+        $this->expectExceptionCode(1784211004);
+
+        $this->resolverFor($configuration)
+            ->getActiveByIdentifierForActor('restricted', AiActorContext::backendUser(3, backendGroupIds: [2, 5]));
+    }
+
+    #[Test]
+    public function anAnonymousActorIsDeniedARestrictedConfiguration(): void
+    {
+        $configuration = $this->restrictedConfiguration([7]);
+
+        $this->expectException(AccessDeniedException::class);
+        $this->expectExceptionCode(1784211004);
+
+        $this->resolverFor($configuration)
+            ->getActiveByIdentifierForActor('restricted', AiActorContext::anonymous());
+    }
+
+    #[Test]
+    public function aServiceAccountWithTheConfigurationUseScopeResolvesARestrictedConfiguration(): void
+    {
+        $configuration = $this->restrictedConfiguration([7]);
+
+        $resolved = $this->resolverFor($configuration)->getActiveByIdentifierForActor(
+            'restricted',
+            AiActorContext::serviceAccount('nightly-report', [ServiceAccountScope::CONFIGURATION_USE]),
+        );
+
+        self::assertSame($configuration, $resolved);
+    }
+
+    #[Test]
+    public function aServiceAccountWithoutTheScopeIsDenied(): void
+    {
+        $configuration = $this->restrictedConfiguration([7]);
+
+        $this->expectException(AccessDeniedException::class);
+        $this->expectExceptionCode(1784211004);
+
+        $this->resolverFor($configuration)->getActiveByIdentifierForActor(
+            'restricted',
+            AiActorContext::serviceAccount('nightly-report', [ServiceAccountScope::AGENT_READ]),
+        );
+    }
+
+    /**
+     * A service account is entitled by its scope, never by group membership:
+     * the branch decides before groups are consulted. Pinned so nobody
+     * "fixes" a denied automation by attaching a backend group to it instead
+     * of granting the scope, which is the auditable path (ADR-110).
+     */
+    #[Test]
+    public function aServiceAccountsGroupMembershipDoesNotSubstituteForTheScope(): void
+    {
+        $configuration = $this->restrictedConfiguration([7]);
+
+        $this->expectException(AccessDeniedException::class);
+        $this->expectExceptionCode(1784211004);
+
+        $this->resolverFor($configuration)->getActiveByIdentifierForActor(
+            'restricted',
+            // fromArray() is the one public path that can carry both a
+            // service-account name and group ids — the persisted-run shape.
+            AiActorContext::fromArray([
+                'backendGroupIds' => [7],
+                'serviceAccount'  => 'nightly-report',
+            ]),
+        );
+    }
+
+    /**
+     * An unpersisted group has no uid; it must count as "matches nobody"
+     * rather than blow up or, worse, match an actor whose group list happens
+     * to contain a null-ish value.
+     */
+    #[Test]
+    public function aGroupWithoutAUidMatchesNoActor(): void
+    {
+        $configuration = $this->restrictedConfiguration([null]);
+
+        $this->expectException(AccessDeniedException::class);
+        $this->expectExceptionCode(1784211004);
+
+        $this->resolverFor($configuration)
+            ->getActiveByIdentifierForActor('restricted', AiActorContext::backendUser(3, backendGroupIds: [2]));
     }
 }


### PR DESCRIPTION
`ConfigurationResolver::actorMayUse()` decides who may drive a call through a group-restricted configuration (ADR-070/083/110), and no test named it. The check deliberately runs against the passed actor rather than the ambient `BE_USER` — that is what lets a queue worker authorise identically to a synchronous request — which also means no controller test or functional fixture exercises it by accident. A regression would have shipped silently.

Nine cases through the public `getActiveByIdentifierForActor()`, covering every branch: unrestricted resolves for anyone including anonymous; an admin passes without membership; a member passes; a non-member and an anonymous actor are denied; a service account passes with the `configuration:use` scope and is denied without it.

Two cases carry the actual value:

**A service account's group membership does not substitute for the scope.** The branch decides before groups are consulted. Pinned so nobody "fixes" a denied automation by attaching a backend group to it instead of granting the scope, which is the auditable path (ADR-110).

**A group without a uid matches no actor** — an unpersisted group counts as "matches nobody" rather than blowing up or matching a null-ish entry in the actor's group list.

One construction detail: the service-account-with-groups case goes through `AiActorContext::fromArray()`, the one public path that carries both a service-account name and group ids — it is also the shape a persisted run restores the actor from.

Test-only change; no production code touched.
