### PR TITLE
feat(provider): enforce structured output natively per provider (ADR-128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   abstract member within a major version), `@internal` for everything else.
   `Documentation/Api/Stability.rst` states the promise in consumer terms;
   ADR-127 records the rules. No runtime behaviour changes.
+- Structured completions are enforced natively where the provider can
+  (ADR-128). The pre-flighted schema rides along as
+  `ChatOptions::withResponseSchema()` and each adapter emits its dialect:
+  OpenAI/Groq/Mistral/OpenRouter send `json_schema` strict mode when the
+  schema qualifies for it (JSON mode otherwise), Gemini sets
+  `responseSchema` + `responseMimeType`, Ollama the `format` field, Claude
+  a single forced tool whose input is the answer. Plain JSON mode
+  (`completeJson()`) now reaches all seven providers instead of OpenAI
+  alone. The local strict validation stays authoritative; the prompt
+  instruction and repair round-trip are unchanged.
 - Tools from an external MCP server can be used in an agent run. An
   administrator configures a server, imports the catalogue it advertises and
   enables individual tools; import is the only network call outside a run and

--- a/Classes/Provider/ClaudeProvider.php
+++ b/Classes/Provider/ClaudeProvider.php
@@ -49,6 +49,10 @@ final class ClaudeProvider extends AbstractProvider implements
 
     private const API_VERSION = '2023-06-01';
 
+    // The forced single tool that carries a `response_schema` natively
+    // (ADR-128); its tool_use input is the structured answer.
+    private const STRUCTURED_OUTPUT_TOOL = 'emit_structured_output';
+
     public function getName(): string
     {
         return 'Anthropic Claude';
@@ -188,9 +192,26 @@ final class ClaudeProvider extends AbstractProvider implements
 
         $payload = array_merge($payload, $this->buildSamplingParams($options));
 
+        // The Messages API has no response_format; the native way to enforce
+        // a schema is a single forced tool whose input_schema IS the schema
+        // (ADR-128). Claude requires an object root; anything else falls back
+        // to the prompt instruction, which the caller sends either way.
+        $responseSchema  = $options['response_schema'] ?? null;
+        $forcedStructure = is_array($responseSchema)
+            && ($responseSchema['type'] ?? null) === 'object';
+        if ($forcedStructure) {
+            $payload['tools'] = [[
+                'name'         => self::STRUCTURED_OUTPUT_TOOL,
+                'description'  => 'Record the answer as JSON matching the schema. Always use this tool.',
+                'input_schema' => $responseSchema,
+            ]];
+            $payload['tool_choice'] = ['type' => 'tool', 'name' => self::STRUCTURED_OUTPUT_TOOL];
+        }
+
         $response = $this->sendRequest('messages', $payload, timeout: $this->resolveRequestTimeout($options));
 
         $content = '';
+        $structuredContent = null;
         $nativeThinkingBlocks = [];
         $contentBlocks = $this->getList($response, 'content');
         foreach ($contentBlocks as $block) {
@@ -200,8 +221,19 @@ final class ClaudeProvider extends AbstractProvider implements
                 $content .= $this->getString($blockArray, 'text');
             } elseif ($blockType === 'thinking') {
                 $nativeThinkingBlocks[] = $this->getString($blockArray, 'thinking');
+            } elseif (
+                $forcedStructure
+                && $blockType === 'tool_use'
+                && $this->getString($blockArray, 'name') === self::STRUCTURED_OUTPUT_TOOL
+            ) {
+                // The forced tool's input IS the structured answer; hand it
+                // back as the JSON string every other provider returns.
+                $structuredContent = json_encode($this->getArray($blockArray, 'input'), JSON_THROW_ON_ERROR);
             }
         }
+
+        // The structured answer wins over any preamble/trailing prose.
+        $content = $structuredContent ?? $content;
 
         $nativeThinking = implode("\n", $nativeThinkingBlocks);
         [$content, $inlineThinking] = $this->extractThinkingBlocks($content);

--- a/Classes/Provider/GeminiProvider.php
+++ b/Classes/Provider/GeminiProvider.php
@@ -167,6 +167,8 @@ final class GeminiProvider extends AbstractProvider implements
             $payload['generationConfig']['stopSequences'] = $options['stop_sequences'];
         }
 
+        $payload['generationConfig'] = $this->applyResponseFormat($payload['generationConfig'], $options);
+
         $response = $this->sendRequest(
             "models/{$model}:generateContent",
             $payload,
@@ -817,6 +819,118 @@ final class GeminiProvider extends AbstractProvider implements
             'RECITATION' => 'content_filter',
             default => strtolower($reason),
         };
