### PR TITLE
feat: capability grants for backend users (ADR-130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Capability grants for backend users (ADR-130). Two grants, assigned per
+  backend group through TYPO3's own permission mechanism (`be_groups`
+  access lists): `Execute AI tasks` opens the two task-execution AJAX
+  endpoints to non-admins (bounded by the per-user budget), `Approve
+  suspended AI runs` lets a granted user decide other users' suspended
+  runs. Nothing changes for anyone until a grant is ticked; admins hold
+  every grant implicitly. Grants live on `AiActorContext` — the door
+  ADR-117 left open — and `backendUser()` gained an optional `$grants`
+  parameter (additive; recorded in the API snapshot). The task module's
+  management surface and a non-admin editing module are the committed
+  follow-up milestone.
 - Task execution enforces the executing user's budget (audit REC #4,
   closing the hook documented in `TaskExecutionService` since slice 13c).
   The controller passes the backend user's uid; the `BudgetMiddleware`

--- a/Classes/Controller/Backend/BackendUserUidTrait.php
+++ b/Classes/Controller/Backend/BackendUserUidTrait.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend;
 
+use Netresearch\NrLlm\Domain\Enum\BackendUserGrant;
 use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 
@@ -17,9 +18,10 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
  * pre-flight — 0 when no real BE user is present (CLI/testing), which the budget
  * check treats as anonymous.
  *
- * Shared by the controllers that continue a suspended agent run
- * ({@see ToolPlaygroundController}, {@see AgentRunController}) so the exact
- * null-safe extraction lives in one place.
+ * Shared by the controllers that need the caller's identity
+ * ({@see ToolPlaygroundController}, {@see AgentRunController},
+ * {@see TaskExecutionController}) so the exact null-safe extraction lives in
+ * one place.
  *
  * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
@@ -60,6 +62,15 @@ trait BackendUserUidTrait
             static fn(int $g): bool => $g > 0,
         ));
 
-        return AiActorContext::backendUser($uid, $backendUser->isAdmin(), $groupIds);
+        // The grants are frozen here for the same reason as the admin flag:
+        // downstream consumers (mayActOnRun) read the actor, never the
+        // ambient user. check() is a per-request read of the live group
+        // permissions, so a revoked grant stops working with the next request.
+        $grants = array_values(array_filter(
+            BackendUserGrant::cases(),
+            static fn(BackendUserGrant $grant): bool => (bool)$backendUser->check('custom_options', $grant->permissionValue()),
+        ));
+
+        return AiActorContext::backendUser($uid, $backendUser->isAdmin(), $groupIds, $grants);
     }
 }

--- a/Classes/Controller/Backend/RequiresBackendAdminTrait.php
+++ b/Classes/Controller/Backend/RequiresBackendAdminTrait.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Controller\Backend;
 
+use Netresearch\NrLlm\Domain\Enum\BackendUserGrant;
 use Psr\Http\Message\ResponseInterface;
 use Throwable;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
