### PR TITLE
feat(task): enforce the executing user's budget on task execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Task execution enforces the executing user's budget (audit REC #4,
+  closing the hook documented in `TaskExecutionService` since slice 13c).
+  The controller passes the backend user's uid; the `BudgetMiddleware`
+  pre-flights the per-user cap before the provider is paid and the
+  recorded usage is attributed to that user. A denial surfaces as its own
+  localized message instead of the generic failure text. Note: the task
+  module is admin-only, so this can now block an administrator whose
+  personal budget is exhausted — configuration limits applied before and
+  still do.
 - The `@api` surface (ADR-127) is frozen in `Tests/Unit/Api/api-surface.txt`:
   a snapshot test renders every marked class's declared public signatures and
   fails on an unintended change; the same pass asserts the closure rule —

--- a/Classes/Controller/Backend/TaskExecutionController.php
+++ b/Classes/Controller/Backend/TaskExecutionController.php
@@ -22,6 +22,7 @@ use Netresearch\NrLlm\Domain\Repository\TaskRepository;
 // thrown by `TaskExecutionService::execute()`, not PHP's built-in
 // (which is also raised in sibling controllers, e.g. by
 // `RecordTableReader::ensureNotExcluded` in `TaskRecordsController`).
+use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Exception\InvalidArgumentException as DomainInvalidArgumentException;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
@@ -65,6 +66,7 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 #[AsController]
 final class TaskExecutionController extends ActionController
 {
+    use BackendUserUidTrait;
     use RequiresBackendAdminTrait;
     use DefensiveLocalizationTrait;
 
@@ -217,8 +219,18 @@ final class TaskExecutionController extends ActionController
     private function runExecution(Task $task, string $input): array
     {
         try {
-            $result  = $this->taskExecutionService->execute($task, $input);
+            // REC #4: the executing admin's uid activates the per-user budget
+            // pre-flight and attributes the recorded usage to them.
+            $result  = $this->taskExecutionService->execute($task, $input, $this->currentBackendUserUid());
             $payload = TaskExecutionResponse::fromResult($result)->jsonSerialize();
+        } catch (BudgetExceededException $e) {
+            // A budget denial is an expected, user-actionable answer — surface
+            // it as such instead of the generic failure message.
+            $this->logger->notice('Task execution denied by budget pre-flight', [
+                'exception' => $e,
+                'task_uid'  => $task->getUid(),
+            ]);
+            $payload = (new ErrorResponse($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.task.budgetExceeded', 'Execution denied: your usage budget is exhausted.')))->jsonSerialize();
         } catch (DomainInvalidArgumentException $e) {
             // Domain validation: message is vetted internal text safe to surface.
             $payload = (new ErrorResponse($e->getMessage()))->jsonSerialize();

--- a/Classes/Service/Task/TaskExecutionService.php
+++ b/Classes/Service/Task/TaskExecutionService.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Service\Task;
 use Netresearch\NrLlm\Domain\Enum\TaskOutputFormat;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Task;
+use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
@@ -26,21 +27,12 @@ use Netresearch\NrLlm\Service\Skill\SkillInjectionService;
  * (otherwise fall back to the global default chat options), and
  * package the response as a typed `TaskExecutionResult`.
  *
- * **REC #4 (audit) hook point.** The future automatic budget pre-flight
- * + usage tracking will plug in here — the natural sequence is:
- *
- *   1. read the calling backend user uid from the controller call
- *      (will need a small signature extension, e.g. an
- *      `ExecutionContext` argument carrying `beUserUid` and any
- *      planned-cost estimate);
- *   2. ask `BudgetServiceInterface::check()` whether the call is
- *      allowed and short-circuit with a typed exception on denial;
- *   3. let the existing pipeline middleware (`UsageMiddleware`,
- *      `BudgetMiddleware`) handle the rest via `LlmServiceManager`.
- *
- * Slice 13c intentionally keeps this surface lean — the controller
- * still passes `(Task, string $input)` and the service still proxies
- * to the manager directly. REC #4 will land in a follow-up.
+ * **REC #4 (audit), landed:** the controller passes the calling backend
+ * user's uid, which flows as budget metadata into the pipeline — the
+ * `BudgetMiddleware` pre-flights the per-user cap and denies with
+ * `BudgetExceededException` before the provider is paid, and the
+ * `UsageMiddleware` attributes the recorded usage to that user. A
+ * null/0 uid skips the user cap (configuration limits still apply).
  */
 final readonly class TaskExecutionService implements TaskExecutionServiceInterface
 {
@@ -49,12 +41,15 @@ final readonly class TaskExecutionService implements TaskExecutionServiceInterfa
         private SkillInjectionService $skillInjection,
     ) {}
 
-    public function execute(Task $task, string $input): TaskExecutionResult
+    public function execute(Task $task, string $input, ?int $beUserUid = null): TaskExecutionResult
     {
         $prompt = $task->buildPrompt(['input' => $input]);
 
         $taskUid  = $task->getUid();
         $metadata = ($taskUid !== null && $taskUid > 0) ? [UsageMiddleware::METADATA_TASK_UID => $taskUid] : [];
+        if ($beUserUid !== null && $beUserUid > 0) {
+            $metadata[BudgetMiddleware::METADATA_BE_USER_UID] = $beUserUid;
+        }
 
         // Resolve the effective configuration exactly once: the task's own
         // configuration when set, otherwise the backend-managed active default
@@ -93,7 +88,17 @@ final readonly class TaskExecutionService implements TaskExecutionServiceInterfa
         // raises the existing "no provider specified" error — preserve that.
         // completeWithConfiguration() takes plain option-override arrays, not
         // ChatOptions — the fourth argument merges over the configuration's
-        // stored defaults.
+        // stored defaults. On the default path the uid travels as a ChatOptions
+        // budget field instead; the manager builds the same metadata from it.
+        $fallbackOptions = new ChatOptions();
+        if ($jsonOutput) {
+            $fallbackOptions = $fallbackOptions->withResponseFormat('json');
+        }
+
+        if ($beUserUid !== null && $beUserUid > 0) {
+            $fallbackOptions = $fallbackOptions->withBeUserUid($beUserUid);
+        }
+
         $response = $configuration instanceof LlmConfiguration
             ? $this->llmServiceManager->completeWithConfiguration(
                 $prompt,
@@ -101,10 +106,7 @@ final readonly class TaskExecutionService implements TaskExecutionServiceInterfa
                 $metadata,
                 $jsonOutput ? ['response_format' => 'json'] : [],
             )
-            : $this->llmServiceManager->complete(
-                $prompt,
-                $jsonOutput ? (new ChatOptions())->withResponseFormat('json') : new ChatOptions(),
-            );
+            : $this->llmServiceManager->complete($prompt, $fallbackOptions);
 
         // The skills injected above contributed to the prompt the provider
         // tokenised, so their cost is already part of $response->usage. Surface

--- a/Classes/Service/Task/TaskExecutionServiceInterface.php
+++ b/Classes/Service/Task/TaskExecutionServiceInterface.php
@@ -29,8 +29,14 @@ interface TaskExecutionServiceInterface
      * exists and is active before delegating here — the service
      * trusts its argument.
      *
+     * @param int|null $beUserUid backend user the call is executed for
+     *                            (REC #4): a positive uid activates the
+     *                            per-user budget pre-flight and usage
+     *                            attribution; null/0 skips the user cap
+     *                            (configuration limits still apply)
+     *
      * @throws Throwable on prompt-build / LLM failure (caller surfaces
      *                   the message)
      */
-    public function execute(Task $task, string $input): TaskExecutionResult;
+    public function execute(Task $task, string $input, ?int $beUserUid = null): TaskExecutionResult;
 }

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -1742,6 +1742,10 @@
                 <source>Task is not active</source>
                 <target>Aufgabe ist nicht aktiv</target>
             </trans-unit>
+            <trans-unit id="error.task.budgetExceeded">
+                <source>Execution denied: your usage budget is exhausted.</source>
+                <target>Ausführung abgelehnt: Ihr Nutzungsbudget ist aufgebraucht.</target>
+            </trans-unit>
             <trans-unit id="error.records.listTablesDbError">
                 <source>Database error while listing tables.</source>
                 <target>Datenbankfehler beim Auflisten der Tabellen.</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1320,6 +1320,9 @@
             <trans-unit id="error.task.notActive">
                 <source>Task is not active</source>
             </trans-unit>
+            <trans-unit id="error.task.budgetExceeded">
+                <source>Execution denied: your usage budget is exhausted.</source>
+            </trans-unit>
             <trans-unit id="error.records.listTablesDbError">
                 <source>Database error while listing tables.</source>
             </trans-unit>

--- a/Tests/Unit/Service/Task/TaskExecutionServiceTest.php
+++ b/Tests/Unit/Service/Task/TaskExecutionServiceTest.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Skill;
 use Netresearch\NrLlm\Domain\Model\Task;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
@@ -78,6 +79,105 @@ final class TaskExecutionServiceTest extends AbstractUnitTestCase
         $result = $this->subject->execute($task, 'the logs');
 
         self::assertSame('result', $result->content);
+    }
+
+    #[Test]
+    public function passesBudgetUidMetadataForConfiguredTask(): void
+    {
+        $response = new CompletionResponse(
+            content: 'result',
+            model: 'gpt-4o',
+            usage: new UsageStatistics(5, 5, 10),
+            provider: 'openai',
+        );
+
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('task-config');
+
+        $task = new Task();
+        $task->setPromptTemplate('Analyse {{input}}');
+        $task->setConfiguration($configuration);
+        $this->setUid($task, 99);
+
+        $this->llmServiceManager->method('resolveEffectiveConfiguration')->willReturnArgument(0);
+
+        // REC #4: a positive uid rides along as budget metadata next to the
+        // task attribution — the BudgetMiddleware pre-flights the user cap.
+        $this->llmServiceManager->expects(self::once())
+            ->method('completeWithConfiguration')
+            ->with(
+                'Analyse the logs',
+                $configuration,
+                [
+                    UsageMiddleware::METADATA_TASK_UID     => 99,
+                    BudgetMiddleware::METADATA_BE_USER_UID => 42,
+                ],
+                [],
+            )
+            ->willReturn($response);
+
+        $this->subject->execute($task, 'the logs', 42);
+    }
+
+    #[Test]
+    public function omitsBudgetUidMetadataForAnonymousUid(): void
+    {
+        $response = new CompletionResponse(
+            content: 'result',
+            model: 'gpt-4o',
+            usage: new UsageStatistics(5, 5, 10),
+            provider: 'openai',
+        );
+
+        $configuration = new LlmConfiguration();
+
+        $task = new Task();
+        $task->setPromptTemplate('Analyse {{input}}');
+        $task->setConfiguration($configuration);
+        $this->setUid($task, 99);
+
+        $this->llmServiceManager->method('resolveEffectiveConfiguration')->willReturnArgument(0);
+
+        // uid 0 means "anonymous / skip the user cap" (REC #4 contract):
+        // the budget key must not appear, exactly like a null uid.
+        $this->llmServiceManager->expects(self::once())
+            ->method('completeWithConfiguration')
+            ->with(
+                self::anything(),
+                $configuration,
+                [UsageMiddleware::METADATA_TASK_UID => 99],
+                [],
+            )
+            ->willReturn($response);
+
+        $this->subject->execute($task, 'the logs', 0);
+    }
+
+    #[Test]
+    public function passesBudgetUidAsChatOptionsFieldWithoutConfiguration(): void
+    {
+        $task = new Task();
+        $task->setPromptTemplate('Analyse {{input}}');
+        $this->setUid($task, 77);
+
+        $this->llmServiceManager->method('resolveEffectiveConfiguration')->willReturn(null);
+
+        // Default path: the uid travels as the ChatOptions budget field; the
+        // manager builds the same budget metadata from it.
+        $this->llmServiceManager->expects(self::once())
+            ->method('complete')
+            ->with(
+                self::anything(),
+                self::callback(static fn(ChatOptions $options): bool => $options->getBeUserUid() === 42),
+            )
+            ->willReturn(new CompletionResponse(
+                content: 'result',
+                model: 'gpt-4o',
+                usage: new UsageStatistics(5, 5, 10),
+                provider: 'openai',
+            ));
+
+        $this->subject->execute($task, 'the logs', 42);
     }
 
     #[Test]


### PR DESCRIPTION
## What

Closes the **audit REC #4 hook** that `TaskExecutionService` has documented since slice 13c: the controller passes the executing backend user's uid, which flows as budget metadata into the middleware pipeline (configured path) or as the `ChatOptions` budget field (default path — the manager builds the same metadata from it). The `BudgetMiddleware` pre-flights the per-user cap **before the provider is paid**; the `UsageMiddleware` attributes the recorded usage to that user. A null/0 uid skips the user cap, configuration limits still apply — the documented REC #4 contract.

A budget denial gets its own catch arm and localized message (EN+DE) instead of the generic "Task execution failed" text — a denial is a user-actionable answer, not an error.

Behavioural note (also in the CHANGELOG): the task module is admin-only, so an administrator with an exhausted personal budget is now blocked too.

## Scope note — what this deliberately is NOT

This is the decision-free remainder of the role-model slice, shaped by a recon plus an adversarial review of the original plan:

- **Preserving the frozen actor across suspend/resume: REFUTED, not built.** Nothing on the resume path reads `isAdmin`/`backendGroupIds` — `ConfigurationResolver::actorMayUse()` is only evaluated on the `ConversationService` path, and tool gates derive privilege from the fresh DB user by doctrine (`ActingBackendUserResolver`: "can lower privilege … but never mint it"). A preserved actor would have been an unread declaration. If an ADR-070 group gate **at resume** is ever wanted, the consumer comes first; the preservation only then.
- **Widget gating: not built.** It depends on the open product decision about a non-admin surface — a gate admins bypass is inert in an admin-only extension (ADR-117's third finding), and TYPO3's own `available_widgets` permission already exists as the core mechanism.

## Tests

3 new unit tests: budget uid in metadata next to task attribution (configured path), uid 0 omits the key (REC #4 contract pin), uid as `ChatOptions` budget field (default path). All six pre-push suites green locally on PHP 8.2 (unit, fuzzy, functional sqlite full run incl. the task-execution controller tests, phpstan, cgl, rector -n).

🤖 Generated with [Claude Code](https://claude.com/claude-code)