+    }
+
+    /**
+     * Emit Gemini's native structured-output fields (ADR-128).
+     *
+     * `response_schema` → `responseSchema` in Gemini's OpenAPI-flavoured
+     * dialect plus `responseMimeType: application/json`; plain
+     * `response_format: 'json'` → the mime type alone. The dialect keeps only
+     * keywords Gemini documents; a schema whose ROOT the dialect cannot
+     * express (union type) degrades to the mime type. Dropping keywords only
+     * ever WIDENS what the model may emit — safe, because the local strict
+     * validation (ADR-126) remains authoritative on the response.
+     *
+     * @param array<string, mixed> $generationConfig
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>
+     */
+    private function applyResponseFormat(array $generationConfig, array $options): array
+    {
+        $schema = $options['response_schema'] ?? null;
+        $format = $options['response_format'] ?? null;
+
+        if (is_array($schema) && $schema !== []) {
+            $generationConfig['responseMimeType'] = 'application/json';
+            $dialectSchema                        = $this->toGeminiSchema($schema);
+            if ($dialectSchema !== null) {
+                $generationConfig['responseSchema'] = $dialectSchema;
+            }
+
+            return $generationConfig;
+        }
+
+        if ($format === 'json') {
+            $generationConfig['responseMimeType'] = 'application/json';
+        }
+
+        return $generationConfig;
+    }
+
+    /**
+     * Reduce an ADR-126 subset schema to Gemini's schema dialect: keep
+     * `type` (single string only), `enum`, `description`, `properties`,
+     * `required`, `items`; drop everything else. Null when the node has no
+     * expressible type.
+     *
+     * @param array<array-key, mixed> $schema
+     *
+     * @return array<string, mixed>|null
+     */
+    private function toGeminiSchema(array $schema): ?array
+    {
+        $type = $schema['type'] ?? null;
+        if (!is_string($type)) {
+            return null;
+        }
+
+        $result = ['type' => strtoupper($type)];
+
+        if (isset($schema['description']) && is_string($schema['description'])) {
+            $result['description'] = $schema['description'];
+        }
+
+        // Gemini enums are string-only. A partially-filtered enum would
+        // NARROW below the real schema and block valid values, so the
+        // keyword is kept only when it is expressible in full.
+        if ($type === 'string' && isset($schema['enum']) && is_array($schema['enum'])) {
+            $values = array_values(array_filter($schema['enum'], is_string(...)));
+            if (count($values) === count($schema['enum'])) {
+                $result['enum'] = $values;
+            }
+        }
+
+        if ($type === 'object' && isset($schema['properties']) && is_array($schema['properties'])) {
+            $properties = [];
+            foreach ($schema['properties'] as $name => $subSchema) {
+                if (!is_string($name)) {
+                    continue;
+                }
+
+                if (!is_array($subSchema)) {
+                    continue;
+                }
+
+                $converted = $this->toGeminiSchema($subSchema);
+                if ($converted !== null) {
+                    $properties[$name] = $converted;
+                }
+            }
+
+            if ($properties !== []) {
+                $result['properties'] = $properties;
+                $required             = array_values(array_filter(
+                    is_array($schema['required'] ?? null) ? $schema['required'] : [],
+                    // A required name whose property was dropped must not
+                    // survive — Gemini rejects required-without-property.
+                    static fn(mixed $name): bool => is_string($name) && isset($properties[$name]),
+                ));
+                if ($required !== []) {
+                    $result['required'] = $required;
+                }
+            }
+        }
+
+        if ($type === 'array' && isset($schema['items']) && is_array($schema['items'])) {
+            $items = $this->toGeminiSchema($schema['items']);
+            if ($items !== null) {
+                $result['items'] = $items;
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/Classes/Provider/GroqProvider.php
+++ b/Classes/Provider/GroqProvider.php
@@ -40,6 +40,8 @@ final class GroqProvider extends AbstractProvider implements
     StreamingCapableInterface,
     ToolCapableInterface
 {
+    use OpenAiResponseFormatTrait;
+
     /** @var array<string> */
     protected array $supportedFeatures = [
         self::FEATURE_CHAT,
@@ -140,6 +142,11 @@ final class GroqProvider extends AbstractProvider implements
             'temperature' => $this->getFloat($options, 'temperature', 0.7),
             'max_tokens' => $this->getInt($options, 'max_tokens', 4096),
         ];
+
+        $responseFormat = $this->buildResponseFormat($options);
+        if ($responseFormat !== null) {
+            $payload['response_format'] = $responseFormat;
+        }
 
         if (isset($options['top_p'])) {
             $payload['top_p'] = $this->getFloat($options, 'top_p');

--- a/Classes/Provider/MistralProvider.php
+++ b/Classes/Provider/MistralProvider.php
@@ -38,6 +38,8 @@ final class MistralProvider extends AbstractProvider implements
     StreamingCapableInterface,
     ToolCapableInterface
 {
+    use OpenAiResponseFormatTrait;
+
     /** @var array<string> */
     protected array $supportedFeatures = [
         self::FEATURE_CHAT,
@@ -133,6 +135,11 @@ final class MistralProvider extends AbstractProvider implements
             'temperature' => $this->getFloat($options, 'temperature', 0.7),
             'max_tokens' => $this->getInt($options, 'max_tokens', 4096),
         ];
+
+        $responseFormat = $this->buildResponseFormat($options);
+        if ($responseFormat !== null) {
+            $payload['response_format'] = $responseFormat;
+        }
 
         if (isset($options['top_p'])) {
             $payload['top_p'] = $this->getFloat($options, 'top_p');

--- a/Classes/Provider/OllamaProvider.php
+++ b/Classes/Provider/OllamaProvider.php
@@ -197,6 +197,16 @@ final class OllamaProvider extends AbstractProvider implements StreamingCapableI
             $payload['think'] = $options['think'];
         }
 
+        // Also a top-level field, like `think`: a JSON schema Ollama enforces
+        // during generation, or the string 'json' for plain JSON mode
+        // (ADR-128). The local strict validation remains authoritative.
+        $responseSchema = $options['response_schema'] ?? null;
+        if (is_array($responseSchema) && $responseSchema !== []) {
+            $payload['format'] = $responseSchema;
+        } elseif (($options['response_format'] ?? null) === 'json') {
+            $payload['format'] = 'json';
+        }
+
         if ($payloadOptions !== []) {
             $payload['options'] = $payloadOptions;
         }

--- a/Classes/Provider/OpenAiProvider.php
+++ b/Classes/Provider/OpenAiProvider.php
@@ -31,6 +31,8 @@ final class OpenAiProvider extends AbstractProvider implements
     StreamingCapableInterface,
     ToolCapableInterface
 {
+    use OpenAiResponseFormatTrait;
+
     /** @var array<string> */
     protected array $supportedFeatures = [
         self::FEATURE_CHAT,
@@ -467,27 +469,9 @@ final class OpenAiProvider extends AbstractProvider implements
         return (bool)preg_match('/^(o[1-9]|gpt-5)/', $model);
     }
 
-    /**
-     * Map the high-level `response_format` option to OpenAI's payload field.
-     *
-     * `completeJson()` requests `'json'` and then strictly `json_decode`s the
-     * reply, so the request MUST carry `response_format: {type: json_object}`
-     * — otherwise the model is free to wrap the JSON in prose/Markdown fences
-     * and the decode throws "Failed to decode JSON response". OpenAI's JSON
-     * mode requires the word "json" somewhere in the messages, which the
-     * callers (e.g. nr_repurpose's DocumentAnalyzer) already guarantee. `text`
-     * and `markdown` map to plain text, so we leave the field unset.
-     *
-     * @param array<string, mixed> $options
-     *
-     * @return array{type: string}|null
-     */
-    private function buildResponseFormat(array $options): ?array
-    {
-        return $this->getString($options, 'response_format') === 'json'
-            ? ['type' => 'json_object']
-            : null;
-    }
+    // buildResponseFormat() is provided by OpenAiResponseFormatTrait
+    // (ADR-128): json_schema strict when the schema qualifies, json_object
+    // otherwise / for plain `'json'`.
 
     /**
      * Build sampling parameters, stripping them for reasoning models.

--- a/Classes/Provider/OpenAiResponseFormatTrait.php
+++ b/Classes/Provider/OpenAiResponseFormatTrait.php
@@ -112,18 +112,31 @@ trait OpenAiResponseFormatTrait
                 return false;
             }
 
-            $propertyNames = array_map(strval(...), array_keys($properties));
+            // Fail closed on malformed maps instead of filtering them into
+            // shape: the ORIGINAL schema is what gets sent, so a dropped
+            // invalid entry would qualify a schema the API then rejects.
+            $propertyNames = [];
+            foreach ($properties as $name => $subSchema) {
+                if (!is_string($name) || !is_array($subSchema) || !$this->strictNodeQualifies($subSchema)) {
+                    return false;
+                }
+
+                $propertyNames[] = $name;
+            }
+
+            $requiredNames = [];
+            foreach ($required as $requiredName) {
+                if (!is_string($requiredName)) {
+                    return false;
+                }
+
+                $requiredNames[] = $requiredName;
+            }
+
             sort($propertyNames);
-            $requiredNames = array_values(array_filter($required, is_string(...)));
             sort($requiredNames);
             if ($propertyNames !== $requiredNames) {
                 return false;
-            }
-
-            foreach ($properties as $subSchema) {
-                if (!is_array($subSchema) || !$this->strictNodeQualifies($subSchema)) {
-                    return false;
-                }
             }
         }
 

--- a/Classes/Provider/OpenAiResponseFormatTrait.php
+++ b/Classes/Provider/OpenAiResponseFormatTrait.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider;
+
+/**
+ * Builds the `response_format` payload field for the OpenAI-compatible
+ * chat-completions dialect (OpenAI, Groq, Mistral, OpenRouter) — ADR-128.
+ *
+ * Three rungs, most enforcing first:
+ *
+ * 1. `response_schema` present AND the schema qualifies for OpenAI's strict
+ *    mode → `{type: json_schema, json_schema: {strict: true, …}}`. The API
+ *    then guarantees schema-conformant output.
+ * 2. `response_schema` present but not strict-qualified → `{type:
+ *    json_object}`. Strict mode rejects the request (HTTP 400) for schemas
+ *    outside its rules, which would turn a valid ADR-126 schema into a
+ *    provider error; JSON mode plus the prompt instruction and the local
+ *    strict validation is the correct degradation.
+ * 3. No schema, `response_format: 'json'` → `{type: json_object}`.
+ *    `completeJson()` strictly `json_decode`s the reply, so the request MUST
+ *    carry JSON mode — otherwise the model is free to wrap the JSON in
+ *    prose/Markdown fences and the decode throws. JSON mode requires the
+ *    word "json" somewhere in the messages, which the callers guarantee.
+ *
+ * `text` and `markdown` map to plain text: field unset.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
+trait OpenAiResponseFormatTrait
+{
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>|null
+     */
+    private function buildResponseFormat(array $options): ?array
+    {
+        $schema = $options['response_schema'] ?? null;
+        if (is_array($schema) && $schema !== []) {
+            if ($this->qualifiesForStrictMode($schema)) {
+                return [
+                    'type' => 'json_schema',
+                    'json_schema' => [
+                        'name' => 'structured_output',
+                        'strict' => true,
+                        'schema' => $schema,
+                    ],
+                ];
+            }
+
+            return ['type' => 'json_object'];
+        }
+
+        return ($options['response_format'] ?? null) === 'json'
+            ? ['type' => 'json_object']
+            : null;
+    }
+
+    /**
+     * Whether the schema satisfies OpenAI's strict-mode rules: root type
+     * `object`, every object node with `additionalProperties: false` and
+     * every property required, and only keywords from a conservative
+     * allowlist. Deliberately narrower than the ADR-126 subset — a schema
+     * strict mode would reject must fall back to JSON mode, never surface
+     * as a provider 400. Widening the allowlist is additive.
+     *
+     * @param array<array-key, mixed> $schema
+     */
+    private function qualifiesForStrictMode(array $schema): bool
+    {
+        return ($schema['type'] ?? null) === 'object' && $this->strictNodeQualifies($schema);
+    }
+
+    /**
+     * @param array<array-key, mixed> $node
+     */
+    private function strictNodeQualifies(array $node): bool
+    {
+        foreach (array_keys($node) as $keyword) {
+            if (!is_string($keyword)
+                || !in_array($keyword, ['type', 'properties', 'required', 'additionalProperties', 'items', 'enum', 'description', 'title'], true)
+            ) {
+                return false;
+            }
+        }
+
+        $type = $node['type'] ?? null;
+        if (!is_string($type)) {
+            // Union types (`['string', 'null']`) are out of the conservative
+            // profile even though strict mode could express some of them.
+            return false;
+        }
+
+        if ($type === 'object') {
+            if (($node['additionalProperties'] ?? null) !== false) {
+                return false;
+            }
+
+            $properties = $node['properties'] ?? [];
+            $required   = $node['required'] ?? [];
+            // Non-empty required too: an empty `properties` map would encode
+            // as JSON `[]` instead of `{}` (the PHP empty-array ambiguity)
+            // and strict mode rejects objects without properties anyway.
+            if (!is_array($properties) || $properties === [] || !is_array($required)) {
+                return false;
+            }
+
+            $propertyNames = array_map(strval(...), array_keys($properties));
+            sort($propertyNames);
+            $requiredNames = array_values(array_filter($required, is_string(...)));
+            sort($requiredNames);
+            if ($propertyNames !== $requiredNames) {
+                return false;
+            }
+
+            foreach ($properties as $subSchema) {
+                if (!is_array($subSchema) || !$this->strictNodeQualifies($subSchema)) {
+                    return false;
+                }
+            }
+        }
+
+        if ($type === 'array') {
+            $items = $node['items'] ?? null;
+            if (!is_array($items) || !$this->strictNodeQualifies($items)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/Classes/Provider/OpenRouterProvider.php
+++ b/Classes/Provider/OpenRouterProvider.php
@@ -53,6 +53,8 @@ final class OpenRouterProvider extends AbstractProvider implements
     StreamingCapableInterface,
     ToolCapableInterface
 {
+    use OpenAiResponseFormatTrait;
+
     /** @var array<string> */
     protected array $supportedFeatures = [
         self::FEATURE_CHAT,
@@ -300,6 +302,11 @@ final class OpenRouterProvider extends AbstractProvider implements
             'temperature' => $this->getFloat($options, 'temperature', 0.7),
             'max_tokens' => $this->getInt($options, 'max_tokens', 4096),
         ];
+
+        $responseFormat = $this->buildResponseFormat($options);
+        if ($responseFormat !== null) {
+            $payload['response_format'] = $responseFormat;
+        }
 
         // Optional parameters
         if (isset($options['top_p'])) {

--- a/Classes/Service/Feature/CompletionService.php
+++ b/Classes/Service/Feature/CompletionService.php
@@ -138,7 +138,10 @@ final readonly class CompletionService implements CompletionServiceInterface
             );
         }
 
-        $options    = ($options ?? new ChatOptions())->withResponseFormat('json');
+        // The schema rides along for providers that can enforce it natively
+        // (ADR-128); the prompt instruction and the strict validation below
+        // stay — native enforcement narrows, local validation decides.
+        $options    = ($options ?? new ChatOptions())->withResponseFormat('json')->withResponseSchema($schema);
         $schemaJson = $this->encodeSchema($schema);
 
         $first  = $this->complete($this->withSchemaInstruction($prompt, $schemaJson), $options)->content;
@@ -235,7 +238,9 @@ final readonly class CompletionService implements CompletionServiceInterface
             );
         }
 
-        $options    = ($options ?? new ChatOptions())->withResponseFormat('json');
+        // Same ride-along as completeStructured(): native enforcement narrows,
+        // local strict validation decides.
+        $options    = ($options ?? new ChatOptions())->withResponseFormat('json')->withResponseSchema($schema);
         $schemaJson = $this->encodeSchema($schema);
 
         $first  = $this->completeForConfiguration($this->withSchemaInstruction($prompt, $schemaJson), $configuration, $options)->content;

--- a/Classes/Service/Option/ChatOptions.php
+++ b/Classes/Service/Option/ChatOptions.php
@@ -50,6 +50,10 @@ class ChatOptions extends AbstractOptions implements BudgetAwareOptionsInterface
     // constructor parameter would collide with the subclass's own parameters.
     private ?bool $suppressRequestCount = null;
 
+    // Same constructor constraint as suppressRequestCount.
+    /** @var array<string, mixed>|null */
+    private ?array $responseSchema = null;
+
     // ========================================
     // Factory Presets
     // ========================================
@@ -173,6 +177,23 @@ class ChatOptions extends AbstractOptions implements BudgetAwareOptionsInterface
         return $clone;
     }
 
+    /**
+     * Attach a JSON schema the provider should enforce natively where it can
+     * (ADR-128). The schema must lie inside the strict subset (ADR-126) —
+     * CompletionService pre-flights that before any provider call; adapters
+     * treat the value as opaque and emit their provider's dialect from it.
+     * Native enforcement narrows what the model can emit; the local strict
+     * validation on the response remains authoritative either way.
+     *
+     * @param array<string, mixed> $responseSchema
+     */
+    public function withResponseSchema(array $responseSchema): static
+    {
+        $clone = clone $this;
+        $clone->responseSchema = $responseSchema;
+        return $clone;
+    }
+
     public function withSystemPrompt(string $systemPrompt): static
     {
         $clone = clone $this;
@@ -280,6 +301,14 @@ class ChatOptions extends AbstractOptions implements BudgetAwareOptionsInterface
         return $this->responseFormat;
     }
 
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getResponseSchema(): ?array
+    {
+        return $this->responseSchema;
+    }
+
     public function getSystemPrompt(): ?string
     {
         return $this->systemPrompt;
@@ -319,6 +348,7 @@ class ChatOptions extends AbstractOptions implements BudgetAwareOptionsInterface
             'frequency_penalty' => $this->frequencyPenalty,
             'presence_penalty' => $this->presencePenalty,
             'response_format' => $this->responseFormat,
+            'response_schema' => $this->responseSchema,
             'system_prompt' => $this->systemPrompt,
             'stop_sequences' => $this->stopSequences,
             'provider' => $this->provider,

--- a/Documentation/Adr/Adr082StructuredOutputs.rst
+++ b/Documentation/Adr/Adr082StructuredOutputs.rst
@@ -58,7 +58,10 @@ requires *strict* schemas (``additionalProperties: false`` and every property
 required), which arbitrary consumer schemas do not satisfy and which would 400
 the request; Claude has no native parameter at all. Wiring native, per-provider
 enforcement — behind a schema-compatibility normaliser — is a separate, additive
-change and is noted as a follow-up, not a blocker.
+change and is noted as a follow-up, not a blocker. (:ref:`ADR-128 <adr-128>`
+delivered that follow-up: native emission behind a conservative
+compatibility profile, degrading to JSON mode; Claude via a forced tool.
+The prompt + local validation + repair architecture described here stands.)
 
 .. _adr-082-consequences:
 

--- a/Documentation/Adr/Adr126StrictSchemaSubset.rst
+++ b/Documentation/Adr/Adr126StrictSchemaSubset.rst
@@ -88,5 +88,6 @@ Consequences
 - ADR-082's "no enum/pattern/oneOf" consequence is superseded by this ADR;
   its no-runtime-dependency decision and the repair round-trip stand.
 - Provider-native structured output (OpenAI ``json_schema``, Gemini
-  ``responseSchema``, Ollama ``format``) remains the separate follow-up
-  ADR-082 named; the subset walker is the compatibility gate it will need.
+  ``responseSchema``, Ollama ``format``) was the separate follow-up ADR-082
+  named; :ref:`ADR-128 <adr-128>` delivered it, with the subset walker as
+  its pre-flight gate.

--- a/Documentation/Adr/Adr128ProviderNativeStructuredOutput.rst
+++ b/Documentation/Adr/Adr128ProviderNativeStructuredOutput.rst
@@ -1,0 +1,82 @@
+.. _adr-128:
+
+===========================================
+ADR-128: Provider-native structured output
+===========================================
+
+:Status: Accepted
+:Date: 2026-08-05
+
+Context
+=======
+
+ADR-082 built structured completions on a prompt instruction plus local
+validation and one repair round-trip, and named native, per-provider
+enforcement as a follow-up behind a schema-compatibility normaliser.
+ADR-126 delivered the missing precondition: a named, pre-flighted schema
+subset. What remained was the transport — the recon found that only the
+OpenAI adapter emitted any ``response_format`` at all; the other six
+adapters silently dropped the option, so even plain JSON mode was
+prompt-only on six of seven providers.
+
+Decision
+========
+
+``ChatOptions`` gains ``withResponseSchema(array)`` (declared outside the
+constructor, like ``suppressRequestCount`` — the
+``@phpstan-consistent-constructor``/``ToolOptions`` constraint). Both
+``completeStructured*()`` methods attach the already-pre-flighted schema;
+it reaches the adapter as ``response_schema`` in the flat options array.
+Each adapter emits its provider's dialect:
+
+- **OpenAI, Groq, Mistral, OpenRouter** share
+  ``OpenAiResponseFormatTrait``. A schema that qualifies for OpenAI's
+  strict mode (conservative profile: object root, every object
+  ``additionalProperties: false`` with all properties required, allowlisted
+  keywords only) is sent as ``response_format: {type: json_schema, strict:
+  true}``; any other schema degrades to ``{type: json_object}`` — strict
+  mode 400s on schemas outside its rules, and a provider error for a valid
+  ADR-126 schema is the failure mode this profile exists to prevent. Plain
+  ``response_format: 'json'`` now emits JSON mode on all four (previously:
+  OpenAI only).
+- **Gemini** sets ``generationConfig.responseMimeType: application/json``
+  and, when the root is expressible, ``responseSchema`` in Gemini's
+  dialect. The dialect conversion only ever **widens** (drops keywords it
+  cannot express — a partially-converted ``enum`` would narrow below the
+  real schema and block valid values, so inexpressible keywords are dropped
+  whole).
+- **Ollama** sends the schema verbatim as the top-level ``format`` field
+  (like ``think``), or ``format: 'json'`` for plain JSON mode.
+- **Claude** has no response-format parameter; the native idiom is a single
+  forced tool whose ``input_schema`` is the schema, and whose ``tool_use``
+  input is returned as the JSON string every other provider returns.
+  Object-root schemas only (Claude's requirement); anything else stays
+  prompt-only.
+
+The invariant that makes all of this safe: **native enforcement narrows
+what the model can emit; the local strict validation (ADR-126) remains
+authoritative on the response.** Native emission may be weaker than the
+schema (Gemini dialect, json_object fallback) but must never be stronger;
+the prompt instruction and the repair round-trip stay untouched.
+
+Consequences
+============
+
+- ``completeJson()`` now gets real JSON mode on Groq, Mistral, OpenRouter,
+  Ollama and Gemini instead of relying on the prompt alone — fewer
+  "Failed to decode JSON response" failures, no API change.
+- Streaming is deliberately out of scope: structured completions never
+  stream (ADR-062), so ``streamChatCompletion()`` does not emit schemas.
+- The strict-mode profile and the Gemini dialect are conservative by
+  design; widening them (more keywords, union types) is additive and needs
+  no API change.
+- Ollama receives the full subset schema; its grammar conversion handles
+  the ADR-126 keyword set, but an exotic schema a future Ollama version
+  rejects would surface as a provider error — accepted, since Ollama is
+  the local reference provider and the schema was pre-flighted.
+- On Claude, a structured completion's ``finishReason`` reflects the
+  forced tool call (``tool_calls``) rather than ``stop``; callers of
+  ``completeStructured*()`` consume the decoded array, not the reason.
+- ADR-082's "no native parameter at all" statement about Claude is
+  superseded by the tool-forcing idiom; its prompt+repair architecture
+  stands.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -425,3 +425,4 @@ Tools
    Adr125PerAdapterCollaborators
    Adr126StrictSchemaSubset
    Adr127ApiSurfaceMarkers
+   Adr128ProviderNativeStructuredOutput

--- a/Tests/Unit/Provider/ClaudeProviderTest.php
+++ b/Tests/Unit/Provider/ClaudeProviderTest.php
@@ -225,6 +225,71 @@ class ClaudeProviderTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function chatCompletionForcesAStructuredOutputToolForAnObjectSchema(): void
+    {
+        $schema = [
+            'type'       => 'object',
+            'properties' => ['name' => ['type' => 'string']],
+            'required'   => ['name'],
+        ];
+
+        $payload = $this->captureChatPayload(['response_schema' => $schema]);
+
+        // The Messages API has no response_format; the schema travels as a
+        // single forced tool (ADR-128).
+        self::assertSame([[
+            'name'         => 'emit_structured_output',
+            'description'  => 'Record the answer as JSON matching the schema. Always use this tool.',
+            'input_schema' => $schema,
+        ]], $payload['tools'] ?? null);
+        self::assertSame(['type' => 'tool', 'name' => 'emit_structured_output'], $payload['tool_choice'] ?? null);
+    }
+
+    #[Test]
+    public function chatCompletionOmitsToolForcingForANonObjectSchema(): void
+    {
+        // Claude requires an object root on input_schema; anything else
+        // stays prompt-only (ADR-128).
+        $payload = $this->captureChatPayload(['response_schema' => ['enum' => ['a', 'b']]]);
+
+        self::assertArrayNotHasKey('tools', $payload);
+        self::assertArrayNotHasKey('tool_choice', $payload);
+    }
+
+    #[Test]
+    public function chatCompletionReturnsTheForcedToolInputAsJsonContent(): void
+    {
+        $apiResponse = [
+            'id' => 'msg_test',
+            'type' => 'message',
+            'role' => 'assistant',
+            'content' => [
+                // Preamble prose must NOT survive into the structured answer.
+                ['type' => 'text', 'text' => 'Here is the result:'],
+                ['type' => 'tool_use', 'id' => 'tu_1', 'name' => 'emit_structured_output', 'input' => ['name' => 'Ada']],
+            ],
+            'model' => 'claude-sonnet-4-20250514',
+            'stop_reason' => 'tool_use',
+            'usage' => ['input_tokens' => 5, 'output_tokens' => 2],
+        ];
+
+        $this->httpClientStub
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($apiResponse));
+
+        $result = $this->subject->chatCompletion(
+            [['role' => 'user', 'content' => 'Emit']],
+            ['response_schema' => [
+                'type'       => 'object',
+                'properties' => ['name' => ['type' => 'string']],
+                'required'   => ['name'],
+            ]],
+        );
+
+        self::assertSame('{"name":"Ada"}', $result->content);
+    }
+
+    #[Test]
     public function chatCompletionThrowsProviderResponseExceptionOn401(): void
     {
         $errorResponse = [

--- a/Tests/Unit/Provider/GeminiProviderTest.php
+++ b/Tests/Unit/Provider/GeminiProviderTest.php
@@ -1816,6 +1816,118 @@ class GeminiProviderTest extends AbstractUnitTestCase
         self::assertSame(0.7, $body['generationConfig']['temperature']);
         self::assertArrayHasKey('maxOutputTokens', $body['generationConfig']);
         self::assertSame(4096, $body['generationConfig']['maxOutputTokens']);
+        // Without response_format/response_schema neither native structured-
+        // output field may appear (ADR-128).
+        self::assertArrayNotHasKey('responseMimeType', $body['generationConfig']);
+        self::assertArrayNotHasKey('responseSchema', $body['generationConfig']);
+    }
+
+    #[Test]
+    public function chatCompletionEmitsResponseMimeTypeForJsonMode(): void
+    {
+        $capturedMethod = null;
+        $capturedUri    = null;
+        $capturedBody   = null;
+
+        $subject = $this->createCapturingSubject(
+            $this->okCandidateResponse(),
+            $capturedMethod,
+            $capturedUri,
+            $capturedBody,
+        );
+
+        $subject->chatCompletion(
+            [['role' => 'user', 'content' => 'Reply as json']],
+            ['response_format' => 'json'],
+        );
+
+        $body   = $this->decodeCapturedBody($capturedBody);
+        $config = $body['generationConfig'];
+        assert(is_array($config));
+        self::assertSame('application/json', $config['responseMimeType'] ?? null);
+        self::assertArrayNotHasKey('responseSchema', $config);
+    }
+
+    #[Test]
+    public function chatCompletionEmitsResponseSchemaInGeminiDialect(): void
+    {
+        $capturedMethod = null;
+        $capturedUri    = null;
+        $capturedBody   = null;
+
+        $subject = $this->createCapturingSubject(
+            $this->okCandidateResponse(),
+            $capturedMethod,
+            $capturedUri,
+            $capturedBody,
+        );
+
+        $subject->chatCompletion(
+            [['role' => 'user', 'content' => 'Reply as json']],
+            ['response_format' => 'json', 'response_schema' => [
+                'type'       => 'object',
+                'properties' => [
+                    'kind' => ['type' => 'string', 'enum' => ['a', 'b']],
+                    'tags' => ['type' => 'array', 'items' => ['type' => 'string']],
+                    // pattern is not expressible in Gemini's dialect: the
+                    // KEYWORD is dropped, the property survives (dropping
+                    // only ever widens — ADR-128).
+                    'code' => ['type' => 'string', 'pattern' => '^[a-z]+$'],
+                ],
+                'required'             => ['kind', 'code'],
+                'additionalProperties' => false,
+            ]],
+        );
+
+        $body   = $this->decodeCapturedBody($capturedBody);
+        $config = $body['generationConfig'];
+        assert(is_array($config));
+        self::assertSame('application/json', $config['responseMimeType'] ?? null);
+        self::assertSame([
+            'type'       => 'OBJECT',
+            'properties' => [
+                'kind' => ['type' => 'STRING', 'enum' => ['a', 'b']],
+                'tags' => ['type' => 'ARRAY', 'items' => ['type' => 'STRING']],
+                'code' => ['type' => 'STRING'],
+            ],
+            'required' => ['kind', 'code'],
+        ], $config['responseSchema'] ?? null);
+    }
+
+    #[Test]
+    public function chatCompletionDropsAnInexpressibleEnumWhole(): void
+    {
+        $capturedMethod = null;
+        $capturedUri    = null;
+        $capturedBody   = null;
+
+        $subject = $this->createCapturingSubject(
+            $this->okCandidateResponse(),
+            $capturedMethod,
+            $capturedUri,
+            $capturedBody,
+        );
+
+        // Gemini enums are string-only; a partially-filtered enum would
+        // NARROW below the real schema and block the value 2 — the keyword
+        // must be dropped in full (ADR-128).
+        $subject->chatCompletion(
+            [['role' => 'user', 'content' => 'Reply as json']],
+            ['response_schema' => [
+                'type'       => 'object',
+                'properties' => ['level' => ['type' => 'integer', 'enum' => [1, 2]]],
+                'required'   => ['level'],
+            ]],
+        );
+
+        $body   = $this->decodeCapturedBody($capturedBody);
+        $config = $body['generationConfig'];
+        assert(is_array($config));
+        self::assertSame([
+            'type'       => 'OBJECT',
+            'properties' => ['level' => ['type' => 'INTEGER']],
+            'required'   => ['level'],
+        ], $config['responseSchema'] ?? null);
     }
 
     #[Test]

--- a/Tests/Unit/Provider/GroqProviderTest.php
+++ b/Tests/Unit/Provider/GroqProviderTest.php
@@ -1111,6 +1111,36 @@ class GroqProviderTest extends AbstractUnitTestCase
         // Without stop/stop_sequences options no `stop` key may appear: pins
         // the `is_array(...)` guard against its `||` mutant (null would leak).
         self::assertArrayNotHasKey('stop', $body);
+        // Without a response_format/response_schema option no response_format
+        // key may appear (ADR-128).
+        self::assertArrayNotHasKey('response_format', $body);
+    }
+
+    #[Test]
+    public function chatCompletionEmitsResponseFormatForJsonMode(): void
+    {
+        $capturedMethod = null;
+        $capturedUrl    = null;
+        $capturedBody   = null;
+
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createCapturingSubject(
+            $capturedMethod,
+            $capturedUrl,
+            $capturedBody,
+        );
+
+        $httpClientMock
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock($this->chatApiResponseFixture()));
+
+        $subject->chatCompletion(
+            [['role' => 'user', 'content' => 'Reply as json']],
+            ['response_format' => 'json'],
+        );
+
+        $body = $this->decodeCapturedBody($capturedBody);
+        self::assertSame(['type' => 'json_object'], $body['response_format'] ?? null);
     }
 
     #[Test]

--- a/Tests/Unit/Provider/MistralProviderTest.php
+++ b/Tests/Unit/Provider/MistralProviderTest.php
@@ -953,6 +953,42 @@ class MistralProviderTest extends AbstractUnitTestCase
         self::assertSame(0.7, $body['temperature']);
         self::assertArrayHasKey('max_tokens', $body);
         self::assertSame(4096, $body['max_tokens']);
+        // Without a response_format/response_schema option no response_format
+        // key may appear (ADR-128).
+        self::assertArrayNotHasKey('response_format', $body);
+    }
+
+    #[Test]
+    public function chatCompletionEmitsResponseFormatForJsonMode(): void
+    {
+        $capturedMethod = null;
+        $capturedUrl    = null;
+        $capturedBody   = null;
+
+        ['subject' => $subject, 'httpClient' => $httpClientMock] = $this->createCapturingSubject(
+            $capturedMethod,
+            $capturedUrl,
+            $capturedBody,
+        );
+
+        $httpClientMock
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createJsonResponseMock([
+                'model' => 'mistral-large-latest',
+                'choices' => [
+                    ['message' => ['role' => 'assistant', 'content' => '{}'], 'finish_reason' => 'stop'],
+                ],
+                'usage' => ['prompt_tokens' => 1, 'completion_tokens' => 1, 'total_tokens' => 2],
+            ]));
+
+        $subject->chatCompletion(
+            [['role' => 'user', 'content' => 'Reply as json']],
+            ['response_format' => 'json'],
+        );
+
+        $body = $this->decodeCapturedBody($capturedBody);
+        self::assertSame(['type' => 'json_object'], $body['response_format'] ?? null);
     }
 
     #[Test]

--- a/Tests/Unit/Provider/OllamaProviderTest.php
+++ b/Tests/Unit/Provider/OllamaProviderTest.php
@@ -1129,6 +1129,66 @@ class OllamaProviderTest extends AbstractUnitTestCase
         // `think` is a top-level field (not an `options` entry) and is only
         // emitted when it is a real bool.
         self::assertTrue($payload['think']);
+        // Without response_format/response_schema no `format` key (ADR-128).
+        self::assertArrayNotHasKey('format', $payload);
+    }
+
+    #[Test]
+    public function chatCompletionSendsResponseSchemaAsTopLevelFormat(): void
+    {
+        $capturedBody   = '';
+        $capturedUrl    = '';
+        $capturedMethod = '';
+
+        $apiResponse = [
+            'model'   => 'llama3.2',
+            'message' => ['role' => 'assistant', 'content' => '{}'],
+            'done'    => true,
+        ];
+
+        $subject = $this->subjectCapturingRequest($apiResponse, $capturedBody, $capturedUrl, $capturedMethod);
+
+        $schema = [
+            'type'       => 'object',
+            'properties' => ['name' => ['type' => 'string']],
+            'required'   => ['name'],
+        ];
+
+        $subject->chatCompletion(
+            [['role' => 'user', 'content' => 'Test']],
+            ['response_format' => 'json', 'response_schema' => $schema],
+        );
+
+        $payload = $this->decodeCapturedPayload($capturedBody);
+
+        // The schema wins over plain JSON mode and is a top-level field,
+        // like `think` (ADR-128).
+        self::assertSame($schema, $payload['format']);
+    }
+
+    #[Test]
+    public function chatCompletionSendsJsonFormatWithoutASchema(): void
+    {
+        $capturedBody   = '';
+        $capturedUrl    = '';
+        $capturedMethod = '';
+
+        $apiResponse = [
+            'model'   => 'llama3.2',
+            'message' => ['role' => 'assistant', 'content' => '{}'],
+            'done'    => true,
+        ];
+
+        $subject = $this->subjectCapturingRequest($apiResponse, $capturedBody, $capturedUrl, $capturedMethod);
+
+        $subject->chatCompletion(
+            [['role' => 'user', 'content' => 'Reply as json']],
+            ['response_format' => 'json'],
+        );
+
+        $payload = $this->decodeCapturedPayload($capturedBody);
+
+        self::assertSame('json', $payload['format']);
     }
 
     #[Test]

--- a/Tests/Unit/Provider/OpenAiProviderTest.php
+++ b/Tests/Unit/Provider/OpenAiProviderTest.php
@@ -210,6 +210,48 @@ class OpenAiProviderTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function chatCompletionEmitsStrictJsonSchemaWhenTheSchemaQualifies(): void
+    {
+        $schema = [
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'properties'           => ['name' => ['type' => 'string']],
+            'required'             => ['name'],
+        ];
+
+        $payload = $this->captureChatCompletionPayload([
+            'response_format' => 'json',
+            'response_schema' => $schema,
+        ]);
+
+        self::assertSame([
+            'type'        => 'json_schema',
+            'json_schema' => [
+                'name'   => 'structured_output',
+                'strict' => true,
+                'schema' => $schema,
+            ],
+        ], $payload['response_format'] ?? null);
+    }
+
+    #[Test]
+    public function chatCompletionFallsBackToJsonObjectForANonStrictQualifiedSchema(): void
+    {
+        // No additionalProperties:false — OpenAI strict mode would 400 this
+        // request; the correct degradation is plain JSON mode (ADR-128).
+        $payload = $this->captureChatCompletionPayload([
+            'response_format' => 'json',
+            'response_schema' => [
+                'type'       => 'object',
+                'properties' => ['name' => ['type' => 'string']],
+                'required'   => ['name'],
+            ],
+        ]);
+
+        self::assertSame(['type' => 'json_object'], $payload['response_format'] ?? null);
+    }
+
+    #[Test]
     public function chatCompletionOmitsResponseFormatForTextAndWhenUnset(): void
     {
         self::assertArrayNotHasKey(

--- a/Tests/Unit/Provider/OpenAiResponseFormatTraitTest.php
+++ b/Tests/Unit/Provider/OpenAiResponseFormatTraitTest.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Provider;
+
+use Netresearch\NrLlm\Provider\OpenAiResponseFormatTrait;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The three rungs of ADR-128's OpenAI-family emission and the conservative
+ * strict-mode profile. The profile's one job: a schema OpenAI's strict mode
+ * would reject must degrade to json_object, never surface as an HTTP 400.
+ */
+#[CoversTrait(OpenAiResponseFormatTrait::class)]
+final class OpenAiResponseFormatTraitTest extends TestCase
+{
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>|null
+     */
+    private function build(array $options): ?array
+    {
+        $subject = new class {
+            use OpenAiResponseFormatTrait;
+
+            /**
+             * @param array<string, mixed> $options
+             *
+             * @return array<string, mixed>|null
+             */
+            public function buildPublic(array $options): ?array
+            {
+                return $this->buildResponseFormat($options);
+            }
+        };
+
+        return $subject->buildPublic($options);
+    }
+
+    #[Test]
+    public function noFormatAndNoSchemaEmitsNothing(): void
+    {
+        self::assertNull($this->build([]));
+        self::assertNull($this->build(['response_format' => 'text']));
+        self::assertNull($this->build(['response_format' => 'markdown']));
+    }
+
+    #[Test]
+    public function plainJsonFormatEmitsJsonObject(): void
+    {
+        self::assertSame(['type' => 'json_object'], $this->build(['response_format' => 'json']));
+    }
+
+    #[Test]
+    public function qualifyingSchemaEmitsStrictJsonSchema(): void
+    {
+        $schema = [
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'properties'           => [
+                'title' => ['type' => 'string', 'description' => 'The title'],
+                'tags'  => [
+                    'type'  => 'array',
+                    'items' => ['type' => 'string', 'enum' => ['a', 'b']],
+                ],
+                'nested' => [
+                    'type'                 => 'object',
+                    'additionalProperties' => false,
+                    'properties'           => ['n' => ['type' => 'integer']],
+                    'required'             => ['n'],
+                ],
+            ],
+            'required' => ['title', 'tags', 'nested'],
+        ];
+
+        $result = $this->build(['response_schema' => $schema]);
+
+        self::assertNotNull($result);
+        self::assertSame('json_schema', $result['type']);
+        assert(isset($result['json_schema']) && is_array($result['json_schema']));
+        self::assertTrue($result['json_schema']['strict']);
+        self::assertSame($schema, $result['json_schema']['schema']);
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>}>
+     */
+    public static function nonQualifyingSchemas(): iterable
+    {
+        yield 'missing additionalProperties:false' => [[
+            'type'       => 'object',
+            'properties' => ['a' => ['type' => 'string']],
+            'required'   => ['a'],
+        ]];
+        yield 'a property not listed as required' => [[
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'properties'           => ['a' => ['type' => 'string'], 'b' => ['type' => 'string']],
+            'required'             => ['a'],
+        ]];
+        yield 'required names outside properties' => [[
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'properties'           => ['a' => ['type' => 'string']],
+            'required'             => ['a', 'ghost'],
+        ]];
+        yield 'union type' => [[
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'properties'           => ['a' => ['type' => ['string', 'null']]],
+            'required'             => ['a'],
+        ]];
+        yield 'keyword outside the conservative allowlist' => [[
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'properties'           => ['a' => ['type' => 'string', 'pattern' => '^x']],
+            'required'             => ['a'],
+        ]];
+        yield 'non-object root' => [['enum' => ['a', 'b']]];
+        yield 'nested object breaks the rules' => [[
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'properties'           => [
+                'inner' => [
+                    'type'       => 'object',
+                    'properties' => ['x' => ['type' => 'string']],
+                    'required'   => ['x'],
+                ],
+            ],
+            'required' => ['inner'],
+        ]];
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     */
+    #[Test]
+    #[DataProvider('nonQualifyingSchemas')]
+    public function nonQualifyingSchemaDegradesToJsonObject(array $schema): void
+    {
+        self::assertSame(['type' => 'json_object'], $this->build(['response_schema' => $schema]));
+    }
+
+    #[Test]
+    public function emptyPropertiesDegradesToJsonObject(): void
+    {
+        // An empty `properties` map would encode as JSON `[]` instead of
+        // `{}` (PHP's empty-array ambiguity) — out of the profile.
+        self::assertSame(['type' => 'json_object'], $this->build(['response_schema' => [
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'properties'           => [],
+            'required'             => [],
+        ]]));
+    }
+}

--- a/Tests/Unit/Provider/OpenAiResponseFormatTraitTest.php
+++ b/Tests/Unit/Provider/OpenAiResponseFormatTraitTest.php
@@ -127,6 +127,21 @@ final class OpenAiResponseFormatTraitTest extends TestCase
             'required'             => ['a'],
         ]];
         yield 'non-object root' => [['enum' => ['a', 'b']]];
+        yield 'a non-string entry in required' => [[
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'properties'           => ['a' => ['type' => 'string']],
+            // Filtering the 5 away would qualify a schema whose ORIGINAL
+            // form is sent — fail closed instead.
+            'required' => ['a', 5],
+        ]];
+        yield 'properties as a list' => [[
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            // A list would JSON-encode as [] instead of {} and be rejected.
+            'properties' => [['type' => 'string']],
+            'required'   => ['0'],
+        ]];
         yield 'nested object breaks the rules' => [[
             'type'                 => 'object',
             'additionalProperties' => false,

--- a/Tests/Unit/Provider/OpenRouterProviderTest.php
+++ b/Tests/Unit/Provider/OpenRouterProviderTest.php
@@ -1838,6 +1838,25 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         self::assertArrayNotHasKey('stop', $body);
         self::assertArrayNotHasKey('transforms', $body);
         self::assertArrayNotHasKey('top_p', $body);
+        // Without a response_format/response_schema option no response_format
+        // key may appear (ADR-128).
+        self::assertArrayNotHasKey('response_format', $body);
+    }
+
+    #[Test]
+    public function chatCompletionEmitsResponseFormatForJsonMode(): void
+    {
+        $captured = [];
+        $provider = $this->createCapturingProvider([], $this->chatResponse(), $captured);
+
+        $provider->chatCompletion(
+            [['role' => 'user', 'content' => 'Reply as json']],
+            ['model' => 'openai/gpt-4o', 'response_format' => 'json'],
+        );
+
+        self::assertCount(1, $captured);
+        $body = $this->decodeCapturedBody($captured[0]['body']);
+        self::assertSame(['type' => 'json_object'], $body['response_format'] ?? null);
     }
 
     #[Test]

--- a/Tests/Unit/Service/Feature/CompletionServiceTest.php
+++ b/Tests/Unit/Service/Feature/CompletionServiceTest.php
@@ -1080,6 +1080,34 @@ class CompletionServiceTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function completeStructuredAttachesTheSchemaToTheOptions(): void
+    {
+        ['subject' => $subject, 'llmManager' => $llmManagerMock] = $this->createSubjectWithMockManager();
+
+        $schema = [
+            'type'       => 'object',
+            'required'   => ['title'],
+            'properties' => ['title' => ['type' => 'string']],
+        ];
+
+        $capturedOptions = null;
+        $llmManagerMock->expects(self::once())->method('chat')
+            ->willReturnCallback(function (mixed $messages, mixed $options) use (&$capturedOptions): CompletionResponse {
+                $capturedOptions = $options;
+
+                return $this->createMockResponse('{"title": "Hello"}');
+            });
+
+        $subject->completeStructured('Generate metadata', $schema);
+
+        // The pre-flighted schema must ride along so adapters can enforce it
+        // natively (ADR-128); JSON mode stays set alongside.
+        self::assertInstanceOf(ChatOptions::class, $capturedOptions);
+        self::assertSame($schema, $capturedOptions->getResponseSchema());
+        self::assertSame('json', $capturedOptions->getResponseFormat());
+    }
+
+    #[Test]
     public function completeStructuredRepairsOnceWhenTheFirstResponseFailsTheSchema(): void
     {
         ['subject' => $subject, 'llmManager' => $llmManagerMock] = $this->createSubjectWithMockManager();

--- a/Tests/Unit/Service/Option/ChatOptionsTest.php
+++ b/Tests/Unit/Service/Option/ChatOptionsTest.php
@@ -275,6 +275,22 @@ class ChatOptionsTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function withResponseSchemaReturnsNewInstanceAndSurvivesToArray(): void
+    {
+        $schema = ['type' => 'object', 'required' => ['name'], 'properties' => ['name' => ['type' => 'string']]];
+
+        $options1 = new ChatOptions();
+        $options2 = $options1->withResponseSchema($schema);
+
+        self::assertNull($options1->getResponseSchema());
+        self::assertSame($schema, $options2->getResponseSchema());
+        // Must reach the adapter through toArray() — the manager serialises
+        // options before dispatch (ADR-128).
+        self::assertSame($schema, $options2->toArray()['response_schema']);
+        self::assertArrayNotHasKey('response_schema', $options1->toArray());
+    }
+
+    #[Test]
     public function withSystemPromptReturnsNewInstance(): void
     {
         $options1 = new ChatOptions(systemPrompt: 'prompt1');


### PR DESCRIPTION
## What

Delivers the follow-up ADR-082 named: native, per-provider structured-output enforcement behind a schema-compatibility profile. The pre-flighted ADR-126 schema rides along as `ChatOptions::withResponseSchema()` and each adapter emits its provider's dialect:

| Provider | Emission |
|---|---|
| OpenAI, Groq, Mistral, OpenRouter | shared `OpenAiResponseFormatTrait`: `response_format: {type: json_schema, strict: true}` when the schema qualifies for strict mode (conservative profile: object root, `additionalProperties: false` + all properties required everywhere, allowlisted keywords); `{type: json_object}` otherwise — a schema strict mode would 400 must degrade, never error |
| Gemini | `generationConfig.responseMimeType: application/json` + `responseSchema` in Gemini's dialect; conversion only ever **widens** (an inexpressible keyword — e.g. a non-string enum — is dropped whole, never partially) |
| Ollama | schema verbatim as top-level `format` (like `think`), or `format: 'json'` |
| Claude | no response-format parameter exists; an object-root schema becomes one forced tool whose `input_schema` is the schema; the `tool_use` input comes back as the JSON string every other provider returns |

**Side effect:** plain JSON mode (`completeJson()`) now reaches all seven providers. Previously only the OpenAI adapter emitted `response_format`; the other six silently dropped the option.

**Invariant:** native enforcement narrows what the model can emit; the local strict validation (ADR-126), the prompt instruction and the repair round-trip stay authoritative and unchanged. Streaming is deliberately out of scope (structured completions never stream, ADR-062).

No breaking change: `withResponseSchema()` is additive (declared outside the constructor — the `@phpstan-consistent-constructor`/`ToolOptions` constraint, same pattern as `suppressRequestCount`).

## Docs

- New `Documentation/Adr/Adr128ProviderNativeStructuredOutput.rst`
- ADR-082 (Claude "no native parameter" superseded by tool-forcing) and ADR-126 (follow-up delivered) annotated

## Tests

- `OpenAiResponseFormatTraitTest`: the three emission rungs + 8 non-qualifying-schema cases (incl. the `properties: []` → JSON-`[]` ambiguity)
- Per-adapter payload assertions: OpenAI (strict json_schema + fallback), Groq/Mistral/OpenRouter (json_object wiring + absent-by-default pin), Ollama (`format` schema + `'json'`), Gemini (mime type, dialect conversion, whole-enum drop), Claude (forced-tool payload, non-object fallback, `tool_use`→content incl. preamble discard)
- `ChatOptionsTest` (`toArray` carriage), `CompletionServiceTest` (schema attached to the options next to JSON mode)

All six pre-push suites green locally on PHP 8.2 (unit, fuzzy, functional sqlite full run, phpstan, cgl, rector -n).

🤖 Generated with [Claude Code](https://claude.com/claude-code)