@@ -45,6 +46,38 @@ trait RequiresBackendAdminTrait
         try {
             $message = LocalizationUtility::translate(
                 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.adminRequired',
+                'NrLlm',
+            ) ?? $fallback;
+        } catch (Throwable) {
+            // Outside a full TYPO3 request (e.g. an isolated unit context) the
+            // language service may be unavailable; fall back to the English message.
+            $message = $fallback;
+        }
+
+        return new JsonResponse(['success' => false, 'error' => $message], 403);
+    }
+
+    /**
+     * Returns a 403 JSON response unless the current backend user is an admin
+     * OR holds the given capability grant (ADR-130). The grant-set sibling of
+     * {@see denyNonAdmin()} for AJAX actions that a non-admin role may use;
+     * the core's `check()` reads the live group permissions per request, so a
+     * revoked grant stops working immediately.
+     */
+    private function denyWithoutGrant(BackendUserGrant $grant): ?ResponseInterface
+    {
+        $backendUser = $GLOBALS['BE_USER'] ?? null;
+        if ($backendUser instanceof BackendUserAuthentication
+            && ($backendUser->isAdmin() || $backendUser->check('custom_options', $grant->permissionValue()))
+        ) {
+            return null;
+        }
+
+        $fallback = 'This action requires a permission your backend account does not hold. Please contact your site administrator.';
+
+        try {
+            $message = LocalizationUtility::translate(
+                'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.grantRequired',
                 'NrLlm',
             ) ?? $fallback;
         } catch (Throwable) {

--- a/Classes/Controller/Backend/TaskExecutionController.php
+++ b/Classes/Controller/Backend/TaskExecutionController.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Controller\Backend\DTO\RefreshInputRequest;
 use Netresearch\NrLlm\Controller\Backend\Response\ErrorResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\TaskExecutionResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\TaskInputResponse;
+use Netresearch\NrLlm\Domain\Enum\BackendUserGrant;
 use Netresearch\NrLlm\Domain\Model\Task;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\TaskRepository;
@@ -184,10 +185,15 @@ final class TaskExecutionController extends ActionController
 
     /**
      * Execute a task via AJAX.
+     *
+     * Gated by the TASKS_USE grant (ADR-130), not admin: executing an
+     * existing task is the one capability the editing role holds. The
+     * per-user budget pre-flight below bounds what a grant holder can
+     * spend, and what a task may read is defined by whoever manages it.
      */
     public function executeAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
+        if (($deny = $this->denyWithoutGrant(BackendUserGrant::TASKS_USE)) instanceof ResponseInterface) {
             return $deny;
         }
 
@@ -269,10 +275,13 @@ final class TaskExecutionController extends ActionController
 
     /**
      * Refresh input data for a task via AJAX.
+     *
+     * Same TASKS_USE gate as {@see executeAction()}: refreshing the input a
+     * task's MANAGER configured is part of using the task.
      */
     public function refreshInputAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (($deny = $this->denyNonAdmin()) instanceof ResponseInterface) {
+        if (($deny = $this->denyWithoutGrant(BackendUserGrant::TASKS_USE)) instanceof ResponseInterface) {
             return $deny;
         }
 

--- a/Classes/Domain/Enum/BackendUserGrant.php
+++ b/Classes/Domain/Enum/BackendUserGrant.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\Enum;
+
+/**
+ * A capability grant for a human backend user (ADR-130) — the grant-set the
+ * ADR-117 door asked for, designed onto {@see \Netresearch\NrLlm\Domain\ValueObject\AiActorContext}
+ * rather than the ambient superglobal.
+ *
+ * Grants are assigned per backend GROUP through TYPO3's custom permission
+ * options (`customPermOptions`) and frozen into the actor at the HTTP
+ * boundary. Administrators hold every grant implicitly (the core `check()`
+ * short-circuits on isAdmin); service accounts hold none — their mechanism
+ * is {@see ServiceAccountScope}. A user without groups can hold no grant:
+ * `custom_options` is a be_groups field.
+ *
+ * Each case maps to exactly one enforcement point — there is no wildcard
+ * grant, and a case is only added TOGETHER with its consumer (a grant
+ * nothing reads is worse than none). `tasks_manage` therefore arrives with
+ * the editing module, not here.
+ *
+ * The values are deliberately underscore-separated, not colon-namespaced
+ * like {@see ServiceAccountScope}: TYPO3 strips `:|,` from custom
+ * permission item keys when rendering the be_groups select
+ * (`TcaItemsProcessorFunctions::populateCustomPermissionOptions()`), so a
+ * colon value would be stored mangled and every `check()` would silently
+ * deny.
+ *
+ * @api
+ */
+enum BackendUserGrant: string
+{
+    /**
+     * Execute an existing task and refresh its input data
+     * ({@see \Netresearch\NrLlm\Controller\Backend\TaskExecutionController::executeAction()},
+     * {@see \Netresearch\NrLlm\Controller\Backend\TaskExecutionController::refreshInputAction()}).
+     */
+    case TASKS_USE = 'tasks_use';
+
+    /**
+     * Approve, deny or submit input to a run suspended for a human decision
+     * ({@see \Netresearch\NrLlm\Domain\ValueObject\AiActorContext::mayActOnRun()})
+     * — the human sibling of {@see ServiceAccountScope::AGENT_APPROVE}.
+     */
+    case AGENT_APPROVE = 'agent_approve';
+
+    /**
+     * The `customPermOptions` value TYPO3 stores in `be_groups.custom_options`
+     * for this grant, checked via
+     * `BackendUserAuthentication::check('custom_options', ...)`.
+     */
+    public function permissionValue(): string
+    {
+        return 'tx_nrllm_grants:' . $this->value;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_map(static fn(self $c): string => $c->value, self::cases());
+    }
+
+    public static function isValid(string $value): bool
+    {
+        return in_array($value, self::values(), true);
+    }
+}

--- a/Classes/Domain/ValueObject/AiActorContext.php
+++ b/Classes/Domain/ValueObject/AiActorContext.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Domain\ValueObject;
 
+use Netresearch\NrLlm\Domain\Enum\BackendUserGrant;
 use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
 
 /**
@@ -32,6 +33,7 @@ final readonly class AiActorContext
     /**
      * @param list<int>                 $backendGroupIds The actor's backend group uids, used to evaluate configuration access restrictions (ADR-070).
      * @param list<ServiceAccountScope> $scopes          The capabilities a service account is permitted (ADR-110); empty (and irrelevant) for a backend user, who is authorised by ownership and admin rights instead.
+     * @param list<BackendUserGrant>    $grants          The capability grants a human backend user holds (ADR-130), frozen from the live user's group permissions at the HTTP boundary; empty (and irrelevant) for a service account, whose mechanism is $scopes.
      */
     private function __construct(
         public int $backendUserUid,
@@ -39,16 +41,18 @@ final readonly class AiActorContext
         public array $backendGroupIds,
         public ?string $serviceAccount,
         public array $scopes = [],
+        public array $grants = [],
     ) {}
 
     /**
      * An authenticated backend user.
      *
-     * @param list<int> $backendGroupIds
+     * @param list<int>              $backendGroupIds
+     * @param list<BackendUserGrant> $grants
      */
-    public static function backendUser(int $uid, bool $isAdmin = false, array $backendGroupIds = []): self
+    public static function backendUser(int $uid, bool $isAdmin = false, array $backendGroupIds = [], array $grants = []): self
     {
-        return new self($uid, $isAdmin, $backendGroupIds, null);
+        return new self($uid, $isAdmin, $backendGroupIds, null, [], array_values($grants));
     }
 
     /**
@@ -89,6 +93,7 @@ final readonly class AiActorContext
         $groupIds       = $data['backendGroupIds'] ?? [];
         $serviceAccount = $data['serviceAccount'] ?? null;
         $scopes         = $data['scopes'] ?? [];
+        $grants         = $data['grants'] ?? [];
 
         return new self(
             is_int($uid) ? $uid : 0,
@@ -96,6 +101,7 @@ final readonly class AiActorContext
             is_array($groupIds) ? array_values(array_filter($groupIds, is_int(...))) : [],
             is_string($serviceAccount) && $serviceAccount !== '' ? $serviceAccount : null,
             is_array($scopes) ? self::decodeScopes($scopes) : [],
+            is_array($grants) ? self::decodeGrants($grants) : [],
         );
     }
 
@@ -121,6 +127,27 @@ final readonly class AiActorContext
         return $scopes;
     }
 
+    /**
+     * Restore the grant set from its serialised string form, dropping anything
+     * that is not a known grant value — same fail-closed rule as the scopes.
+     *
+     * @param array<array-key, mixed> $values
+     *
+     * @return list<BackendUserGrant>
+     */
+    private static function decodeGrants(array $values): array
+    {
+        $grants = [];
+        foreach ($values as $value) {
+            $grant = is_string($value) ? BackendUserGrant::tryFrom($value) : null;
+            if ($grant !== null) {
+                $grants[] = $grant;
+            }
+        }
+
+        return $grants;
+    }
+
     public function isServiceAccount(): bool
     {
         return $this->serviceAccount !== null;
@@ -135,6 +162,22 @@ final readonly class AiActorContext
     public function hasScope(ServiceAccountScope $scope): bool
     {
         return in_array($scope, $this->scopes, true);
+    }
+
+    /**
+     * Whether a human backend user holds the given capability grant (ADR-130).
+     * Administrators hold every grant implicitly — mirroring both the core's
+     * `check()` and the admin-first branches of {@see mayAccessSession()} /
+     * {@see mayActOnRun()}. Always false for a service account (its mechanism
+     * is {@see hasScope()}) and for an anonymous caller.
+     */
+    public function hasGrant(BackendUserGrant $grant): bool
+    {
+        if ($this->isServiceAccount()) {
+            return false;
+        }
+
+        return $this->isAdmin || in_array($grant, $this->grants, true);
     }
 
     public function isAuthenticated(): bool
@@ -179,6 +222,14 @@ final readonly class AiActorContext
             return $this->hasScope($scope);
         }
 
+        // The human sibling of the AGENT_APPROVE scope (ADR-130): a backend
+        // user granted approval may decide OTHER users' suspended runs, not
+        // only their own. Deliberately the only scope with a grant
+        // equivalent — every other case stays owner-or-admin.
+        if ($scope === ServiceAccountScope::AGENT_APPROVE && $this->hasGrant(BackendUserGrant::AGENT_APPROVE)) {
+            return true;
+        }
+
         return $this->backendUserUid > 0 && $this->backendUserUid === $run->beUser;
     }
 
@@ -203,7 +254,7 @@ final readonly class AiActorContext
      * The serialised form persisted with a queued run so a worker can restore
      * the full actor (not just a backend-user id) via {@see fromArray()}.
      *
-     * @return array{backendUserUid: int, isAdmin: bool, backendGroupIds: list<int>, serviceAccount: string|null, scopes: list<string>}
+     * @return array{backendUserUid: int, isAdmin: bool, backendGroupIds: list<int>, serviceAccount: string|null, scopes: list<string>, grants: list<string>}
      */
     public function toArray(): array
     {
@@ -213,6 +264,7 @@ final readonly class AiActorContext
             'backendGroupIds' => $this->backendGroupIds,
             'serviceAccount'  => $this->serviceAccount,
             'scopes'          => array_map(static fn(ServiceAccountScope $s): string => $s->value, $this->scopes),
+            'grants'          => array_map(static fn(BackendUserGrant $g): string => $g->value, $this->grants),
         ];
     }
 }

