### PR TITLE
feat(schema): enforce a named strict subset for structured outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **BREAKING for external `completeStructured()` callers:** the schema is now
+  validated against a named strict subset (ADR-126). Every subset keyword —
+  enum, pattern, bounds, `oneOf` and friends — is enforced on the response,
+  and a schema carrying unknown keywords (notably `$ref`) is rejected up
+  front with its own error code, before any provider call. Annotations
+  (`description`, `format`, `$schema`, …) stay accepted. The tool-input gate
+  and the evaluation grader are unchanged. No in-repo caller is affected.
+
 - OpenRouter's model routing lives in its own class
   (`Provider/OpenRouter/ModelRouter`), the first per-adapter collaborator
   (ADR-125). Same strategies, same keyword heuristics, same fallbacks; a call

--- a/Classes/Service/Feature/CompletionService.php
+++ b/Classes/Service/Feature/CompletionService.php
@@ -117,7 +117,7 @@ final readonly class CompletionService implements CompletionServiceInterface
      *                                     keywords are rejected up front.
      *
      * @throws InvalidArgumentException when the schema lies outside the
-     *                                  supported subset (code 1784500002 —
+     *                                  supported subset (code 1784500003 —
      *                                  thrown BEFORE any provider call), or
      *                                  when the response still fails to match
      *                                  after one repair attempt (1784500001)
@@ -132,7 +132,7 @@ final readonly class CompletionService implements CompletionServiceInterface
         if (!$this->schemaValidator->supportsSchema($schema)) {
             throw new InvalidArgumentException(
                 'The schema lies outside the supported strict subset (ADR-126); it would reject every response.',
-                1784500002,
+                1784500003,
             );
         }
 
@@ -229,7 +229,7 @@ final readonly class CompletionService implements CompletionServiceInterface
         if (!$this->schemaValidator->supportsSchema($schema)) {
             throw new InvalidArgumentException(
                 'The schema lies outside the supported strict subset (ADR-126); it would reject every response.',
-                1784500002,
+                1784500003,
             );
         }
 

--- a/Classes/Service/Feature/CompletionService.php
+++ b/Classes/Service/Feature/CompletionService.php
@@ -110,17 +110,32 @@ final readonly class CompletionService implements CompletionServiceInterface
      * {@see JsonSchemaValidator}. A native provider structured-output guarantee
      * is a separate concern (see ADR-082).
      *
-     * @param array<string, mixed> $schema Subset JSON Schema: top-level `type`,
-     *                                     object `required` keys and per-key
-     *                                     `properties` types are enforced.
+     * @param array<string, mixed> $schema JSON Schema inside the strict named
+     *                                     subset (ADR-126): type/enum/const/
+     *                                     pattern/bounds/items/oneOf and
+     *                                     friends are enforced, unknown
+     *                                     keywords are rejected up front.
      *
-     * @throws InvalidArgumentException when the response still fails to match the
-     *                                  schema after one repair attempt
+     * @throws InvalidArgumentException when the schema lies outside the
+     *                                  supported subset (code 1784500002 —
+     *                                  thrown BEFORE any provider call), or
+     *                                  when the response still fails to match
+     *                                  after one repair attempt (1784500001)
      *
      * @return array<string, mixed> The decoded, schema-valid JSON payload
      */
     public function completeStructured(string $prompt, array $schema, ?ChatOptions $options = null): array
     {
+        // Pre-flight BEFORE the first provider call: a schema outside the
+        // subset fails validation for every possible response, and finding
+        // that out after the repair round-trip costs two paid requests.
+        if (!$this->schemaValidator->supportsSchema($schema)) {
+            throw new InvalidArgumentException(
+                'The schema lies outside the supported strict subset (ADR-126); it would reject every response.',
+                1784500002,
+            );
+        }
+
         $options    = ($options ?? new ChatOptions())->withResponseFormat('json');
         $schemaJson = $this->encodeSchema($schema);
 
@@ -209,6 +224,15 @@ final readonly class CompletionService implements CompletionServiceInterface
      */
     public function completeStructuredForConfiguration(string $prompt, LlmConfiguration $configuration, array $schema, ?ChatOptions $options = null): array
     {
+        // Same pre-flight as completeStructured(): never pay for a schema
+        // that cannot be satisfied.
+        if (!$this->schemaValidator->supportsSchema($schema)) {
+            throw new InvalidArgumentException(
+                'The schema lies outside the supported strict subset (ADR-126); it would reject every response.',
+                1784500002,
+            );
+        }
+
         $options    = ($options ?? new ChatOptions())->withResponseFormat('json');
         $schemaJson = $this->encodeSchema($schema);
 
@@ -276,7 +300,7 @@ final readonly class CompletionService implements CompletionServiceInterface
             return null;
         }
 
-        if (!$this->schemaValidator->validate($decoded, $schema)) {
+        if (!$this->schemaValidator->validateStrict($decoded, $schema)) {
             return null;
         }
 

--- a/Classes/Service/Schema/JsonSchemaValidator.php
+++ b/Classes/Service/Schema/JsonSchemaValidator.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Service\Schema;
 
 /**
- * Lightweight structural JSON-Schema matcher (ADR-082).
+ * Lightweight structural JSON-Schema matcher (ADR-082, ADR-126).
  *
  * Validates a decoded value against a subset schema — the top-level ``type``,
  * an object's ``required`` keys, and recursive ``properties`` types. Extra keys
@@ -20,9 +20,32 @@ namespace Netresearch\NrLlm\Service\Schema;
  * The logic was extracted verbatim from `DeterministicGrader` (ADR-060) so the
  * evaluation grader and the structured-completion path share one matcher instead
  * of duplicating it.
+ *
+ * Two modes since ADR-126, and the boundary between them is load-bearing:
+ *
+ * - `validate()` is the LENIENT mode above, byte-identical to its pre-126
+ *   behaviour. The ADR-105 tool-input gate, the resume paths and the
+ *   evaluation grader all sit on it; changing its semantics moves a security
+ *   boundary, so the strict mode is a separate method rather than a flag.
+ * - `validateStrict()` enforces the named subset in {@see StrictSchemaSubset}:
+ *   every subset keyword is honoured, any unknown keyword or degenerate
+ *   schema FAILS. Callers should pre-flight the schema with
+ *   {@see self::supportsSchema()} before spending money on a provider call —
+ *   an out-of-subset schema fails for every possible response.
+ *
+ * The invariant tying the modes together, pinned by a fuzzy test: anything
+ * strict accepts, lenient accepts. Strict only ever rejects MORE, which is
+ * why its primitive type matcher byte-mirrors the lenient one (`5.0` is not
+ * an integer here, unlike in the spec).
  */
 final readonly class JsonSchemaValidator
 {
+    public function __construct(
+        // A promoted-parameter default so the six constructor-default wirings
+        // across the codebase keep working without a Services.yaml entry.
+        private StrictSchemaSubset $subset = new StrictSchemaSubset(),
+    ) {}
+
     /**
      * Validate a decoded value against a subset JSON Schema.
      *
@@ -82,8 +105,417 @@ final readonly class JsonSchemaValidator
         return $this->validate($data, $schema);
     }
 
+    /**
+     * Whether a schema lies entirely inside the strict subset (ADR-126).
+     *
+     * Callers on a paid path MUST pre-flight with this before the first
+     * provider call: an out-of-subset schema fails strict validation for
+     * every possible response, and discovering that after the repair
+     * round-trip costs two requests.
+     *
+     * @param array<array-key, mixed> $schema
+     */
+    public function supportsSchema(array $schema): bool
+    {
+        return $this->subset->supported($schema);
+    }
+
+    /**
+     * Validate a decoded value against the strict subset (ADR-126).
+     *
+     * Fail-closed twice over: a schema outside the subset returns false, and
+     * every subset keyword present is enforced. Assertions apply only to
+     * instances of their type, per JSON Schema — a `pattern` does not reject
+     * an integer, a `minimum` does not reject a string.
+     *
+     * @param array<array-key, mixed> $schema
+     */
+    public function validateStrict(mixed $data, array $schema): bool
+    {
+        if (!$this->subset->supported($schema)) {
+            return false;
+        }
+
+        return $this->strictNode($data, $schema);
+    }
+
+    /**
+     * Strict counterpart of {@see self::validateJson()}.
+     */
+    public function validateJsonStrict(string $json, string $schemaJson): bool
+    {
+        $data = json_decode($json, true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return false;
+        }
+
+        $schema = json_decode($schemaJson, true);
+        if (!is_array($schema)) {
+            return false;
+        }
+
+        return $this->validateStrict($data, $schema);
+    }
+
+    /**
+     * @param array<array-key, mixed> $schema already subset-checked
+     */
+    private function strictNode(mixed $data, array $schema): bool
+    {
+        if (isset($schema['type']) && !$this->strictMatchesTypeValue($data, $schema['type'])) {
+            return false;
+        }
+
+        if (isset($schema['enum']) && is_array($schema['enum']) && !$this->inEnum($data, $schema['enum'])) {
+            return false;
+        }
+
+        if (array_key_exists('const', $schema) && !$this->jsonEquals($data, $schema['const'])) {
+            return false;
+        }
+
+        if (!$this->strictStringAssertions($data, $schema)) {
+            return false;
+        }
+
+        if (!$this->strictNumberAssertions($data, $schema)) {
+            return false;
+        }
+
+        if (!$this->strictArrayAssertions($data, $schema)) {
+            return false;
+        }
+
+        if (!$this->strictObjectAssertions($data, $schema)) {
+            return false;
+        }
+
+        return $this->strictApplicators($data, $schema);
+    }
+
+    /**
+     * @param array<array-key, mixed> $schema
+     */
+    private function strictStringAssertions(mixed $data, array $schema): bool
+    {
+        if (!is_string($data)) {
+            return true;
+        }
+
+        // Code points, not bytes — the spec counts characters, and a schema
+        // written for "max 10 characters" must not reject 4 umlauts.
+        if (isset($schema['minLength']) && is_int($schema['minLength']) && mb_strlen($data) < $schema['minLength']) {
+            return false;
+        }
+
+        if (isset($schema['maxLength']) && is_int($schema['maxLength']) && mb_strlen($data) > $schema['maxLength']) {
+            return false;
+        }
+
+        if (isset($schema['pattern']) && is_string($schema['pattern'])) {
+            $compiled = $this->subset->compilePattern($schema['pattern']);
+            // A pattern that stopped compiling (or hits the backtrack limit at
+            // match time, where preg_match returns false) rejects: fail-closed.
+            if ($compiled === null || preg_match($compiled, $data) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<array-key, mixed> $schema
+     */
+    private function strictNumberAssertions(mixed $data, array $schema): bool
+    {
+        if (!is_int($data) && !is_float($data)) {
+            return true;
+        }
+
+        $min = $schema['minimum'] ?? null;
+        if ((is_int($min) || is_float($min)) && $data < $min) {
+            return false;
+        }
+
+        $max = $schema['maximum'] ?? null;
+        if ((is_int($max) || is_float($max)) && $data > $max) {
+            return false;
+        }
+
+        $exMin = $schema['exclusiveMinimum'] ?? null;
+        if ((is_int($exMin) || is_float($exMin)) && $data <= $exMin) {
+            return false;
+        }
+
+        $exMax = $schema['exclusiveMaximum'] ?? null;
+        if ((is_int($exMax) || is_float($exMax)) && $data >= $exMax) {
+            return false;
+        }
+
+        $multiple = $schema['multipleOf'] ?? null;
+        if (is_int($multiple) && $multiple > 0) {
+            $isMultiple = is_int($data) ? $data % $multiple === 0 : fmod($data, (float)$multiple) === 0.0;
+            if (!$isMultiple) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<array-key, mixed> $schema
+     */
+    private function strictArrayAssertions(mixed $data, array $schema): bool
+    {
+        // Mirrors the lenient matcher: [] counts as object AND array; a
+        // non-empty map is not a list.
+        if (!is_array($data) || !array_is_list($data)) {
+            return true;
+        }
+
+        $count = count($data);
+        if (isset($schema['minItems']) && is_int($schema['minItems']) && $count < $schema['minItems']) {
+            return false;
+        }
+
+        if (isset($schema['maxItems']) && is_int($schema['maxItems']) && $count > $schema['maxItems']) {
+            return false;
+        }
+
+        if (($schema['uniqueItems'] ?? false) === true) {
+            $seen = [];
+            foreach ($data as $item) {
+                $normalised = $this->normaliseJson($item);
+                if (in_array($normalised, $seen, true)) {
+                    return false;
+                }
+
+                $seen[] = $normalised;
+            }
+        }
+
+        $prefix = $schema['prefixItems'] ?? null;
+        $prefixCount = 0;
+        if (is_array($prefix)) {
+            $prefixCount = count($prefix);
+            foreach ($prefix as $i => $itemSchema) {
+                if (is_int($i) && is_array($itemSchema) && array_key_exists($i, $data)
+                    && !$this->strictNode($data[$i], $itemSchema)
+                ) {
+                    return false;
+                }
+            }
+        }
+
+        // In 2020-12, `items` constrains the elements AFTER prefixItems.
+        $items = $schema['items'] ?? null;
+        if (is_array($items)) {
+            foreach ($data as $i => $item) {
+                if ($i >= $prefixCount && !$this->strictNode($item, $items)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<array-key, mixed> $schema
+     */
+    private function strictObjectAssertions(mixed $data, array $schema): bool
+    {
+        $isObject = is_array($data) && (!array_is_list($data) || $data === []);
+
+        if (isset($schema['required']) && is_array($schema['required'])) {
+            if (!$isObject) {
+                return false;
+            }
+
+            foreach ($schema['required'] as $key) {
+                if (!is_string($key) || !array_key_exists($key, $data)) {
+                    return false;
+                }
+            }
+        }
+
+        if (!$isObject || !is_array($data)) {
+            return true;
+        }
+
+        $properties = $schema['properties'] ?? null;
+        $declared = [];
+        if (is_array($properties)) {
+            foreach ($properties as $key => $propSchema) {
+                $declared[$key] = true;
+                if (is_array($propSchema) && array_key_exists($key, $data)
+                    && !$this->strictNode($data[$key], $propSchema)
+                ) {
+                    return false;
+                }
+            }
+        }
+
+        $additional = $schema['additionalProperties'] ?? null;
+        if ($additional === false) {
+            foreach (array_keys($data) as $key) {
+                if (!isset($declared[$key])) {
+                    return false;
+                }
+            }
+        } elseif (is_array($additional)) {
+            foreach ($data as $key => $value) {
+                if (!isset($declared[$key]) && !$this->strictNode($value, $additional)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<array-key, mixed> $schema
+     */
+    private function strictApplicators(mixed $data, array $schema): bool
+    {
+        $allOf = $schema['allOf'] ?? null;
+        if (is_array($allOf)) {
+            foreach ($allOf as $branch) {
+                if (!is_array($branch) || !$this->strictNode($data, $branch)) {
+                    return false;
+                }
+            }
+        }
+
+        $anyOf = $schema['anyOf'] ?? null;
+        if (is_array($anyOf)) {
+            $matched = false;
+            foreach ($anyOf as $branch) {
+                if (is_array($branch) && $this->strictNode($data, $branch)) {
+                    $matched = true;
+                    break;
+                }
+            }
+
+            if (!$matched) {
+                return false;
+            }
+        }
+
+        $oneOf = $schema['oneOf'] ?? null;
+        if (is_array($oneOf)) {
+            $matches = 0;
+            foreach ($oneOf as $branch) {
+                if (is_array($branch) && $this->strictNode($data, $branch)) {
+                    ++$matches;
+                    if ($matches > 1) {
+                        return false;
+                    }
+                }
+            }
+
+            if ($matches !== 1) {
+                return false;
+            }
+        }
+
+        $not = $schema['not'] ?? null;
+        return !is_array($not) || !$this->strictNode($data, $not);
+    }
+
+    /**
+     * Strict primitive matching — a BYTE MIRROR of the lenient
+     * {@see self::matchesType()} for the shared type names, minus its
+     * fail-open default arm. That mirroring is what makes the invariant
+     * "strict accepts implies lenient accepts" hold: notably `5.0` is NOT an
+     * integer here, although the spec says it is (ADR-126 names the
+     * deviation). Do not "fix" either matcher toward the spec alone.
+     */
+    private function strictMatchesTypeValue(mixed $data, mixed $type): bool
+    {
+        if (is_string($type)) {
+            return $this->strictMatchesType($data, $type);
+        }
+
+        if (is_array($type)) {
+            foreach ($type as $candidate) {
+                if (is_string($candidate) && $this->strictMatchesType($data, $candidate)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return false;
+    }
+
+    private function strictMatchesType(mixed $data, string $type): bool
+    {
+        return match ($type) {
+            'object' => is_array($data) && (!array_is_list($data) || $data === []),
+            'array' => is_array($data) && array_is_list($data),
+            'string' => is_string($data),
+            'number' => is_int($data) || is_float($data),
+            'integer' => is_int($data),
+            'boolean' => is_bool($data),
+            'null' => $data === null,
+            default => false,
+        };
+    }
+
+    /**
+     * @param array<array-key, mixed> $enum
+     */
+    private function inEnum(mixed $data, array $enum): bool
+    {
+        foreach ($enum as $member) {
+            if ($this->jsonEquals($data, $member)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * JSON value equality on decoded data: maps compare key-order-insensitive,
+     * lists order-sensitive, scalars with === (so 1 and "1" differ, and — a
+     * named ADR-126 deviation — 1 and 1.0 differ although JSON has one number
+     * type).
+     */
+    private function jsonEquals(mixed $a, mixed $b): bool
+    {
+        return $this->normaliseJson($a) === $this->normaliseJson($b);
+    }
+
+    private function normaliseJson(mixed $value): mixed
+    {
+        if (!is_array($value)) {
+            return $value;
+        }
+
+        $normalised = [];
+        foreach ($value as $key => $item) {
+            $normalised[$key] = $this->normaliseJson($item);
+        }
+
+        if (!array_is_list($normalised)) {
+            ksort($normalised);
+        }
+
+        return $normalised;
+    }
+
     private function matchesType(mixed $data, string $type): bool
     {
+        // LENIENT ONLY. The `default => true` arm is load-bearing: unknown
+        // type names pass here, and the ADR-105 input gate depends on that
+        // staying true. Strict mode has its own matcher above — never point
+        // strict at this one, never remove the default arm.
         return match ($type) {
             // An empty JSON object and array both decode to []; ambiguity is
             // accepted for this lightweight matcher.

--- a/Classes/Service/Schema/StrictSchemaSubset.php
+++ b/Classes/Service/Schema/StrictSchemaSubset.php
@@ -80,6 +80,7 @@ final readonly class StrictSchemaSubset
             return false;
         }
 
+        $hasAssertion = false;
         foreach ($schema as $keyword => $value) {
             if (!is_string($keyword)) {
                 return false;
@@ -96,9 +97,14 @@ final readonly class StrictSchemaSubset
             if (!$this->keywordValueSupported($keyword, $value)) {
                 return false;
             }
+
+            $hasAssertion = true;
         }
 
-        return true;
+        // Annotations alone assert nothing: a schema of only description/
+        // title/format would let strict validation accept every response,
+        // which is the degenerate case in prettier clothes.
+        return $hasAssertion;
     }
 
     /**

--- a/Classes/Service/Schema/StrictSchemaSubset.php
+++ b/Classes/Service/Schema/StrictSchemaSubset.php
@@ -1,0 +1,219 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Schema;
+
+/**
+ * The named JSON-Schema subset the strict validator enforces (ADR-126).
+ *
+ * One class owns both halves of the contract: which keywords exist, and what
+ * shape each keyword's value must have. `supported()` walks a SCHEMA and
+ * answers whether it lies entirely inside the subset — fail-closed on any
+ * unknown keyword, so the subset is enforceable rather than aspirational.
+ * The walker runs BEFORE the first provider call, because an out-of-subset
+ * schema fails validation for every possible model response and must never
+ * cost a paid request, let alone the repair round-trip (ADR-082).
+ *
+ * Deviations from JSON Schema 2020-12, each deliberate and documented in
+ * ADR-126:
+ *
+ * - `pattern` is compiled as PCRE (delimiters added here), not ECMA-262.
+ * - `multipleOf` is honoured for positive integers only; float steps would
+ *   need epsilon arithmetic that quietly lies about conformance.
+ * - `5.0` is NOT an integer: primitive matching mirrors the lenient
+ *   validator's PHP-native checks, which is what keeps the invariant
+ *   "strict accepts ⇒ lenient accepts" true.
+ * - `{}` and `[]` decode identically in PHP; the ambiguity is accepted
+ *   exactly as the lenient matcher documents.
+ * - No `$ref`/`$defs`: reference resolution is the point at which a subset
+ *   becomes a JSON-Schema implementation, and ADR-082's no-runtime-dependency
+ *   decision stands.
+ */
+final readonly class StrictSchemaSubset
+{
+    /**
+     * Keywords whose value shape `supported()` checks and the validator
+     * enforces.
+     *
+     * @var list<string>
+     */
+    public const ASSERTIONS = [
+        'type', 'enum', 'const', 'pattern',
+        'minLength', 'maxLength',
+        'minimum', 'maximum', 'exclusiveMinimum', 'exclusiveMaximum',
+        'multipleOf',
+        'items', 'prefixItems', 'minItems', 'maxItems', 'uniqueItems',
+        'properties', 'required', 'additionalProperties',
+        'oneOf', 'anyOf', 'allOf', 'not',
+    ];
+
+    /**
+     * Keywords accepted and ignored: annotations per JSON Schema 2020-12
+     * (`format` is annotation-only by default there), plus the schema's own
+     * meta declarations, which nearly every generated schema carries.
+     *
+     * @var list<string>
+     */
+    public const ANNOTATIONS = [
+        'description', 'title', 'default', 'examples', 'format',
+        '$schema', '$id',
+    ];
+
+    private const TYPE_NAMES = ['object', 'array', 'string', 'number', 'integer', 'boolean', 'null'];
+
+    /**
+     * Whether the schema lies entirely inside the subset.
+     *
+     * @param array<array-key, mixed> $schema
+     */
+    public function supported(array $schema): bool
+    {
+        // A degenerate schema is a programming error, not "accept anything"
+        // (see InputSchema for the same reasoning on the tool-input path).
+        if ($schema === []) {
+            return false;
+        }
+
+        foreach ($schema as $keyword => $value) {
+            if (!is_string($keyword)) {
+                return false;
+            }
+
+            if (in_array($keyword, self::ANNOTATIONS, true)) {
+                continue;
+            }
+
+            if (!in_array($keyword, self::ASSERTIONS, true)) {
+                return false;
+            }
+
+            if (!$this->keywordValueSupported($keyword, $value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Compile a delimiterless JSON-Schema pattern into a PCRE the validator
+     * can run, or null when it does not compile.
+     *
+     * The schema keyword carries an ECMA-262-style regex WITHOUT delimiters;
+     * PCRE needs them, so they are added here with the delimiter escaped.
+     * Compilability is checked with a temporary error handler rather than the
+     * `@` operator — the idiom Assertion::isValidPattern() established.
+     */
+    public function compilePattern(string $pattern): ?string
+    {
+        // Bound what a hostile schema can make the engine chew on. Runtime
+        // backtracking is already fail-closed (pcre.backtrack_limit makes
+        // preg_match return false), so the cap only guards absurd inputs.
+        if ($pattern === '' || strlen($pattern) > 1000) {
+            return null;
+        }
+
+        $compiled = '~' . str_replace('~', '\\~', $pattern) . '~u';
+
+        set_error_handler(static fn(): bool => true);
+
+        try {
+            return preg_match($compiled, '') !== false ? $compiled : null;
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    private function keywordValueSupported(string $keyword, mixed $value): bool
+    {
+        return match ($keyword) {
+            'type' => $this->typeValueSupported($value),
+            'enum' => is_array($value) && $value !== [] && array_is_list($value),
+            'const' => true,
+            'pattern' => is_string($value) && $this->compilePattern($value) !== null,
+            'minLength', 'maxLength', 'minItems', 'maxItems' => is_int($value) && $value >= 0,
+            'minimum', 'maximum', 'exclusiveMinimum', 'exclusiveMaximum' => is_int($value) || is_float($value),
+            // Positive integers only — float steps would need epsilon
+            // arithmetic; zero would divide by zero. Anything else is
+            // out-of-subset, not "ignored".
+            'multipleOf' => is_int($value) && $value > 0,
+            'uniqueItems' => is_bool($value),
+            'required' => $this->stringListSupported($value),
+            'items', 'not' => is_array($value) && $this->supported($value),
+            'prefixItems', 'oneOf', 'anyOf', 'allOf' => $this->schemaListSupported($value),
+            'properties' => $this->propertyMapSupported($value),
+            'additionalProperties' => is_bool($value) || (is_array($value) && $this->supported($value)),
+            default => false,
+        };
+    }
+
+    private function typeValueSupported(mixed $value): bool
+    {
+        if (is_string($value)) {
+            return in_array($value, self::TYPE_NAMES, true);
+        }
+
+        if (!is_array($value) || $value === [] || !array_is_list($value)) {
+            return false;
+        }
+
+        foreach ($value as $type) {
+            if (!is_string($type) || !in_array($type, self::TYPE_NAMES, true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function stringListSupported(mixed $value): bool
+    {
+        if (!is_array($value) || !array_is_list($value)) {
+            return false;
+        }
+
+        foreach ($value as $entry) {
+            if (!is_string($entry)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function schemaListSupported(mixed $value): bool
+    {
+        if (!is_array($value) || $value === [] || !array_is_list($value)) {
+            return false;
+        }
+
+        foreach ($value as $subSchema) {
+            if (!is_array($subSchema) || !$this->supported($subSchema)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function propertyMapSupported(mixed $value): bool
+    {
+        if (!is_array($value)) {
+            return false;
+        }
+
+        foreach ($value as $name => $subSchema) {
+            if (!is_string($name) || !is_array($subSchema) || !$this->supported($subSchema)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/Documentation/Adr/Adr082StructuredOutputs.rst
+++ b/Documentation/Adr/Adr082StructuredOutputs.rst
@@ -73,7 +73,10 @@ Consequences
 - Validation is *structural* (the documented subset), not full JSON Schema draft
   semantics — no ``enum``, ``minLength``, ``pattern``, ``oneOf`` etc. That is the
   same contract the grader has always offered; a full validator would add a
-  runtime dependency and is out of scope.
+  runtime dependency and is out of scope. *Superseded for structured
+  completions by* :ref:`adr-126`, *which enforces a named strict subset
+  including those keywords; the grader and the ADR-105 input gate keep this
+  lenient contract.*
 - The repair round-trip costs at most one extra provider call, only when the first
   response fails. It is capped at one attempt to bound cost.
 - `CompletionService` and `DeterministicGrader` take the validator as a

--- a/Documentation/Adr/Adr126StrictSchemaSubset.rst
+++ b/Documentation/Adr/Adr126StrictSchemaSubset.rst
@@ -43,7 +43,7 @@ Its contract is a **named subset**, owned by :php:`StrictSchemaSubset`:
   decision stands.
 
 :php:`completeStructured()` **pre-flights** the schema against the subset and
-throws (code ``1784500002``) before the first provider call: an out-of-subset
+throws (code ``1784500003``) before the first provider call: an out-of-subset
 schema fails for every possible response, and discovering that after the
 repair round-trip would cost two paid requests.
 

--- a/Documentation/Adr/Adr126StrictSchemaSubset.rst
+++ b/Documentation/Adr/Adr126StrictSchemaSubset.rst
@@ -1,0 +1,92 @@
+.. _adr-126:
+
+====================================================
+ADR-126: A named JSON-Schema subset, enforced strict
+====================================================
+
+:Status: Accepted
+:Date: 2026-08-05
+
+Context
+=======
+
+ADR-082 shipped structured completions with a three-keyword structural matcher
+— ``type``, ``required``, ``properties`` — and deliberately excluded ``enum``,
+``pattern``, ``oneOf`` and the rest: a full validator would add a runtime
+dependency. The matcher is fail-open: unknown keywords are silently ignored,
+an empty schema accepts everything.
+
+That posture is correct for the paths the matcher also guards — the ADR-105
+tool-input gate and the resume paths depend on its exact semantics — but wrong
+for structured completions, where a caller who writes ``enum`` deserves either
+enforcement or an error, never silent acceptance. The roadmap asked for
+"enum, pattern, ``oneOf``, full draft support".
+
+Decision
+========
+
+The validator gains a second, STRICT mode next to the untouched lenient one.
+Its contract is a **named subset**, owned by :php:`StrictSchemaSubset`:
+
+- Enforced: ``type`` (incl. union arrays), ``enum``, ``const``, ``pattern``,
+  string lengths, numeric bounds (incl. numeric ``exclusive*``), integer
+  ``multipleOf``, ``items``/``prefixItems`` and the array assertions,
+  ``properties``/``required``/``additionalProperties`` (bool and schema
+  forms), ``oneOf``/``anyOf``/``allOf``/``not``.
+- Annotations accepted and ignored: ``description``, ``title``, ``default``,
+  ``examples``, ``format`` (annotation-only in 2020-12), ``$schema``, ``$id``.
+- Everything else — notably ``$ref``/``$defs`` — is **out of subset**, and out
+  of subset is **fail-closed**: the schema is rejected as a whole, so the
+  subset is enforceable rather than aspirational. "Full draft support" is
+  deliberately not built; reference resolution is the point at which a subset
+  becomes a JSON-Schema implementation, and ADR-082's no-runtime-dependency
+  decision stands.
+
+:php:`completeStructured()` **pre-flights** the schema against the subset and
+throws (code ``1784500002``) before the first provider call: an out-of-subset
+schema fails for every possible response, and discovering that after the
+repair round-trip would cost two paid requests.
+
+The lenient mode is byte-identical to before. The two modes are tied together
+by an invariant a fuzzy test pins: anything strict accepts, lenient accepts.
+Strict only ever rejects more, which is what makes it safe to introduce next
+to a mode that guards a security boundary.
+
+Named deviations from JSON Schema 2020-12
+=========================================
+
+Each deliberate, none silent:
+
+1. ``pattern`` is compiled as PCRE (delimiters added, ``u`` modifier), not
+   ECMA-262. A non-compiling pattern is out of subset; a match aborted by the
+   backtracking limit rejects — fail-closed either way.
+2. ``multipleOf`` is honoured for positive integers only. Float steps need
+   epsilon arithmetic that quietly lies about conformance
+   (``fmod(0.3, 0.1)`` ≠ 0).
+3. ``5.0`` is **not** an integer. Primitive matching byte-mirrors the lenient
+   matcher's PHP-native checks — the price of the strict-implies-lenient
+   invariant, and cheaper than two subtly different type systems.
+4. String lengths count code points (``mb_strlen``).
+5. ``enum``/``const``/``uniqueItems`` compare JSON values: maps key-order-
+   insensitive, lists order-sensitive, scalars with ``===`` — so ``1`` and
+   ``"1"`` differ, and ``1`` vs ``1.0`` differ although JSON has one number
+   type. ``{}`` and ``[]`` decode identically in PHP and compare equal; the
+   ambiguity is the same one the lenient matcher documents.
+
+Consequences
+============
+
+- External callers of :php:`CompletionServiceInterface::completeStructured()`
+  whose schemas carry out-of-subset keywords (``$schema`` and friends are
+  fine — they are annotations) now get an immediate typed error instead of
+  silent partial validation. Breaking, recorded in the CHANGELOG; there are
+  no in-repo callers.
+- The ADR-105 input gate, the resume paths and the evaluation grader keep the
+  lenient mode untouched. Migrating any of them to strict is a separate,
+  deliberate decision with its own compatibility analysis — suspended runs
+  persisted under lenient semantics must never start failing on resume.
+- ADR-082's "no enum/pattern/oneOf" consequence is superseded by this ADR;
+  its no-runtime-dependency decision and the repair round-trip stand.
+- Provider-native structured output (OpenAI ``json_schema``, Gemini
+  ``responseSchema``, Ollama ``format``) remains the separate follow-up
+  ADR-082 named; the subset walker is the compatibility gate it will need.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -423,3 +423,4 @@ Tools
    Adr123OneSecretShapeCatalogue
    Adr124ProviderKeyFromTheCommandLine
    Adr125PerAdapterCollaborators
+   Adr126StrictSchemaSubset

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,9 +42,11 @@ operations dashboard with a queryable governance audit trail.
   administration, AI management, AI operation, editing) instead of the current
   admin-centric permissions, plus a purpose-built editor action API rather
   than generic record CRUD.
-- **Complete structured outputs.** Close the schema-feature gaps (enum,
-  pattern, `oneOf`, full draft support) and use provider-native structured
-  output where a provider offers it.
+- **Complete structured outputs.** The schema gaps are closed as a named,
+  fail-closed strict subset (enum, pattern, `oneOf`, bounds, combinators —
+  ADR-126); full draft support, i.e. `$ref` resolution, stays deliberately
+  out. Remaining: use provider-native structured output where a provider
+  offers it, behind the subset walker as the compatibility gate.
 - **A public, versioned API surface.** Mark the supported surface with `@api`,
   adopt an explicit backward-compatibility policy, and add upgrade tests so
   consumer extensions can rely on it.

--- a/Tests/Fuzzy/Service/Schema/JsonSchemaValidatorFuzzyTest.php
+++ b/Tests/Fuzzy/Service/Schema/JsonSchemaValidatorFuzzyTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Fuzzy\Service\Schema;
+
+use Eris\Generator;
+use Netresearch\NrLlm\Service\Schema\JsonSchemaValidator;
+use Netresearch\NrLlm\Tests\Fuzzy\AbstractFuzzyTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The property that ties the two validation modes together (ADR-126):
+ * anything strict accepts, lenient accepts. Strict only ever rejects MORE.
+ *
+ * This is what makes the strict mode safe to introduce next to a lenient
+ * mode that guards a security boundary (ADR-105): no input can be waved
+ * through by strict that lenient would have caught. The property holds
+ * because strict's primitive type matcher byte-mirrors the lenient one —
+ * if either matcher is ever "fixed" toward the JSON-Schema spec alone
+ * (`5.0` as integer), this test is the tripwire.
+ */
+#[CoversClass(JsonSchemaValidator::class)]
+class JsonSchemaValidatorFuzzyTest extends AbstractFuzzyTestCase
+{
+    #[Test]
+    public function strictAcceptanceImpliesLenientAcceptance(): void
+    {
+        $validator = new JsonSchemaValidator();
+
+        $this
+            ->forAll(
+                $this->jsonValue(),
+                $this->subsetSchema(),
+            )
+            ->then(function (mixed $data, array $schema) use ($validator): void {
+                if ($validator->validateStrict($data, $schema)) {
+                    $this->assertTrue(
+                        $validator->validate($data, $schema),
+                        'strict accepted a value lenient rejects — the modes have diverged on a primitive',
+                    );
+                }
+
+                // And regardless of outcome: neither mode may crash on any
+                // combination — a validator that throws on hostile input is
+                // itself the vulnerability.
+                $this->assertIsBool($validator->validate($data, $schema));
+            });
+    }
+
+    #[Test]
+    public function strictNeverCrashesOnArbitraryData(): void
+    {
+        $validator = new JsonSchemaValidator();
+
+        $this
+            ->forAll($this->jsonValue())
+            ->then(function (mixed $data) use ($validator): void {
+                $this->assertIsBool($validator->validateStrict($data, [
+                    'type'       => ['object', 'array', 'string', 'number', 'boolean', 'null'],
+                    'minLength'  => 1,
+                    'minimum'    => 0,
+                    'minItems'   => 0,
+                    'uniqueItems' => true,
+                    'pattern'    => '^[\s\S]*$',
+                ]));
+            });
+    }
+
+    /**
+     * Arbitrary JSON-decodable values: scalars, lists, maps, shallow nesting.
+     *
+     * @return Generator\OneOfGenerator<mixed>
+     */
+    private function jsonValue(): Generator\OneOfGenerator
+    {
+        $scalar = Generator\oneOf( // @phpstan-ignore function.notFound
+            Generator\int(), // @phpstan-ignore function.notFound
+            Generator\float(), // @phpstan-ignore function.notFound
+            Generator\string(), // @phpstan-ignore function.notFound
+            Generator\bool(), // @phpstan-ignore function.notFound
+            Generator\constant(null), // @phpstan-ignore function.notFound
+        );
+
+        return Generator\oneOf( // @phpstan-ignore function.notFound
+            $scalar,
+            Generator\seq($scalar), // @phpstan-ignore function.notFound
+            Generator\associative([ // @phpstan-ignore function.notFound
+                'a' => $scalar,
+                'b' => $scalar,
+            ]),
+        );
+    }
+
+    /**
+     * Schemas inside the strict subset, exercising the keywords whose
+     * primitive semantics the two modes share.
+     *
+     * @return Generator\OneOfGenerator<array<string, mixed>>
+     */
+    private function subsetSchema(): Generator\OneOfGenerator
+    {
+        return Generator\oneOf( // @phpstan-ignore function.notFound
+            Generator\constant(['type' => 'string']), // @phpstan-ignore function.notFound
+            Generator\constant(['type' => 'integer']), // @phpstan-ignore function.notFound
+            Generator\constant(['type' => 'number']), // @phpstan-ignore function.notFound
+            Generator\constant(['type' => 'boolean']), // @phpstan-ignore function.notFound
+            Generator\constant(['type' => 'null']), // @phpstan-ignore function.notFound
+            Generator\constant(['type' => 'array']), // @phpstan-ignore function.notFound
+            Generator\constant(['type' => 'object']), // @phpstan-ignore function.notFound
+            Generator\constant(['type' => 'object', 'required' => ['a']]), // @phpstan-ignore function.notFound
+            Generator\constant(['type' => 'object', 'required' => ['a'], 'properties' => ['a' => ['type' => 'integer']]]), // @phpstan-ignore function.notFound
+            Generator\constant(['type' => 'object', 'properties' => ['a' => ['type' => 'string']], 'additionalProperties' => false]), // @phpstan-ignore function.notFound
+            Generator\constant(['type' => ['string', 'null']]), // @phpstan-ignore function.notFound
+            Generator\constant(['enum' => [1, 'a', true]]), // @phpstan-ignore function.notFound
+            Generator\constant(['type' => 'string', 'minLength' => 1, 'maxLength' => 3]), // @phpstan-ignore function.notFound
+            Generator\constant(['type' => 'number', 'minimum' => -1, 'maximum' => 1]), // @phpstan-ignore function.notFound
+            Generator\constant(['type' => 'array', 'items' => ['type' => 'integer'], 'uniqueItems' => true]), // @phpstan-ignore function.notFound
+            Generator\constant(['oneOf' => [['type' => 'string'], ['type' => 'integer']]]), // @phpstan-ignore function.notFound
+        );
+    }
+}

--- a/Tests/Unit/Service/Feature/CompletionServiceTest.php
+++ b/Tests/Unit/Service/Feature/CompletionServiceTest.php
@@ -1006,6 +1006,57 @@ class CompletionServiceTest extends AbstractUnitTestCase
         $subject->completeForConfiguration('hello', $configuration);
     }
 
+    /**
+     * The pre-flight (ADR-126): a schema outside the strict subset throws
+     * BEFORE any provider call — never a paid request, never the repair
+     * round-trip, and a distinct code so "your schema is wrong" is not
+     * mistaken for "the model's data is wrong".
+     */
+    #[Test]
+    public function completeStructuredRejectsAnOutOfSubsetSchemaBeforeAnyProviderCall(): void
+    {
+        ['subject' => $subject, 'llmManager' => $llmManagerMock] = $this->createSubjectWithMockManager();
+        $llmManagerMock->expects(self::never())->method('chat');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1784500002);
+
+        $subject->completeStructured('Generate metadata', [
+            'type' => 'object',
+            '$ref' => '#/definitions/thing',
+        ]);
+    }
+
+    /**
+     * Strict keywords are enforced on the response: an enum violation is a
+     * schema failure and triggers the repair round-trip, exactly like a
+     * missing required key did before ADR-126.
+     */
+    #[Test]
+    public function completeStructuredEnforcesEnumAndPatternOnTheResponse(): void
+    {
+        ['subject' => $subject, 'llmManager' => $llmManagerMock] = $this->createSubjectWithMockManager();
+        $llmManagerMock->expects(self::exactly(2))->method('chat')
+            ->willReturnOnConsecutiveCalls(
+                $this->createMockResponse('{"status": "unknown", "slug": "Hello World"}'),
+                $this->createMockResponse('{"status": "draft", "slug": "hello-world"}'),
+            );
+
+        $schema = [
+            'type'       => 'object',
+            'required'   => ['status', 'slug'],
+            'properties' => [
+                'status' => ['type' => 'string', 'enum' => ['draft', 'published']],
+                'slug'   => ['type' => 'string', 'pattern' => '^[a-z0-9-]+$'],
+            ],
+        ];
+
+        $result = $subject->completeStructured('Generate metadata', $schema);
+
+        self::assertSame('draft', $result['status']);
+        self::assertSame('hello-world', $result['slug']);
+    }
+
     #[Test]
     public function completeStructuredReturnsValidatedPayloadOnFirstAttempt(): void
     {

--- a/Tests/Unit/Service/Feature/CompletionServiceTest.php
+++ b/Tests/Unit/Service/Feature/CompletionServiceTest.php
@@ -1019,7 +1019,7 @@ class CompletionServiceTest extends AbstractUnitTestCase
         $llmManagerMock->expects(self::never())->method('chat');
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionCode(1784500002);
+        $this->expectExceptionCode(1784500003);
 
         $subject->completeStructured('Generate metadata', [
             'type' => 'object',

--- a/Tests/Unit/Service/Schema/JsonSchemaValidatorStrictTest.php
+++ b/Tests/Unit/Service/Schema/JsonSchemaValidatorStrictTest.php
@@ -1,0 +1,213 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Schema;
+
+use Netresearch\NrLlm\Service\Schema\JsonSchemaValidator;
+use Netresearch\NrLlm\Service\Schema\StrictSchemaSubset;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The strict mode (ADR-126): every subset keyword enforced, everything
+ * outside the subset fail-closed. The lenient mode's own 9 tests next door
+ * stay untouched — its semantics are a security boundary (ADR-105) and must
+ * not move.
+ */
+#[CoversClass(JsonSchemaValidator::class)]
+#[CoversClass(StrictSchemaSubset::class)]
+final class JsonSchemaValidatorStrictTest extends TestCase
+{
+    private JsonSchemaValidator $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new JsonSchemaValidator();
+    }
+
+    // ---- subset membership (the pre-flight surface) ----
+
+    /**
+     * @return iterable<string, array{array<string, mixed>, bool}>
+     */
+    public static function subsetMembership(): iterable
+    {
+        yield 'plain object schema' => [['type' => 'object', 'required' => ['a'], 'properties' => ['a' => ['type' => 'string']]], true];
+        yield 'annotations are welcome' => [['type' => 'string', 'description' => 'x', 'title' => 't', 'default' => 'd', 'format' => 'email', '$schema' => 'https://json-schema.org/draft/2020-12/schema', '$id' => 'x', 'examples' => ['a']], true];
+        yield 'enum, const, pattern' => [['type' => 'string', 'enum' => ['a', 'b'], 'const' => 'a', 'pattern' => '^[a-z]+$'], true];
+        yield 'numeric bounds' => [['type' => 'number', 'minimum' => 0, 'maximum' => 10.5, 'exclusiveMinimum' => -1, 'exclusiveMaximum' => 11, 'multipleOf' => 2], true];
+        yield 'array keywords' => [['type' => 'array', 'items' => ['type' => 'integer'], 'prefixItems' => [['type' => 'string']], 'minItems' => 0, 'maxItems' => 5, 'uniqueItems' => true], true];
+        yield 'combinators' => [['oneOf' => [['type' => 'string'], ['type' => 'integer']], 'not' => ['type' => 'null']], true];
+        yield 'additionalProperties as schema' => [['type' => 'object', 'additionalProperties' => ['type' => 'string']], true];
+
+        yield 'empty schema is degenerate' => [[], false];
+        yield 'unknown keyword' => [['type' => 'string', 'if' => ['type' => 'string']], false];
+        yield '$ref is out of subset' => [['$ref' => '#/definitions/x'], false];
+        yield 'definitions are out of subset' => [['type' => 'object', 'definitions' => []], false];
+        yield 'unknown type name' => [['type' => 'text'], false];
+        yield 'non-compiling pattern' => [['type' => 'string', 'pattern' => '([a-z'], false];
+        yield 'float multipleOf is out of subset' => [['type' => 'number', 'multipleOf' => 0.1], false];
+        yield 'zero multipleOf is out of subset' => [['type' => 'integer', 'multipleOf' => 0], false];
+        yield 'negative minLength' => [['type' => 'string', 'minLength' => -1], false];
+        yield 'empty enum' => [['enum' => []], false];
+        yield 'nested unknown keyword fails the whole schema' => [['type' => 'object', 'properties' => ['a' => ['type' => 'string', 'patternProperties' => []]]], false];
+        yield 'tuple items form of draft-04 is out of subset' => [['type' => 'array', 'items' => [['type' => 'string']]], false];
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     */
+    #[Test]
+    #[DataProvider('subsetMembership')]
+    public function supportsSchemaDrawsTheSubsetBoundary(array $schema, bool $expected): void
+    {
+        self::assertSame($expected, $this->subject->supportsSchema($schema));
+    }
+
+    /**
+     * An out-of-subset schema rejects every instance — fail-closed, and the
+     * reason callers must pre-flight before paying for a provider call.
+     */
+    #[Test]
+    public function strictRejectsAnyDataAgainstAnUnsupportedSchema(): void
+    {
+        self::assertFalse($this->subject->validateStrict('anything', ['unknownKeyword' => true]));
+        self::assertFalse($this->subject->validateStrict([], []));
+    }
+
+    // ---- data validation per keyword ----
+
+    /**
+     * @return iterable<string, array{mixed, array<string, mixed>, bool}>
+     */
+    public static function strictCases(): iterable
+    {
+        // enum / const — JSON equality: maps key-order-insensitive
+        yield 'enum hit' => ['b', ['enum' => ['a', 'b']], true];
+        yield 'enum miss' => ['c', ['enum' => ['a', 'b']], false];
+        yield 'enum with object member, key order irrelevant' => [['y' => 2, 'x' => 1], ['enum' => [['x' => 1, 'y' => 2]]], true];
+        yield 'enum does not type-juggle' => ['1', ['enum' => [1]], false];
+        yield 'const hit' => [42, ['const' => 42], true];
+        yield 'const miss int vs float' => [1.0, ['const' => 1], false];
+
+        // pattern — applies to strings only
+        yield 'pattern match' => ['abc', ['type' => 'string', 'pattern' => '^[a-c]+$'], true];
+        yield 'pattern miss' => ['abd', ['type' => 'string', 'pattern' => '^[a-c]+$'], false];
+        yield 'pattern ignores non-strings' => [7, ['pattern' => '^[a-c]+$'], true];
+        yield 'pattern with slash needs no delimiter escaping by the author' => ['a/b', ['pattern' => '^a/b$'], true];
+
+        // string lengths — code points, not bytes
+        yield 'minLength boundary hit' => ['ab', ['minLength' => 2], true];
+        yield 'minLength boundary miss' => ['a', ['minLength' => 2], false];
+        yield 'maxLength boundary hit' => ['ab', ['maxLength' => 2], true];
+        yield 'maxLength boundary miss' => ['abc', ['maxLength' => 2], false];
+        yield 'umlauts count as one' => ['äöüß', ['maxLength' => 4], true];
+
+        // numeric bounds — boundary twins for the mutation gate
+        yield 'minimum inclusive' => [5, ['minimum' => 5], true];
+        yield 'minimum miss' => [4, ['minimum' => 5], false];
+        yield 'maximum inclusive' => [5, ['maximum' => 5], true];
+        yield 'maximum miss' => [6, ['maximum' => 5], false];
+        yield 'exclusiveMinimum boundary rejected' => [5, ['exclusiveMinimum' => 5], false];
+        yield 'exclusiveMinimum above passes' => [6, ['exclusiveMinimum' => 5], true];
+        yield 'exclusiveMaximum boundary rejected' => [5, ['exclusiveMaximum' => 5], false];
+        yield 'exclusiveMaximum below passes' => [4, ['exclusiveMaximum' => 5], true];
+        yield 'multipleOf hit' => [9, ['multipleOf' => 3], true];
+        yield 'multipleOf miss' => [10, ['multipleOf' => 3], false];
+        yield 'multipleOf on integral float' => [9.0, ['multipleOf' => 3], true];
+        yield 'bounds ignore strings' => ['x', ['minimum' => 5], true];
+
+        // union types
+        yield 'union type first branch' => ['x', ['type' => ['string', 'null']], true];
+        yield 'union type second branch' => [null, ['type' => ['string', 'null']], true];
+        yield 'union type miss' => [5, ['type' => ['string', 'null']], false];
+        yield 'five point zero is not an integer' => [5.0, ['type' => 'integer'], false];
+
+        // arrays
+        yield 'items enforced on every element' => [[1, 2], ['type' => 'array', 'items' => ['type' => 'integer']], true];
+        yield 'items rejects a stray string' => [[1, 'x'], ['type' => 'array', 'items' => ['type' => 'integer']], false];
+        yield 'prefixItems positional' => [['a', 1], ['prefixItems' => [['type' => 'string'], ['type' => 'integer']]], true];
+        yield 'prefixItems positional miss' => [[1, 'a'], ['prefixItems' => [['type' => 'string'], ['type' => 'integer']]], false];
+        yield 'items constrains the rest after prefixItems' => [['a', 1, 2], ['prefixItems' => [['type' => 'string']], 'items' => ['type' => 'integer']], true];
+        yield 'rest violation after prefixItems' => [['a', 1, 'x'], ['prefixItems' => [['type' => 'string']], 'items' => ['type' => 'integer']], false];
+        yield 'minItems boundary' => [[1], ['minItems' => 1], true];
+        yield 'minItems miss' => [[], ['type' => 'array', 'minItems' => 1], false];
+        yield 'maxItems boundary' => [[1, 2], ['maxItems' => 2], true];
+        yield 'maxItems miss' => [[1, 2, 3], ['maxItems' => 2], false];
+        yield 'uniqueItems on scalars' => [[1, 2, 1], ['uniqueItems' => true], false];
+        yield 'uniqueItems key-order-insensitive on objects' => [[['a' => 1, 'b' => 2], ['b' => 2, 'a' => 1]], ['uniqueItems' => true], false];
+        yield 'uniqueItems does not juggle types' => [[1, '1'], ['uniqueItems' => true], true];
+
+        // objects
+        yield 'required present' => [['a' => 1], ['type' => 'object', 'required' => ['a']], true];
+        yield 'required missing' => [['b' => 1], ['type' => 'object', 'required' => ['a']], false];
+        yield 'required with explicit null passes, as in lenient' => [['a' => null], ['type' => 'object', 'required' => ['a']], true];
+        yield 'required on a non-object fails' => ['x', ['required' => ['a']], false];
+        yield 'additionalProperties false rejects extras' => [['a' => 1, 'b' => 2], ['type' => 'object', 'properties' => ['a' => ['type' => 'integer']], 'additionalProperties' => false], false];
+        yield 'additionalProperties false with only declared keys' => [['a' => 1], ['type' => 'object', 'properties' => ['a' => ['type' => 'integer']], 'additionalProperties' => false], true];
+        yield 'additionalProperties schema validates extras' => [['a' => 1, 'b' => 'x'], ['type' => 'object', 'properties' => ['a' => ['type' => 'integer']], 'additionalProperties' => ['type' => 'string']], true];
+        yield 'additionalProperties schema rejects wrong extras' => [['a' => 1, 'b' => 2], ['type' => 'object', 'properties' => ['a' => ['type' => 'integer']], 'additionalProperties' => ['type' => 'string']], false];
+        yield 'nested property enforcement' => [['a' => ['b' => 'x']], ['type' => 'object', 'properties' => ['a' => ['type' => 'object', 'required' => ['b'], 'properties' => ['b' => ['type' => 'string', 'minLength' => 1]]]]], true];
+
+        // combinators
+        yield 'oneOf exactly one' => ['x', ['oneOf' => [['type' => 'string'], ['type' => 'integer']]], true];
+        yield 'oneOf zero matches' => [null, ['oneOf' => [['type' => 'string'], ['type' => 'integer']]], false];
+        yield 'oneOf two matches rejected' => [5, ['oneOf' => [['type' => 'integer'], ['type' => 'number']]], false];
+        yield 'anyOf at least one' => [5, ['anyOf' => [['type' => 'integer'], ['type' => 'number']]], true];
+        yield 'anyOf none' => ['x', ['anyOf' => [['type' => 'integer'], ['type' => 'number']]], false];
+        yield 'allOf all must hold' => [5, ['allOf' => [['type' => 'integer'], ['minimum' => 5]]], true];
+        yield 'allOf one branch fails' => [4, ['allOf' => [['type' => 'integer'], ['minimum' => 5]]], false];
+        yield 'not inverts' => ['x', ['type' => 'string', 'not' => ['const' => 'y']], true];
+        yield 'not rejects the match' => ['y', ['type' => 'string', 'not' => ['const' => 'y']], false];
+
+        // the shared ambiguity, mirrored from lenient
+        yield 'empty array counts as object' => [[], ['type' => 'object'], true];
+        yield 'empty array counts as array too' => [[], ['type' => 'array'], true];
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     */
+    #[Test]
+    #[DataProvider('strictCases')]
+    public function strictEnforcesEveryKeywordInTheSubset(mixed $data, array $schema, bool $expected): void
+    {
+        self::assertSame($expected, $this->subject->validateStrict($data, $schema));
+    }
+
+    #[Test]
+    public function validateJsonStrictParsesBothSides(): void
+    {
+        self::assertTrue($this->subject->validateJsonStrict('{"a": "x"}', '{"type":"object","required":["a"],"properties":{"a":{"type":"string","enum":["x","y"]}}}'));
+        self::assertFalse($this->subject->validateJsonStrict('{"a": "z"}', '{"type":"object","properties":{"a":{"enum":["x","y"]}}}'));
+        self::assertFalse($this->subject->validateJsonStrict('not json', '{"type":"object"}'));
+        self::assertFalse($this->subject->validateJsonStrict('{}', 'not json'));
+    }
+
+    /**
+     * A pattern that stops matching because the engine gave up (backtrack
+     * limit) is a fail-closed rejection, not a warning. Asserted on outcome,
+     * not on timing.
+     */
+    #[Test]
+    public function aCatastrophicPatternFailsClosed(): void
+    {
+        $schema = ['type' => 'string', 'pattern' => '^(a+)+$'];
+
+        self::assertTrue($this->subject->supportsSchema($schema), 'the pattern itself compiles');
+        self::assertFalse(
+            $this->subject->validateStrict(str_repeat('a', 40) . 'b', $schema),
+            'the non-matching input is rejected regardless of how the engine got there',
+        );
+    }
+}

--- a/Tests/Unit/Service/Schema/JsonSchemaValidatorStrictTest.php
+++ b/Tests/Unit/Service/Schema/JsonSchemaValidatorStrictTest.php
@@ -51,6 +51,7 @@ final class JsonSchemaValidatorStrictTest extends TestCase
         yield 'additionalProperties as schema' => [['type' => 'object', 'additionalProperties' => ['type' => 'string']], true];
 
         yield 'empty schema is degenerate' => [[], false];
+        yield 'annotations alone assert nothing' => [['description' => 'x', 'title' => 't'], false];
         yield 'unknown keyword' => [['type' => 'string', 'if' => ['type' => 'string']], false];
         yield '$ref is out of subset' => [['$ref' => '#/definitions/x'], false];
         yield 'definitions are out of subset' => [['type' => 'object', 'definitions' => []], false];


### PR DESCRIPTION
[ADR-082](Documentation/Adr/Adr082StructuredOutputs.rst) shipped structured completions with a three-keyword matcher and a deliberate gap: `enum`, `pattern`, `oneOf` and friends were silently ignored. A caller who writes `enum` deserves enforcement or an error — never silent acceptance. [ADR-126](Documentation/Adr/Adr126StrictSchemaSubset.rst) closes the gap as a **named subset, fail-closed**: every subset keyword is enforced, any unknown keyword rejects the schema whole, so the contract is enforceable rather than aspirational. Full draft support — `$ref` resolution — stays deliberately out: that is where a subset becomes a JSON-Schema implementation, and ADR-082's no-runtime-dependency decision stands. The ROADMAP wording changes accordingly.

## The boundary that does not move

The lenient mode is byte-identical. The ADR-105 input gate, the resume paths and the evaluation grader keep their exact semantics — that is why strict is a separate method, not a flag. A fuzzy property test pins the invariant that ties the modes together: **anything strict accepts, lenient accepts.** The invariant is also why strict's primitive type matcher byte-mirrors the lenient one (`5.0` is not an integer here; the deviation is named in the ADR) — the adversarial plan review found the spec-correct version would have broken exactly this property.

## Never pay for an unsatisfiable schema

`completeStructured()` pre-flights the schema against the subset and throws with its own code (`1784500002`) **before the first provider call**. An out-of-subset schema fails for every possible response; discovering that after the repair round-trip would cost two paid requests. Also from the adversarial review, along with: `pattern` arrives delimiterless from the schema and is compiled as PCRE behind the error-handler idiom `Assertion` established; `multipleOf` is positive-integer only (float steps need epsilon arithmetic that lies about conformance); `enum`/`const`/`uniqueItems` compare JSON values with maps key-order-insensitive and no type juggling.

## Breaking

External `completeStructured()` callers whose schemas carry out-of-subset keywords now get an immediate typed error instead of silent partial validation. Annotations (`description`, `format`, `$schema`, …) stay accepted. **No in-repo caller is affected** — the method has zero production call sites today. CHANGELOG carries the entry.

## Tests

86 keyword cases including boundary twins for the mutation gate, the two fuzzy properties (strict-implies-lenient over ~15k random assertions, no-crash on arbitrary data), a fail-closed catastrophic-pattern case asserted on outcome rather than timing, and two new `CompletionServiceTest` cases (pre-flight throws before any provider call; enum+pattern violations trigger the repair round-trip). The lenient mode's nine existing tests are untouched.

Locally on PHP 8.2, canonical order (rector apply → cgl fix → both `-n` → PHPStan → unit → fuzzy → functional): all green — unit 5958, fuzzy 81, functional 1342.
