### PR TITLE
chore(deps): drop dev-dependencies the shared package already provides

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.24",
-        "netresearch/typo3-ci-workflows": "^1.3",
+        "netresearch/typo3-ci-workflows": "^1.4",
         "tpwd/ke_search": "^7.0",
         "typo3/cms-dashboard": "^13.4 || ^14.3",
         "typo3/cms-indexed-search": "^13.4 || ^14.3",

--- a/composer.json
+++ b/composer.json
@@ -40,9 +40,7 @@
         "typo3/cms-core": "^13.4 || ^14.3"
     },
     "require-dev": {
-        "ergebnis/composer-normalize": "^2.52",
         "fakerphp/faker": "^1.24",
-        "giorgiosironi/eris": "^1.1",
         "netresearch/typo3-ci-workflows": "^1.3",
         "tpwd/ke_search": "^7.0",
         "typo3/cms-dashboard": "^13.4 || ^14.3",


### PR DESCRIPTION
Part of the fleet-wide dedup pass. Companion to [netresearch/typo3-ci-workflows#158](https://github.com/netresearch/typo3-ci-workflows/pull/158), released as v1.4.0.

## What is removed

2 tools declared both here and by `netresearch/typo3-ci-workflows`, which this repo requires: `ergebnis/composer-normalize`, `giorgiosironi/eris`.

Composer intersects the consumer constraint with the shared one and the narrower wins, so each duplicate is a place where a future narrowing holds an update back unnoticed. That is not hypothetical — in [t3x-contexts_wurfl#44](https://github.com/netresearch/t3x-contexts_wurfl/pull/44) a local `^2.0` kept `saschaegerer/phpstan-typo3` off 3.x while every other consumer had it, latest being 3.1.0.

Anything this repo declares for itself is untouched; only packages the shared package already provides are removed.

## Why the constraint moves from `^1.3` to `^1.4`

The branch stops declaring `ergebnis/composer-normalize` itself and relies on the shared package to supply it, which only v1.4.0 does — `^1.3` also admits v1.3.x, which does not carry the tool. So `^1.3` declared less than the branch assumes, and the floor moves to say what the branch actually depends on.

That is a declaration fix and nothing more. `^1.3` means `>=1.3.0 <2.0.0`, a caret takes the highest matching release, and with no `composer.lock` committed it resolves to v1.4.0 — composer-normalize included — so no resolution was ever broken here. The commit message on this branch previously claimed that a lower constraint "reproducibly picked v1.3.2" without composer-normalize; that reading was a stale-cache artefact from the hour v1.4.0 was published. It is false, and the amended commit message withdraws it explicitly.

## Verification

Resolution measured before and after, in a scratch tree with an empty `COMPOSER_CACHE_DIR` and no lockfile, rather than argued from constraint algebra. Package counts are `- Locking` lines. An earlier revision of this body counted every `^  - ` line instead, which counts each package twice — once as `- Locking`, once as `- Installing` — and therefore reported 400 where the figure is 200. The before/after equality is unaffected.

```
$ composer update --dry-run --no-scripts --no-plugins --ignore-platform-reqs
before: 200 packages   (400 "^  - " lines: 200 Locking + 200 Installing)
after:  200 packages   (400 "^  - " lines: 200 Locking + 200 Installing)
$ diff before after
(empty)
```

The resolution after the change, proving the shared package now carries the removed tools:

```
  - Locking ergebnis/composer-normalize (2.52.0)
  - Locking giorgiosironi/eris (1.1.0)
  - Locking netresearch/typo3-ci-workflows (v1.4.0)
```