--- a/Documentation/Administration/Index.rst
+++ b/Documentation/Administration/Index.rst
@@ -71,6 +71,7 @@ left-hand navigation:
    Tools
    Wizards
    UserBudgets
+   Permissions
    SpecializedServices
    Analytics
    AgentRuns

--- a/Documentation/Administration/Permissions.rst
+++ b/Documentation/Administration/Permissions.rst
@@ -1,0 +1,67 @@
+..  include:: /Includes.rst.txt
+
+..  _administration-permissions:
+
+===========================
+Backend user permissions
+===========================
+
+nr_llm is administrator-only by default: every module and every AJAX
+action denies non-admins, and nothing changes at update time. Access for
+non-admin users is opened **per capability grant** (:ref:`ADR-130
+<adr-130>`), never wholesale.
+
+Assigning grants
+================
+
+Grants are ordinary TYPO3 custom permission options. In the
+**backend group** record (:guilabel:`Access Lists` tab, section
+:guilabel:`AI (nr_llm) permissions`), tick the grants the group should
+hold. Notes:
+
+- Grants are **group-scoped** — a backend user without groups cannot hold
+  a grant.
+- Administrators hold every grant implicitly.
+- Revoking a grant takes effect with the user's next request.
+
+Available grants
+================
+
+Execute AI tasks (``tasks_use``)
+    Run existing AI tasks and refresh their input data. What a task may
+    read and which model and configuration it uses is defined by whoever
+    manages the task — that is the trust boundary: task managers define,
+    grant holders execute. Every run is pre-flighted against the user's
+    own :ref:`usage budget <administration-user-budgets>` and attributed
+    to them.
+
+Approve suspended AI runs (``agent_approve``)
+    Approve, deny or answer agent runs suspended for a human decision —
+    including runs started by **other** users. Without this grant a user
+    can only ever decide their own runs. Deliberately part of no
+    recommended preset: granting it is an explicit trust decision.
+
+Recommended presets
+===================
+
+Roles are named grant bundles, not code:
+
+===============  ======================================================
+Preset           Grants
+===============  ======================================================
+AI editor        ``tasks_use``
+AI operator      ``tasks_use`` (task management arrives with the
+                 non-admin editing module)
+===============  ======================================================
+
+Approval (``agent_approve``) sits in no preset — add it deliberately
+where the organisation wants non-admin approvers.
+
+Current reach
+=============
+
+Until the dedicated non-admin editing module ships, grant holders reach
+the granted actions through their endpoints, not through the admin
+modules (which stay admin-only). Everything else — configuration,
+providers, models, the playground, record browsing — remains
+administrator-only regardless of grants.

