### PR TITLE
refactor(provider): extract OpenRouter's model routing into its own class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- OpenRouter's model routing lives in its own class
+  (`Provider/OpenRouter/ModelRouter`), the first per-adapter collaborator
+  (ADR-125). Same strategies, same keyword heuristics, same fallbacks; a call
+  that names its model explicitly still triggers no catalogue fetch. Purely
+  internal.
+
 - The agent loop's tool gate is no longer something a wiring can omit. The
   composite tool-call policy is a required constructor argument on
   `ToolLoopService`, the per-configuration allow-list resolver is gone, and the

--- a/Classes/Provider/OpenRouter/ModelRouter.php
+++ b/Classes/Provider/OpenRouter/ModelRouter.php
@@ -1,0 +1,208 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\OpenRouter;
+
+use Closure;
+use Netresearch\NrLlm\Provider\ResponseParserTrait;
+
+/**
+ * OpenRouter's model routing, extracted from the provider (ADR-125).
+ *
+ * "OpenRouter is a router" is the product's premise, and this is the one
+ * cluster in the adapter that is pure decision logic: no HTTP, no PSR-7, no
+ * response objects. It picks a model id from the live catalogue by strategy —
+ * cheapest by average token price, fastest or balanced by id keyword, vision
+ * by capability flag — and falls back to the configured default whenever the
+ * catalogue or the candidates run dry.
+ *
+ * Deliberately stateless. The routing strategy stays a property of the
+ * provider (its `configure()` owns and validates it) and arrives per call, and
+ * the catalogue arrives as a closure so a call that names its model explicitly
+ * still performs no network fetch — exactly the short-circuit the inline code
+ * had. Bodies were moved verbatim; the keyword heuristics and the hardcoded
+ * vision preference list are documented behaviour, not accidents of the move.
+ *
+ * Constructed inline by the provider, not injected: the adapter constructor
+ * signature is shared by all seven providers and fixed by the compiler pass,
+ * and this collaborator is an implementation detail of one of them.
+ */
+final readonly class ModelRouter
+{
+    use ResponseParserTrait;
+
+    /**
+     * Select model based on routing strategy.
+     *
+     * @param array<string, mixed>                                                                                                                                   $options
+     * @param Closure(): array<string, array{name: string, context_length: int, pricing: array<string, float>, capabilities: array<string, bool>, provider: string}> $fetchModels
+     */
+    public function select(array $options, string $routingStrategy, string $defaultModel, Closure $fetchModels): string
+    {
+        // Explicit model specified in options
+        $model = $this->getString($options, 'model');
+        if ($model !== '') {
+            return $model;
+        }
+
+        // Non-explicit strategies attempt smart routing over the available models.
+        if ($routingStrategy !== 'explicit') {
+            $models = $fetchModels();
+
+            // Filter models by requirements
+            $candidates = $models === []
+                ? []
+                : $this->filterModelsByRequirements($models, $options);
+
+            if ($candidates !== []) {
+                return match ($routingStrategy) {
+                    'cost_optimized' => $this->selectCheapestModel($candidates, $defaultModel),
+                    'performance' => $this->selectFastestModel($candidates, $defaultModel),
+                    'balanced' => $this->selectBalancedModel($candidates, $defaultModel),
+                    default => $defaultModel,
+                };
+            }
+        }
+
+        // Explicit strategy, no models available, or no matching candidates: use default model
+        return $defaultModel;
+    }
+
+    /**
+     * Select vision-capable model.
+     *
+     * @param array<string, array{name: string, context_length: int, pricing: array<string, float>, capabilities: array<string, bool>, provider: string}> $models
+     */
+    public function selectVisionModel(array $models, string $defaultModel): string
+    {
+        $visionModels = [
+            'anthropic/claude-sonnet-4-5',
+            'anthropic/claude-opus-4-5',
+            'openai/gpt-5.2',
+            'openai/gpt-5.2-pro',
+            'google/gemini-3-flash',
+        ];
+
+        // Check if default model supports vision
+        if (isset($models[$defaultModel]['capabilities']['vision'])
+            && $models[$defaultModel]['capabilities']['vision']) {
+            return $defaultModel;
+        }
+
+        // Find first available vision model
+        foreach ($visionModels as $model) {
+            if (isset($models[$model]) || $models === []) {
+                return $model;
+            }
+        }
+
+        return 'openai/gpt-5.2'; // Fallback
+    }
+
+    /**
+     * Filter models by requirements from options.
+     *
+     * @param array<string, array{name: string, context_length: int, pricing: array<string, float>, capabilities: array<string, bool>, provider: string}> $models
+     * @param array<string, mixed>                                                                                                                        $options
+     *
+     * @return array<string, array{name: string, context_length: int, pricing: array<string, float>, capabilities: array<string, bool>, provider: string}>
+     */
+    private function filterModelsByRequirements(array $models, array $options): array
+    {
+        $filtered = $models;
+
+        // Context length requirement
+        $minContext = $this->getInt($options, 'min_context');
+        if ($minContext > 0) {
+            $filtered = array_filter(
+                $filtered,
+                static fn(array $model): bool => $model['context_length'] >= $minContext,
+            );
+        }
+
+        // Vision capability
+        if ($this->getBool($options, 'vision_required')) {
+            $filtered = array_filter(
+                $filtered,
+                static fn(array $model) => $model['capabilities']['vision'] ?? false,
+            );
+        }
+
+        // Function calling
+        if ($this->getBool($options, 'function_calling')) {
+            return array_filter(
+                $filtered,
+                static fn(array $model) => $model['capabilities']['function_calling'] ?? false,
+            );
+        }
+
+        return $filtered;
+    }
+
+    /**
+     * Select cheapest model from candidates.
+     *
+     * @param array<string, array{name: string, context_length: int, pricing: array<string, float>, capabilities: array<string, bool>, provider: string}> $candidates
+     */
+    private function selectCheapestModel(array $candidates, string $defaultModel): string
+    {
+        $cheapest = null;
+        $lowestCost = PHP_FLOAT_MAX;
+
+        foreach ($candidates as $id => $model) {
+            $avgCost = (($model['pricing']['prompt'] ?? 0) + ($model['pricing']['completion'] ?? 0)) / 2;
+            if ($avgCost < $lowestCost) {
+                $lowestCost = $avgCost;
+                $cheapest = $id;
+            }
+        }
+
+        return $cheapest ?? $defaultModel;
+    }
+
+    /**
+     * Select fastest model (heuristic: flash/haiku/turbo models).
+     *
+     * @param array<string, array{name: string, context_length: int, pricing: array<string, float>, capabilities: array<string, bool>, provider: string}> $candidates
+     */
+    private function selectFastestModel(array $candidates, string $defaultModel): string
+    {
+        $fastKeywords = ['flash', 'haiku', 'turbo', 'instant', 'mini'];
+
+        foreach ($candidates as $id => $model) {
+            foreach ($fastKeywords as $keyword) {
+                if (stripos($id, $keyword) !== false) {
+                    return $id;
+                }
+            }
+        }
+
+        return $defaultModel;
+    }
+
+    /**
+     * Select balanced model (mid-tier quality and speed).
+     *
+     * @param array<string, array{name: string, context_length: int, pricing: array<string, float>, capabilities: array<string, bool>, provider: string}> $candidates
+     */
+    private function selectBalancedModel(array $candidates, string $defaultModel): string
+    {
+        $balancedKeywords = ['sonnet', 'medium', '3.5', 'pro'];
+
+        foreach ($candidates as $id => $model) {
+            foreach ($balancedKeywords as $keyword) {
+                if (stripos($id, $keyword) !== false) {
+                    return $id;
+                }
+            }
+        }
+
+        return $defaultModel;
+    }
+}

