### PR TITLE
refactor(tool): extract the byte bounds on tool output into ToolResultBounder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (`Provider/OpenRouter/ModelRouter`), the first per-adapter collaborator
   (ADR-125). Same strategies, same keyword heuristics, same fallbacks; a call
   that names its model explicitly still triggers no catalogue fetch. Purely
+
+- The byte caps on tool output live in their own class
+  (`Service/Tool/ToolResultBounder`): UTF-8 coercion plus the independent
+  content and artifact bounds, moved verbatim out of the agent loop. The loop
+  still applies them at its single invoke seam; the bounder is a defaulted,
+  non-nullable collaborator, so no wiring can leave the caps absent. Purely
   internal.
 
 - Model discovery is split into one discoverer class per provider

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -9,17 +9,14 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool;
 
-use JsonException;
 use LogicException;
 use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
-use Netresearch\NrLlm\Domain\Enum\ArtifactType;
 use Netresearch\NrLlm\Domain\Enum\GovernanceDecision;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\GovernanceEvent;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
-use Netresearch\NrLlm\Domain\ValueObject\ToolArtifact;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolInvocation;
 use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
@@ -65,23 +62,6 @@ use Throwable;
  */
 final readonly class ToolLoopService implements ToolLoopServiceInterface
 {
-    /**
-     * Hard cap on a single tool result appended to the message list. A buggy or
-     * malicious tool returning multi-megabyte output would otherwise blow the
-     * provider payload limit, bypass the token budget and pressure memory.
-     */
-    private const MAX_TOOL_RESULT_BYTES = 50000;
-
-    /**
-     * Hard cap on the total serialised bytes of a single tool call's artifacts.
-     * Independent of {@see self::MAX_TOOL_RESULT_BYTES}: content and artifacts
-     * are separate egress channels, so each is bounded on its own so a large one
-     * cannot mask an over-budget other. The rationale is crash-safety and
-     * DOM/persistence size, NOT provider-context starvation — artifacts have no
-     * provider path, so they can never starve model-visible content.
-     */
-    private const MAX_TOOL_ARTIFACT_BYTES = 50000;
-
     public function __construct(
         private LlmServiceManagerInterface $mgr,
         private ToolRegistry $registry,
@@ -113,6 +93,11 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         // absent it the denial is still decided and still logged, it just does
         // not become a queryable row.
         private ?GovernanceEventRepositoryInterface $governanceEvents = null,
+        // Bounds every tool result before it leaves the loop. Defaulted rather
+        // than optional, like the schema validator above: the bounder is
+        // stateless and has no constructor, so there is no wiring under which
+        // the byte caps can be absent (ADR-120's pattern).
+        private ToolResultBounder $bounder = new ToolResultBounder(),
     ) {}
 
     /**
@@ -784,7 +769,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
      *
      * Both channels are bounded here — the single seam every executed call passes
      * through — before any ToolResult leaves the process: `content` via
-     * {@see self::capResult()}, `artifacts` via {@see self::boundArtifacts()}.
+     * {@see ToolResultBounder::content()}, `artifacts` via {@see ToolResultBounder::artifacts()}.
      *
      * @param list<string> $allowedNames
      */
@@ -827,143 +812,11 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         }
 
         return $result->isError
-            ? ToolResult::error($this->capResult($result->content))
+            ? ToolResult::error($this->bounder->content($result->content))
             : ToolResult::text(
-                $this->capResult($result->content),
-                ...$this->boundArtifacts($result->artifacts),
+                $this->bounder->content($result->content),
+                ...$this->bounder->artifacts($result->artifacts),
             );