--- a/Documentation/Adr/Adr130BackendUserGrants.rst
+++ b/Documentation/Adr/Adr130BackendUserGrants.rst
@@ -1,0 +1,117 @@
+.. _adr-130:
+
+===========================================
+ADR-130: Capability grants for backend users
+===========================================
+
+:Status: Accepted
+:Date: 2026-08-06
+
+Context
+=======
+
+nr_llm is admin-only end to end: every backend module is ``access =>
+admin``, every AJAX action carries ``denyNonAdmin()``, half the builtin
+tools require an administrator. :ref:`ADR-117 <adr-117>` withdrew the first
+attempt at finer permissions (capability checkboxes) on three verified
+findings — no chokepoint for streaming, a polarity that turned enforcement
+into a bypass on user-less paths, and inertness inside an admin-only UI —
+but left one door open, verbatim: should per-capability permissions become
+worth it, *"they should be designed onto AiActorContext — which already
+carries the acting identity across the synchronous, queued and
+service-account paths"*.
+
+The product decision has now been made: a grant-set (not a role ladder),
+nothing without an explicit grant, approval as its own grant outside any
+preset, two coarse task grants, and a non-admin editing surface as a
+separate follow-up milestone.
+
+Decision
+========
+
+**Grants, not roles.** :php:`BackendUserGrant` is a string-backed enum
+mirroring :php:`ServiceAccountScope`: each case documents exactly one
+enforcement point, there is no wildcard, and a case is only added together
+with its consumer — a grant nothing reads is worse than none. Roles are
+documentation-level presets (named grant bundles), not code.
+
+**Assignment via TYPO3's own mechanism.** Grants are registered as
+``customPermOptions`` and assigned per backend **group** in the be_groups
+access lists; enforcement reads ``check('custom_options', …)`` on the live
+user. The core check short-circuits for administrators, so "admins hold
+every grant implicitly" comes from the platform, not from our code. A
+grant is revoked by unticking it — effective with the next request, since
+every check reads the live group data.
+
+**Frozen into the actor at the boundary.** ``currentActor()`` captures the
+grant set next to the admin flag and group ids; downstream consumers read
+the actor, never the ambient user. :php:`AiActorContext::hasGrant()` is
+fail-closed: false for service accounts (their mechanism stays scopes) and
+for anonymous callers.
+
+The two initial grants:
+
+- ``tasks_use`` — execute an existing task and refresh its input data
+  (the two ``TaskExecutionController`` AJAX actions). The per-user budget
+  pre-flight (audit REC 4) bounds what a grant holder can spend.
+- ``agent_approve`` — decide OTHER users' suspended runs, as a new branch
+  in :php:`AiActorContext::mayActOnRun()`; the human sibling of the
+  ``agent:approve`` service-account scope. Deliberately the only scope
+  with a grant equivalent — everything else stays owner-or-admin.
+
+Named constraints, each verified against the code
+=================================================
+
+1. **No colons in grant values.** TYPO3 strips ``:|,`` from custom
+   permission item keys when rendering the be_groups select
+   (``TcaItemsProcessorFunctions::populateCustomPermissionOptions()``); a
+   colon-namespaced value would be stored mangled and every check would
+   silently deny. The values are therefore underscore-separated
+   (``tasks_use``), breaking the naming symmetry with
+   ``ServiceAccountScope`` (``agent:approve``) on purpose.
+2. **The AJAX endpoints go live immediately.** AJAX routes bypass the
+   module access check (that is why ``denyNonAdmin()`` exists, ADR-037).
+   Swapping the two task-execution gates to ``tasks_use`` makes them
+   reachable for grant holders **now**, without any UI — the intended end
+   semantics, bounded by the per-user budget. This ADR must not be read as
+   "inert until the editing module ships".
+3. **``agent_approve`` is doubly unreachable for non-admins today** — both
+   human approval surfaces sit behind admin gates (the AgentRun module's
+   ``access => admin``, the Playground's ``denyNonAdmin()``). The
+   ``mayActOnRun()`` branch is real, tested code, but only becomes
+   exercisable for non-admins with the editing module. Stated here so
+   nobody reads it as an already-active control.
+4. **``tasks_manage`` does not exist yet.** The list/wizard actions have
+   no per-action gate to migrate (they are module-gated only), and the
+   trait's JSON 403 body is the wrong shape for HTML module actions. The
+   grant arrives together with its consumer in the editing-module
+   milestone.
+5. **The record picker stays admin-only.** ``TaskRecordsController``
+   reads arbitrary table rows with only a housekeeping-prefix exclusion —
+   no ``tables_select`` check, no denylist for ``be_users``/``sys_log``/
+   vault tables. Opening it to ``tasks_use`` without a read-boundary would
+   be a data-exfiltration primitive; the denylist (modelled on the tool
+   denylist) is a prerequisite the editing-module milestone owns.
+6. **Grants are group-scoped.** ``custom_options`` is a be_groups field;
+   a user without groups cannot hold a grant.
+7. **The ADR-117 findings, answered:** the chokepoints here are concrete
+   controller gates and ``mayActOnRun()`` (not a pipeline that streaming
+   bypasses); the polarity is deny-on-absence everywhere, including
+   user-less paths (``hasGrant()`` is false for service accounts and
+   anonymous callers, so the queue worker cannot flip a decision); and the
+   inertness concern is exactly why the editing surface is a committed
+   follow-up rather than an afterthought.
+
+Consequences
+============
+
+- ``AiActorContext::backendUser()`` gains an optional ``$grants``
+  parameter and the context serialises/rehydrates the grant set with the
+  same fail-closed ``tryFrom`` filtering as scopes (recorded in the API
+  snapshot; CHANGELOG entry per the 0.x rules).
+- The resume path still reconstructs the run owner without grants
+  (``ResumeCoordinator``) — harmless today because nothing on that path
+  reads them; anything that ever does will see the fail-closed empty set.
+- Recommended presets (documentation, not code): *AI editor* =
+  ``tasks_use``; approval is granted separately and deliberately sits in
+  no preset.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -427,3 +427,4 @@ Tools
    Adr127ApiSurfaceMarkers
    Adr128ProviderNativeStructuredOutput
    Adr129StructuredConsumers
+   Adr130BackendUserGrants

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -234,6 +234,30 @@
                 <source>This action requires backend administrator privileges. Please contact your site administrator to enable LLM management for your account.</source>
                 <target>Diese Aktion erfordert Backend-Administratorrechte. Bitte wenden Sie sich an Ihren Website-Administrator, um die LLM-Verwaltung für Ihr Konto zu aktivieren.</target>
             </trans-unit>
+            <trans-unit id="error.grantRequired">
+                <source>This action requires a permission your backend account does not hold. Please contact your site administrator.</source>
+                <target>Diese Aktion erfordert eine Berechtigung, die Ihr Backend-Konto nicht besitzt. Bitte wenden Sie sich an Ihren Website-Administrator.</target>
+            </trans-unit>
+            <trans-unit id="grants.header">
+                <source>AI (nr_llm) permissions</source>
+                <target>KI-Berechtigungen (nr_llm)</target>
+            </trans-unit>
+            <trans-unit id="grants.tasksUse">
+                <source>Execute AI tasks</source>
+                <target>KI-Aufgaben ausführen</target>
+            </trans-unit>
+            <trans-unit id="grants.tasksUse.description">
+                <source>Run existing AI tasks and refresh their input data. What a task may read and which model it uses is defined by its manager; every run counts against the user's own usage budget.</source>
+                <target>Bestehende KI-Aufgaben ausführen und deren Eingabedaten aktualisieren. Was eine Aufgabe lesen darf und welches Modell sie nutzt, legt deren Verwalter fest; jede Ausführung zählt gegen das eigene Nutzungsbudget.</target>
+            </trans-unit>
+            <trans-unit id="grants.agentApprove">
+                <source>Approve suspended AI runs</source>
+                <target>Angehaltene KI-Läufe freigeben</target>
+            </trans-unit>
+            <trans-unit id="grants.agentApprove.description">
+                <source>Approve, deny or answer AI agent runs that are suspended for a human decision — including runs started by other users. Without this permission a user can only decide their own runs.</source>
+                <target>KI-Agentenläufe freigeben, ablehnen oder beantworten, die auf eine menschliche Entscheidung warten — auch Läufe anderer Benutzer. Ohne diese Berechtigung kann ein Benutzer nur über eigene Läufe entscheiden.</target>
+            </trans-unit>
             <trans-unit id="provider">
                 <source>Provider</source>
                 <target>Anbieter</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -178,6 +178,24 @@
             <trans-unit id="error.adminRequired">
                 <source>This action requires backend administrator privileges. Please contact your site administrator to enable LLM management for your account.</source>
             </trans-unit>
+            <trans-unit id="error.grantRequired">
+                <source>This action requires a permission your backend account does not hold. Please contact your site administrator.</source>
+            </trans-unit>
+            <trans-unit id="grants.header">
+                <source>AI (nr_llm) permissions</source>
+            </trans-unit>
+            <trans-unit id="grants.tasksUse">
+                <source>Execute AI tasks</source>
+            </trans-unit>
+            <trans-unit id="grants.tasksUse.description">
+                <source>Run existing AI tasks and refresh their input data. What a task may read and which model it uses is defined by its manager; every run counts against the user's own usage budget.</source>
+            </trans-unit>
+            <trans-unit id="grants.agentApprove">
+                <source>Approve suspended AI runs</source>
+            </trans-unit>
+            <trans-unit id="grants.agentApprove.description">
+                <source>Approve, deny or answer AI agent runs that are suspended for a human decision — including runs started by other users. Without this permission a user can only decide their own runs.</source>
+            </trans-unit>
             <trans-unit id="provider">
                 <source>Provider</source>
             </trans-unit>

--- a/Tests/Unit/Api/api-surface.txt
+++ b/Tests/Unit/Api/api-surface.txt
@@ -153,6 +153,18 @@ Netresearch\NrLlm\Domain\Enum\ArtifactType (enum)
   property readonly name: string
   property readonly value: string
 
+Netresearch\NrLlm\Domain\Enum\BackendUserGrant (enum)
+  case AGENT_APPROVE
+  case TASKS_USE
+  method permissionValue(): string
+  method static cases(): array
+  method static from(int|string $value): static
+  method static isValid(string $value): bool
+  method static tryFrom(int|string $value): ?static
+  method static values(): array
+  property readonly name: string
+  property readonly value: string
+
 Netresearch\NrLlm\Domain\Enum\GuardrailVerdict (enum)
   case ALLOW
   case DENY
@@ -666,18 +678,20 @@ Netresearch\NrLlm\Domain\ValueObject\AgentRun (class)
 
 Netresearch\NrLlm\Domain\ValueObject\AiActorContext (class)
   method describe(): string
+  method hasGrant(Netresearch\NrLlm\Domain\Enum\BackendUserGrant $grant): bool
   method hasScope(Netresearch\NrLlm\Domain\Enum\ServiceAccountScope $scope): bool
   method isAuthenticated(): bool
   method isServiceAccount(): bool
   method mayAccessSession(Netresearch\NrLlm\Domain\ValueObject\AiSession $session): bool
   method mayActOnRun(Netresearch\NrLlm\Domain\ValueObject\AgentRun $run, Netresearch\NrLlm\Domain\Enum\ServiceAccountScope $scope): bool
   method static anonymous(): self
-  method static backendUser(int $uid, bool $isAdmin = …, array $backendGroupIds = …): self
+  method static backendUser(int $uid, bool $isAdmin = …, array $backendGroupIds = …, array $grants = …): self
   method static fromArray(array $data): self
   method static serviceAccount(string $name, array $scopes = …): self
   method toArray(): array
   property readonly backendGroupIds: array
   property readonly backendUserUid: int
+  property readonly grants: array
   property readonly isAdmin: bool
   property readonly scopes: array
   property readonly serviceAccount: ?string

--- a/Tests/Unit/Controller/Backend/RequiresBackendAdminTraitTest.php
+++ b/Tests/Unit/Controller/Backend/RequiresBackendAdminTraitTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Controller\Backend;
 
 use Netresearch\NrLlm\Controller\Backend\RequiresBackendAdminTrait;
+use Netresearch\NrLlm\Domain\Enum\BackendUserGrant;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -105,5 +106,76 @@ final class RequiresBackendAdminTraitTest extends TestCase
         $payload = json_decode((string)$response->getBody(), true);
         self::assertIsArray($payload);
         self::assertFalse($payload['success']);
+    }
+
+    /**
+     * Run the grant guard via an anonymous class exposing the private method.
+     */
+    private function grantGuardResult(): ?ResponseInterface
+    {
+        $subject = new class {
+            use RequiresBackendAdminTrait;
+
+            public function expose(): ?ResponseInterface
+            {
+                return $this->denyWithoutGrant(BackendUserGrant::TASKS_USE);
+            }
+        };
+
+        return $subject->expose();
+    }
+
+    #[Test]
+    public function denyWithoutGrantPassesAdminsWithoutAnyGrant(): void
+    {
+        $backendUser = self::createStub(BackendUserAuthentication::class);
+        $backendUser->method('isAdmin')->willReturn(true);
+        $backendUser->method('check')->willReturn(false);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        self::assertNull($this->grantGuardResult());
+    }
+
+    #[Test]
+    public function denyWithoutGrantPassesANonAdminHoldingTheGrant(): void
+    {
+        $backendUser = self::createStub(BackendUserAuthentication::class);
+        $backendUser->method('isAdmin')->willReturn(false);
+        $backendUser->method('check')->willReturnCallback(
+            static fn(string $type, string $value): bool => $type === 'custom_options'
+                && $value === BackendUserGrant::TASKS_USE->permissionValue(),
+        );
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        self::assertNull($this->grantGuardResult());
+    }
+
+    #[Test]
+    public function denyWithoutGrantReturnsForbiddenForAGrantlessNonAdmin(): void
+    {
+        $backendUser = self::createStub(BackendUserAuthentication::class);
+        $backendUser->method('isAdmin')->willReturn(false);
+        $backendUser->method('check')->willReturn(false);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $response = $this->grantGuardResult();
+
+        self::assertInstanceOf(ResponseInterface::class, $response);
+        self::assertSame(403, $response->getStatusCode());
+        $payload = json_decode((string)$response->getBody(), true);
+        self::assertIsArray($payload);
+        self::assertFalse($payload['success']);
+        self::assertIsString($payload['error']);
+    }
+
+    #[Test]
+    public function denyWithoutGrantReturnsForbiddenWhenNoBackendUserIsPresent(): void
+    {
+        unset($GLOBALS['BE_USER']);
+
+        $response = $this->grantGuardResult();
+
+        self::assertInstanceOf(ResponseInterface::class, $response);
+        self::assertSame(403, $response->getStatusCode());
     }
 }