--- a/Classes/Provider/OpenRouterProvider.php
+++ b/Classes/Provider/OpenRouterProvider.php
@@ -28,6 +28,7 @@ use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Netresearch\NrLlm\Provider\Exception\ProviderRateLimitException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
+use Netresearch\NrLlm\Provider\OpenRouter\ModelRouter;
 use Psr\Http\Message\RequestInterface;
 use Throwable;
 
@@ -101,6 +102,14 @@ final class OpenRouterProvider extends AbstractProvider implements
      * @var array<string, array{name: string, context_length: int, pricing: array<string, float>, capabilities: array<string, bool>, provider: string}>|null
      */
     private ?array $cachedModels = null;
+
+    /**
+     * Lazily built routing collaborator (ADR-125). A property initializer
+     * cannot contain `new`, and the adapter constructor is owned by
+     * AbstractProvider and shared by all seven providers — hence the ??= in
+     * {@see self::router()}.
+     */
+    private ?ModelRouter $router = null;
 
     public function getName(): string
     {
@@ -280,7 +289,7 @@ final class OpenRouterProvider extends AbstractProvider implements
             $messages,
         );
 
-        $model = $this->selectModel($options);
+        $model = $this->router()->select($options, $this->routingStrategy, $this->getDefaultModel(), fn(): array => $this->fetchAvailableModels());
 
         $payload = [
             'model' => $model,
@@ -370,7 +379,7 @@ final class OpenRouterProvider extends AbstractProvider implements
             $messages,
         );
 
