### PR TITLE
test(architecture): pin core independent of the tool module

### DIFF
--- a/Classes/Controller/Backend/TaskListController.php
+++ b/Classes/Controller/Backend/TaskListController.php
@@ -91,7 +91,7 @@ final class TaskListController extends ActionController
             $groupedTasks[$category]['tasks'][] = $task;
         }
 
-        $groupedTasks = array_filter($groupedTasks, fn(array $group): bool => !empty($group['tasks']));
+        $groupedTasks = array_filter($groupedTasks, fn(array $group): bool => $group['tasks'] !== []);
 
         $period = AnalyticsPeriod::fromPreset('30d', new DateTimeImmutable());
         $usage = UsageAnalyticsService::formatUsageColumns(

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,11 +48,12 @@ operations dashboard with a queryable governance audit trail.
 - **A public, versioned API surface.** Mark the supported surface with `@api`,
   adopt an explicit backward-compatibility policy, and add upgrade tests so
   consumer extensions can rely on it.
-- **Enforced horizontal boundaries.** Mostly shipped: `ModuleSeamTest` asserts
-  that specialized services and the tool/agent module do not depend on each
-  other, that guardrails depend on neither, and that nothing outside the
-  backend package depends on it. The remaining rule is core independent of the
-  tool module.
+- **Enforced horizontal boundaries.** Shipped: `ModuleSeamTest` asserts that
+  specialized services and the tool/agent module do not depend on each other,
+  that guardrails depend on neither, that nothing outside the backend package
+  depends on it, and that core does not depend on the tool module — six named
+  classes excepted as that module's own surface in shared directories, each
+  recorded with the package it moves to in a split.
 - **Re-evaluate a package split only after 1.0.** The seams from the runtime
   decomposition are the prerequisite; until they are stable, one package
   (ADR-090) stays the right call.

--- a/Tests/Architecture/ModuleSeamTest.php
+++ b/Tests/Architecture/ModuleSeamTest.php
@@ -9,6 +9,12 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Architecture;
 
+use Netresearch\NrLlm\Command\CancelAgentRunCommand;
+use Netresearch\NrLlm\Command\PurgePrivacyDataCommand;
+use Netresearch\NrLlm\Command\ReapStaleAgentRunsCommand;
+use Netresearch\NrLlm\Form\Tca\ToolGroupItems;
+use Netresearch\NrLlm\Service\Evaluation\LexicalSearchRetriever;
+use Netresearch\NrLlm\Service\Overview\OverviewReadinessService;
 use PHPat\Selector\Selector;
 use PHPat\Test\Builder\Rule;
 use PHPat\Test\PHPat;
@@ -166,5 +172,64 @@ final class ModuleSeamTest
                 Selector::inNamespace(self::NS_WIDGETS),
             )
             ->because('nr_llm_backend depends on the other packages; nothing outside it may depend on the backend (ADR-090).');
+    }
+
+    /**
+     * Core must not depend on the tool/agent/retrieval module — the remaining
+     * seam the roadmap names, and the prerequisite for the post-1.0 split:
+     * every feature package depends on core, so a core class reaching back
+     * into `nr_llm_tools` would make the two packages mutually dependent.
+     *
+     * "Core" here is the remainder: everything that is not one of the mapped
+     * module namespaces above. Six classes are excluded BY NAME rather than by
+     * directory, because they are the tool module's own operational surface
+     * living in shared directories — in a split each moves WITH its module,
+     * so their coupling is ownership, not leakage:
+     *
+     * - `CancelAgentRunCommand`, `ReapStaleAgentRunsCommand` — CLI entry
+     *   points of the agent runtime (→ nr_llm_tools)
+     * - `PurgePrivacyDataCommand` — sweeps, among others, the agent-run
+     *   tables through their repository (→ split into per-module sweeps when
+     *   the packages separate)
+     * - `ToolGroupItems` — the TCA itemsProcFunc that lists tool groups
+     *   (→ nr_llm_tools)
+     * - `LexicalSearchRetriever` — the evaluation harness's baseline over the
+     *   retrieval API (→ nr_llm_tools, retrieval scope)
+     * - `OverviewReadinessService` — feeds the backend Overview module's
+     *   readiness card (→ nr_llm_backend)
+     *
+     * A NEW core class that imports the tool module fails this rule; the
+     * named list is the complete, deliberate exception set. Do not grow it
+     * without recording where the class moves in a split.
+     */
+    public function testCoreDoesNotDependOnTheToolModule(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::AllOf(
+                Selector::inNamespace(self::NS_ROOT),
+                Selector::NoneOf(
+                    Selector::inNamespace(self::NS_SPECIALIZED),
+                    Selector::inNamespace(self::NS_TOOL),
+                    Selector::inNamespace(self::NS_AGENT),
+                    Selector::inNamespace(self::NS_RETRIEVAL),
+                    Selector::inNamespace(self::NS_GUARDRAIL),
+                    Selector::inNamespace(self::NS_CONTROLLER),
+                    Selector::inNamespace(self::NS_WIDGETS),
+                    Selector::inNamespace(self::NS_TESTS),
+                    Selector::classname(CancelAgentRunCommand::class),
+                    Selector::classname(PurgePrivacyDataCommand::class),
+                    Selector::classname(ReapStaleAgentRunsCommand::class),
+                    Selector::classname(ToolGroupItems::class),
+                    Selector::classname(LexicalSearchRetriever::class),
+                    Selector::classname(OverviewReadinessService::class),
+                ),
+            ))
+            ->shouldNotDependOn()
+            ->classes(
+                Selector::inNamespace(self::NS_TOOL),
+                Selector::inNamespace(self::NS_AGENT),
+                Selector::inNamespace(self::NS_RETRIEVAL),
+            )
+            ->because('Core is what every package depends on; core reaching back into nr_llm_tools would make the split circular (ADR-090).');
     }
 }


### PR DESCRIPTION
The last horizontal seam the roadmap names, and the prerequisite that keeps the post-1.0 split acyclic: every feature package depends on core, so a core class reaching back into `nr_llm_tools` would make the extraction circular (ADR-090).

## The rule

Core is the remainder — everything outside the mapped module namespaces. Six classes are excluded **by name** rather than by directory, because each is the tool module's own operational surface living in a shared directory: the two agent-run CLI commands, the privacy purge command, the tool-group TCA itemsProcFunc, the evaluation baseline over the retrieval API, and the Overview readiness service. Each is recorded with the package it moves to in a split, so the exception list is a record, not a loophole — a **new** core class importing the tool module fails the rule.

**Verified to bite:** a `ToolRegistry`-typed parameter injected into a core class fails with this rule's own identifier and because-text; the suite returns to green on revert. (The first bite attempt was invalid — a defaulted public property on a readonly class is a compile error, not a phpat finding — and was redone properly.)

## The ride-along style commit

`typo3-ci-workflows` v1.3.4 pins rector to **2.6.1**, whose `empty()`-fixer flags one pre-existing line in `TaskListController` — and its suggested rewrite (`isset()` + comparison) is then rejected by PHPStan level 10 because the offset always exists. The plain strict comparison satisfies both tools. Without this, any PR whose CI resolves fresh goes red on the rector job; same shape as [`257d1943`](https://github.com/netresearch/t3x-nr-llm/commit/257d1943).

The roadmap's "Enforced horizontal boundaries" bullet now reads shipped.

Locally on PHP 8.2: rector -n, cgl -n, PHPStan, architecture, unit (5870) — all after the apply-mode passes, in that order.