--- a/Tests/Unit/Domain/Enum/BackendUserGrantTest.php
+++ b/Tests/Unit/Domain/Enum/BackendUserGrantTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Domain\Enum;
+
+use Netresearch\NrLlm\Domain\Enum\BackendUserGrant;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class BackendUserGrantTest extends TestCase
+{
+    #[Test]
+    public function valuesListsEveryCase(): void
+    {
+        self::assertSame(['tasks_use', 'agent_approve'], BackendUserGrant::values());
+    }
+
+    #[Test]
+    public function isValidAcceptsKnownAndRejectsUnknownValues(): void
+    {
+        self::assertTrue(BackendUserGrant::isValid('tasks_use'));
+        self::assertFalse(BackendUserGrant::isValid('root'));
+        self::assertFalse(BackendUserGrant::isValid(''));
+    }
+
+    #[Test]
+    public function permissionValuesCarryThePrefixAndNoStrippedCharacters(): void
+    {
+        foreach (BackendUserGrant::cases() as $grant) {
+            self::assertSame('tx_nrllm_grants:' . $grant->value, $grant->permissionValue());
+            // TYPO3 strips `:|,` from custom permission ITEM keys when
+            // rendering the be_groups select — a value containing one would
+            // be stored mangled and silently deny (ADR-130). The single
+            // colon separating prefix and value is the core's own separator.
+            self::assertDoesNotMatchRegularExpression('/[:|,]/', $grant->value);
+        }
+    }
+}

