### PR TITLE
test(provider): cover the terminal refusal of nrllm:provider:set-key

### DIFF
--- a/Classes/Command/SetProviderApiKeyCommand.php
+++ b/Classes/Command/SetProviderApiKeyCommand.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Command;
 
+use Closure;
 use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
 use Netresearch\NrVault\Service\VaultServiceInterface;
@@ -61,11 +62,20 @@ final class SetProviderApiKeyCommand extends Command
         ],
     ];
 
+    /**
+     * @param (Closure(resource): bool)|null $isTerminal How to tell a terminal
+     *                                                   from a pipe. Substituted in tests only: there is no portable way
+     *                                                   to hand a unit test a real TTY, so the branch that refuses to read
+     *                                                   from one would otherwise be unreachable. Left null in production,
+     *                                                   where it falls back to `stream_isatty()`; the container has no
+     *                                                   service of this type and uses the default.
+     */
     public function __construct(
         private readonly ProviderRepository $providerRepository,
         private readonly PersistenceManagerInterface $persistenceManager,
         private readonly VaultServiceInterface $vault,
         private readonly LoggerInterface $logger,
+        private readonly ?Closure $isTerminal = null,
     ) {
         parent::__construct();
     }
@@ -184,6 +194,10 @@ final class SetProviderApiKeyCommand extends Command
 
         if (!is_resource($stream)) {
             return null;
+        }
+
+        if ($this->isTerminal instanceof Closure) {
+            return ($this->isTerminal)($stream) ? null : $stream;
         }
 
         return stream_isatty($stream) ? null : $stream;

--- a/Tests/Unit/Command/SetProviderApiKeyCommandTest.php
+++ b/Tests/Unit/Command/SetProviderApiKeyCommandTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Command;
 
+use Closure;
 use Netresearch\NrLlm\Command\SetProviderApiKeyCommand;
 use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
@@ -125,6 +126,46 @@ final class SetProviderApiKeyCommandTest extends TestCase
     }
 
     #[Test]
+    public function refusesToReadFromATerminal(): void
+    {
+        // A provisioning script that reaches a prompt hangs, and a hang reads
+        // as a broken deploy rather than as a missing key. There is no portable
+        // way to hand a unit test a real TTY, so the detector is substituted.
+        $provider = $this->provider('openai', apiKey: '');
+        $vault    = new InMemoryVaultService();
+
+        $exit = $this->runCommand(
+            $this->command($provider, $vault, static fn($stream): bool => true),
+            'openai',
+            self::SECRET,
+        );
+
+        self::assertSame(Command::INVALID, $exit);
+        self::assertStringContainsString('Refusing to read the key from a terminal', $this->output->fetch());
+        self::assertSame('', $provider->getApiKey(), 'nothing may be linked when the key was never read');
+        self::assertSame([], $vault->storeCalls);
+        self::assertSame([], $vault->rotateCalls);
+    }
+
+    #[Test]
+    public function readsThePipeWhenTheDetectorSaysItIsNotATerminal(): void
+    {
+        // The twin of the case above: same substituted detector, opposite
+        // answer, so a detector wired backwards cannot pass both.
+        $provider = $this->provider('openai', apiKey: '');
+        $vault    = new InMemoryVaultService();
+
+        $exit = $this->runCommand(
+            $this->command($provider, $vault, static fn($stream): bool => false),
+            'openai',
+            self::SECRET,
+        );
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertSame(self::SECRET, $vault->secrets[$provider->getApiKey()] ?? null);
+    }
+
+    #[Test]
     public function stripsTrailingLineBreaksButKeepsEveryOtherCharacter(): void
     {
         $provider = $this->provider('openai', apiKey: '');
@@ -184,8 +225,14 @@ final class SetProviderApiKeyCommandTest extends TestCase
         }
     }
 
-    private function command(?Provider $provider, InMemoryVaultService $vault): SetProviderApiKeyCommand
-    {
+    /**
+     * @param (Closure(resource): bool)|null $isTerminal
+     */
+    private function command(
+        ?Provider $provider,
+        InMemoryVaultService $vault,
+        ?Closure $isTerminal = null,
+    ): SetProviderApiKeyCommand {
         $repository = $this->createMock(ProviderRepository::class);
         $repository->method('findOneByIdentifier')->willReturn($provider);
 
@@ -194,6 +241,7 @@ final class SetProviderApiKeyCommandTest extends TestCase
             self::createStub(PersistenceManagerInterface::class),
             $vault,
             new NullLogger(),
+            $isTerminal,
         );
     }
 


### PR DESCRIPTION
Closes #584

## Why the branch was untestable

`nrllm:provider:set-key` refuses to read the key when STDIN is a terminal — a prompt in a provisioning script hangs, and a hang reads as a broken deploy rather than as a missing key. That refusal was the one failure path from #581's acceptance criteria with no test behind it: every existing case supplies a `php://memory` stream, which is never a TTY, so `resolveInputStream()` always returned the stream and the branch was unreachable. A detector wired backwards would have passed the whole suite.

There is no portable way to hand a unit test a real TTY — `posix_openpt()` needs ext-posix, `/dev/tty` does not exist in CI.

## The seam

`stream_isatty()` moves behind an optional constructor argument:

```php
private readonly ?Closure $isTerminal = null,
```

Null in production, where the code calls `stream_isatty()` directly. The container has no service of that type and uses the default — confirmed by the functional suite, which boots the real container (1311 tests, unchanged).

Two tests drive it from both sides: `true` must produce the refusal and leave the provider untouched, `false` must take the normal pipe path and store the key. Pinning both polarities is the point — a single test on the refusal would pass just as happily if the condition were inverted.

## Notes on the gates

Three findings came out of the gates rather than out of review, all in this change:

- PHPStan level 10 rejected the first version: an arrow-function default put `mixed` into `stream_isatty()`. Calling it directly in the null branch keeps `$stream` narrowed by the preceding `is_resource()` and needs no annotation.
- PHPStan also wanted the test helper's `Closure` signature spelled out; it now carries `@param (Closure(resource): bool)|null`.
- Rector turned `!== null` into `instanceof Closure` for the same check.

## Verification

All six pre-push suites plus architecture, on PHP 8.2 — the version `ci.yml` pins for Rector and the floor of the matrix:

```
unit               OK (5806 tests, 16089 assertions)
functional sqlite  Tests: 1311, Assertions: 14348   SUCCESS
phpstan            [OK] No errors        (level 10)
cgl                SUCCESS
rector -n          [OK] Rector is done!
fuzzy              SUCCESS
architecture       SUCCESS
```
