### PR TITLE
docs: mark the versioned API surface (ADR-127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Every class states its API stability: `@api` for the callable surface
+  (semver-covered, including every type its signatures mention), `@api`
+  extension points for the interfaces third parties implement (no new
+  abstract member within a major version), `@internal` for everything else.
+  `Documentation/Api/Stability.rst` states the promise in consumer terms;
+  ADR-127 records the rules. No runtime behaviour changes.
 - Tools from an external MCP server can be used in an agent run. An
   administrator configures a server, imports the catalogue it advertises and
   enables individual tools; import is the only network call outside a run and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,15 @@ ddev exec ".Build/bin/phpunit -c Build/phpunit.xml"
 ddev exec ".Build/bin/rector process --config=Build/rector/rector.php --dry-run"
 ```
 
+## API Stability Markers
+
+Every class-level docblock carries `@api`, `@api Extension point: …` or
+`@internal` (ADR-127, `Documentation/Api/Stability.rst`). New classes pick a
+marker at creation time. `@api` means the semver promise covers it — every
+type in its method signatures must be `@api` too. Extension-point interfaces
+must not gain a new abstract member within a major version. Everything else
+is `@internal`.
+
 ## Testing Requirements
 
 **All contributions MUST include appropriate tests.**

--- a/Classes/Attribute/AsLlmProvider.php
+++ b/Classes/Attribute/AsLlmProvider.php
@@ -36,6 +36,9 @@ use Attribute;
  * `tags: [{ name: nr_llm.provider, priority: N }]` in their own
  * Services.yaml — which remains fully supported and takes precedence when
  * both mechanisms are present on the same service.
+ *
+ * @api Extension point: third parties implement this. No new abstract
+ * member within a major version (ADR-127).
  */
 #[Attribute(Attribute::TARGET_CLASS)]
 final readonly class AsLlmProvider

--- a/Classes/Attribute/AsTranslator.php
+++ b/Classes/Attribute/AsTranslator.php
@@ -43,6 +43,9 @@ use Attribute;
  * Third-party translators outside that namespace should keep using the
  * legacy yaml-tag path — `tags: [{ name: nr_llm.translator }]` in their
  * own Services.yaml — which remains fully supported.
+ *
+ * @api Extension point: third parties implement this. No new abstract
+ * member within a major version (ADR-127).
  */
 #[Attribute(Attribute::TARGET_CLASS)]
 final readonly class AsTranslator

--- a/Classes/Command/CancelAgentRunCommand.php
+++ b/Classes/Command/CancelAgentRunCommand.php
@@ -36,6 +36,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
     name: 'nrllm:agent:cancel',
     description: 'Cancel an agent run that is still queued, running or awaiting a decision.',
 )]
+/**
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
 final class CancelAgentRunCommand extends Command
 {
     public function __construct(

--- a/Classes/Command/EvalRunCommand.php
+++ b/Classes/Command/EvalRunCommand.php
@@ -39,6 +39,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
     name: 'nrllm:eval:run',
     description: 'Run a golden prompt set against a model and report grading and regression.',
 )]
+/**
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
 final class EvalRunCommand extends Command
 {
     public function __construct(

--- a/Classes/Command/PurgeAiSessionsCommand.php
+++ b/Classes/Command/PurgeAiSessionsCommand.php
@@ -33,6 +33,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
     name: 'nrllm:session:purge',
     description: 'Delete conversation sessions inactive for longer than the configured retention window.',
 )]
+/**
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
 final class PurgeAiSessionsCommand extends Command
 {
     public function __construct(

--- a/Classes/Command/PurgeGovernanceCommand.php
+++ b/Classes/Command/PurgeGovernanceCommand.php
@@ -32,6 +32,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
     name: 'nrllm:governance:purge',
     description: 'Delete governance-event rows older than the configured retention window.',
 )]
+/**
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
 final class PurgeGovernanceCommand extends Command
 {
     public function __construct(

--- a/Classes/Command/PurgePrivacyDataCommand.php
+++ b/Classes/Command/PurgePrivacyDataCommand.php
@@ -44,6 +44,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
     name: 'nrllm:privacy:purge',
     description: 'Delete content-bearing rows (eval results, skill audit, telemetry, conversations, agent runs, governance events) past their retention window.',
 )]
+/**
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
 final class PurgePrivacyDataCommand extends Command
 {
     public function __construct(

--- a/Classes/Command/PurgeTelemetryCommand.php
+++ b/Classes/Command/PurgeTelemetryCommand.php
@@ -32,6 +32,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
     name: 'nrllm:telemetry:purge',
     description: 'Delete provider telemetry rows older than the configured retention window.',
 )]
+/**
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
 final class PurgeTelemetryCommand extends Command
 {
     public function __construct(

--- a/Classes/Command/ReapStaleAgentRunsCommand.php
+++ b/Classes/Command/ReapStaleAgentRunsCommand.php
@@ -47,6 +47,9 @@ use Throwable;
     name: 'nrllm:agent:reap',
     description: 'Reclaim or dead-letter queued agent runs whose worker lease has expired.',
 )]
+/**
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
 final class ReapStaleAgentRunsCommand extends Command
 {
     /** Default upper bound on runs handled per invocation, so one tick is bounded. */

--- a/Classes/Command/RetrievalEvalRunCommand.php
+++ b/Classes/Command/RetrievalEvalRunCommand.php
@@ -40,6 +40,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
     name: 'nrllm:eval:retrieval',
     description: 'Run a golden question set against a retriever and report hit rates and regression.',
 )]
+/**
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
 final class RetrievalEvalRunCommand extends Command
 {
     public function __construct(

--- a/Classes/Command/SetProviderApiKeyCommand.php
+++ b/Classes/Command/SetProviderApiKeyCommand.php
@@ -41,6 +41,9 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
     name: 'nrllm:provider:set-key',
     description: 'Store a provider API key read from STDIN and link it to the provider record.',
 )]
+/**
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
 final class SetProviderApiKeyCommand extends Command
 {
     /**

--- a/Classes/Controller/Backend/AgentRunController.php
+++ b/Classes/Controller/Backend/AgentRunController.php
@@ -50,6 +50,8 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
  * re-render that preserves the operator's raw input. The CSRF defence is the
  * backend module route token the `<f:form action=...>` URL carries (validated by
  * the RouteDispatcher), NOT `__trustedProperties`.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 #[AsController]
 final class AgentRunController extends ActionController

--- a/Classes/Controller/Backend/AnalyticsController.php
+++ b/Classes/Controller/Backend/AnalyticsController.php
@@ -25,6 +25,8 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
  * Read-only: all data comes from UsageAnalyticsService (never a repository
  * directly — see Tests/Architecture/ControllerLayerTest). The date range is a
  * GET parameter (`range`), so the page is a plain reload with no AJAX.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 #[AsController]
 final class AnalyticsController extends ActionController

--- a/Classes/Controller/Backend/BackendUserUidTrait.php
+++ b/Classes/Controller/Backend/BackendUserUidTrait.php
@@ -20,6 +20,8 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
  * Shared by the controllers that continue a suspended agent run
  * ({@see ToolPlaygroundController}, {@see AgentRunController}) so the exact
  * null-safe extraction lives in one place.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 trait BackendUserUidTrait
 {

--- a/Classes/Controller/Backend/ConfigurationController.php
+++ b/Classes/Controller/Backend/ConfigurationController.php
@@ -55,6 +55,8 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
  *
  * Uses TYPO3 FormEngine for record editing (TCA-based forms).
  * Custom actions for AJAX operations (toggle active, set default, test).
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 #[AsController]
 final class ConfigurationController extends ActionController

--- a/Classes/Controller/Backend/DefensiveLocalizationTrait.php
+++ b/Classes/Controller/Backend/DefensiveLocalizationTrait.php
@@ -23,6 +23,8 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
  * {@see RequiresBackendAdminTrait}: translate when a language service is
  * available, otherwise return the English fallback so the surface always carries
  * a human-readable string.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 trait DefensiveLocalizationTrait
 {

--- a/Classes/Controller/Backend/FormEngineUrlBuilder.php
+++ b/Classes/Controller/Backend/FormEngineUrlBuilder.php
@@ -17,6 +17,8 @@ use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
  * Centralizes the record_edit route construction every backend list
  * controller needs: edit and new-record links that send the user back
  * to the originating module after save/close.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final readonly class FormEngineUrlBuilder
 {

--- a/Classes/Controller/Backend/LlmModuleController.php
+++ b/Classes/Controller/Backend/LlmModuleController.php
@@ -32,6 +32,9 @@ use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
+/**
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
 #[AsController]
 final class LlmModuleController extends ActionController
 {

--- a/Classes/Controller/Backend/McpServerController.php
+++ b/Classes/Controller/Backend/McpServerController.php
@@ -33,6 +33,8 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
  * list; the AJAX route needs its own check because a backend route bypasses the
  * module's `access` setting (ADR-037), and the import is exactly the kind of
  * outbound action that must not be reachable without it.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 #[AsController]
 final class McpServerController extends ActionController

--- a/Classes/Controller/Backend/ModelController.php
+++ b/Classes/Controller/Backend/ModelController.php
@@ -42,6 +42,8 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
  *
  * Uses TYPO3 FormEngine for record editing (TCA-based forms).
  * Custom actions for AJAX operations (toggle active, test model, etc.).
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 #[AsController]
 final class ModelController extends ActionController

--- a/Classes/Controller/Backend/ModelDiscoveryController.php
+++ b/Classes/Controller/Backend/ModelDiscoveryController.php
@@ -33,6 +33,8 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
  * Reached only through AJAX routes, which dispatch outside the module route and
  * so bypass its `access => 'admin'`; every action calls denyNonAdmin() first
  * (ADR-037).
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 #[AsController]
 final class ModelDiscoveryController extends ActionController

--- a/Classes/Controller/Backend/ModelTestController.php
+++ b/Classes/Controller/Backend/ModelTestController.php
@@ -43,6 +43,8 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
  * and so bypasses its `access => 'admin'`; the action calls denyNonAdmin()
  * first (ADR-037). That matters more here than elsewhere — the probe decrypts
  * the provider's vault API key.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 #[AsController]
 final class ModelTestController extends ActionController

--- a/Classes/Controller/Backend/PresetController.php
+++ b/Classes/Controller/Backend/PresetController.php
@@ -36,6 +36,8 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
  *
  * Both actions are admin-gated via {@see RequiresBackendAdminTrait} FIRST
  * (ADR-037) — AJAX routes bypass the module's `access => admin` check.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 #[AsController]
 final class PresetController extends ActionController

--- a/Classes/Controller/Backend/PromptSnippetController.php
+++ b/Classes/Controller/Backend/PromptSnippetController.php
@@ -29,6 +29,8 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
  * by consuming extensions. See ADR-031.
  *
  * Uses TYPO3 FormEngine for record editing (TCA-based forms).
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 #[AsController]
 final class PromptSnippetController extends ActionController

--- a/Classes/Controller/Backend/ProviderController.php
+++ b/Classes/Controller/Backend/ProviderController.php
@@ -42,6 +42,8 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
  *
  * Uses TYPO3 FormEngine for record editing (TCA-based forms).
  * Custom actions for AJAX operations (toggle active, test connection).
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 #[AsController]
 final class ProviderController extends ActionController

--- a/Classes/Controller/Backend/RequiresBackendAdminTrait.php
+++ b/Classes/Controller/Backend/RequiresBackendAdminTrait.php
@@ -25,6 +25,8 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
  * provider test-calls that decrypt vault keys, task execution, and arbitrary
  * record reads. Each AJAX action calls {@see denyNonAdmin()} at its very top
  * so only a backend admin proceeds. See ADR-037.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 trait RequiresBackendAdminTrait
 {

--- a/Classes/Controller/Backend/Response/PlaygroundRunResponse.php
+++ b/Classes/Controller/Backend/Response/PlaygroundRunResponse.php
@@ -20,6 +20,8 @@ use Netresearch\NrLlm\Domain\ValueObject\RunStep;
  * Built in {@see \Netresearch\NrLlm\Controller\Backend\ToolPlaygroundController::runAction()}
  * from a {@see \Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult} and the
  * {@see \Netresearch\NrLlm\Service\Tool\RunTrace} steps.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final readonly class PlaygroundRunResponse
 {

--- a/Classes/Controller/Backend/SetupWizardController.php
+++ b/Classes/Controller/Backend/SetupWizardController.php
@@ -52,6 +52,8 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
  * Provides a guided setup experience for configuring LLM providers,
  * models, and configurations with auto-detection and LLM-assisted
  * configuration generation.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 #[AsController]
 final class SetupWizardController extends ActionController

--- a/Classes/Controller/Backend/SkillSourceController.php
+++ b/Classes/Controller/Backend/SkillSourceController.php
@@ -31,6 +31,9 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
+/**
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
 #[AsController]
 final class SkillSourceController extends ActionController
 {

--- a/Classes/Controller/Backend/SpecializedTestController.php
+++ b/Classes/Controller/Backend/SpecializedTestController.php
@@ -39,6 +39,8 @@ use TYPO3\CMS\Core\Http\JsonResponse;
  *
  * Registered in AjaxRoutes.php, so the module's `access => admin` does not
  * apply — every action calls denyNonAdmin() first (ADR-037).
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 #[AsController]
 final readonly class SpecializedTestController

--- a/Classes/Controller/Backend/TaskExecutionController.php
+++ b/Classes/Controller/Backend/TaskExecutionController.php
@@ -59,6 +59,8 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
  *
  * Constructor scope is narrow: only the dependencies these three
  * actions actually use.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 #[AsController]
 final class TaskExecutionController extends ActionController

--- a/Classes/Controller/Backend/TaskListController.php
+++ b/Classes/Controller/Backend/TaskListController.php
@@ -33,6 +33,8 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
  * Slice 13e of the `TaskController` split (ADR-027). Owns the
  * single `listAction()` that renders the grouped-by-category Task
  * dashboard.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 #[AsController]
 final class TaskListController extends ActionController

--- a/Classes/Controller/Backend/TaskRecordsController.php
+++ b/Classes/Controller/Backend/TaskRecordsController.php
@@ -45,6 +45,8 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
  * Single dependency: `RecordTableReaderInterface`. The controller
  * itself is a thin coordinator — DTO parse, delegate to the reader,
  * wrap in a typed Response.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 #[AsController]
 final class TaskRecordsController extends ActionController

--- a/Classes/Controller/Backend/TaskWizardController.php
+++ b/Classes/Controller/Backend/TaskWizardController.php
@@ -48,6 +48,8 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
  * Constructor scope is wider than the sibling controllers (the
  * wizard touches every relevant repository) but narrower than the
  * pre-13e god class.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 #[AsController]
 final class TaskWizardController extends ActionController

--- a/Classes/Controller/Backend/ToolController.php
+++ b/Classes/Controller/Backend/ToolController.php
@@ -31,6 +31,8 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
  * the agent loop) are separate modules. {@see listAction()} renders the tool
  * table; the AJAX {@see toggleToolAction()} persists the global override that
  * the fail-closed runtime gate then enforces on every later run (ADR-038).
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 #[AsController]
 final class ToolController extends ActionController

--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -67,6 +67,8 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
  * ActionController whose list action is the module entry point, gated to
  * admins via the module's ``access => admin`` and (for the AJAX actions) the
  * {@see RequiresBackendAdminTrait} guard.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 #[AsController]
 final class ToolPlaygroundController extends ActionController implements LoggerAwareInterface

--- a/Classes/DependencyInjection/ProviderCompilerPass.php
+++ b/Classes/DependencyInjection/ProviderCompilerPass.php
@@ -16,6 +16,9 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
+/**
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
 final class ProviderCompilerPass implements CompilerPassInterface
 {
     /**

--- a/Classes/DependencyInjection/TranslatorCompilerPass.php
+++ b/Classes/DependencyInjection/TranslatorCompilerPass.php
@@ -28,6 +28,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  * are left untouched to avoid double-registration. Third-party
  * translators outside the scan namespace can opt in via the legacy yaml
  * tag path, which remains the supported escape hatch.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final readonly class TranslatorCompilerPass implements CompilerPassInterface
 {

--- a/Classes/Domain/DTO/BudgetCheckResult.php
+++ b/Classes/Domain/DTO/BudgetCheckResult.php
@@ -15,6 +15,8 @@ namespace Netresearch\NrLlm\Domain\DTO;
  * When allowed() is false, the remaining fields describe which bucket
  * was tripped so the caller can surface a meaningful message without
  * re-computing anything.
+ *
+ * @api
  */
 final readonly class BudgetCheckResult
 {

--- a/Classes/Domain/DTO/CapabilitySet.php
+++ b/Classes/Domain/DTO/CapabilitySet.php
@@ -45,6 +45,8 @@ use Netresearch\NrLlm\Domain\Enum\ModelCapability;
  * problem. The factories `fromCsv()` / `fromArray()` are the safe
  * entry points for arbitrary input; they dedupe and skip unknown
  * tokens. Tests can construct directly when they need a known shape.
+ *
+ * @api
  */
 final readonly class CapabilitySet implements Countable, JsonSerializable
 {

--- a/Classes/Domain/DTO/FallbackChain.php
+++ b/Classes/Domain/DTO/FallbackChain.php
@@ -26,6 +26,8 @@ use JsonSerializable;
  *
  * The constructor itself does NOT normalise — it trusts already-sanitised
  * input (see the sanitize() docblock).
+ *
+ * @api
  */
 final readonly class FallbackChain implements JsonSerializable
 {

--- a/Classes/Domain/DTO/ModelSelectionCriteria.php
+++ b/Classes/Domain/DTO/ModelSelectionCriteria.php
@@ -17,6 +17,8 @@ use Netresearch\NrLlm\Domain\Enum\ModelCapability;
  *
  * Encapsulates the criteria used for dynamic model selection,
  * including required capabilities, provider types, and cost constraints.
+ *
+ * @api
  */
 final readonly class ModelSelectionCriteria implements JsonSerializable
 {

--- a/Classes/Domain/DTO/ProviderOptions.php
+++ b/Classes/Domain/DTO/ProviderOptions.php
@@ -51,6 +51,8 @@ use JsonSerializable;
  * TRUSTS its input. `fromArray()` and `fromJson()` are the safe entry
  * points for arbitrary input — they extract the well-known keys and
  * funnel the rest into `$extra` without throwing.
+ *
+ * @api
  */
 final readonly class ProviderOptions implements JsonSerializable
 {

--- a/Classes/Domain/Enum/AgentRunStatus.php
+++ b/Classes/Domain/Enum/AgentRunStatus.php
@@ -18,6 +18,8 @@ namespace Netresearch\NrLlm\Domain\Enum;
  * of the vocabulary from the outset so the human-in-the-loop and batch epics can
  * reuse this enum without a migration; the persistence layer added here only
  * ever writes RUNNING → COMPLETED/FAILED.
+ *
+ * @api
  */
 enum AgentRunStatus: string
 {

--- a/Classes/Domain/Enum/AgentRunTerminationReason.php
+++ b/Classes/Domain/Enum/AgentRunTerminationReason.php
@@ -18,6 +18,8 @@ namespace Netresearch\NrLlm\Domain\Enum;
  * `truncated = true`, and without a reason an operator cannot tell a cost
  * problem from a prompt problem — nor can a retry policy decide whether
  * retrying is pointless.
+ *
+ * @api
  */
 enum AgentRunTerminationReason: string
 {

--- a/Classes/Domain/Enum/MessageRole.php
+++ b/Classes/Domain/Enum/MessageRole.php
@@ -21,6 +21,8 @@ namespace Netresearch\NrLlm\Domain\Enum;
  * string call sites (`new ChatMessage('user', ...)`) keep working because
  * `ChatMessage` accepts `string|MessageRole` and normalises through this
  * enum at construction time.
+ *
+ * @api
  */
 enum MessageRole: string
 {

--- a/Classes/Domain/Enum/ModelCapability.php
+++ b/Classes/Domain/Enum/ModelCapability.php
@@ -13,6 +13,8 @@ namespace Netresearch\NrLlm\Domain\Enum;
  * Enum representing model capabilities.
  *
  * Used to define what features a model supports (chat, completion, embeddings, etc.).
+ *
+ * @api
  */
 enum ModelCapability: string
 {

--- a/Classes/Domain/Enum/ModelSelectionMode.php
+++ b/Classes/Domain/Enum/ModelSelectionMode.php
@@ -13,6 +13,8 @@ namespace Netresearch\NrLlm\Domain\Enum;
  * Enum representing model selection modes.
  *
  * Defines how a model is selected for a task (fixed model or criteria-based).
+ *
+ * @api
  */
 enum ModelSelectionMode: string
 {

--- a/Classes/Domain/Enum/ServiceAccountScope.php
+++ b/Classes/Domain/Enum/ServiceAccountScope.php
@@ -23,6 +23,8 @@ namespace Netresearch\NrLlm\Domain\Enum;
  *
  * Each case maps to exactly one enforcement point — there is no wildcard scope,
  * so a new automation must name precisely what it needs.
+ *
+ * @api
  */
 enum ServiceAccountScope: string
 {

--- a/Classes/Domain/Enum/SkillTrustLevel.php
+++ b/Classes/Domain/Enum/SkillTrustLevel.php
@@ -20,6 +20,8 @@ namespace Netresearch\NrLlm\Domain\Enum;
  * injection path enforce a configurable *minimum* trust fail-closed: an
  * unknown/invalid stored value resolves to the lowest rank, so it is gated out
  * whenever a minimum above `untrusted` is configured.
+ *
+ * @api
  */
 enum SkillTrustLevel: string
 {

--- a/Classes/Domain/Enum/SupportStatus.php
+++ b/Classes/Domain/Enum/SupportStatus.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\Enum;
 
+/**
+ * @api
+ */
 enum SupportStatus: string
 {
     case FULL = 'full';

--- a/Classes/Domain/Enum/ToolDataClass.php
+++ b/Classes/Domain/Enum/ToolDataClass.php
@@ -33,6 +33,8 @@ namespace Netresearch\NrLlm\Domain\Enum;
  *   backend users — a GDPR concern, not a secrecy level. Mapping them to
  *   {@see self::SECRET_ADJACENT} is conservative rather than semantically
  *   precise; a proper PERSONAL_DATA concept needs its own axis, not a rank.
+ *
+ * @api
  */
 enum ToolDataClass: string
 {

--- a/Classes/Domain/Enum/TrustZone.php
+++ b/Classes/Domain/Enum/TrustZone.php
@@ -24,6 +24,8 @@ namespace Netresearch\NrLlm\Domain\Enum;
  * per-installation matrix: a 6x4 grid is configuration nobody gets right, and
  * an operator who disagrees with a ceiling can move the provider to another
  * zone.
+ *
+ * @api
  */
 enum TrustZone: string
 {

--- a/Classes/Domain/Model/AdapterType.php
+++ b/Classes/Domain/Model/AdapterType.php
@@ -14,6 +14,8 @@ namespace Netresearch\NrLlm\Domain\Model;
  *
  * Each case represents a distinct API provider with its own endpoint format,
  * authentication method, and request/response structure.
+ *
+ * @api
  */
 enum AdapterType: string
 {

--- a/Classes/Domain/Model/CompletionResponse.php
+++ b/Classes/Domain/Model/CompletionResponse.php
@@ -13,6 +13,8 @@ use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 
 /**
  * Response object for text completion requests.
+ *
+ * @api
  */
 final readonly class CompletionResponse
 {

--- a/Classes/Domain/Model/EmbeddingResponse.php
+++ b/Classes/Domain/Model/EmbeddingResponse.php
@@ -13,6 +13,8 @@ use Netresearch\NrLlm\Exception\InvalidArgumentException;
 
 /**
  * Response object for embedding requests.
+ *
+ * @api
  */
 final readonly class EmbeddingResponse
 {

--- a/Classes/Domain/Model/LlmConfiguration.php
+++ b/Classes/Domain/Model/LlmConfiguration.php
@@ -24,6 +24,8 @@ use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
  * usage limits, and access control.
  *
  * Uses the three-tier model: Configuration → Model → Provider.
+ *
+ * @api
  */
 class LlmConfiguration extends AbstractEntity
 {

--- a/Classes/Domain/Model/Model.php
+++ b/Classes/Domain/Model/Model.php
@@ -18,6 +18,8 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
  *
  * Represents an available LLM model with capabilities, pricing, and provider relation.
  * Models can be reused across multiple configurations.
+ *
+ * @api
  */
 class Model extends AbstractEntity
 {

--- a/Classes/Domain/Model/Provider.php
+++ b/Classes/Domain/Model/Provider.php
@@ -24,6 +24,8 @@ use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
  *
  * Represents an API provider connection with endpoint, credentials, and adapter type.
  * Supports multiple provider instances of the same type (e.g., openai-prod, openai-dev).
+ *
+ * @api
  */
 class Provider extends AbstractEntity
 {

--- a/Classes/Domain/Model/Skill.php
+++ b/Classes/Domain/Model/Skill.php
@@ -13,6 +13,9 @@ use Netresearch\NrLlm\Domain\Enum\SkillTrustLevel;
 use Netresearch\NrLlm\Domain\Enum\SupportStatus;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
+/**
+ * @api
+ */
 class Skill extends AbstractEntity
 {
     protected int $source = 0;

--- a/Classes/Domain/Model/TranslationResult.php
+++ b/Classes/Domain/Model/TranslationResult.php
@@ -11,6 +11,8 @@ namespace Netresearch\NrLlm\Domain\Model;
 
 /**
  * Result object for translation requests.
+ *
+ * @api
  */
 final readonly class TranslationResult
 {

--- a/Classes/Domain/Model/UsageStatistics.php
+++ b/Classes/Domain/Model/UsageStatistics.php
@@ -11,6 +11,8 @@ namespace Netresearch\NrLlm\Domain\Model;
 
 /**
  * Token usage statistics from LLM requests.
+ *
+ * @api
  */
 final readonly class UsageStatistics
 {

--- a/Classes/Domain/Model/VisionResponse.php
+++ b/Classes/Domain/Model/VisionResponse.php
@@ -11,6 +11,8 @@ namespace Netresearch\NrLlm\Domain\Model;
 
 /**
  * Response object for vision/image analysis requests.
+ *
+ * @api
  */
 final readonly class VisionResponse
 {

--- a/Classes/Domain/Repository/LlmConfigurationRepository.php
+++ b/Classes/Domain/Repository/LlmConfigurationRepository.php
@@ -18,6 +18,8 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  * Repository for LlmConfiguration domain model.
  *
  * @extends Repository<LlmConfiguration>
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 class LlmConfigurationRepository extends Repository
 {

--- a/Classes/Domain/Repository/ModelRepository.php
+++ b/Classes/Domain/Repository/ModelRepository.php
@@ -23,6 +23,8 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  * Repository for Model domain model.
  *
  * @extends Repository<Model>
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 class ModelRepository extends Repository
 {

--- a/Classes/Domain/Repository/PromptSnippetRepository.php
+++ b/Classes/Domain/Repository/PromptSnippetRepository.php
@@ -17,6 +17,8 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  * Repository for PromptSnippet domain model.
  *
  * @extends Repository<PromptSnippet>
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 class PromptSnippetRepository extends Repository
 {

--- a/Classes/Domain/Repository/ProviderRepository.php
+++ b/Classes/Domain/Repository/ProviderRepository.php
@@ -18,6 +18,8 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  * Repository for Provider domain model.
  *
  * @extends Repository<Provider>
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 class ProviderRepository extends Repository
 {

--- a/Classes/Domain/Repository/SkillRepository.php
+++ b/Classes/Domain/Repository/SkillRepository.php
@@ -15,6 +15,8 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * @extends Repository<Skill>
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 class SkillRepository extends Repository
 {

--- a/Classes/Domain/Repository/SkillSourceRepository.php
+++ b/Classes/Domain/Repository/SkillSourceRepository.php
@@ -15,6 +15,8 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * @extends Repository<SkillSource>
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final class SkillSourceRepository extends Repository
 {

--- a/Classes/Domain/Repository/TaskRepository.php
+++ b/Classes/Domain/Repository/TaskRepository.php
@@ -20,6 +20,8 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  * Repository for Task domain model.
  *
  * @extends Repository<Task>
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 class TaskRepository extends Repository
 {

--- a/Classes/Domain/Repository/UserBudgetRepository.php
+++ b/Classes/Domain/Repository/UserBudgetRepository.php
@@ -14,6 +14,8 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * @extends Repository<UserBudget>
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 class UserBudgetRepository extends Repository
 {

--- a/Classes/Domain/ValueObject/AgentRun.php
+++ b/Classes/Domain/ValueObject/AgentRun.php
@@ -18,6 +18,8 @@ use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
  * The immutable read model of one run of {@see \Netresearch\NrLlm\Service\Tool\ToolLoopService}.
  * The mutable in-flight counterpart is {@see \Netresearch\NrLlm\Service\Tool\AgentRunHandle},
  * which the persister threads through a run before this read model exists.
+ *
+ * @api
  */
 final readonly class AgentRun
 {

--- a/Classes/Domain/ValueObject/AiActorContext.php
+++ b/Classes/Domain/ValueObject/AiActorContext.php
@@ -24,6 +24,8 @@ use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
  * Passing the context explicitly keeps the decision auditable and testable, and
  * lets a queue consumer act on behalf of the user who queued the work rather
  * than inheriting whatever ambient user happens to be logged in.
+ *
+ * @api
  */
 final readonly class AiActorContext
 {

--- a/Classes/Domain/ValueObject/AiSession.php
+++ b/Classes/Domain/ValueObject/AiSession.php
@@ -16,6 +16,8 @@ namespace Netresearch\NrLlm\Domain\ValueObject;
  * The immutable read model of one multi-turn conversation. Messages live in
  * `tx_nrllm_ai_session_message` and are read as {@see AiSessionMessage} value
  * objects; this row carries the session's identity, owner and activity summary.
+ *
+ * @api
  */
 final readonly class AiSession
 {

--- a/Classes/Domain/ValueObject/ChatMessage.php
+++ b/Classes/Domain/ValueObject/ChatMessage.php
@@ -33,6 +33,8 @@ use stdClass;
  * it is sourced from the enum's value, so the two cannot drift. New
  * code is encouraged to read `getRole(): MessageRole` instead of the
  * string field.
+ *
+ * @api
  */
 final readonly class ChatMessage implements JsonSerializable
 {

--- a/Classes/Domain/ValueObject/ContextFitResult.php
+++ b/Classes/Domain/ValueObject/ContextFitResult.php
@@ -19,6 +19,8 @@ namespace Netresearch\NrLlm\Domain\ValueObject;
  * true when even that floor still exceeds the budget: the caller must NOT send
  * it (a provider 4xx), and stops the run on
  * {@see \Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason::CONTEXT_TRUNCATED}.
+ *
+ * @api
  */
 final readonly class ContextFitResult
 {

--- a/Classes/Domain/ValueObject/GuardrailResult.php
+++ b/Classes/Domain/ValueObject/GuardrailResult.php
@@ -20,6 +20,8 @@ use Netresearch\NrLlm\Domain\Enum\GuardrailVerdict;
  * Built through the named constructors so a guardrail never has to remember
  * which fields a verdict needs. A null `redactedThinking` on a REDACT means
  * "leave the thinking as-is".
+ *
+ * @api
  */
 final readonly class GuardrailResult
 {

--- a/Classes/Domain/ValueObject/SuspendedRunState.php
+++ b/Classes/Domain/ValueObject/SuspendedRunState.php
@@ -26,6 +26,8 @@ namespace Netresearch\NrLlm\Domain\ValueObject;
  * ({@see ChatMessage::toArray()} / {@see ToolCall::toArray()}) form so the state
  * is a plain JSON-encodable structure; {@see self::toolCalls()} rebuilds the
  * typed calls for execution on resume.
+ *
+ * @api
  */
 final readonly class SuspendedRunState
 {

--- a/Classes/Domain/ValueObject/ToolArtifact.php
+++ b/Classes/Domain/ValueObject/ToolArtifact.php
@@ -24,6 +24,8 @@ use Netresearch\NrLlm\Domain\Enum\ArtifactType;
  * and byte-bounds them before egress. An emitting tool MUST apply the SAME
  * redaction to `$data` that it applies to its text output — an artifact must
  * never re-expose a field the text path deliberately withheld.
+ *
+ * @api
  */
 final readonly class ToolArtifact
 {

--- a/Classes/Domain/ValueObject/ToolCall.php
+++ b/Classes/Domain/ValueObject/ToolCall.php
@@ -28,6 +28,8 @@ use Netresearch\NrLlm\Exception\InvalidArgumentException;
  * preserved verbatim by `toArray()` so the migration of providers and
  * `CompletionResponse` can land in a follow-up slice without
  * disturbing this data model.
+ *
+ * @api
  */
 final readonly class ToolCall implements JsonSerializable
 {

--- a/Classes/Domain/ValueObject/ToolLoopResult.php
+++ b/Classes/Domain/ValueObject/ToolLoopResult.php
@@ -24,6 +24,8 @@ use Netresearch\NrLlm\Domain\Model\UsageStatistics;
  * answer is incomplete, the reason says what made it so. An iteration cap and
  * an exhausted budget both truncate, and only the reason tells them apart
  * (ADR-092).
+ *
+ * @api
  */
 final readonly class ToolLoopResult
 {

--- a/Classes/Domain/ValueObject/ToolPolicyDecision.php
+++ b/Classes/Domain/ValueObject/ToolPolicyDecision.php
@@ -20,6 +20,8 @@ use Netresearch\NrLlm\Domain\Enum\TrustZone;
  * playground and the run trace can tell an administrator why a tool they ticked
  * did not appear. Without it, a tool silently missing from a run looks like a
  * bug in the checkbox.
+ *
+ * @api
  */
 final readonly class ToolPolicyDecision
 {

--- a/Classes/Domain/ValueObject/ToolResult.php
+++ b/Classes/Domain/ValueObject/ToolResult.php
@@ -22,6 +22,8 @@ namespace Netresearch\NrLlm\Domain\ValueObject;
  *   before egress.
  *
  * Fail-closed: {@see self::error()} carries NO artifacts.
+ *
+ * @api
  */
 final readonly class ToolResult
 {

--- a/Classes/Domain/ValueObject/ToolSpec.php
+++ b/Classes/Domain/ValueObject/ToolSpec.php
@@ -32,6 +32,8 @@ use stdClass;
  * Pairs with :php:`ToolCall` on the response side: callers declare
  * `ToolSpec` instances; the model returns `ToolCall` instances pointing
  * back at one of those specs by name.
+ *
+ * @api
  */
 final readonly class ToolSpec implements JsonSerializable
 {

--- a/Classes/Exception/AccessDeniedException.php
+++ b/Classes/Exception/AccessDeniedException.php
@@ -13,5 +13,7 @@ use RuntimeException;
 
 /**
  * Exception thrown when access to an LLM configuration is denied.
+ *
+ * @api
  */
 class AccessDeniedException extends RuntimeException implements NrLlmExceptionInterface {}

--- a/Classes/Exception/BudgetExceededException.php
+++ b/Classes/Exception/BudgetExceededException.php
@@ -19,6 +19,8 @@ use Throwable;
  * Carries the full BudgetCheckResult so consumers (controllers, logs,
  * flash messages) can surface which bucket tripped, the current usage,
  * and the limit without re-running the check.
+ *
+ * @api
  */
 final class BudgetExceededException extends RuntimeException implements NrLlmExceptionInterface
 {

--- a/Classes/Exception/ConfigurationInactiveException.php
+++ b/Classes/Exception/ConfigurationInactiveException.php
@@ -13,5 +13,7 @@ use RuntimeException;
 
 /**
  * Exception thrown when an LLM configuration exists but is deactivated.
+ *
+ * @api
  */
 class ConfigurationInactiveException extends RuntimeException implements NrLlmExceptionInterface {}

--- a/Classes/Exception/ConfigurationNotFoundException.php
+++ b/Classes/Exception/ConfigurationNotFoundException.php
@@ -13,5 +13,7 @@ use RuntimeException;
 
 /**
  * Exception thrown when an LLM configuration cannot be found.
+ *
+ * @api
  */
 class ConfigurationNotFoundException extends RuntimeException implements NrLlmExceptionInterface {}

--- a/Classes/Exception/ContextTruncatedException.php
+++ b/Classes/Exception/ContextTruncatedException.php
@@ -21,6 +21,8 @@ use RuntimeException;
  * {@see \Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason::CONTEXT_TRUNCATED}
  * — a legible terminal state instead of a misclassified provider 4xx. Carries
  * the {@see ContextFitResult} for observability.
+ *
+ * @api
  */
 final class ContextTruncatedException extends RuntimeException implements NrLlmExceptionInterface
 {

--- a/Classes/Exception/GuardrailApprovalRequiredException.php
+++ b/Classes/Exception/GuardrailApprovalRequiredException.php
@@ -19,6 +19,8 @@ use Throwable;
  * response is withheld from automatic use but not rejected — a consumer with a
  * run/review context catches this to route it to approval (the Epic-D /
  * review-queue seam), rather than to an error.
+ *
+ * @api
  */
 final class GuardrailApprovalRequiredException extends RuntimeException implements GuardrailPolicyException
 {

--- a/Classes/Exception/GuardrailPolicyException.php
+++ b/Classes/Exception/GuardrailPolicyException.php
@@ -21,5 +21,7 @@ namespace Netresearch\NrLlm\Exception;
  * records a policy exception as a SUCCESSFUL provider run — the provider
  * produced a response; the guardrail simply refused to release it — so guardrail
  * denials never distort the provider failure-rate.
+ *
+ * @api
  */
 interface GuardrailPolicyException extends NrLlmExceptionInterface {}

--- a/Classes/Exception/GuardrailViolationException.php
+++ b/Classes/Exception/GuardrailViolationException.php
@@ -18,6 +18,8 @@ use Throwable;
  * Carries the denying guardrail's class so operators can tell which policy
  * tripped; the message is the guardrail's reason. Mirrors
  * {@see BudgetExceededException} — a typed, catchable pipeline denial.
+ *
+ * @api
  */
 final class GuardrailViolationException extends RuntimeException implements GuardrailPolicyException
 {

--- a/Classes/Exception/InvalidArgumentException.php
+++ b/Classes/Exception/InvalidArgumentException.php
@@ -11,5 +11,7 @@ namespace Netresearch\NrLlm\Exception;
 
 /**
  * Exception thrown when invalid arguments are provided to services.
+ *
+ * @api
  */
 class InvalidArgumentException extends \InvalidArgumentException implements NrLlmExceptionInterface {}

--- a/Classes/Exception/NrLlmExceptionInterface.php
+++ b/Classes/Exception/NrLlmExceptionInterface.php
@@ -21,5 +21,7 @@ use Throwable;
  * `AccessDeniedException`, `ConfigurationNotFoundException`,
  * `InvalidArgumentException`, ...) — an enumeration that silently goes
  * stale whenever a new exception type is added (ADR-053).
+ *
+ * @api
  */
 interface NrLlmExceptionInterface extends Throwable {}

--- a/Classes/Form/Element/ModelIdElement.php
+++ b/Classes/Form/Element/ModelIdElement.php
@@ -20,6 +20,8 @@ use TYPO3\CMS\Core\Utility\StringUtility;
  * Renders an input field with a "Fetch Models" button and a dropdown
  * that populates from the selected provider's API. When a model is
  * selected, capabilities, context_length, and pricing are auto-filled.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final class ModelIdElement extends AbstractFormElement
 {

--- a/Classes/Form/FieldWizard/ModelConstraintsWizard.php
+++ b/Classes/Form/FieldWizard/ModelConstraintsWizard.php
@@ -18,6 +18,8 @@ use TYPO3\CMS\Core\Page\JavaScriptModuleInstruction;
  *
  * Injects the ConfigurationConstraints JS module and provides
  * the AJAX URL for fetching model-specific parameter constraints.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final class ModelConstraintsWizard extends AbstractNode
 {

--- a/Classes/Form/Tca/GuardrailItems.php
+++ b/Classes/Form/Tca/GuardrailItems.php
@@ -22,6 +22,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * be un-selected. Values already stored on the record but no longer known (an
  * uninstalled extension's guardrail) are appended so the stored selection stays
  * visible and editable rather than silently dropped.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final class GuardrailItems
 {

--- a/Classes/Form/Tca/ToolGroupItems.php
+++ b/Classes/Form/Tca/ToolGroupItems.php
@@ -21,6 +21,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * tools' groups appear automatically. Values already stored on the record but
  * no longer known (an uninstalled extension's group) are appended so the
  * stored selection stays visible and editable rather than silently dropped.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final class ToolGroupItems
 {

--- a/Classes/Hook/ProviderEndpointNormalizationHook.php
+++ b/Classes/Hook/ProviderEndpointNormalizationHook.php
@@ -27,6 +27,8 @@ use TYPO3\CMS\Core\Utility\MathUtility;
  * request URLs as ``baseUrl + '/' + path`` and do not add the version segment
  * themselves. This DataHandler hook makes the manual write path store the same
  * canonical base URL as the wizard (#300).
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final class ProviderEndpointNormalizationHook
 {

--- a/Classes/Provider/Contract/DocumentCapableInterface.php
+++ b/Classes/Provider/Contract/DocumentCapableInterface.php
@@ -9,6 +9,10 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Contract;
 
+/**
+ * @api Extension point: third parties implement this. No new abstract
+ * member within a major version (ADR-127).
+ */
 interface DocumentCapableInterface
 {
     public function supportsDocuments(): bool;

--- a/Classes/Provider/Contract/ProviderInterface.php
+++ b/Classes/Provider/Contract/ProviderInterface.php
@@ -15,6 +15,10 @@ use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 
+/**
+ * @api Extension point: third parties implement this. No new abstract
+ * member within a major version (ADR-127).
+ */
 interface ProviderInterface
 {
     public function getName(): string;

--- a/Classes/Provider/Contract/StreamingCapableInterface.php
+++ b/Classes/Provider/Contract/StreamingCapableInterface.php
@@ -12,6 +12,10 @@ namespace Netresearch\NrLlm\Provider\Contract;
 use Generator;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 
+/**
+ * @api Extension point: third parties implement this. No new abstract
+ * member within a major version (ADR-127).
+ */
 interface StreamingCapableInterface
 {
     /**

--- a/Classes/Provider/Contract/ToolCapableInterface.php
+++ b/Classes/Provider/Contract/ToolCapableInterface.php
@@ -13,6 +13,10 @@ use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 
+/**
+ * @api Extension point: third parties implement this. No new abstract
+ * member within a major version (ADR-127).
+ */
 interface ToolCapableInterface
 {
     /**

--- a/Classes/Provider/Contract/VisionCapableInterface.php
+++ b/Classes/Provider/Contract/VisionCapableInterface.php
@@ -12,6 +12,10 @@ namespace Netresearch\NrLlm\Provider\Contract;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
 
+/**
+ * @api Extension point: third parties implement this. No new abstract
+ * member within a major version (ADR-127).
+ */
 interface VisionCapableInterface
 {
     /**

--- a/Classes/Provider/Exception/CircuitOpenException.php
+++ b/Classes/Provider/Exception/CircuitOpenException.php
@@ -20,6 +20,8 @@ namespace Netresearch\NrLlm\Provider\Exception;
  * to the next configuration in the fallback chain rather than surfacing as a
  * hard error — the whole point of tripping fast is to free the request to try a
  * healthy provider.
+ *
+ * @api
  */
 final class CircuitOpenException extends ProviderException
 {

--- a/Classes/Provider/Exception/FallbackChainExhaustedException.php
+++ b/Classes/Provider/Exception/FallbackChainExhaustedException.php
@@ -15,6 +15,8 @@ use Throwable;
  * Thrown when every configuration in a fallback chain (primary + fallbacks)
  * failed with a retryable error. Carries per-attempt errors so callers can
  * reason about the full failure sequence.
+ *
+ * @api
  */
 final class FallbackChainExhaustedException extends ProviderException
 {

--- a/Classes/Provider/Exception/ProviderAuthenticationException.php
+++ b/Classes/Provider/Exception/ProviderAuthenticationException.php
@@ -18,5 +18,7 @@ namespace Netresearch\NrLlm\Provider\Exception;
  * message text or the raw `httpStatus`. All typed fields (`httpStatus`,
  * `responseBody`, `endpoint`) and `getCode() === 401` are inherited unchanged,
  * so existing `catch (ProviderResponseException)` handlers keep matching.
+ *
+ * @api
  */
 final class ProviderAuthenticationException extends ProviderResponseException {}

--- a/Classes/Provider/Exception/ProviderConfigurationException.php
+++ b/Classes/Provider/Exception/ProviderConfigurationException.php
@@ -9,4 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Exception;
 
+/**
+ * @api
+ */
 final class ProviderConfigurationException extends ProviderException {}

--- a/Classes/Provider/Exception/ProviderConnectionException.php
+++ b/Classes/Provider/Exception/ProviderConnectionException.php
@@ -9,4 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Exception;
 
+/**
+ * @api
+ */
 final class ProviderConnectionException extends ProviderException {}

--- a/Classes/Provider/Exception/ProviderException.php
+++ b/Classes/Provider/Exception/ProviderException.php
@@ -12,4 +12,7 @@ namespace Netresearch\NrLlm\Provider\Exception;
 use Netresearch\NrLlm\Exception\NrLlmExceptionInterface;
 use RuntimeException;
 
+/**
+ * @api
+ */
 class ProviderException extends RuntimeException implements NrLlmExceptionInterface {}

--- a/Classes/Provider/Exception/ProviderRateLimitException.php
+++ b/Classes/Provider/Exception/ProviderRateLimitException.php
@@ -19,5 +19,7 @@ namespace Netresearch\NrLlm\Provider\Exception;
  * `responseBody`, `endpoint`) are inherited unchanged, and — critically —
  * `getCode() === 429` is preserved, so the retry/fallback and circuit-breaker
  * middleware that key off code 429 keep firing.
+ *
+ * @api
  */
 final class ProviderRateLimitException extends ProviderResponseException {}

--- a/Classes/Provider/Exception/ProviderResponseException.php
+++ b/Classes/Provider/Exception/ProviderResponseException.php
@@ -46,6 +46,8 @@ use Throwable;
  * the exception class, while `catch (ProviderResponseException)` still catches
  * every non-2xx decoded response (ADR-080). The constructor and typed fields
  * are inherited unchanged.
+ *
+ * @api
  */
 class ProviderResponseException extends ProviderException
 {

--- a/Classes/Provider/Exception/UnsupportedFeatureException.php
+++ b/Classes/Provider/Exception/UnsupportedFeatureException.php
@@ -9,4 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Exception;
 
+/**
+ * @api
+ */
 final class UnsupportedFeatureException extends ProviderException {}

--- a/Classes/Provider/Middleware/ProviderCallContext.php
+++ b/Classes/Provider/Middleware/ProviderCallContext.php
@@ -27,6 +27,8 @@ use Symfony\Component\Uid\Uuid;
  * string fields are the source of truth for telemetry; when it is present they
  * are ignored and the entity wins. {@see FallbackMiddleware} swaps the
  * configuration on a retryable failure via {@see self::withConfiguration()}.
+ *
+ * @api
  */
 final readonly class ProviderCallContext
 {

--- a/Classes/Provider/Middleware/ProviderMiddlewareInterface.php
+++ b/Classes/Provider/Middleware/ProviderMiddlewareInterface.php
@@ -34,6 +34,9 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * different typed responses (CompletionResponse, EmbeddingResponse,
  * VisionResponse, Generator for streaming, etc.). Concrete middleware should
  * keep the value unchanged unless its purpose is to transform it.
+ *
+ * @api Extension point: third parties implement this. No new abstract
+ * member within a major version (ADR-127).
  */
 #[AutoconfigureTag(name: self::TAG_NAME)]
 interface ProviderMiddlewareInterface

--- a/Classes/Provider/Middleware/ProviderOperation.php
+++ b/Classes/Provider/Middleware/ProviderOperation.php
@@ -15,6 +15,8 @@ namespace Netresearch\NrLlm\Provider\Middleware;
  * Middleware uses this to decide whether it applies (e.g. a cache middleware
  * that caches deterministic embeddings but passes through stateful chat
  * completions) and to emit meaningful log / trace / metric labels.
+ *
+ * @api
  */
 enum ProviderOperation: string
 {

--- a/Classes/Provider/Middleware/Usage/ProviderUsageRecord.php
+++ b/Classes/Provider/Middleware/Usage/ProviderUsageRecord.php
@@ -19,6 +19,8 @@ namespace Netresearch\NrLlm\Provider\Middleware\Usage;
  * so the middleware forwards it verbatim — the extractor owns the operation-
  * specific accounting (image count, characters, audio seconds, cost), the
  * middleware owns the single write.
+ *
+ * @api
  */
 final readonly class ProviderUsageRecord
 {

--- a/Classes/Provider/Middleware/Usage/UsageMetricsExtractorInterface.php
+++ b/Classes/Provider/Middleware/Usage/UsageMetricsExtractorInterface.php
@@ -28,6 +28,9 @@ use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
  * detection, or a metadata lookup) yields no record — {@see supports()} or
  * {@see extract()} returns false / null — so nothing is recorded, exactly as
  * before.
+ *
+ * @api Extension point: third parties implement this. No new abstract
+ * member within a major version (ADR-127).
  */
 interface UsageMetricsExtractorInterface
 {

--- a/Classes/Provider/ProviderAdapterRegistry.php
+++ b/Classes/Provider/ProviderAdapterRegistry.php
@@ -33,6 +33,8 @@ use TYPO3\CMS\Core\SingletonInterface;
  * `$adapterOverrides` argument passed at construction time. Production
  * code uses the empty default; tests and edge-case extension scenarios
  * pass an override map. See audit 2026-04-23 REC #3.
+ *
+ * @api
  */
 final class ProviderAdapterRegistry implements ProviderAdapterRegistryInterface, SingletonInterface
 {

--- a/Classes/Provider/ProviderAdapterRegistryInterface.php
+++ b/Classes/Provider/ProviderAdapterRegistryInterface.php
@@ -27,6 +27,8 @@ use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
  * REC #3 ("lock the registry, no public mutator"). Adding a new
  * built-in adapter type means adding a case to {@see \Netresearch\NrLlm\Domain\Model\AdapterType}
  * and an entry to `ProviderAdapterRegistry::ADAPTER_CLASS_MAP`.
+ *
+ * @api
  */
 interface ProviderAdapterRegistryInterface
 {

--- a/Classes/Service/Agent/AgentRunRequest.php
+++ b/Classes/Service/Agent/AgentRunRequest.php
@@ -22,6 +22,8 @@ use Netresearch\NrLlm\Service\Tool\RunAugmentation;
  * the queue epic lands — a worker rehydrating a queued request. Deliberately a
  * plain value object so it can later be serialised for queued execution without
  * changing the runtime interface.
+ *
+ * @api
  */
 final readonly class AgentRunRequest
 {

--- a/Classes/Service/Agent/AgentRunResult.php
+++ b/Classes/Service/Agent/AgentRunResult.php
@@ -35,6 +35,8 @@ use Throwable;
  * `steps` carries the trace recorded up to the end of the segment on every
  * outcome. `runUuid` is '' when the run could not be persisted (the run still
  * executed, unrecorded — the persister's fail-soft contract).
+ *
+ * @api
  */
 final readonly class AgentRunResult
 {

--- a/Classes/Service/Agent/AgentRuntimeInterface.php
+++ b/Classes/Service/Agent/AgentRuntimeInterface.php
@@ -31,6 +31,8 @@ use Netresearch\NrLlm\Service\Agent\Exception\AgentRuntimeException;
  * {@see \Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface} stays public
  * for consumers that want the bare loop without persistence or approval; this
  * runtime is the preferred surface.
+ *
+ * @api
  */
 interface AgentRuntimeInterface
 {

--- a/Classes/Service/Agent/ApprovalDecision.php
+++ b/Classes/Service/Agent/ApprovalDecision.php
@@ -19,6 +19,8 @@ namespace Netresearch\NrLlm\Service\Agent;
  * best-effort, like every event write — so who approved or denied, and when, is
  * part of the run's audit stream. Deliberately no free-text note: the event
  * stream is privacy-filtered (ADR-064) and a prose field would bypass that.
+ *
+ * @api
  */
 final readonly class ApprovalDecision
 {

--- a/Classes/Service/Agent/Exception/AgentRuntimeException.php
+++ b/Classes/Service/Agent/Exception/AgentRuntimeException.php
@@ -20,6 +20,8 @@ use RuntimeException;
  * concurrency claim. Run OUTCOMES (completion, suspension, guardrail block,
  * failure) are never exceptions; they come back as a settled
  * {@see \Netresearch\NrLlm\Service\Agent\AgentRunResult}.
+ *
+ * @api
  */
 abstract class AgentRuntimeException extends RuntimeException
 {

--- a/Classes/Service/Agent/InputSubmission.php
+++ b/Classes/Service/Agent/InputSubmission.php
@@ -22,6 +22,8 @@ namespace Netresearch\NrLlm\Service\Agent;
  *
  * Persisted only as an {@see \Netresearch\NrLlm\Domain\Enum\AgentEventKind::INPUT}
  * event recording ``{submittedBy: int}`` — never the values (ADR-064).
+ *
+ * @api
  */
 final readonly class InputSubmission
 {

--- a/Classes/Service/BudgetServiceInterface.php
+++ b/Classes/Service/BudgetServiceInterface.php
@@ -19,6 +19,8 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
  * Consumers (middleware, feature services, tests) should depend on this
  * interface rather than the concrete `BudgetService` so the
  * implementation can be substituted without inheritance.
+ *
+ * @api
  */
 interface BudgetServiceInterface
 {

--- a/Classes/Service/CacheManagerInterface.php
+++ b/Classes/Service/CacheManagerInterface.php
@@ -13,6 +13,8 @@ namespace Netresearch\NrLlm\Service;
  * Interface for cache management operations.
  *
  * Extracted from CacheManager to enable testing with mocks.
+ *
+ * @api
  */
 interface CacheManagerInterface
 {

--- a/Classes/Service/Evaluation/EvaluatableRetrieverInterface.php
+++ b/Classes/Service/Evaluation/EvaluatableRetrieverInterface.php
@@ -31,6 +31,9 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * DI tag (auto-applied by AutoconfigureTag) and collected by
  * EvaluatableRetrieverRegistry, so `nrllm:eval:retrieval` can address them
  * by identifier.
+ *
+ * @api Extension point: third parties implement this. No new abstract
+ * member within a major version (ADR-127).
  */
 #[AutoconfigureTag(name: self::TAG_NAME)]
 interface EvaluatableRetrieverInterface

--- a/Classes/Service/Evaluation/GoldenPromptSetProviderInterface.php
+++ b/Classes/Service/Evaluation/GoldenPromptSetProviderInterface.php
@@ -21,6 +21,9 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * GoldenPromptSetRegistry through a tagged iterator. A consuming extension
  * only needs to implement this interface and register its class as a
  * service — no further wiring.
+ *
+ * @api Extension point: third parties implement this. No new abstract
+ * member within a major version (ADR-127).
  */
 #[AutoconfigureTag(name: self::TAG_NAME)]
 interface GoldenPromptSetProviderInterface

--- a/Classes/Service/Evaluation/GoldenQuestionSetProviderInterface.php
+++ b/Classes/Service/Evaluation/GoldenQuestionSetProviderInterface.php
@@ -21,6 +21,9 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * GoldenQuestionSetRegistry through a tagged iterator. A consuming
  * extension only needs to implement this interface and register its class
  * as a service — no further wiring.
+ *
+ * @api Extension point: third parties implement this. No new abstract
+ * member within a major version (ADR-127).
  */
 #[AutoconfigureTag(name: self::TAG_NAME)]
 interface GoldenQuestionSetProviderInterface

--- a/Classes/Service/Feature/CompletionService.php
+++ b/Classes/Service/Feature/CompletionService.php
@@ -34,6 +34,8 @@ use Netresearch\NrLlm\Service\Schema\JsonSchemaValidator;
  * care about the messaging path can omit it; in production DI the
  * Symfony container always autowires it from
  * `Configuration/Services.yaml`.
+ *
+ * @api
  */
 final readonly class CompletionService implements CompletionServiceInterface
 {

--- a/Classes/Service/Feature/CompletionServiceInterface.php
+++ b/Classes/Service/Feature/CompletionServiceInterface.php
@@ -21,6 +21,8 @@ use Netresearch\NrLlm\Service\Option\ChatOptions;
  * should depend on this interface rather than the concrete
  * `CompletionService` so the implementation can be substituted without
  * inheritance.
+ *
+ * @api
  */
 interface CompletionServiceInterface
 {

--- a/Classes/Service/Feature/ConversationService.php
+++ b/Classes/Service/Feature/ConversationService.php
@@ -44,6 +44,8 @@ use Symfony\Component\Uid\Uuid;
  *   session was opened with, resolved fresh each time so a deactivated or
  *   newly restricted configuration stops the conversation instead of silently
  *   continuing on the installation default.
+ *
+ * @api
  */
 final readonly class ConversationService implements ConversationServiceInterface
 {

--- a/Classes/Service/Feature/ConversationServiceInterface.php
+++ b/Classes/Service/Feature/ConversationServiceInterface.php
@@ -30,6 +30,8 @@ use Netresearch\NrLlm\Service\Option\ChatOptions;
  * checked against the owner on every turn. CLI, scheduler and queue callers
  * identify themselves as a service account instead of borrowing whichever
  * backend user happens to be logged in.
+ *
+ * @api
  */
 interface ConversationServiceInterface
 {

--- a/Classes/Service/Feature/EmbeddingService.php
+++ b/Classes/Service/Feature/EmbeddingService.php
@@ -32,6 +32,8 @@ use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
  * having to remember the wiring. The resolver is optional so unit
  * tests omit it; production DI always autowires it via
  * `Configuration/Services.yaml`.
+ *
+ * @api
  */
 final readonly class EmbeddingService implements EmbeddingServiceInterface
 {

--- a/Classes/Service/Feature/EmbeddingServiceInterface.php
+++ b/Classes/Service/Feature/EmbeddingServiceInterface.php
@@ -21,6 +21,8 @@ use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
  * extensions) should depend on this interface rather than the concrete
  * `EmbeddingService` so the implementation can be substituted without
  * inheritance.
+ *
+ * @api
  */
 interface EmbeddingServiceInterface
 {

--- a/Classes/Service/Feature/ToolCallingService.php
+++ b/Classes/Service/Feature/ToolCallingService.php
@@ -33,6 +33,8 @@ use Netresearch\NrLlm\Service\Option\ToolOptions;
  * care about the messaging path can omit it; in production DI the
  * Symfony container always autowires it from
  * `Configuration/Services.yaml`.
+ *
+ * @api
  */
 final readonly class ToolCallingService implements ToolCallingServiceInterface
 {

--- a/Classes/Service/Feature/ToolCallingServiceInterface.php
+++ b/Classes/Service/Feature/ToolCallingServiceInterface.php
@@ -24,6 +24,8 @@ use Netresearch\NrLlm\Service\Option\ToolOptions;
  * capability, so a consumer's test double covers two methods instead
  * of the whole manager surface and does not break when the manager
  * interface grows unrelated methods (ADR-051).
+ *
+ * @api
  */
 interface ToolCallingServiceInterface
 {

--- a/Classes/Service/Feature/TranslationPromptBuilder.php
+++ b/Classes/Service/Feature/TranslationPromptBuilder.php
@@ -14,6 +14,8 @@ namespace Netresearch\NrLlm\Service\Feature;
  *
  * Extracted from TranslationService so both translate() and
  * translateForConfiguration() share one prompt template.
+ *
+ * @api
  */
 final readonly class TranslationPromptBuilder
 {

--- a/Classes/Service/Feature/TranslationService.php
+++ b/Classes/Service/Feature/TranslationService.php
@@ -49,6 +49,8 @@ use Netresearch\NrLlm\Specialized\Translation\TranslatorResult;
  * though: the resolved uid is re-attached to the translator options
  * array (`beUserUid` key, see `attachBeUserUid()`) and the
  * translators forward it to `trackUsage()` (ADR-052).
+ *
+ * @api
  */
 final readonly class TranslationService implements TranslationServiceInterface
 {

--- a/Classes/Service/Feature/TranslationServiceInterface.php
+++ b/Classes/Service/Feature/TranslationServiceInterface.php
@@ -33,6 +33,8 @@ use Netresearch\NrLlm\Specialized\Translation\TranslatorResult;
  *   `translateBatchWithTranslator`, plus registry queries — bypass the
  *   LLM pipeline and dispatch to translators registered via
  *   `#[AsTranslator]` (DeepL, etc.).
+ *
+ * @api
  */
 interface TranslationServiceInterface
 {

--- a/Classes/Service/Feature/VisionService.php
+++ b/Classes/Service/Feature/VisionService.php
@@ -25,6 +25,8 @@ use Netresearch\NrLlm\Service\Option\VisionOptions;
  * Budget pre-flight (REC #4 slice 15b): mirrors `CompletionService`
  * (slice 15a). The resolver is optional so unit tests omit it;
  * production DI autowires it.
+ *
+ * @api
  */
 final readonly class VisionService implements VisionServiceInterface
 {

--- a/Classes/Service/Feature/VisionServiceInterface.php
+++ b/Classes/Service/Feature/VisionServiceInterface.php
@@ -24,6 +24,8 @@ use Netresearch\NrLlm\Service\Option\VisionOptions;
  * Most methods accept either a single image URL/data-URI or an array
  * of them; pass an array to batch in a single call. The full-response
  * variant `analyzeImageFull` always operates on a single image.
+ *
+ * @api
  */
 interface VisionServiceInterface
 {

--- a/Classes/Service/Guardrail/GuardrailIdentity.php
+++ b/Classes/Service/Guardrail/GuardrailIdentity.php
@@ -25,6 +25,9 @@ namespace Netresearch\NrLlm\Service\Guardrail;
  * {@see GuardrailPolicyResolver} reads the registry's identifier-level verdict,
  * never a raw per-instance flag, so no selection can drop a mandatory guardrail
  * on any axis.
+ *
+ * @api Extension point: third parties implement this. No new abstract
+ * member within a major version (ADR-127).
  */
 interface GuardrailIdentity
 {

--- a/Classes/Service/Guardrail/GuardrailInterface.php
+++ b/Classes/Service/Guardrail/GuardrailInterface.php
@@ -27,6 +27,9 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * than a stage of this pipeline: the pipeline context deliberately carries no
  * payload (ADR-026), so the prompt is screened at the call site before the
  * pipeline is entered (ADR-087).
+ *
+ * @api Extension point: third parties implement this. No new abstract
+ * member within a major version (ADR-127).
  */
 #[AutoconfigureTag(name: self::TAG_NAME)]
 interface GuardrailInterface extends GuardrailIdentity

--- a/Classes/Service/Guardrail/InputGuardrailInterface.php
+++ b/Classes/Service/Guardrail/InputGuardrailInterface.php
@@ -28,6 +28,9 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * middleware-side check could not). A DENY / REQUIRE_APPROVAL blocks the call
  * with the same typed exception the output side throws. RETRY has no meaning
  * before a provider call and is ignored.
+ *
+ * @api Extension point: third parties implement this. No new abstract
+ * member within a major version (ADR-127).
  */
 #[AutoconfigureTag(name: self::TAG_NAME)]
 interface InputGuardrailInterface extends GuardrailIdentity

--- a/Classes/Service/LlmConfigurationServiceInterface.php
+++ b/Classes/Service/LlmConfigurationServiceInterface.php
@@ -19,6 +19,8 @@ use Netresearch\NrLlm\Exception\ConfigurationNotFoundException;
  * Consumers (controllers, feature services, tests) should depend on this
  * interface rather than the concrete `LlmConfigurationService` so the
  * implementation can be substituted without inheritance.
+ *
+ * @api
  */
 interface LlmConfigurationServiceInterface
 {

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -37,6 +37,9 @@ use Netresearch\NrLlm\Service\Skill\SkillInjectionService;
 use Netresearch\NrLlm\Service\Streaming\StreamingDispatcher;
 use TYPO3\CMS\Core\SingletonInterface;
 
+/**
+ * @api
+ */
 final readonly class LlmServiceManager implements LlmServiceManagerInterface, SingletonInterface
 {
     public function __construct(

--- a/Classes/Service/LlmServiceManagerInterface.php
+++ b/Classes/Service/LlmServiceManagerInterface.php
@@ -27,6 +27,8 @@ use Netresearch\NrLlm\Service\Option\VisionOptions;
  * Interface for LLM service management.
  *
  * Extracted from LlmServiceManager to enable testing with mocks.
+ *
+ * @api
  */
 interface LlmServiceManagerInterface
 {

--- a/Classes/Service/Option/AbstractOptions.php
+++ b/Classes/Service/Option/AbstractOptions.php
@@ -16,6 +16,8 @@ use Netresearch\NrLlm\Exception\InvalidArgumentException;
  *
  * Provides common functionality for all option classes including
  * array conversion, merging, and validation helpers.
+ *
+ * @api
  */
 abstract class AbstractOptions
 {

--- a/Classes/Service/Option/BudgetAwareOptionsInterface.php
+++ b/Classes/Service/Option/BudgetAwareOptionsInterface.php
@@ -27,6 +27,8 @@ namespace Netresearch\NrLlm\Service\Option;
  * narrowing to a concrete class. Implementers MUST keep these fields
  * out of `toArray()` — they are pipeline metadata, not provider wire
  * payload.
+ *
+ * @api
  */
 interface BudgetAwareOptionsInterface
 {

--- a/Classes/Service/Option/BudgetFieldsTrait.php
+++ b/Classes/Service/Option/BudgetFieldsTrait.php
@@ -33,6 +33,8 @@ use Netresearch\NrLlm\Exception\InvalidArgumentException;
  * - NOT include these fields in `toArray()` — they are pipeline
  *   metadata, not provider wire payload, and must never reach the
  *   provider.
+ *
+ * @api
  */
 trait BudgetFieldsTrait
 {

--- a/Classes/Service/Option/ChatOptions.php
+++ b/Classes/Service/Option/ChatOptions.php
@@ -16,6 +16,8 @@ namespace Netresearch\NrLlm\Service\Option;
  * for common use cases like factual, creative, and code generation.
  *
  * @phpstan-consistent-constructor
+ *
+ * @api
  */
 class ChatOptions extends AbstractOptions implements BudgetAwareOptionsInterface
 {

--- a/Classes/Service/Option/EmbeddingOptions.php
+++ b/Classes/Service/Option/EmbeddingOptions.php
@@ -15,6 +15,8 @@ namespace Netresearch\NrLlm\Service\Option;
  * Embeddings are deterministic, so caching is enabled by default.
  *
  * @phpstan-consistent-constructor
+ *
+ * @api
  */
 class EmbeddingOptions extends AbstractOptions implements BudgetAwareOptionsInterface
 {

--- a/Classes/Service/Option/ToolOptions.php
+++ b/Classes/Service/Option/ToolOptions.php
@@ -15,6 +15,8 @@ namespace Netresearch\NrLlm\Service\Option;
  * Extends ChatOptions with tool-specific configuration.
  *
  * @phpstan-consistent-constructor
+ *
+ * @api
  */
 class ToolOptions extends ChatOptions
 {

--- a/Classes/Service/Option/TranslationOptions.php
+++ b/Classes/Service/Option/TranslationOptions.php
@@ -13,6 +13,8 @@ namespace Netresearch\NrLlm\Service\Option;
  * Options for translation requests.
  *
  * @phpstan-consistent-constructor
+ *
+ * @api
  */
 class TranslationOptions extends AbstractOptions implements BudgetAwareOptionsInterface
 {

--- a/Classes/Service/Option/VisionOptions.php
+++ b/Classes/Service/Option/VisionOptions.php
@@ -13,6 +13,8 @@ namespace Netresearch\NrLlm\Service\Option;
  * Options for vision/image analysis requests.
  *
  * @phpstan-consistent-constructor
+ *
+ * @api
  */
 class VisionOptions extends AbstractOptions implements BudgetAwareOptionsInterface
 {

--- a/Classes/Service/Preset/ConfigurationPresetProviderInterface.php
+++ b/Classes/Service/Preset/ConfigurationPresetProviderInterface.php
@@ -26,6 +26,9 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * is a criteria-mode configuration that ModelSelectionService resolves at
  * runtime against whatever providers/models the admin has configured
  * (ADR-056).
+ *
+ * @api Extension point: third parties implement this. No new abstract
+ * member within a major version (ADR-127).
  */
 #[AutoconfigureTag(name: self::TAG_NAME)]
 interface ConfigurationPresetProviderInterface

--- a/Classes/Service/Prompt/PromptSnippetComposer.php
+++ b/Classes/Service/Prompt/PromptSnippetComposer.php
@@ -17,6 +17,8 @@ use Netresearch\NrLlm\Domain\Model\PromptSnippet;
  * Consuming extensions resolve snippets (e.g. via
  * PromptSnippetRepository::findActiveByTag()) and pass them here to
  * build the snippet-backed part of their prompt.
+ *
+ * @api
  */
 final class PromptSnippetComposer
 {

--- a/Classes/Service/Rerank/RerankerInterface.php
+++ b/Classes/Service/Rerank/RerankerInterface.php
@@ -18,6 +18,8 @@ use Netresearch\NrLlm\Service\Rerank\Exception\RerankerException;
  * scores come back as plain ``id``/``score`` shapes — no consumer DTOs
  * cross this boundary. Consumers own DTO mapping, the ordering merge,
  * the degradation policy on failure, and any score-threshold gate.
+ *
+ * @api
  */
 interface RerankerInterface
 {

--- a/Classes/Service/Retrieval/AccessContext.php
+++ b/Classes/Service/Retrieval/AccessContext.php
@@ -21,6 +21,8 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
  * regardless of context: RAG evidence is what the anonymous visitor could
  * read, so no additional per-user narrowing exists today — the variants
  * only preserve WHO asked for future widening.
+ *
+ * @api
  */
 final readonly class AccessContext
 {

--- a/Classes/Service/Retrieval/EvidenceList.php
+++ b/Classes/Service/Retrieval/EvidenceList.php
@@ -14,6 +14,8 @@ namespace Netresearch\NrLlm\Service\Retrieval;
  * answered, the curated sources, and human-readable degradation notes
  * (skipped backends, fallback reasons) so the model knows the evidence
  * quality.
+ *
+ * @api
  */
 final readonly class EvidenceList
 {

--- a/Classes/Service/Retrieval/KeywordSearchInterface.php
+++ b/Classes/Service/Retrieval/KeywordSearchInterface.php
@@ -32,6 +32,8 @@ namespace Netresearch\NrLlm\Service\Retrieval;
  * index-backed-only variant that excludes the fallback — for consumers
  * (e.g. hybrid dense+sparse fusion) that must see "index unavailable"
  * as empty rather than receive LIKE hits.
+ *
+ * @api
  */
 interface KeywordSearchInterface
 {

--- a/Classes/Service/Retrieval/ReciprocalRankFusion.php
+++ b/Classes/Service/Retrieval/ReciprocalRankFusion.php
@@ -21,6 +21,8 @@ namespace Netresearch\NrLlm\Service\Retrieval;
  * Newable utility, deliberately not a DI service (excluded from container
  * autoconfiguration): consumers construct it with `new`. nr_llm's own
  * retrieval cascade stays first-available-wins (ADR-049) and does not call it.
+ *
+ * @api
  */
 final readonly class ReciprocalRankFusion
 {

--- a/Classes/Service/Retrieval/RetrievalQuery.php
+++ b/Classes/Service/Retrieval/RetrievalQuery.php
@@ -17,6 +17,8 @@ use Netresearch\NrLlm\Exception\InvalidArgumentException;
  * Constructing an out-of-range query throws — callers that accept
  * model-chosen or user-supplied values MUST clamp before constructing
  * (the tools do; see SiteRagQueryTool).
+ *
+ * @api
  */
 final readonly class RetrievalQuery
 {

--- a/Classes/Service/Retrieval/SearchBackendInterface.php
+++ b/Classes/Service/Retrieval/SearchBackendInterface.php
@@ -26,6 +26,9 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * public-only in this iteration (see AccessContext). Returned excerpts
  * egress to the external provider and the backend DOM — never include
  * content the anonymous visitor could not read.
+ *
+ * @api Extension point: third parties implement this. No new abstract
+ * member within a major version (ADR-127).
  */
 #[AutoconfigureTag(name: self::TAG_NAME)]
 interface SearchBackendInterface

--- a/Classes/Service/Retrieval/SourceReference.php
+++ b/Classes/Service/Retrieval/SourceReference.php
@@ -16,6 +16,8 @@ namespace Netresearch\NrLlm\Service\Retrieval;
  * `site_fetch_source` receives them back), so parsing is strict: a fixed
  * grammar, bounded length, no surprises. Anything else is rejected with
  * null — never an exception — because the input is model-chosen.
+ *
+ * @api
  */
 final readonly class SourceReference
 {

--- a/Classes/Service/Schema/JsonSchemaValidator.php
+++ b/Classes/Service/Schema/JsonSchemaValidator.php
@@ -37,6 +37,8 @@ namespace Netresearch\NrLlm\Service\Schema;
  * strict accepts, lenient accepts. Strict only ever rejects MORE, which is
  * why its primitive type matcher byte-mirrors the lenient one (`5.0` is not
  * an integer here, unlike in the spec).
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final readonly class JsonSchemaValidator
 {

--- a/Classes/Service/Schema/StrictSchemaSubset.php
+++ b/Classes/Service/Schema/StrictSchemaSubset.php
@@ -34,6 +34,8 @@ namespace Netresearch\NrLlm\Service\Schema;
  * - No `$ref`/`$defs`: reference resolution is the point at which a subset
  *   becomes a JSON-Schema implementation, and ADR-082's no-runtime-dependency
  *   decision stands.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final readonly class StrictSchemaSubset
 {

--- a/Classes/Service/SetupWizard/ConfigurationGenerator.php
+++ b/Classes/Service/SetupWizard/ConfigurationGenerator.php
@@ -30,6 +30,8 @@ use Throwable;
  * gated via `SecureHttpClientFactory::isHostAllowed()` first, so the wizard
  * cannot be coerced into an SSRF request — the same hardened path the
  * providers and specialised services use.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final class ConfigurationGenerator
 {

--- a/Classes/Service/SetupWizard/DTO/DetectedProvider.php
+++ b/Classes/Service/SetupWizard/DTO/DetectedProvider.php
@@ -11,6 +11,8 @@ namespace Netresearch\NrLlm\Service\SetupWizard\DTO;
 
 /**
  * DTO for detected provider information from endpoint URL.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final readonly class DetectedProvider
 {

--- a/Classes/Service/SetupWizard/DTO/DiscoveredModel.php
+++ b/Classes/Service/SetupWizard/DTO/DiscoveredModel.php
@@ -11,6 +11,8 @@ namespace Netresearch\NrLlm\Service\SetupWizard\DTO;
 
 /**
  * DTO for a discovered model from API.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final readonly class DiscoveredModel
 {

--- a/Classes/Service/SetupWizard/DTO/SuggestedConfiguration.php
+++ b/Classes/Service/SetupWizard/DTO/SuggestedConfiguration.php
@@ -11,6 +11,8 @@ namespace Netresearch\NrLlm\Service\SetupWizard\DTO;
 
 /**
  * DTO for a suggested LLM configuration use case.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final readonly class SuggestedConfiguration
 {

--- a/Classes/Service/SetupWizard/DTO/WizardResult.php
+++ b/Classes/Service/SetupWizard/DTO/WizardResult.php
@@ -11,6 +11,8 @@ namespace Netresearch\NrLlm\Service\SetupWizard\DTO;
 
 /**
  * Complete result from the setup wizard.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final readonly class WizardResult
 {

--- a/Classes/Service/SetupWizard/Discovery/AbstractModelDiscoverer.php
+++ b/Classes/Service/SetupWizard/Discovery/AbstractModelDiscoverer.php
@@ -33,6 +33,8 @@ use Throwable;
  * discoverers are an implementation detail of ModelDiscovery, and the
  * facade must be able to fan its test-only HTTP seam out to them
  * ({@see SecureHttpDispatchTrait::setHttpClient()}).
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 abstract class AbstractModelDiscoverer
 {

--- a/Classes/Service/SetupWizard/Discovery/AnthropicModelDiscoverer.php
+++ b/Classes/Service/SetupWizard/Discovery/AnthropicModelDiscoverer.php
@@ -16,6 +16,8 @@ use Throwable;
  * Anthropic model discovery: x-api-key + anthropic-version listing, spec
  * enrichment with API display names, recommended-first sort; falls back to a
  * hand-maintained catalog.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final class AnthropicModelDiscoverer extends AbstractModelDiscoverer
 {

--- a/Classes/Service/SetupWizard/Discovery/DiscoveryResult.php
+++ b/Classes/Service/SetupWizard/Discovery/DiscoveryResult.php
@@ -20,6 +20,8 @@ use Netresearch\NrLlm\Service\SetupWizard\DTO\DiscoveredModel;
  * reach that flag, so fallback-ness travels with the models instead — which is
  * also the honest shape: whether a catalog is live or canned is a property of
  * the result, not of the service that produced it.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final readonly class DiscoveryResult
 {

--- a/Classes/Service/SetupWizard/Discovery/GeminiModelDiscoverer.php
+++ b/Classes/Service/SetupWizard/Discovery/GeminiModelDiscoverer.php
@@ -16,6 +16,8 @@ use Throwable;
  * Gemini model discovery: x-goog-api-key listing with the models/ prefix
  * stripped, relevance filter, spec enrichment with API token limits, API
  * order preserved (deliberately unsorted); falls back to a static catalog.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final class GeminiModelDiscoverer extends AbstractModelDiscoverer
 {

--- a/Classes/Service/SetupWizard/Discovery/GroqModelDiscoverer.php
+++ b/Classes/Service/SetupWizard/Discovery/GroqModelDiscoverer.php
@@ -15,6 +15,8 @@ use Throwable;
 /**
  * Groq model discovery via the shared Bearer listing, carrying the API's
  * context_window. A failure yields an empty list.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final class GroqModelDiscoverer extends AbstractModelDiscoverer
 {

--- a/Classes/Service/SetupWizard/Discovery/MistralModelDiscoverer.php
+++ b/Classes/Service/SetupWizard/Discovery/MistralModelDiscoverer.php
@@ -15,6 +15,8 @@ use Throwable;
 /**
  * Mistral model discovery via the shared Bearer listing; falls back to a
  * small static catalog.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final class MistralModelDiscoverer extends AbstractModelDiscoverer
 {

--- a/Classes/Service/SetupWizard/Discovery/OllamaModelDiscoverer.php
+++ b/Classes/Service/SetupWizard/Discovery/OllamaModelDiscoverer.php
@@ -16,6 +16,8 @@ use Throwable;
  * Ollama model discovery: unauthenticated /api/tags listing with per-model
  * /api/show enrichment capped per run; a failure yields an empty list, never
  * a canned catalog — a local daemon that is down has no models.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final class OllamaModelDiscoverer extends AbstractModelDiscoverer
 {

--- a/Classes/Service/SetupWizard/Discovery/OpenAiModelDiscoverer.php
+++ b/Classes/Service/SetupWizard/Discovery/OpenAiModelDiscoverer.php
@@ -16,6 +16,8 @@ use Throwable;
  * OpenAI model discovery: Bearer-authenticated /models listing, relevance
  * filter, spec-catalog enrichment, recommended-first sort; falls back to a
  * static catalog derived from the same spec table.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final class OpenAiModelDiscoverer extends AbstractModelDiscoverer
 {

--- a/Classes/Service/SetupWizard/Discovery/OpenRouterModelDiscoverer.php
+++ b/Classes/Service/SetupWizard/Discovery/OpenRouterModelDiscoverer.php
@@ -16,6 +16,8 @@ use Throwable;
  * OpenRouter model discovery via the shared Bearer listing; carries the
  * published per-token prices into the catalog. A failure yields an empty
  * list — the router's catalog is too large and volatile to can.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final class OpenRouterModelDiscoverer extends AbstractModelDiscoverer
 {

--- a/Classes/Service/SetupWizard/Exception/HostNotAllowedException.php
+++ b/Classes/Service/SetupWizard/Exception/HostNotAllowedException.php
@@ -15,6 +15,8 @@ use RuntimeException;
  * Thrown when the setup wizard refuses to dispatch an HTTP request because
  * the target host is not covered by the nr-vault SSRF host allowlist
  * (`SecureHttpClientFactory::isHostAllowed()`).
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final class HostNotAllowedException extends RuntimeException
 {

--- a/Classes/Service/SetupWizard/ModelDiscoveryInterface.php
+++ b/Classes/Service/SetupWizard/ModelDiscoveryInterface.php
@@ -14,6 +14,8 @@ use Netresearch\NrLlm\Service\SetupWizard\DTO\DiscoveredModel;
 
 /**
  * Interface for model discovery from LLM providers.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 interface ModelDiscoveryInterface
 {

--- a/Classes/Service/SetupWizard/ProviderDetector.php
+++ b/Classes/Service/SetupWizard/ProviderDetector.php
@@ -25,6 +25,8 @@ use Netresearch\NrLlm\Service\SetupWizard\DTO\DetectedProvider;
  * - Ollama (localhost:11434 or ollama in hostname)
  * - Azure OpenAI (*.openai.azure.com)
  * - Custom/Unknown endpoints
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final class ProviderDetector
 {

--- a/Classes/Service/Tool/RunAugmentation.php
+++ b/Classes/Service/Tool/RunAugmentation.php
@@ -24,6 +24,8 @@ use Netresearch\NrLlm\Domain\Model\Skill;
  *   system messages, one per snippet, before the user prompt.
  * - {@see self::$dryRun}: assemble the full message list (system prompt +
  *   snippets + skills + user) and record it WITHOUT calling the provider.
+ *
+ * @api
  */
 final readonly class RunAugmentation
 {

--- a/Classes/Service/Tool/RunTrace.php
+++ b/Classes/Service/Tool/RunTrace.php
@@ -31,6 +31,8 @@ use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
  * It is a mutable collector, deliberately NOT a readonly value object: the
  * readonly transport type is {@see RunStep}, which this hands out via
  * {@see self::getSteps()}.
+ *
+ * @api
  */
 final class RunTrace
 {

--- a/Classes/Service/Tool/ToolCallPolicyInterface.php
+++ b/Classes/Service/Tool/ToolCallPolicyInterface.php
@@ -27,6 +27,8 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
  *
  * Consumers ask this rather than re-deriving the rules, so a new entry point
  * cannot accidentally ship with four of the five.
+ *
+ * @api
  */
 interface ToolCallPolicyInterface
 {

--- a/Classes/Service/Tool/ToolExecutionContext.php
+++ b/Classes/Service/Tool/ToolExecutionContext.php
@@ -29,6 +29,8 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
  * reconstructs it from the actor's uid; a service account, an anonymous actor or
  * a deleted/disabled user yields `null`, which every user-scoped tool treats as
  * "no permission" — fail-closed, exactly as an absent `$GLOBALS['BE_USER']` did.
+ *
+ * @api
  */
 final readonly class ToolExecutionContext
 {

--- a/Classes/Service/Tool/ToolInterface.php
+++ b/Classes/Service/Tool/ToolInterface.php
@@ -42,6 +42,9 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * context (ADR-083), NEVER read from the ambient `$GLOBALS['BE_USER']`, so a
  * run authorises identically synchronously and in a queue worker. Both levels
  * fail CLOSED when the context has no `BackendUserAuthentication`.
+ *
+ * @api Extension point: third parties implement this. No new abstract
+ * member within a major version (ADR-127).
  */
 #[AutoconfigureTag(name: self::TAG_NAME)]
 interface ToolInterface

--- a/Classes/Service/Tool/ToolLoopServiceInterface.php
+++ b/Classes/Service/Tool/ToolLoopServiceInterface.php
@@ -22,6 +22,8 @@ use Netresearch\NrLlm\Service\Option\ToolOptions;
  * {@see ToolLoopService} stays final, mirroring the pattern used by
  * {@see \Netresearch\NrLlm\Service\LlmServiceManagerInterface} and
  * {@see \Netresearch\NrLlm\Service\UsageTrackerServiceInterface}.
+ *
+ * @api
  */
 interface ToolLoopServiceInterface
 {

--- a/Classes/Service/Tool/ToolProviderInterface.php
+++ b/Classes/Service/Tool/ToolProviderInterface.php
@@ -25,6 +25,9 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  *
  * A provider must not perform network I/O. It reads what an explicit
  * administrator action already persisted; discovery is never on a request path.
+ *
+ * @api Extension point: third parties implement this. No new abstract
+ * member within a major version (ADR-127).
  */
 #[AutoconfigureTag(name: ToolProviderInterface::TAG_NAME)]
 interface ToolProviderInterface

--- a/Classes/Service/UsageTrackerServiceInterface.php
+++ b/Classes/Service/UsageTrackerServiceInterface.php
@@ -15,6 +15,8 @@ use DateTimeInterface;
  * Interface for usage tracking services.
  *
  * Allows for mocking in tests while keeping UsageTrackerService final.
+ *
+ * @api
  */
 interface UsageTrackerServiceInterface
 {

--- a/Classes/Specialized/Document/DocumentAnalysisResult.php
+++ b/Classes/Specialized/Document/DocumentAnalysisResult.php
@@ -11,6 +11,8 @@ namespace Netresearch\NrLlm\Specialized\Document;
 
 /**
  * Result of a document analysis (ADR-076).
+ *
+ * @api
  */
 final readonly class DocumentAnalysisResult
 {

--- a/Classes/Specialized/Document/DocumentAnalysisService.php
+++ b/Classes/Specialized/Document/DocumentAnalysisService.php
@@ -38,6 +38,8 @@ use Netresearch\NrLlm\Specialized\Exception\UnsupportedFormatException;
  * capping. Budget attribution mirrors the feature services: `beUserUid`
  * is auto-populated from the backend user context when the caller did not
  * set it (REC #4).
+ *
+ * @api
  */
 final readonly class DocumentAnalysisService
 {

--- a/Classes/Specialized/Image/DallEImageService.php
+++ b/Classes/Specialized/Image/DallEImageService.php
@@ -35,6 +35,8 @@ use Throwable;
  * - Image editing and variations (DALL-E 2)
  *
  * @see https://platform.openai.com/docs/guides/images
+ *
+ * @api
  */
 final class DallEImageService extends AbstractSpecializedService implements ImageGeneratorInterface
 {

--- a/Classes/Specialized/Image/FalImageService.php
+++ b/Classes/Specialized/Image/FalImageService.php
@@ -33,6 +33,8 @@ use Throwable;
  * - Fast inference with queue-based processing
  *
  * @see https://fal.ai/docs
+ *
+ * @api
  */
 final class FalImageService extends AbstractSpecializedService implements ImageGeneratorInterface
 {

--- a/Classes/Specialized/Image/ImageGenerationResult.php
+++ b/Classes/Specialized/Image/ImageGenerationResult.php
@@ -11,6 +11,8 @@ namespace Netresearch\NrLlm\Specialized\Image;
 
 /**
  * Result from image generation services (DALL-E, FAL, etc.).
+ *
+ * @api
  */
 final readonly class ImageGenerationResult
 {

--- a/Classes/Specialized/Option/DeepLOptions.php
+++ b/Classes/Specialized/Option/DeepLOptions.php
@@ -13,6 +13,8 @@ use Netresearch\NrLlm\Service\Option\AbstractOptions;
 
 /**
  * Options specific to DeepL translation service.
+ *
+ * @api
  */
 final class DeepLOptions extends AbstractOptions
 {

--- a/Classes/Specialized/Option/ImageGenerationOptions.php
+++ b/Classes/Specialized/Option/ImageGenerationOptions.php
@@ -16,6 +16,8 @@ use Netresearch\NrLlm\Service\Option\BudgetFieldsTrait;
 
 /**
  * Options for image generation (DALL-E).
+ *
+ * @api
  */
 final class ImageGenerationOptions extends AbstractOptions implements BudgetAwareOptionsInterface
 {

--- a/Classes/Specialized/Option/SpeechSynthesisOptions.php
+++ b/Classes/Specialized/Option/SpeechSynthesisOptions.php
@@ -15,6 +15,8 @@ use Netresearch\NrLlm\Service\Option\BudgetFieldsTrait;
 
 /**
  * Options for text-to-speech synthesis (OpenAI TTS).
+ *
+ * @api
  */
 final class SpeechSynthesisOptions extends AbstractOptions implements BudgetAwareOptionsInterface
 {

--- a/Classes/Specialized/Option/TranscriptionOptions.php
+++ b/Classes/Specialized/Option/TranscriptionOptions.php
@@ -15,6 +15,8 @@ use Netresearch\NrLlm\Service\Option\BudgetFieldsTrait;
 
 /**
  * Options for speech-to-text transcription (Whisper).
+ *
+ * @api
  */
 final class TranscriptionOptions extends AbstractOptions implements BudgetAwareOptionsInterface
 {

--- a/Classes/Specialized/Speech/SpeechSynthesisResult.php
+++ b/Classes/Specialized/Speech/SpeechSynthesisResult.php
@@ -11,6 +11,8 @@ namespace Netresearch\NrLlm\Specialized\Speech;
 
 /**
  * Result from text-to-speech synthesis.
+ *
+ * @api
  */
 final readonly class SpeechSynthesisResult
 {

--- a/Classes/Specialized/Speech/TextToSpeechService.php
+++ b/Classes/Specialized/Speech/TextToSpeechService.php
@@ -37,6 +37,8 @@ use Throwable;
  * endpoint construction) comes from `AbstractSpecializedService`.
  *
  * @see https://platform.openai.com/docs/guides/text-to-speech
+ *
+ * @api
  */
 final class TextToSpeechService extends AbstractSpecializedService
 {

--- a/Classes/Specialized/Speech/TranscriptionResult.php
+++ b/Classes/Specialized/Speech/TranscriptionResult.php
@@ -11,6 +11,8 @@ namespace Netresearch\NrLlm\Specialized\Speech;
 
 /**
  * Result from speech-to-text transcription (Whisper).
+ *
+ * @api
  */
 final readonly class TranscriptionResult
 {

--- a/Classes/Specialized/Speech/WhisperTranscriptionService.php
+++ b/Classes/Specialized/Speech/WhisperTranscriptionService.php
@@ -41,6 +41,8 @@ use Throwable;
  * construction (`encodeMultipartBody`) is shared via the trait.
  *
  * @see https://platform.openai.com/docs/guides/speech-to-text
+ *
+ * @api
  */
 final class WhisperTranscriptionService extends AbstractSpecializedService
 {

--- a/Classes/Specialized/Translation/TranslatorInterface.php
+++ b/Classes/Specialized/Translation/TranslatorInterface.php
@@ -14,6 +14,9 @@ namespace Netresearch\NrLlm\Specialized\Translation;
  *
  * Implement this interface to create a new translator (e.g., DeepL, Google Translate).
  * All translators are registered via the `nr_llm.translator` service tag.
+ *
+ * @api Extension point: third parties implement this. No new abstract
+ * member within a major version (ADR-127).
  */
 interface TranslatorInterface
 {

--- a/Classes/Specialized/Translation/TranslatorRegistryInterface.php
+++ b/Classes/Specialized/Translation/TranslatorRegistryInterface.php
@@ -15,6 +15,8 @@ use Netresearch\NrLlm\Specialized\Exception\ServiceUnavailableException;
  * Interface for translator registry.
  *
  * Extracted from TranslatorRegistry to enable testing with mocks.
+ *
+ * @api
  */
 interface TranslatorRegistryInterface
 {

--- a/Classes/Specialized/Translation/TranslatorResult.php
+++ b/Classes/Specialized/Translation/TranslatorResult.php
@@ -14,6 +14,8 @@ namespace Netresearch\NrLlm\Specialized\Translation;
  *
  * Note: This is separate from Domain\Model\TranslationResult which is
  * used by LLM-based translation and includes UsageStatistics.
+ *
+ * @api
  */
 final readonly class TranslatorResult
 {

--- a/Classes/Testing/FakeBudgetService.php
+++ b/Classes/Testing/FakeBudgetService.php
@@ -32,6 +32,8 @@ use Throwable;
  * Not a DI service: excluded from container autoconfiguration in
  * `Configuration/Services.yaml`. It is a fixture for consumer test suites,
  * never wire it into production.
+ *
+ * @api
  */
 final class FakeBudgetService implements BudgetServiceInterface
 {

--- a/Classes/Testing/FakeCompletionService.php
+++ b/Classes/Testing/FakeCompletionService.php
@@ -35,6 +35,8 @@ use Throwable;
  * Not a DI service: excluded from container autoconfiguration in
  * `Configuration/Services.yaml`. It is a fixture for consumer test suites,
  * never wire it into production.
+ *
+ * @api
  */
 final class FakeCompletionService implements CompletionServiceInterface
 {

--- a/Classes/Testing/FakeEmbeddingService.php
+++ b/Classes/Testing/FakeEmbeddingService.php
@@ -36,6 +36,8 @@ use Throwable;
  * Not a DI service: excluded from container autoconfiguration in
  * `Configuration/Services.yaml`. It is a fixture for consumer test suites,
  * never wire it into production.
+ *
+ * @api
  */
 final class FakeEmbeddingService implements EmbeddingServiceInterface
 {

--- a/Classes/Testing/FakeToolCallingService.php
+++ b/Classes/Testing/FakeToolCallingService.php
@@ -36,6 +36,8 @@ use Throwable;
  * Not a DI service: excluded from container autoconfiguration in
  * `Configuration/Services.yaml`. It is a fixture for consumer test suites,
  * never wire it into production.
+ *
+ * @api
  */
 final class FakeToolCallingService implements ToolCallingServiceInterface
 {

--- a/Classes/Testing/FakeVisionService.php
+++ b/Classes/Testing/FakeVisionService.php
@@ -34,6 +34,8 @@ use Throwable;
  * Not a DI service: excluded from container autoconfiguration in
  * `Configuration/Services.yaml`. It is a fixture for consumer test suites,
  * never wire it into production.
+ *
+ * @api
  */
 final class FakeVisionService implements VisionServiceInterface
 {

--- a/Classes/Updates/DataClassEnforcementDefaultUpdateWizard.php
+++ b/Classes/Updates/DataClassEnforcementDefaultUpdateWizard.php
@@ -31,6 +31,8 @@ use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
  * wizard does not fire. An operator who ALREADY chose a mode explicitly (the
  * stored config carries a value) is left untouched: an explicit ``enforce`` is
  * respected, an explicit ``observe`` already matches.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 #[UpgradeWizard('nrLlm_dataClassEnforcementObserveForExisting')]
 final readonly class DataClassEnforcementDefaultUpdateWizard implements UpgradeWizardInterface

--- a/Classes/Updates/EmbeddingModelDimensionsUpdateWizard.php
+++ b/Classes/Updates/EmbeddingModelDimensionsUpdateWizard.php
@@ -25,6 +25,8 @@ use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
  * This wizard fills `dimensions` from the EmbeddingModelDimensions catalog
  * for rows whose model_id is a known embedding model and whose value is
  * still 0 — an explicitly configured value is never touched.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 #[UpgradeWizard('nrLlm_embeddingModelDimensions')]
 final readonly class EmbeddingModelDimensionsUpdateWizard implements UpgradeWizardInterface

--- a/Classes/Updates/ProviderApiTimeoutUpdateWizard.php
+++ b/Classes/Updates/ProviderApiTimeoutUpdateWizard.php
@@ -26,6 +26,8 @@ use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
  * A deliberately-chosen 30 is indistinguishable from the never-applied
  * default, so it is migrated too — operators who want a 30 second timeout
  * must re-set it after the upgrade.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 #[UpgradeWizard('nrLlm_providerApiTimeout120')]
 final readonly class ProviderApiTimeoutUpdateWizard implements UpgradeWizardInterface

--- a/Classes/Updates/StampProviderTrustZoneUpdateWizard.php
+++ b/Classes/Updates/StampProviderTrustZoneUpdateWizard.php
@@ -32,6 +32,8 @@ use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
  * wizard the stored column is the single source of truth — nothing derives a
  * zone from the adapter type at runtime, because that would make the operator's
  * declaration optional.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 #[UpgradeWizard('nrLlm_stampProviderTrustZone')]
 final readonly class StampProviderTrustZoneUpdateWizard implements UpgradeWizardInterface

--- a/Classes/Widgets/DataProvider/AgentRunsByStatusDataProvider.php
+++ b/Classes/Widgets/DataProvider/AgentRunsByStatusDataProvider.php
@@ -22,6 +22,8 @@ use TYPO3\CMS\Dashboard\Widgets\ChartDataProviderInterface;
  * {@see AgentRunStatus} case order so the doughnut is stable regardless of which
  * statuses happen to be present, each labelled via XLIFF and coloured by a fixed
  * semantic map (terminal green/red/grey, waiting amber, running/queued blue).
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final readonly class AgentRunsByStatusDataProvider implements ChartDataProviderInterface
 {

--- a/Classes/Widgets/DataProvider/AverageLatencyDataProvider.php
+++ b/Classes/Widgets/DataProvider/AverageLatencyDataProvider.php
@@ -20,6 +20,8 @@ use TYPO3\CMS\Dashboard\Widgets\NumberWithIconDataProviderInterface;
  * the last N days, from tx_nrllm_telemetry. Paired with the success-rate tile:
  * a percent and a millisecond figure are heterogeneous, so they are two tiles,
  * never one misleading shared axis.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final readonly class AverageLatencyDataProvider implements NumberWithIconDataProviderInterface
 {

--- a/Classes/Widgets/DataProvider/GovernanceBlocksOverTimeDataProvider.php
+++ b/Classes/Widgets/DataProvider/GovernanceBlocksOverTimeDataProvider.php
@@ -23,6 +23,8 @@ use TYPO3\CMS\Dashboard\Widgets\ChartDataProviderInterface;
  * content-filter blocks — the outcomes that were previously only logged or
  * reflected on a run. Bars are emitted in {@see GovernanceDecision} case order
  * so the chart is stable.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final readonly class GovernanceBlocksOverTimeDataProvider implements ChartDataProviderInterface
 {

--- a/Classes/Widgets/DataProvider/MonthlyCostDataProvider.php
+++ b/Classes/Widgets/DataProvider/MonthlyCostDataProvider.php
@@ -19,6 +19,8 @@ use TYPO3\CMS\Dashboard\Widgets\NumberWithIconDataProviderInterface;
  * aggregated from tx_nrllm_service_usage. Fractions of a dollar are
  * truncated deliberately — the dashboard tile is an at-a-glance indicator,
  * not an accounting source. Precise figures belong in the usage report.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final readonly class MonthlyCostDataProvider implements NumberWithIconDataProviderInterface
 {

--- a/Classes/Widgets/DataProvider/RequestSuccessRateDataProvider.php
+++ b/Classes/Widgets/DataProvider/RequestSuccessRateDataProvider.php
@@ -19,6 +19,8 @@ use TYPO3\CMS\Dashboard\Widgets\NumberWithIconDataProviderInterface;
  * Returns the share (integer percent, 0-100) of provider pipeline runs that
  * succeeded over the last N days, from tx_nrllm_telemetry. The tile is an
  * at-a-glance health indicator, not an SLA report.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final readonly class RequestSuccessRateDataProvider implements NumberWithIconDataProviderInterface
 {

--- a/Classes/Widgets/DataProvider/RequestsByProviderDataProvider.php
+++ b/Classes/Widgets/DataProvider/RequestsByProviderDataProvider.php
@@ -20,6 +20,8 @@ use TYPO3\CMS\Dashboard\Widgets\ChartDataProviderInterface;
  * UsageTrackerService::getUsageReport() this spans every service_type
  * (chat, vision, translation, ...) because the widget gives an overall
  * provider-traffic view, not a per-service breakdown.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final readonly class RequestsByProviderDataProvider implements ChartDataProviderInterface
 {

--- a/Classes/Widgets/DataProvider/RunTerminationReasonsDataProvider.php
+++ b/Classes/Widgets/DataProvider/RunTerminationReasonsDataProvider.php
@@ -24,6 +24,8 @@ use TYPO3\CMS\Dashboard\Widgets\ChartDataProviderInterface;
  * from a provider failure (provider_failed): all three otherwise surface as a
  * completed-but-truncated or failed run. Bars are emitted in
  * {@see AgentRunTerminationReason} case order so the chart is stable.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final readonly class RunTerminationReasonsDataProvider implements ChartDataProviderInterface
 {

--- a/Classes/Widgets/DataProvider/RunsAwaitingApprovalDataProvider.php
+++ b/Classes/Widgets/DataProvider/RunsAwaitingApprovalDataProvider.php
@@ -19,6 +19,8 @@ use TYPO3\CMS\Dashboard\Widgets\NumberWithIconDataProviderInterface;
  * A live gauge — no time window: an agent run suspended WAITING_FOR_APPROVAL
  * (ADR-084) from last week still needs a human decision now. Served by the
  * status_lookup index on tx_nrllm_agentrun.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final readonly class RunsAwaitingApprovalDataProvider implements NumberWithIconDataProviderInterface
 {

--- a/Classes/Widgets/DataProvider/ToolDenialsByReasonDataProvider.php
+++ b/Classes/Widgets/DataProvider/ToolDenialsByReasonDataProvider.php
@@ -22,6 +22,8 @@ use TYPO3\CMS\Dashboard\Widgets\ChartDataProviderInterface;
  * their {@see ToolDenialReason}. Bars are emitted in enum order so the chart is
  * stable; the NONE case never carries a count (a denial always has a reason)
  * and is skipped with every other zero-count reason.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final readonly class ToolDenialsByReasonDataProvider implements ChartDataProviderInterface
 {

--- a/Classes/Widgets/DataProvider/ToolUsageByNameDataProvider.php
+++ b/Classes/Widgets/DataProvider/ToolUsageByNameDataProvider.php
@@ -26,6 +26,8 @@ use TYPO3\CMS\Dashboard\Widgets\ChartDataProviderInterface;
  * successful-invocation volume; genuine successful tool usage still lives in
  * tx_nrllm_agentrun_event (kind = tool, name inside the payload). The widget is
  * labelled accordingly so the two are never conflated.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
 final readonly class ToolUsageByNameDataProvider implements ChartDataProviderInterface
 {

--- a/Documentation/Adr/Adr127ApiSurfaceMarkers.rst
+++ b/Documentation/Adr/Adr127ApiSurfaceMarkers.rst
@@ -34,10 +34,11 @@ semver covers:
    itself ``@api`` (the response objects, option classes, value objects and
    typed exceptions a caller necessarily touches). A hand-curated list
    inevitably drifts; the closure rule is checkable.
-2. **``@api`` extension point** — interfaces and attributes third parties
-   *implement* rather than call (tool, guardrail, provider, translator,
-   search-backend, preset, evaluation and middleware contracts). These carry
-   the stricter promise the direction of implementation forces: **no new
+2. **``@api Extension point``** (the marker's literal casing) — interfaces
+   and attributes third parties *implement* rather than call (tool,
+   guardrail, provider, translator, search-backend, preset, evaluation and
+   middleware contracts). These carry a stricter promise, forced by the
+   direction of implementation: **no new
    abstract member within a major version**, because adding one breaks every
    existing implementor, not just callers.
 3. **``@internal``** — everything else, explicitly. Controllers, widgets,

--- a/Documentation/Adr/Adr127ApiSurfaceMarkers.rst
+++ b/Documentation/Adr/Adr127ApiSurfaceMarkers.rst
@@ -1,0 +1,79 @@
+.. _adr-127:
+
+===========================================
+ADR-127: A marked, versioned API surface
+===========================================
+
+:Status: Accepted
+:Date: 2026-08-05
+
+Context
+=======
+
+The roadmap asks for a "public versioned API surface". The extension already
+has most of the ingredients: ADR-028/065/101 govern which services are
+container-public, the ``Documentation/Api/`` pages describe the consumer
+services, and semantic versioning is practised in releases. What is missing is
+the *identity* of the API: nothing in the code says which classes the semver
+promise covers. A downstream developer whose autocompletion offers
+:php:`AgentRunPersister` next to :php:`CompletionServiceInterface` has no
+signal that one is a contract and the other an implementation detail that may
+vanish in a minor release.
+
+Decision
+========
+
+Every class-level docblock carries one of three markers, and the marker — not
+the container visibility, not the documentation — is the authority on what
+semver covers:
+
+1. **``@api``** — the consumer surface. Calling these is covered by semver:
+   no removal, no signature break, no behavioural contract break within a
+   major version. Membership is the **signature-transitive closure** of the
+   entry points: every type that appears in an ``@api`` method signature is
+   itself ``@api`` (the response objects, option classes, value objects and
+   typed exceptions a caller necessarily touches). A hand-curated list
+   inevitably drifts; the closure rule is checkable.
+2. **``@api`` extension point** — interfaces and attributes third parties
+   *implement* rather than call (tool, guardrail, provider, translator,
+   search-backend, preset, evaluation and middleware contracts). These carry
+   the stricter promise the direction of implementation forces: **no new
+   abstract member within a major version**, because adding one breaks every
+   existing implementor, not just callers.
+3. **``@internal``** — everything else, explicitly. Controllers, widgets,
+   hooks, upgrade wizards, commands, DI passes, form elements, repositories
+   and the setup wizard may change without notice in any release.
+
+What this deliberately is not
+=============================
+
+- **Not a phpat rule.** phpat selects by namespace and inheritance, not by
+  docblock tag, and cannot assert "signature types of ``@api`` methods are
+  ``@api``". The closure property is instead asserted by the API snapshot
+  test (follow-up to this ADR): the snapshot renders every ``@api`` signature,
+  so an out-of-closure type surfaces as an unmarked name in a rendered
+  signature.
+- **Not a change to container visibility.** ``public: true`` in
+  ``Services.yaml`` remains governed by ADR-028/065; :ref:`ADR-101 <adr-101>`
+  remains the count authority. The two sets overlap but are not equal: a
+  service can be container-public for a TCA ``itemsProcFunc`` (Category E)
+  and still ``@internal``, and a value object can be ``@api`` without being a
+  service at all.
+- **Not a compatibility promise for protected members.** The promise covers
+  what a consumer calls and what an implementor must provide. Subclassing
+  internals of ``@api`` classes is out of contract.
+
+Consequences
+============
+
+- 128 classes are ``@api`` (85 entry points and hand-verified members plus
+  43 added by running the closure to its fixpoint), 20 are extension points,
+  and every previously unmarked class in the internal directories carries
+  ``@internal`` (82 new markers; the rest existed). IDEs and PHPStan surface ``@internal`` usage from
+  outside the package.
+- ``Documentation/Api/Stability.rst`` states the promise in consumer terms
+  and is the first page of the API reference.
+- A follow-up PR adds the snapshot test that freezes the rendered ``@api``
+  signatures in-repo, so an unintended break fails CI before review.
+- New code must pick a marker at creation time; the snapshot test's file list
+  makes an unmarked new public-namespace class visible in review.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -424,3 +424,4 @@ Tools
    Adr124ProviderKeyFromTheCommandLine
    Adr125PerAdapterCollaborators
    Adr126StrictSchemaSubset
+   Adr127ApiSurfaceMarkers

--- a/Documentation/Api/Index.rst
+++ b/Documentation/Api/Index.rst
@@ -11,6 +11,7 @@ Complete API reference for the TYPO3 LLM extension.
 .. toctree::
    :maxdepth: 2
 
+   Stability
    LlmServiceManager
    CompletionService
    EmbeddingService

--- a/Documentation/Api/Stability.rst
+++ b/Documentation/Api/Stability.rst
@@ -28,7 +28,7 @@ and the typed exceptions they throw. Within a major version:
 Everything a marked method's signature mentions is itself ``@api`` — you
 never receive an object you are not allowed to rely on.
 
-``@api`` extension point — implement it
+``@api Extension point`` — implement it
 ---------------------------------------
 
 Interfaces and attributes third parties *implement*:
@@ -36,7 +36,8 @@ Interfaces and attributes third parties *implement*:
 and the capability interfaces, :php:`TranslatorInterface`,
 :php:`SearchBackendInterface`, the preset/evaluation providers, the
 middleware contracts, and the ``#[AsLlmProvider]`` / ``#[AsTranslator]``
-attributes. These carry the stricter promise implementation forces:
+attributes. These carry a stricter promise, forced by the direction of
+implementation:
 **no new abstract member within a major version** — adding one would break
 every existing implementation, not just callers.
 

--- a/Documentation/Api/Stability.rst
+++ b/Documentation/Api/Stability.rst
@@ -1,0 +1,68 @@
+.. include:: /Includes.rst.txt
+
+.. _api-stability:
+
+=============
+API stability
+=============
+
+Which classes the semantic-versioning promise covers, and what it promises.
+The authority is the marker in each class-level docblock, not this page and
+not the DI container visibility (:ref:`ADR-127 <adr-127>`).
+
+The three markers
+=================
+
+``@api`` — call it
+------------------
+
+Classes and interfaces you *call*: the feature services
+(:php:`CompletionServiceInterface` and friends), :php:`LlmServiceManager`,
+the option classes, the response and value objects they accept and return,
+and the typed exceptions they throw. Within a major version:
+
+- no class or method is removed,
+- no method signature changes incompatibly,
+- documented behaviour does not break.
+
+Everything a marked method's signature mentions is itself ``@api`` — you
+never receive an object you are not allowed to rely on.
+
+``@api`` extension point — implement it
+---------------------------------------
+
+Interfaces and attributes third parties *implement*:
+:php:`ToolInterface`, :php:`GuardrailInterface`, :php:`ProviderInterface`
+and the capability interfaces, :php:`TranslatorInterface`,
+:php:`SearchBackendInterface`, the preset/evaluation providers, the
+middleware contracts, and the ``#[AsLlmProvider]`` / ``#[AsTranslator]``
+attributes. These carry the stricter promise implementation forces:
+**no new abstract member within a major version** — adding one would break
+every existing implementation, not just callers.
+
+``@internal`` — hands off
+-------------------------
+
+Everything else: backend controllers, dashboard widgets, hooks, upgrade
+wizards, console commands, DI compiler passes, TCA form elements, Extbase
+repositories and the setup wizard. These may change or disappear in **any**
+release, including patch releases. PHPStan and modern IDEs warn when code
+outside this package touches them.
+
+What is out of contract
+=======================
+
+- Subclassing internals: protected members of ``@api`` classes are not part
+  of the promise. Extend via the extension points, not inheritance.
+- Constructor signatures of ``@api`` *services*: obtain them from the DI
+  container, never via ``new``. Constructing option/value objects directly
+  is fine — their constructors are part of the signature promise.
+- Anything reached by reflection or by reading private state.
+
+Versioning during 0.x
+=====================
+
+While the extension is pre-1.0, the promise applies one level down, as is
+conventional: **minor releases (0.N → 0.N+1) may break**, and do so only
+with a CHANGELOG entry under a BREAKING heading; patch releases do not
+break. From 1.0.0 on the promise applies as written above.

--- a/Tests/Unit/Configuration/PublicServicesPolicyTest.php
+++ b/Tests/Unit/Configuration/PublicServicesPolicyTest.php
@@ -67,11 +67,12 @@ final class PublicServicesPolicyTest extends TestCase
      *   PromptSnippetComposer (ADR-031, no interface).
      * - Category D (Specialized standalone consumer API): 5 —
      *   Whisper, TextToSpeech, DallE, Fal, DocumentAnalysis (ADR-076).
-     * - Category E (resolved outside DI via makeInstance()): 2 —
-     *   ToolRegistry (TCA itemsProcFunc, ADR-042) and ProviderDetector
+     * - Category E (resolved outside DI via makeInstance()): 3 —
+     *   ToolRegistry (TCA itemsProcFunc, ADR-042), GuardrailRegistry
+     *   (TCA itemsProcFunc `GuardrailItems`, ADR-106) and ProviderDetector
      *   (ProviderEndpointNormalizationHook, a DataHandler hook).
      *
-     * Total: 19 + 8 + 1 + 5 + 2 = **35**.
+     * Total: 19 + 8 + 1 + 5 + 3 = **36**.
      *
      * To intentionally change this number: update both this
      * constant AND the matching breakdown in


### PR DESCRIPTION
## What

Every class-level docblock now states its stability tier (ADR-127):

- **`@api`** (128 classes): the callable consumer surface. Membership is the signature-transitive closure of the entry points, computed to its fixpoint — every type an `@api` signature mentions is `@api` (response objects, option classes, value objects, enums, typed exceptions, the `Classes/Testing/` fakes).
- **`@api` extension point** (20 interfaces/attributes): contracts third parties implement — the 11 `TAG_NAME` interfaces, `ProviderInterface` + the 4 capability interfaces, `TranslatorInterface`, `GuardrailIdentity`, `#[AsLlmProvider]`/`#[AsTranslator]`, middleware/usage contracts. Stricter promise: no new abstract member within a major version.
- **`@internal`** (82 new markers): controllers, widgets, hooks, upgrade wizards, commands, DI passes, form elements, repositories, setup wizard — and the ADR-126 schema classes.

New pages:
- `Documentation/Api/Stability.rst` — the promise in consumer terms, first page of the API reference (incl. the 0.x convention: minor may break with a CHANGELOG BREAKING entry, patch never).
- `Documentation/Adr/Adr127ApiSurfaceMarkers.rst` — the rules, and what this deliberately is not (no phpat rule — the closure is asserted by the follow-up snapshot test; no change to ADR-028/065/101 container-visibility authority).
- CONTRIBUTING: new classes pick a marker at creation time.

Ride-along: the `PublicServicesPolicyTest` docblock caught up with reality — Category E includes `GuardrailRegistry` (ADR-106), total 36, matching the constant that was already 36.

No runtime behaviour changes; the diff is docblocks and docs.

## Follow-up (separate PR)

`ApiSurfaceSnapshotTest`: renders every `@api` signature into a committed snapshot so an unintended break fails CI; the closure property is asserted there.

## Tests

All six pre-push suites green locally on PHP 8.2 (unit 5958, fuzzy, functional sqlite, phpstan, cgl, rector), re-verified after the rebase onto ADR-126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)