--- a/Tests/Unit/Domain/ValueObject/AiActorContextTest.php
+++ b/Tests/Unit/Domain/ValueObject/AiActorContextTest.php
@@ -9,7 +9,9 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Domain\ValueObject;
 
+use Netresearch\NrLlm\Domain\Enum\BackendUserGrant;
 use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
 use Netresearch\NrLlm\Domain\ValueObject\AiSession;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -146,6 +148,70 @@ final class AiActorContextTest extends TestCase
         self::assertFalse(
             AiActorContext::serviceAccount('w')->mayAccessSession($session),
             'scopeless service account is denied',
+        );
+    }
+
+    #[Test]
+    public function grantsSurviveTheQueueRoundTripAndUnknownValuesAreDropped(): void
+    {
+        $actor = AiActorContext::backendUser(9, grants: [BackendUserGrant::TASKS_USE]);
+
+        $restored = AiActorContext::fromArray($actor->toArray());
+        self::assertSame([BackendUserGrant::TASKS_USE], $restored->grants);
+
+        // A tampered or future row can never yield a grant this process does
+        // not define (fail-closed, same rule as scopes).
+        $tampered = AiActorContext::fromArray([
+            'backendUserUid' => 9,
+            'grants'         => ['tasks_use', 'root', 42, null],
+        ]);
+        self::assertSame([BackendUserGrant::TASKS_USE], $tampered->grants);
+    }
+
+    #[Test]
+    public function hasGrantIsImplicitForAdminsAndFailClosedOtherwise(): void
+    {
+        self::assertTrue(
+            AiActorContext::backendUser(9, grants: [BackendUserGrant::TASKS_USE])->hasGrant(BackendUserGrant::TASKS_USE),
+            'granted user',
+        );
+        self::assertFalse(
+            AiActorContext::backendUser(9)->hasGrant(BackendUserGrant::TASKS_USE),
+            'grantless user',
+        );
+        self::assertTrue(
+            AiActorContext::backendUser(9, isAdmin: true)->hasGrant(BackendUserGrant::TASKS_USE),
+            'admins hold every grant implicitly (ADR-130)',
+        );
+        self::assertFalse(
+            AiActorContext::serviceAccount('w', [ServiceAccountScope::AGENT_APPROVE])->hasGrant(BackendUserGrant::AGENT_APPROVE),
+            'grants never govern service accounts - their mechanism is scopes',
+        );
+        self::assertFalse(
+            AiActorContext::anonymous()->hasGrant(BackendUserGrant::TASKS_USE),
+            'anonymous caller',
+        );
+    }
+
+    #[Test]
+    public function theApproveGrantExtendsMayActOnRunToOtherUsersRunsOnly(): void
+    {
+        $someoneElsesRun = new AgentRun(1, 'uuid', 'waiting_for_approval', 0, '', 42, 0, false, 0, 0, 0, 0.0, '', '', 0, 0, 0, '{}');
+
+        $approver = AiActorContext::backendUser(7, grants: [BackendUserGrant::AGENT_APPROVE]);
+
+        // The human sibling of the AGENT_APPROVE scope (ADR-130): the granted
+        // user may decide runs they do not own...
+        self::assertTrue($approver->mayActOnRun($someoneElsesRun, ServiceAccountScope::AGENT_APPROVE));
+
+        // ...but the grant covers ONLY approval - every other operation stays
+        // owner-or-admin.
+        self::assertFalse($approver->mayActOnRun($someoneElsesRun, ServiceAccountScope::AGENT_CANCEL));
+        self::assertFalse($approver->mayActOnRun($someoneElsesRun, ServiceAccountScope::AGENT_READ));
+
+        // And without the grant, a stranger stays denied.
+        self::assertFalse(
+            AiActorContext::backendUser(7)->mayActOnRun($someoneElsesRun, ServiceAccountScope::AGENT_APPROVE),
         );
     }
 }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -7,6 +7,7 @@
 
 declare(strict_types=1);
 