-    }
-
-    /**
-     * Bound and sanitise a tool's artifacts before they enter the trace /
-     * inspector / persisted stream. UTF-8-coerces every string leaf (reusing the
-     * same seam that makes untrusted tool bytes JSON-safe for `content`), then
-     * validates the whole list with the EXACT json_encode flags AND a depth cap
-     * the downstream sinks use ({@see \Netresearch\NrLlm\Controller\Backend\ToolPlaygroundController}
-     * and {@see AgentRunPersister::recordStep()} all encode with
-     * JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE). Anything that survives
-     * here therefore CANNOT throw at those sinks — crash-safety by construction,
-     * not by a lenient superset.
-     *
-     * Fail-closed: on a JsonException (non-finite float, unencodable type,
-     * over-depth from a corrupt/cyclic structure) or an over-budget encode, the
-     * WHOLE list is replaced by one TEXT marker — never a mid-structure
-     * truncation.
-     *
-     * @param list<ToolArtifact> $artifacts
-     *
-     * @return list<ToolArtifact>
-     */
-    private function boundArtifacts(array $artifacts): array
-    {
-        if ($artifacts === []) {
-            return [];
-        }
-
-        $coerced = array_map(
-            fn(ToolArtifact $a): ToolArtifact => new ToolArtifact(
-                $a->type,
-                $this->toValidUtf8($a->label),
-                $this->coerceLeaves($a->data),
-            ),
-            $artifacts,
-        );
-
-        try {
-            // Depth 64 leaves ample headroom below json_encode's default 512 so
-            // an artifact that encodes here also encodes when the sink nests it a
-            // few levels deeper inside the RunStep payload. A legitimate TABLE
-            // nests ~4 deep; a malicious deep structure trips the fail-closed
-            // marker.
-            $json = json_encode(
-                array_map(static fn(ToolArtifact $a): array => $a->toArray(), $coerced),
-                JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE,
-                64,
-            );
-        } catch (JsonException) {
-            return [$this->artifactsOmitted('could not be encoded')];
-        }
-
-        if (strlen($json) > self::MAX_TOOL_ARTIFACT_BYTES) {
-            return [$this->artifactsOmitted('exceeded ' . self::MAX_TOOL_ARTIFACT_BYTES . ' bytes')];
-        }
-
-        return array_values($coerced);
-    }
-
-    /**
-     * Recursively coerce every string leaf of an artifact payload to valid UTF-8,
-     * reusing {@see self::toValidUtf8()}. `array<array-key, mixed>` (not
-     * `array<string, mixed>`): a TABLE's `rows` are int-keyed sub-arrays.
-     *
-     * @param array<array-key, mixed> $data
-     *
-     * @return array<array-key, mixed>
-     */
-    private function coerceLeaves(array $data): array
-    {
-        $out = [];
-        foreach ($data as $key => $value) {
-            if (is_string($value)) {
-                $out[$key] = $this->toValidUtf8($value);
-            } elseif (is_array($value)) {
-                $out[$key] = $this->coerceLeaves($value);
-            } else {
-                $out[$key] = $value;
-            }
-        }
-
-        return $out;
-    }
-
-    private function artifactsOmitted(string $reason): ToolArtifact
-    {
-        return new ToolArtifact(ArtifactType::TEXT, 'Artifacts omitted', ['text' => $reason]);
-    }
-
-    /**
-     * Bound a tool result to {@see self::MAX_TOOL_RESULT_BYTES}. Uses mb_strcut
-     * so the byte cap never splits a multibyte character (which would corrupt
-     * the later JSON encoding), and appends a visible truncation marker.
-     */
-    private function capResult(string $result): string
-    {
-        // Tool output is untrusted bytes (logs, phpinfo, env, DB rows) and may
-        // not be valid UTF-8. It is appended to the message list and re-encoded
-        // as JSON on the next provider request — and serialised into the
-        // inspector trace — where a single invalid byte makes json_encode()
-        // throw a JsonException ("Malformed UTF-8"). Coerce to valid UTF-8 first
-        // so neither path can crash on a misbehaving tool.
-        $result = $this->toValidUtf8($result);
-
-        if (strlen($result) <= self::MAX_TOOL_RESULT_BYTES) {
-            return $result;
-        }
-
-        // Reserve the marker's bytes from the budget so the returned string
-        // (content + marker) never exceeds the cap. mb_strcut with an explicit
-        // UTF-8 encoding cuts on a byte boundary without splitting a character.
-        $marker = "\n…[tool result truncated at " . self::MAX_TOOL_RESULT_BYTES . ' bytes]';
-        $budget = self::MAX_TOOL_RESULT_BYTES - strlen($marker);
-
-        return mb_strcut($result, 0, max(0, $budget), 'UTF-8') . $marker;
-    }
-
-    /**
-     * Coerce a byte string to valid UTF-8, replacing invalid sequences (the
-     * substitution is visible in the inspector rather than silently dropped).
-     * A no-op for already-valid input.
-     */
-    private function toValidUtf8(string $result): string
-    {
-        if (mb_check_encoding($result, 'UTF-8')) {
-            return $result;
-        }
-
-        // Cast defends the string return type: mb_convert_encoding is typed
-        // string|false, and false (unreachable for the literal 'UTF-8' names)
-        // would otherwise be a TypeError.
-        return mb_convert_encoding($result, 'UTF-8', 'UTF-8');
     }
 
     /**

--- a/Classes/Service/Tool/ToolResultBounder.php
+++ b/Classes/Service/Tool/ToolResultBounder.php
@@ -173,9 +173,9 @@ final readonly class ToolResultBounder
             return $result;
         }
 
-        // Cast defends the string return type: mb_convert_encoding is typed
-        // string|false, and false (unreachable for the literal 'UTF-8' names)
-        // would otherwise be a TypeError.
+        // No cast needed: with literal 'UTF-8' encoding names PHPStan narrows
+        // mb_convert_encoding()'s string|false to string — the false branch is
+        // unreachable, and level 10 verifies exactly that.
         return mb_convert_encoding($result, 'UTF-8', 'UTF-8');
     }
 }

--- a/Classes/Service/Tool/ToolResultBounder.php
+++ b/Classes/Service/Tool/ToolResultBounder.php
@@ -1,0 +1,181 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+use JsonException;
+use Netresearch\NrLlm\Domain\Enum\ArtifactType;
+use Netresearch\NrLlm\Domain\ValueObject\ToolArtifact;
+
+/**
+ * Bounds untrusted tool output before it leaves the loop, extracted verbatim
+ * from ToolLoopService.
+ *
+ * Tool results are untrusted bytes and cross two boundaries — the provider
+ * wire (content) and the trace/inspector/persisted stream (artifacts). Each
+ * channel has its own independent byte cap, and every string is coerced to
+ * valid UTF-8 first so neither boundary can crash on a misbehaving tool.
+ *
+ * Stateless and pure: no collaborator, no logger, no policy branch. It is
+ * instantiated as a defaulted, NON-nullable constructor argument of the loop
+ * — the JsonSchemaValidator pattern from ADR-120 — so there is no wiring
+ * under which the bound can be absent. invoke() remains the single seam that
+ * applies it (ADR-108); this class only owns the how, never the where.
+ */
+final readonly class ToolResultBounder
+{
+    /**
+     * Hard cap on a single tool result appended to the message list. A buggy or
+     * malicious tool returning multi-megabyte output would otherwise blow the
+     * provider payload limit, bypass the token budget and pressure memory.
+     */
+    private const MAX_TOOL_RESULT_BYTES = 50000;
+
+    /**
+     * Hard cap on the total serialised bytes of a single tool call's artifacts.
+     * Independent of {@see self::MAX_TOOL_RESULT_BYTES}: content and artifacts
+     * are separate egress channels, so each is bounded on its own so a large one
+     * cannot mask an over-budget other. The rationale is crash-safety and
+     * DOM/persistence size, NOT provider-context starvation — artifacts have no
+     * provider path, so they can never starve model-visible content.
+     */
+    private const MAX_TOOL_ARTIFACT_BYTES = 50000;
+
+    /**
+     * Bound and sanitise a tool's artifacts before they enter the trace /
+     * inspector / persisted stream. UTF-8-coerces every string leaf (reusing the
+     * same seam that makes untrusted tool bytes JSON-safe for `content`), then
+     * validates the whole list with the EXACT json_encode flags AND a depth cap
+     * the downstream sinks use ({@see \Netresearch\NrLlm\Controller\Backend\ToolPlaygroundController}
+     * and {@see AgentRunPersister::recordStep()} all encode with
+     * JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE). Anything that survives
+     * here therefore CANNOT throw at those sinks — crash-safety by construction,
+     * not by a lenient superset.
+     *
+     * Fail-closed: on a JsonException (non-finite float, unencodable type,
+     * over-depth from a corrupt/cyclic structure) or an over-budget encode, the
+     * WHOLE list is replaced by one TEXT marker — never a mid-structure
+     * truncation.
+     *
+     * @param list<ToolArtifact> $artifacts
+     *
+     * @return list<ToolArtifact>
+     */
+    public function artifacts(array $artifacts): array
+    {
+        if ($artifacts === []) {
+            return [];
+        }
+
+        $coerced = array_map(
+            fn(ToolArtifact $a): ToolArtifact => new ToolArtifact(
+                $a->type,
+                $this->toValidUtf8($a->label),
+                $this->coerceLeaves($a->data),
+            ),
+            $artifacts,
+        );
+
+        try {
+            // Depth 64 leaves ample headroom below json_encode's default 512 so
+            // an artifact that encodes here also encodes when the sink nests it a
+            // few levels deeper inside the RunStep payload. A legitimate TABLE
+            // nests ~4 deep; a malicious deep structure trips the fail-closed
+            // marker.
+            $json = json_encode(
+                array_map(static fn(ToolArtifact $a): array => $a->toArray(), $coerced),
+                JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE,
+                64,
+            );
+        } catch (JsonException) {
+            return [$this->artifactsOmitted('could not be encoded')];
+        }
+
+        if (strlen($json) > self::MAX_TOOL_ARTIFACT_BYTES) {
+            return [$this->artifactsOmitted('exceeded ' . self::MAX_TOOL_ARTIFACT_BYTES . ' bytes')];
+        }
+
+        return array_values($coerced);
+    }
+
+    /**
+     * Recursively coerce every string leaf of an artifact payload to valid UTF-8,
+     * reusing {@see self::toValidUtf8()}. `array<array-key, mixed>` (not
+     * `array<string, mixed>`): a TABLE's `rows` are int-keyed sub-arrays.
+     *
+     * @param array<array-key, mixed> $data
+     *
+     * @return array<array-key, mixed>
+     */
+    private function coerceLeaves(array $data): array
+    {
+        $out = [];
+        foreach ($data as $key => $value) {
+            if (is_string($value)) {
+                $out[$key] = $this->toValidUtf8($value);
+            } elseif (is_array($value)) {
+                $out[$key] = $this->coerceLeaves($value);
+            } else {
+                $out[$key] = $value;
+            }
+        }
+
+        return $out;
+    }
+
+    private function artifactsOmitted(string $reason): ToolArtifact
+    {
+        return new ToolArtifact(ArtifactType::TEXT, 'Artifacts omitted', ['text' => $reason]);
+    }
+
+    /**
+     * Bound a tool result to {@see self::MAX_TOOL_RESULT_BYTES}. Uses mb_strcut
+     * so the byte cap never splits a multibyte character (which would corrupt
+     * the later JSON encoding), and appends a visible truncation marker.
+     */
+    public function content(string $result): string
+    {
+        // Tool output is untrusted bytes (logs, phpinfo, env, DB rows) and may
+        // not be valid UTF-8. It is appended to the message list and re-encoded
+        // as JSON on the next provider request — and serialised into the
+        // inspector trace — where a single invalid byte makes json_encode()
+        // throw a JsonException ("Malformed UTF-8"). Coerce to valid UTF-8 first
+        // so neither path can crash on a misbehaving tool.
+        $result = $this->toValidUtf8($result);
+
+        if (strlen($result) <= self::MAX_TOOL_RESULT_BYTES) {
+            return $result;
+        }
+
+        // Reserve the marker's bytes from the budget so the returned string
+        // (content + marker) never exceeds the cap. mb_strcut with an explicit
+        // UTF-8 encoding cuts on a byte boundary without splitting a character.
+        $marker = "\n…[tool result truncated at " . self::MAX_TOOL_RESULT_BYTES . ' bytes]';
+        $budget = self::MAX_TOOL_RESULT_BYTES - strlen($marker);
+
+        return mb_strcut($result, 0, max(0, $budget), 'UTF-8') . $marker;
+    }
+
+    /**
+     * Coerce a byte string to valid UTF-8, replacing invalid sequences (the
+     * substitution is visible in the inspector rather than silently dropped).
+     * A no-op for already-valid input.
+     */
+    private function toValidUtf8(string $result): string
+    {
+        if (mb_check_encoding($result, 'UTF-8')) {
+            return $result;
+        }
+
+        // Cast defends the string return type: mb_convert_encoding is typed
+        // string|false, and false (unreachable for the literal 'UTF-8' names)
+        // would otherwise be a TypeError.
+        return mb_convert_encoding($result, 'UTF-8', 'UTF-8');
+    }
+}

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -10,8 +10,8 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
 
 use LogicException;