-        $model = $this->selectModel($options);
+        $model = $this->router()->select($options, $this->routingStrategy, $this->getDefaultModel(), fn(): array => $this->fetchAvailableModels());
 
         $payload = [
             'model' => $model,
@@ -488,7 +497,7 @@ final class OpenRouterProvider extends AbstractProvider implements
     public function analyzeImage(array $content, array $options = []): VisionResponse
     {
         // Select vision-capable model
-        $model = $this->getString($options, 'model', $this->selectVisionModel());
+        $model = $this->getString($options, 'model', $this->router()->selectVisionModel($this->fetchAvailableModels(), $this->getDefaultModel()));
 
         $messages = [
             [
@@ -574,7 +583,7 @@ final class OpenRouterProvider extends AbstractProvider implements
             $messages,
         );
 
-        $model = $this->selectModel($options);
+        $model = $this->router()->select($options, $this->routingStrategy, $this->getDefaultModel(), fn(): array => $this->fetchAvailableModels());
 
         $payload = $this->buildStreamPayload($messages, $model, $options);
 
@@ -703,173 +712,9 @@ final class OpenRouterProvider extends AbstractProvider implements
         return true;
     }
 
-    /**
-     * Select model based on routing strategy.
-     *
-     * @param array<string, mixed> $options
-     */
-    private function selectModel(array $options): string
+    private function router(): ModelRouter
     {
-        // Explicit model specified in options
-        $model = $this->getString($options, 'model');
-        if ($model !== '') {
-            return $model;
-        }
-
-        // Non-explicit strategies attempt smart routing over the available models.
-        if ($this->routingStrategy !== 'explicit') {
-            $models = $this->fetchAvailableModels();
-
-            // Filter models by requirements
-            $candidates = $models === []
-                ? []
-                : $this->filterModelsByRequirements($models, $options);
-
-            if ($candidates !== []) {
-                return match ($this->routingStrategy) {
-                    'cost_optimized' => $this->selectCheapestModel($candidates),
-                    'performance' => $this->selectFastestModel($candidates),
-                    'balanced' => $this->selectBalancedModel($candidates),
-                    default => $this->getDefaultModel(),
-                };
-            }
-        }
-
-        // Explicit strategy, no models available, or no matching candidates: use default model
-        return $this->getDefaultModel();
-    }
-
-    /**
-     * Filter models by requirements from options.
-     *
-     * @param array<string, array{name: string, context_length: int, pricing: array<string, float>, capabilities: array<string, bool>, provider: string}> $models
-     * @param array<string, mixed>                                                                                                                        $options
-     *
-     * @return array<string, array{name: string, context_length: int, pricing: array<string, float>, capabilities: array<string, bool>, provider: string}>
-     */
-    private function filterModelsByRequirements(array $models, array $options): array
-    {
-        $filtered = $models;
-
-        // Context length requirement
-        $minContext = $this->getInt($options, 'min_context');
-        if ($minContext > 0) {
-            $filtered = array_filter(
-                $filtered,
-                static fn(array $model): bool => $model['context_length'] >= $minContext,
-            );
-        }
-
-        // Vision capability
-        if ($this->getBool($options, 'vision_required')) {
-            $filtered = array_filter(
-                $filtered,
-                static fn(array $model) => $model['capabilities']['vision'] ?? false,
-            );
-        }
-
-        // Function calling
-        if ($this->getBool($options, 'function_calling')) {
-            return array_filter(
-                $filtered,
-                static fn(array $model) => $model['capabilities']['function_calling'] ?? false,
-            );
-        }
-
-        return $filtered;
-    }
-
-    /**
-     * Select cheapest model from candidates.
-     *
-     * @param array<string, array{name: string, context_length: int, pricing: array<string, float>, capabilities: array<string, bool>, provider: string}> $candidates
-     */
-    private function selectCheapestModel(array $candidates): string
-    {
-        $cheapest = null;
-        $lowestCost = PHP_FLOAT_MAX;
-
-        foreach ($candidates as $id => $model) {
-            $avgCost = (($model['pricing']['prompt'] ?? 0) + ($model['pricing']['completion'] ?? 0)) / 2;
-            if ($avgCost < $lowestCost) {
-                $lowestCost = $avgCost;
-                $cheapest = $id;
-            }
-        }
-
-        return $cheapest ?? $this->getDefaultModel();
-    }
-
-    /**
-     * Select fastest model (heuristic: flash/haiku/turbo models).
-     *
-     * @param array<string, array{name: string, context_length: int, pricing: array<string, float>, capabilities: array<string, bool>, provider: string}> $candidates
-     */
-    private function selectFastestModel(array $candidates): string
-    {
-        $fastKeywords = ['flash', 'haiku', 'turbo', 'instant', 'mini'];
-
-        foreach ($candidates as $id => $model) {
-            foreach ($fastKeywords as $keyword) {
-                if (stripos($id, $keyword) !== false) {
-                    return $id;
-                }
-            }
-        }
-
-        return $this->getDefaultModel();
-    }
-
-    /**
-     * Select balanced model (mid-tier quality and speed).
-     *
-     * @param array<string, array{name: string, context_length: int, pricing: array<string, float>, capabilities: array<string, bool>, provider: string}> $candidates
-     */
-    private function selectBalancedModel(array $candidates): string
-    {
-        $balancedKeywords = ['sonnet', 'medium', '3.5', 'pro'];
-
-        foreach ($candidates as $id => $model) {
-            foreach ($balancedKeywords as $keyword) {
-                if (stripos($id, $keyword) !== false) {
-                    return $id;
-                }
-            }
-        }
-
-        return $this->getDefaultModel();
-    }
-
-    /**
-     * Select vision-capable model.
-     */
-    private function selectVisionModel(): string
-    {
-        $visionModels = [
-            'anthropic/claude-sonnet-4-5',
-            'anthropic/claude-opus-4-5',
-            'openai/gpt-5.2',
-            'openai/gpt-5.2-pro',
-            'google/gemini-3-flash',
-        ];
-
-        // Check if default model supports vision
-        $models = $this->fetchAvailableModels();
-        $defaultModel = $this->getDefaultModel();
-
-        if (isset($models[$defaultModel]['capabilities']['vision'])
-            && $models[$defaultModel]['capabilities']['vision']) {
-            return $defaultModel;
-        }
-
-        // Find first available vision model
-        foreach ($visionModels as $model) {
-            if (isset($models[$model]) || $models === []) {
-                return $model;
-            }
-        }
-
-        return 'openai/gpt-5.2'; // Fallback
+        return $this->router ??= new ModelRouter();
     }
 
     /**

--- a/Classes/Provider/OpenRouterProvider.php
+++ b/Classes/Provider/OpenRouterProvider.php
@@ -104,8 +104,11 @@ final class OpenRouterProvider extends AbstractProvider implements
     private ?array $cachedModels = null;
 
     /**
-     * Lazily built routing collaborator (ADR-125). A property initializer
-     * cannot contain `new`, and the adapter constructor is owned by
+     * Lazily built routing collaborator (ADR-125). A class property DEFAULT
+     * cannot contain `new` on any current PHP (the new-in-initializers RFC
+     * covers promoted constructor parameters, not property defaults —
+     * verified: 8.2 and 8.5 both fatal with "New expressions are not
+     * supported in this context"), and the adapter constructor is owned by
      * AbstractProvider and shared by all seven providers — hence the ??= in
      * {@see self::router()}.
      */

--- a/Documentation/Adr/Adr125PerAdapterCollaborators.rst
+++ b/Documentation/Adr/Adr125PerAdapterCollaborators.rst
@@ -1,0 +1,63 @@
+.. _adr-125:
+
+=========================================
+ADR-125: Per-adapter collaborator classes
+=========================================
+
+:Status: Accepted
+:Date: 2026-08-04
+
+Context
+=======
+
+Every provider adapter keeps its private helpers inline; shared behaviour has
+so far moved *up* into :php:`AbstractProvider` or *sideways* into traits
+(:php:`ResponseParserTrait`, :php:`ErrorMessageSanitizerTrait`). There was no
+precedent for a class that belongs to exactly one adapter.
+
+:php:`OpenRouterProvider` carried one cluster that neither direction fits: the
+model routing — six methods, 163 contiguous lines, pure decision logic with no
+HTTP, no PSR-7 and no response objects. It is also the part most likely to
+grow, because routing strategies are the product's premise. Pulled up it would
+burden six adapters that route nothing; as a trait it would stay untestable in
+isolation and keep the adapter's line count.
+
+Decision
+========
+
+Adapter-specific logic that is pure — no transport, no credential path, no
+response parsing — MAY be extracted into a collaborator class in a
+sub-namespace named after the adapter (here
+:php:`Netresearch\NrLlm\Provider\OpenRouter\ModelRouter`). Rules:
+
+1. **The provider constructs it inline.** The adapter constructor signature is
+   owned by :php:`AbstractProvider`, shared by all seven adapters and wired by
+   the compiler pass; a collaborator is an implementation detail and never a
+   DI service of its own.
+2. **The collaborator is stateless.** Configuration the adapter's
+   :php:`configure()` owns and validates (here the routing strategy) stays on
+   the adapter and arrives per call. Runtime caches (here the fetched model
+   catalogue) stay on the adapter and arrive as an argument — as a closure
+   where the inline code fetched lazily, so extraction cannot introduce a
+   network call that was not there before.
+3. **The architecture guard covers the sub-namespace.** The PHPat rule that
+   keeps :php:`Service\*` off concrete adapters matches classes ending in
+   ``Provider``; a collaborator named anything else would quietly escape it.
+   Each new adapter sub-namespace is added to the deny set in the same change
+   that creates it.
+4. **Transport is out of scope.** Anything touching the HTTP client, auth
+   headers, retries or error mapping stays on the adapter, where
+   :php:`AbstractProvider`'s vault client and SSRF gating are unavoidable.
+
+Consequences
+============
+
+- :php:`OpenRouterProvider` drops from 983 to 829 lines and the routing
+  becomes directly unit-testable; the existing ~22 routing tests keep passing
+  unchanged because they assert through the captured request body.
+- The first collaborator sets the naming and placement pattern for any future
+  one (e.g. a Gemini message converter), each requiring the same guard
+  extension.
+- The golden-sample note in :file:`AGENTS.md` still points at
+  :php:`OpenAiProvider` — the inline shape remains the default; extraction is
+  for clusters that meet the purity bar above, not a target size.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -422,3 +422,4 @@ Tools
    Adr122ToolEffectContractDeferred
    Adr123OneSecretShapeCatalogue
    Adr124ProviderKeyFromTheCommandLine
+   Adr125PerAdapterCollaborators

--- a/Tests/Architecture/ServiceLayerTest.php
+++ b/Tests/Architecture/ServiceLayerTest.php
@@ -72,6 +72,10 @@ final class ServiceLayerTest
             ->shouldNotDependOn()
             ->classes(
                 Selector::classname('/^Netresearch\\\\NrLlm\\\\Provider\\\\[A-Z][A-Za-z0-9]*Provider$/', true),
+                // Per-adapter collaborators (ADR-125) are adapter internals just
+                // like the adapters themselves; without this a helper named
+                // anything but *Provider would quietly escape the guard.
+                Selector::inNamespace('Netresearch\NrLlm\Provider\OpenRouter'),
             )
             ->because('Services must invoke providers through ProviderInterface / MiddlewarePipeline / ProviderAdapterRegistry, never via concrete adapter classes (ADR-026).');
     }

--- a/Tests/Unit/Provider/OpenRouterProviderMutationTest.php
+++ b/Tests/Unit/Provider/OpenRouterProviderMutationTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;
 
+use Netresearch\NrLlm\Provider\OpenRouter\ModelRouter;
 use Netresearch\NrLlm\Provider\OpenRouterProvider;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -20,6 +21,7 @@ use ReflectionClass;
  * Mutation-killing tests for OpenRouterProvider.
  */
 #[CoversClass(OpenRouterProvider::class)]
+#[CoversClass(ModelRouter::class)]
 class OpenRouterProviderMutationTest extends AbstractUnitTestCase
 {
     private function createProvider(): OpenRouterProvider

--- a/Tests/Unit/Provider/OpenRouterProviderTest.php
+++ b/Tests/Unit/Provider/OpenRouterProviderTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;
 
-use Netresearch\NrLlm\Provider\OpenRouter\ModelRouter;
 use GuzzleHttp\Psr7\HttpFactory;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
@@ -21,6 +20,7 @@ use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\ProviderRateLimitException;
+use Netresearch\NrLlm\Provider\OpenRouter\ModelRouter;
 use Netresearch\NrLlm\Provider\OpenRouterProvider;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/Tests/Unit/Provider/OpenRouterProviderTest.php
+++ b/Tests/Unit/Provider/OpenRouterProviderTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider;
 
+use Netresearch\NrLlm\Provider\OpenRouter\ModelRouter;
 use GuzzleHttp\Psr7\HttpFactory;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
@@ -34,6 +35,7 @@ use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
 #[CoversClass(OpenRouterProvider::class)]
+#[CoversClass(ModelRouter::class)]
 class OpenRouterProviderTest extends AbstractUnitTestCase
 {
     private OpenRouterProvider $subject;


### PR DESCRIPTION
The routing cluster — six methods, 163 contiguous lines — was the one part of the adapter that is pure decision logic: no HTTP, no PSR-7, no response objects. It is also the part most likely to grow, because routing strategies are the product's premise. It now lives in `Provider/OpenRouter/ModelRouter`, the first per-adapter collaborator; the pattern rules are in [ADR-125](Documentation/Adr/Adr125PerAdapterCollaborators.rst).

## What moved, and what deliberately kept its shape

Bodies moved verbatim. The router is stateless: the strategy stays on the provider — its `configure()` owns and validates it — and arrives per call, and the catalogue arrives as a **closure**, so a call that names its model explicitly still performs no network fetch. That laziness is the one place a naive extraction would have changed behaviour: an eager `$models` parameter would have added a catalogue request to every explicit-model call. The vision path keeps its eager fetch, as before.

The PHPat guard that keeps `Service\*` off concrete adapters matched only classes ending in `Provider`; the new sub-namespace is added to its deny set in the same change, so a collaborator cannot quietly escape the rule the adapters live under.

## What is deliberately NOT extracted

The seam analysis (with the full class read) concluded the rest of the adapter is at the house norm — 634 code lines against Gemini's 588 and Claude's 534 — and not disorganised:

- The four request/response methods are irreducible adapter surface; a `RequestBuilder` would move the same lines behind a call and thread four shared properties as parameters.
- The streaming trio is already factored into named privates.
- `sendOpenRouterRequest()` stays byte-identical: its divergences from `AbstractProvider::sendRequest()` — no retries, 200-only, no audit-reason stamp — look like drift and are load-bearing behaviour. A "unification" would silently add retries to every OpenRouter POST.

## Tests

All 130 provider tests pass unchanged — the ~22 routing tests assert through the captured request body and never noticed the move. The two mutation tests that reflect on `$routingStrategy` keep working because the property stayed on the provider. `#[CoversClass(ModelRouter::class)]` added to both suites so coverage and mutation attribution follow the code.

Locally on PHP 8.2: cgl, rector, PHPStan, unit (5870), architecture, fuzzy.