+use Netresearch\NrLlm\Domain\Enum\BackendUserGrant;
 use Netresearch\NrLlm\Form\Element\ModelIdElement;
 use Netresearch\NrLlm\Form\FieldWizard\ModelConstraintsWizard;
 use Netresearch\NrLlm\Hook\ProviderEndpointNormalizationHook;
@@ -98,5 +99,28 @@ defined('TYPO3') || die();
     // @phpstan-ignore-next-line $GLOBALS access returns mixed at each nesting level
     $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['dashboard']['widgetGroups']['nrllm'] ??= [
         'title' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widgetGroup.nrllm.title',
+    ];
+
+    // Capability grants for human backend users (ADR-130): assigned per
+    // backend GROUP through the be_groups access lists, checked via
+    // BackendUserAuthentication::check('custom_options', ...). Item keys must
+    // not contain ':', '|' or ',' — TYPO3 strips those when rendering the
+    // select, so a colon-namespaced key would be stored mangled and silently
+    // deny (see BackendUserGrant).
+    // @phpstan-ignore-next-line $GLOBALS access returns mixed at each nesting level
+    $GLOBALS['TYPO3_CONF_VARS']['BE']['customPermOptions']['tx_nrllm_grants'] = [
+        'header' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:grants.header',
+        'items'  => [
+            BackendUserGrant::TASKS_USE->value => [
+                'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:grants.tasksUse',
+                'module-nrllm',
+                'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:grants.tasksUse.description',
+            ],
+            BackendUserGrant::AGENT_APPROVE->value => [
+                'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:grants.agentApprove',
+                'module-nrllm',
+                'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:grants.agentApprove.description',
+            ],
+        ],
     ];
 })();


