### PR TITLE
docs(roadmap): the MCP client is shipped, move it out of Toward 1.0

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,7 +55,8 @@ or audited — one registry, one gate, one agent loop (ADR-116).
 Things nr_llm deliberately does not do, so the scope stays sharp:
 
 - **No general-purpose MCP server.** The direction matters: nr_llm *consumes*
-  MCP servers as a client and aggregates their tools (see Toward 1.0), but it
+  MCP servers as a client and aggregates their tools (shipped — see "Where we
+  are" and ADR-116), but it
   does not *expose* TYPO3 as an MCP server to third-party clients. That is a
   different product with a different security model.
 - **No backend coding agent.** The agent runtime automates editorial and

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,10 @@ The security-hardening arc is shipped: explicit actor context and fail-closed
 authorization through the whole agent runtime, at-least-once queue delivery
 with a declared tool-effect classification and a fail-closed write audit, tool
 data-class enforcement on by default, agent state encrypted at rest, and an
-operations dashboard with a queryable governance audit trail.
+operations dashboard with a queryable governance audit trail. The MCP
+client is shipped too: operator-configured servers are imported into the one
+tool registry, and origin does not change how a tool is authorised, approved
+or audited — one registry, one gate, one agent loop (ADR-116).
 
 ## Next — agent runtime maturity
 
@@ -27,17 +30,6 @@ operations dashboard with a queryable governance audit trail.
 
 ## Toward 1.0
 
-- **MCP client — one tooling authority.** nr_llm connects to externally
-  configured MCP servers over HTTP, lists their tools and registers
-  them into `ToolRegistry` alongside the builtins, so a consumer obtains
-  builtin and MCP tooling together and never opens an MCP connection itself.
-  Origin does not change how a tool is authorised, approved or audited: one
-  registry, one gate, one agent loop (ADR-116). The server configuration — url,
-  credential, and the data-class ceiling the operator declares for it — is
-  managed centrally in nr_llm. That declaration is required, not optional: an
-  MCP tool has no group, so it would otherwise resolve to the strictest data
-  class and never be offered, while its effect would resolve to read-only and
-  lose the write fence. stdio is out of scope (ADR-116).
 - **Role model and editor actions.** Distinct operational roles (system
   administration, AI management, AI operation, editing) instead of the current
   admin-centric permissions, plus a purpose-built editor action API rather


### PR DESCRIPTION
The roadmap's own rule: anything already shipped lives in CHANGELOG.md, not here. The MCP client landed via [#580](https://github.com/netresearch/t3x-nr-llm/pull/580) and [#585](https://github.com/netresearch/t3x-nr-llm/pull/585); "Where we are" now says so in two sentences, and the Toward-1.0 entry is removed.

One precision over the commit message: the stdio exclusion is carried by [ADR-116](Documentation/Adr/Adr116CentralToolingAuthority.rst) itself — the Non-goals section covers the server *direction*, not the transport. The durable statement lives in the ADR, which is where a scope decision belongs.

Docs-only change.