-
 use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
+
 use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
 use Netresearch\NrLlm\Domain\Enum\ArtifactType;
 use Netresearch\NrLlm\Domain\Enum\TrustZone;
@@ -49,6 +49,7 @@ use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Service\Tool\ToolLoopService;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Service\Tool\ToolResultBounder;
 use Netresearch\NrLlm\Service\Tool\TrustZoneResolver;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeInputTool;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
@@ -63,6 +64,7 @@ use Throwable;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 
 #[CoversClass(ToolLoopService::class)]
+#[CoversClass(ToolResultBounder::class)]
 final class ToolLoopServiceTest extends TestCase
 {
     #[Test]


### PR DESCRIPTION
Tool results are untrusted bytes and cross two boundaries — the provider wire (content) and the trace/inspector/persisted stream (artifacts). The UTF-8 coercion and the two independent byte caps now live in a stateless `ToolResultBounder`, moved verbatim; the loop drops from 995 to 852 lines and the "untrusted bytes" concern stops being interleaved with the control flow.

## What deliberately did not move

Everything else, per the seam analysis with the full class read. The three entry points share the gating resolution and the invoke seam; the two resume refusal ladders differ in exactly the 15% that **is** ADR-105; the suspension scans read five loop-local counters, and separating them from where the offered-names list is computed is precisely the mistake that would let a not-offered tool suspend — or an offered one execute. ADR-093/108 concentrated authority at `resolveOfferedNames()` and `invoke()` on purpose, and [ADR-120](Documentation/Adr/Adr120RequiredToolGate.rst) records what happened the last time a tidy-up touched this constructor. `invoke()` remains the single seam that applies the bounds; the bounder owns the *how*, never the *where*.

## Wiring

The bounder is a defaulted, **non**-nullable constructor argument — the `JsonSchemaValidator` pattern ADR-120 chose over nullability — so no wiring can leave the caps absent, and all nine positional and named test constructions compile unchanged. Constructor slots 1–10 are byte-identical.

## The regression net proved itself during the build

The extracted class briefly lacked its `JsonException` import. The catch silently never fired — and `unencodableArtifactCollapsesToTheFailClosedMarker` failed immediately with the raw exception. That is exactly the class of silent-weakening this extraction was screened against, caught by the existing end-to-end tests with zero test-body changes.

Locally on PHP 8.2: cgl (re-run after apply-mode rector), rector, PHPStan, unit (5870), fuzzy, functional sqlite (1342).