### PR DESCRIPTION
## What

The grant-set the ADR-117 door asked for, designed onto `AiActorContext`. Implements the maintainer's decisions: grant-set (not a role ladder), nothing without an explicit grant, approval as its own grant outside any preset. `BackendUserGrant` mirrors `ServiceAccountScope`: each case documents exactly one enforcement point, no wildcard, and a case is only added **together with its consumer**.

Two initial grants, assigned per backend **group** through TYPO3's own `customPermOptions` (be_groups access lists, EN+DE labels):

- **`tasks_use`** opens the two task-execution AJAX endpoints (`executeAction`, `refreshInputAction`) to non-admins, bounded by the per-user budget pre-flight ([#605](https://github.com/netresearch/t3x-nr-llm/pull/605)). ⚠️ These endpoints bypass the module access check by construction (ADR-037), so the grant is **effective immediately** — review this PR as a live security surface, not as inert plumbing.
- **`agent_approve`** extends `mayActOnRun()`: a granted user may decide **other** users' suspended runs (the human sibling of the `agent:approve` service-account scope). Approval only — cancel/read stay owner-or-admin. Doubly unreachable for non-admins until the editing module ships (both approval surfaces sit behind admin gates); stated in ADR-130 so nobody reads it as an already-active control.

Enforcement reads `check()` on the live user per request (revocation is immediate); admins hold every grant implicitly via the core's own short-circuit. Fail-closed on every user-less path (`hasGrant()` is false for service accounts and anonymous callers) — the ADR-117 polarity finding, answered.

**Non-obvious constraint, pinned by a test:** TYPO3 strips `:|,` from custom permission item keys when rendering the be_groups select — a colon-namespaced value (`tasks:use`) would be stored mangled and every check would silently deny. The grant values are therefore underscore-separated, deliberately breaking the naming symmetry with `ServiceAccountScope`.

## Deliberately NOT in this PR (reasons in ADR-130)

- `tasks_manage` — the list/wizard actions have no per-action gate to migrate (module-gated only) and the trait's JSON 403 is the wrong shape for HTML module actions; arrives with the editing module.
- The record-picker endpoints (`TaskRecordsController`) stay admin-only — arbitrary table read without a read boundary; the denylist is a prerequisite the editing-module milestone owns.
- The non-admin editing module itself (next PR).

## API surface

`AiActorContext::backendUser()` gains an optional `$grants` parameter (snapshot line changed — noted in the CHANGELOG per the 0.x rules), plus `hasGrant()`, the readonly `grants` property and the `@api` enum block. Snapshot regenerated; grants serialise/rehydrate with the same fail-closed `tryFrom` filtering as scopes.

## Tests

New/extended units: grant queue-round-trip incl. tamper filtering, admin-implicit `hasGrant`, `mayActOnRun` approve-branch (approval only, strangers stay denied), all four `denyWithoutGrant` gate states, and the colon-free-values regression pin. All six pre-push suites green locally on PHP 8.2 (unit, fuzzy, functional sqlite full run, phpstan, cgl, rector -n).

Heads-up unrelated to this diff: since [#601](https://github.com/netresearch/t3x-nr-llm/pull/601) a fresh dependency resolve without explicit `-p 8.2` installs phpunit 13 (runTests.sh now defaults to PHP 8.5), which cannot run on 8.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)