### PR TITLE
feat: editor-facing AI Tasks module (ADR-131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- An editor-facing **AI Tasks** backend module in the Web area (ADR-131).
+  Editors with the module permission AND the `Execute AI tasks` grant run
+  prepared tasks (minus table-input tasks, whose record picker stays
+  admin-only) through a slim surface without any management affordances;
+  the approvals inbox is shared with the admin module and scopes
+  visibility by actor — admins and `Approve suspended AI runs` holders
+  see every run, everyone else only their own. Both ADR-130 grants are
+  observable for the first time. The runs infobox now states the actual
+  visibility rule instead of claiming to be admin-only.
 - Capability grants for backend users (ADR-130). Two grants, assigned per
   backend group through TYPO3's own permission mechanism (`be_groups`
   access lists): `Execute AI tasks` opens the two task-execution AJAX

--- a/Classes/Controller/Backend/AgentRunController.php
+++ b/Classes/Controller/Backend/AgentRunController.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Controller\Backend;
 
 use Netresearch\NrLlm\Domain\Enum\AgentRunOutcome;
+use Netresearch\NrLlm\Domain\Enum\BackendUserGrant;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Service\Agent\AgentRunResult;
 use Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface;
@@ -37,12 +38,17 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
  * The "Agent Runs" approvals inbox (ADR-109): the human-facing surface for runs
  * suspended WAITING_FOR_APPROVAL (ADR-084) or WAITING_FOR_INPUT (ADR-105).
  *
- * All three actions are module-route controllerActions gated by the module's
- * `access => admin` (Configuration/Backend/Modules.php) — the sole authorization
- * gate. Unlike the AJAX endpoints on {@see ToolPlaygroundController}, a
- * module-route action cannot be reached without that access, so
- * RequiresBackendAdminTrait is not needed here (and its JSON 403 body would be
- * wrong for an HTML page). Any admin may act on any run; the recorded
+ * The three actions are module-route controllerActions, reachable through TWO
+ * modules since ADR-131: the admin inbox (`nrllm_runs`, `access => admin`) and
+ * the editor module (`nrllm_aitasks`, `access => user`). Unlike the AJAX
+ * endpoints on {@see ToolPlaygroundController}, a module-route action cannot
+ * be reached without module access, so RequiresBackendAdminTrait is not
+ * needed here (and its JSON 403 body would be wrong for an HTML page).
+ * Visibility is actor-scoped: an admin or an `agent_approve` grant holder
+ * sees every run, everyone else only their own — and the WRITE side is
+ * independently authorised per run by
+ * {@see \Netresearch\NrLlm\Domain\ValueObject\AiActorContext::mayActOnRun()},
+ * so the list filter is a viewport, never the security boundary. The recorded
  * decidedBy/submittedBy uid is audit-only.
  *
  * The page works fully with JavaScript OFF: native `<f:form>` POST, a
@@ -204,17 +210,28 @@ final class AgentRunController extends ActionController
      */
     private function renderList(string $errorRunUuid, array $rawInput, string $errorSummary): ResponseInterface
     {
-        $waitingRuns  = $this->persister->findAwaitingRuns();
-        $terminalRuns = $this->persister->findRecentTerminalRuns();
+        // Actor-scoped viewport (ADR-131): admins and approval-grant holders
+        // see every run, everyone else only their own. The write side stays
+        // independently authorised per run by mayActOnRun(), so this filter
+        // shapes the list, never the security boundary. An absent BE user
+        // degrades to uid 0 = empty lists (fail-closed).
+        $actor      = $this->currentActor();
+        $restrictTo = ($actor->isAdmin || $actor->hasGrant(BackendUserGrant::AGENT_APPROVE))
+            ? null
+            : $actor->backendUserUid;
+
+        $waitingRuns  = $this->persister->findAwaitingRuns(beUser: $restrictTo);
+        $terminalRuns = $this->persister->findRecentTerminalRuns(beUser: $restrictTo);
         $dataLoadError = $waitingRuns === null || $terminalRuns === null;
 
         $this->moduleTemplate->assignMultiple([
-            'waiting'       => $this->viewFactory->buildWaiting($waitingRuns ?? []),
-            'terminal'      => $this->viewFactory->buildTerminal($terminalRuns ?? []),
-            'dataLoadError' => $dataLoadError,
-            'errorRunUuid'  => $errorRunUuid,
-            'rawInput'      => $rawInput,
-            'errorSummary'  => $errorSummary,
+            'waiting'        => $this->viewFactory->buildWaiting($waitingRuns ?? []),
+            'terminal'       => $this->viewFactory->buildTerminal($terminalRuns ?? []),
+            'dataLoadError'  => $dataLoadError,
+            'errorRunUuid'   => $errorRunUuid,
+            'rawInput'       => $rawInput,
+            'errorSummary'   => $errorSummary,
+            'restrictedView' => $restrictTo !== null,
         ]);
 
         return $this->moduleTemplate->renderResponse('Backend/AgentRun/List');

--- a/Classes/Controller/Backend/AiTaskController.php
+++ b/Classes/Controller/Backend/AiTaskController.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Controller\Backend;
+
+use Netresearch\NrLlm\Domain\Enum\BackendUserGrant;
+use Netresearch\NrLlm\Domain\Enum\TaskInputType;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Task;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Domain\Repository\TaskRepository;
+use Netresearch\NrLlm\Service\Task\TaskInputResolverInterface;
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Backend\Attribute\AsController;
+use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
+use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
+use TYPO3\CMS\Core\Http\RedirectResponse;
+use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+
+/**
+ * The editor-facing task surface (ADR-131): list executable tasks and run
+ * one — nothing else. Registered under the `nrllm_aitasks` module
+ * (`access => 'user'`), so reaching it takes BOTH the module permission
+ * (be_groups module list) AND the `tasks_use` grant checked per action here
+ * — the module switch alone never grants execution.
+ *
+ * Deliberately narrower than the admin task module: no FormEngine edit
+ * links (an editor cannot edit tx_nrllm_* records), no analytics, no
+ * wizard, and tasks with the `table` input type are filtered out — the
+ * record picker has no read boundary yet (ADR-130) and stays admin-only.
+ * The execute/refresh AJAX endpoints this page drives are grant-gated
+ * themselves (ADR-130) and budget-bounded per user.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
+#[AsController]
+final class AiTaskController extends ActionController
+{
+    use BackendUserUidTrait;
+    use DefensiveLocalizationTrait;
+    use RequiresBackendAdminTrait;
+
+    private const LL = 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:';
+
+    public function __construct(
+        private readonly ModuleTemplateFactory $moduleTemplateFactory,
+        private readonly TaskRepository $taskRepository,
+        private readonly LlmConfigurationRepository $configurationRepository,
+        private readonly TaskInputResolverInterface $taskInputResolver,
+        private readonly BackendUriBuilder $backendUriBuilder,
+        private readonly PageRenderer $pageRenderer,
+    ) {}
+
+    /**
+     * Executable tasks, grouped for selection. A user holding only the
+     * approval grant is forwarded to the runs view — for them this module IS
+     * the approvals inbox.
+     */
+    public function listAction(): ResponseInterface
+    {
+        if (($deny = $this->denyWithoutGrantHtml(BackendUserGrant::TASKS_USE)) instanceof ResponseInterface) {
+            $actor = $this->currentActor();
+            if ($actor->hasGrant(BackendUserGrant::AGENT_APPROVE)) {
+                return new RedirectResponse((string)$this->backendUriBuilder->buildUriFromRoute('nrllm_aitasks', [
+                    'controller' => 'Backend\\AgentRun',
+                    'action'     => 'list',
+                ]));
+            }
+
+            return $deny;
+        }
+
+        $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
+        $moduleTemplate->setFlashMessageQueue($this->getFlashMessageQueue());
+
+        $moduleTemplate->assignMultiple([
+            'tasks'        => $this->executableTasks(),
+            'showApprovals' => $this->currentActor()->hasGrant(BackendUserGrant::AGENT_APPROVE),
+        ]);
+
+        return $moduleTemplate->renderResponse('Backend/AiTask/List');
+    }
+
+    /**
+     * The run form for one task — the editor sibling of the admin module's
+     * execute form, minus every management affordance.
+     */
+    public function executeFormAction(int $uid): ResponseInterface
+    {
+        if (($deny = $this->denyWithoutGrantHtml(BackendUserGrant::TASKS_USE)) instanceof ResponseInterface) {
+            return $deny;
+        }
+
+        $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
+        $moduleTemplate->setFlashMessageQueue($this->getFlashMessageQueue());
+
+        $task = $this->taskRepository->findByUid($uid);
+        if (!$task instanceof Task || !$task->isActive() || $task->getInputTypeEnum() === TaskInputType::TABLE) {
+            // TABLE tasks stay admin-only until the record picker has a read
+            // boundary (ADR-130/131) — same redirect as an unknown task, so
+            // a guessed uid leaks nothing about what exists.
+            $this->addFlashMessage(
+                $this->localize(self::LL . 'aitasks.notAvailable', 'This task is not available.'),
+                $this->localize(self::LL . 'task.error', 'Error'),
+                ContextualFeedbackSeverity::ERROR,
+            );
+
+            return new RedirectResponse((string)$this->backendUriBuilder->buildUriFromRoute('nrllm_aitasks'));
+        }
+
+        $this->pageRenderer->addInlineSettingArray('ajaxUrls', [
+            'nrllm_task_refresh_input' => (string)$this->backendUriBuilder->buildUriFromRoute('ajax_nrllm_task_refresh_input'),
+            'nrllm_task_execute'       => (string)$this->backendUriBuilder->buildUriFromRoute('ajax_nrllm_task_execute'),
+        ]);
+        $this->pageRenderer->loadJavaScriptModule('@netresearch/nr-llm/Backend/TaskExecute.js');
+
+        $configuration  = $task->getConfiguration();
+        $isUsingDefault = false;
+        if (!$configuration instanceof LlmConfiguration) {
+            $configuration  = $this->configurationRepository->findDefault();
+            $isUsingDefault = true;
+        }
+
+        $moduleTemplate->assignMultiple([
+            'task'                 => $task,
+            'inputData'            => $this->taskInputResolver->resolve($task),
+            'requiresManualInput'  => $task->requiresManualInput(),
+            'effectiveConfig'      => $configuration,
+            'isUsingDefaultConfig' => $isUsingDefault,
+        ]);
+
+        return $moduleTemplate->renderResponse('Backend/AiTask/Execute');
+    }
+
+    /**
+     * Active tasks an editor may run: everything except the `table` input
+     * type (no record-picker read boundary yet), grouped by category.
+     *
+     * @return array<string, list<Task>>
+     */
+    private function executableTasks(): array
+    {
+        $grouped = [];
+        foreach ($this->taskRepository->findActive() as $task) {
+            if (!$task instanceof Task) {
+                continue;
+            }
+
+            if ($task->getInputTypeEnum() === TaskInputType::TABLE) {
+                continue;
+            }
+
+            $grouped[$task->getCategory()][] = $task;
+        }
+
+        ksort($grouped);
+
+        return $grouped;
+    }
+}

--- a/Classes/Controller/Backend/RequiresBackendAdminTrait.php
+++ b/Classes/Controller/Backend/RequiresBackendAdminTrait.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Domain\Enum\BackendUserGrant;
 use Psr\Http\Message\ResponseInterface;
 use Throwable;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
@@ -87,5 +88,37 @@ trait RequiresBackendAdminTrait
         }
 
         return new JsonResponse(['success' => false, 'error' => $message], 403);
+    }
+
+    /**
+     * The HTML sibling of {@see denyWithoutGrant()} for module-route actions
+     * (ADR-131): a JSON body would be the wrong shape for a page a user
+     * navigated to. Returns a minimal 403 page, or null when the current
+     * backend user is an admin or holds the grant.
+     */
+    private function denyWithoutGrantHtml(BackendUserGrant $grant): ?ResponseInterface
+    {
+        $backendUser = $GLOBALS['BE_USER'] ?? null;
+        if ($backendUser instanceof BackendUserAuthentication
+            && ($backendUser->isAdmin() || $backendUser->check('custom_options', $grant->permissionValue()))
+        ) {
+            return null;
+        }
+
+        $fallback = 'This action requires a permission your backend account does not hold. Please contact your site administrator.';
+
+        try {
+            $message = LocalizationUtility::translate(
+                'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.grantRequired',
+                'NrLlm',
+            ) ?? $fallback;
+        } catch (Throwable) {
+            $message = $fallback;
+        }
+
+        return new HtmlResponse(
+            '<div class="callout callout-danger"><p>' . htmlspecialchars($message, ENT_QUOTES) . '</p></div>',
+            403,
+        );
     }
 }

--- a/Classes/Service/Tool/AgentRunPersister.php
+++ b/Classes/Service/Tool/AgentRunPersister.php
@@ -399,10 +399,10 @@ final readonly class AgentRunPersister
      *
      * @return list<AgentRun>|null null on a load error, else the (possibly empty) list
      */
-    public function findAwaitingRuns(int $limit = 100): ?array
+    public function findAwaitingRuns(int $limit = 100, ?int $beUser = null): ?array
     {
         try {
-            return $this->repository->findAwaiting($limit);
+            return $this->repository->findAwaiting($limit, $beUser);
         } catch (Throwable $exception) {
             $this->logger?->warning('Awaiting agent runs could not be loaded', ['exception' => $exception]);
 
@@ -416,10 +416,10 @@ final readonly class AgentRunPersister
      *
      * @return list<AgentRun>|null null on a load error, else the (possibly empty) list
      */
-    public function findRecentTerminalRuns(int $limit = 20): ?array
+    public function findRecentTerminalRuns(int $limit = 20, ?int $beUser = null): ?array
     {
         try {
-            return $this->repository->findRecentTerminal($limit);
+            return $this->repository->findRecentTerminal($limit, $beUser);
         } catch (Throwable $exception) {
             $this->logger?->warning('Recent terminal agent runs could not be loaded', ['exception' => $exception]);
 

--- a/Classes/Service/Tool/AgentRunRepository.php
+++ b/Classes/Service/Tool/AgentRunRepository.php
@@ -521,20 +521,27 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
         return $this->hydrateRun($row);
     }
 
-    public function findAwaiting(int $limit = 100): array
+    public function findAwaiting(int $limit = 100, ?int $beUser = null): array
     {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_RUN);
         $queryBuilder->getRestrictions()->removeAll();
 
+        $constraints = [
+            $queryBuilder->expr()->in(
+                'status',
+                $queryBuilder->createNamedParameter(AgentRunStatus::awaitingValues(), Connection::PARAM_STR_ARRAY),
+            ),
+        ];
+        if ($beUser !== null) {
+            // Ownership view (ADR-131): a non-admin without the approval
+            // grant sees only the runs they initiated.
+            $constraints[] = $queryBuilder->expr()->eq('be_user', $queryBuilder->createNamedParameter($beUser, Connection::PARAM_INT));
+        }
+
         $rows = $queryBuilder
             ->select('*')
             ->from(self::TABLE_RUN)
-            ->where(
-                $queryBuilder->expr()->in(
-                    'status',
-                    $queryBuilder->createNamedParameter(AgentRunStatus::awaitingValues(), Connection::PARAM_STR_ARRAY),
-                ),
-            )
+            ->where(...$constraints)
             // Oldest first: act on the longest-waiting run first. The
             // status_lookup(status, crdate) index serves the status filter;
             // ordering across the two waiting values is a cheap filesort at this
@@ -547,20 +554,25 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
         return array_map($this->hydrateRun(...), $rows);
     }
 
-    public function findRecentTerminal(int $limit = 20): array
+    public function findRecentTerminal(int $limit = 20, ?int $beUser = null): array
     {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_RUN);
         $queryBuilder->getRestrictions()->removeAll();
 
+        $constraints = [
+            $queryBuilder->expr()->in(
+                'status',
+                $queryBuilder->createNamedParameter(AgentRunStatus::terminalValues(), Connection::PARAM_STR_ARRAY),
+            ),
+        ];
+        if ($beUser !== null) {
+            $constraints[] = $queryBuilder->expr()->eq('be_user', $queryBuilder->createNamedParameter($beUser, Connection::PARAM_INT));
+        }
+
         $rows = $queryBuilder
             ->select('*')
             ->from(self::TABLE_RUN)
-            ->where(
-                $queryBuilder->expr()->in(
-                    'status',
-                    $queryBuilder->createNamedParameter(AgentRunStatus::terminalValues(), Connection::PARAM_STR_ARRAY),
-                ),
-            )
+            ->where(...$constraints)
             ->orderBy('crdate', 'DESC')
             ->setMaxResults($limit)
             ->executeQuery()

--- a/Classes/Service/Tool/AgentRunRepositoryInterface.php
+++ b/Classes/Service/Tool/AgentRunRepositoryInterface.php
@@ -163,7 +163,7 @@ interface AgentRunRepositoryInterface
      *
      * @return list<AgentRun>
      */
-    public function findAwaiting(int $limit = 100): array;
+    public function findAwaiting(int $limit = 100, ?int $beUser = null): array;
 
     /**
      * The most recent terminal runs (completed, failed, cancelled), newest
@@ -172,7 +172,7 @@ interface AgentRunRepositoryInterface
      *
      * @return list<AgentRun>
      */
-    public function findRecentTerminal(int $limit = 20): array;
+    public function findRecentTerminal(int $limit = 20, ?int $beUser = null): array;
 
     /**
      * Count runs per lifecycle status created on/after $since (0 = all time).

--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -8,6 +8,7 @@
 declare(strict_types=1);
 
 use Netresearch\NrLlm\Controller\Backend\AgentRunController;
+use Netresearch\NrLlm\Controller\Backend\AiTaskController;
 use Netresearch\NrLlm\Controller\Backend\AnalyticsController;
 use Netresearch\NrLlm\Controller\Backend\ConfigurationController;
 use Netresearch\NrLlm\Controller\Backend\LlmModuleController;
@@ -290,6 +291,39 @@ return [
         'controllerActions' => [
             AnalyticsController::class => [
                 'index',
+            ],
+        ],
+    ],
+    // Editor-facing task/approvals module (ADR-131). Deliberately OUTSIDE the
+    // admin-only 'nrllm' tree: the menu filters out every top-level module
+    // whose own access check fails, so a child of 'nrllm' would be invisible
+    // to non-admins. Lives in the 'web' group where editors work.
+    //
+    // access => 'user' (NOT 'user,group': v14 resolves access strings through
+    // a gate registry that only knows user/admin/systemMaintainer — anything
+    // else denies EVERYONE, admins included). 'user' means the module must be
+    // ticked in be_groups; the tasks_use/agent_approve grants are checked per
+    // action on top — the module switch alone never grants execution.
+    'nrllm_aitasks' => [
+        'parent' => 'web',
+        'access' => 'user',
+        'iconIdentifier' => 'module-nrllm-task',
+        'path' => '/module/web/nrllm-aitasks',
+        'labels' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_aitasks.xlf',
+        'extensionName' => 'NrLlm',
+        'controllerActions' => [
+            AiTaskController::class => [
+                'list',
+                'executeForm',
+            ],
+            // The approvals inbox actions, shared with 'nrllm_runs': the
+            // controller scopes visibility by actor (admin/approval grant =>
+            // all runs, else own) and the write side is authorised per run by
+            // mayActOnRun() — no logic is duplicated for the second module.
+            AgentRunController::class => [
+                'list',
+                'approve',
+                'submitInput',
             ],
         ],
     ],

--- a/Documentation/Administration/Index.rst
+++ b/Documentation/Administration/Index.rst
@@ -42,7 +42,7 @@ All AI management happens in
    :guilabel:`Set up & manage` grid, and the :guilabel:`For developers`
    section.
 
-The module has twelve sections accessible from the
+The admin module tree has thirteen sections accessible from the
 left-hand navigation:
 
 - **Overview** — guided dashboard: usage & cost, per-module setup state, and

--- a/Documentation/Administration/Permissions.rst
+++ b/Documentation/Administration/Permissions.rst
@@ -50,8 +50,8 @@ Roles are named grant bundles, not code:
 Preset           Grants
 ===============  ======================================================
 AI editor        ``tasks_use``
-AI operator      ``tasks_use`` (task management arrives with the
-                 non-admin editing module)
+AI operator      ``tasks_use`` (a management grant still awaits a
+                 management surface — ADR-131 adds none)
 ===============  ======================================================
 
 Approval (``agent_approve``) sits in no preset — add it deliberately
@@ -60,8 +60,11 @@ where the organisation wants non-admin approvers.
 Current reach
 =============
 
-Until the dedicated non-admin editing module ships, grant holders reach
-the granted actions through their endpoints, not through the admin
-modules (which stay admin-only). Everything else — configuration,
-providers, models, the playground, record browsing — remains
-administrator-only regardless of grants.
+Grant holders work in the dedicated **AI Tasks** module (``web`` group,
+:ref:`ADR-131 <adr-131>`). Reaching it takes BOTH switches: the module
+must be ticked in the group's module list (``access => user``) AND the
+grant must be held — the module switch alone never grants execution.
+Tasks with the ``table`` input type are not offered to editors (their
+record picker has no read boundary yet and stays admin-only).
+Everything else — configuration, providers, models, the playground,
+record browsing — remains administrator-only regardless of grants.

--- a/Documentation/Adr/Adr131EditorModule.rst
+++ b/Documentation/Adr/Adr131EditorModule.rst
@@ -1,0 +1,85 @@
+.. _adr-131:
+
+===================================
+ADR-131: The editor-facing module
+===================================
+
+:Status: Accepted
+:Date: 2026-08-06
+
+Context
+=======
+
+:ref:`ADR-130 <adr-130>` shipped capability grants, and its own constraints
+list said why they were not yet observable: every nr_llm module is
+``access => admin``, so a gate administrators bypass is inert inside the
+admin UI (ADR-117's third finding). The committed follow-up is a surface
+non-admins can actually reach.
+
+Decision
+========
+
+One new backend module, ``nrllm_aitasks`` ("AI Tasks"), containing exactly
+what the editing role holds: run a prepared task, and decide agent runs
+waiting for approval. Everything else — configuration, providers, models,
+playground, wizards, analytics — stays admin-only.
+
+Four structural choices, each forced by a verified platform constraint:
+
+1. **Top-level in the ``web`` group, not a child of ``nrllm``.** The module
+   menu drops every top-level module whose own access check fails; since
+   ``nrllm`` is admin-only, any child would be invisible to non-admins no
+   matter its own access. Editors work in ``web``, so that is where their
+   module lives.
+2. **``access => 'user'``, never ``'user,group'``.** TYPO3 v14 resolves the
+   access string through a gate registry that knows only ``user``,
+   ``admin`` and ``systemMaintainer`` — an unknown string denies everyone,
+   administrators included. ``'user'`` means the module must be ticked in
+   the be_groups module list; the ADR-130 grants are checked per action on
+   top. Two switches, both required, both documented.
+3. **The approvals inbox is the SAME controller, not a copy.**
+   :php:`AgentRunController` (stale-review digest, schema coercion, the
+   exception map) is registered in both modules. Visibility is
+   actor-scoped in one place: an admin or an ``agent_approve`` holder sees
+   every run, everyone else only their own (a new optional ``beUser``
+   filter on the run queries). The list filter is a viewport — the write
+   side stays independently authorised per run by
+   :php:`AiActorContext::mayActOnRun()`.
+4. **The task surface is a NEW slim controller**
+   (:php:`AiTaskController`), because the admin execute form cannot be
+   reused as-is: it renders FormEngine edit links for four tables an
+   editor cannot touch, and it embeds the database record picker. The
+   editor templates share the ``data-task-execute`` contract, so
+   ``TaskExecute.js`` is reused unchanged (its element lookups are
+   null-safe where the picker is absent).
+
+What stays out, and why
+=======================
+
+- **Tasks with the ``table`` input type are filtered from the editor
+  list** (and their execute form redirects like an unknown uid, so a
+  guessed id leaks nothing). The record-picker endpoints read arbitrary
+  tables with only housekeeping exclusions — no ``tables_select`` check,
+  no sensitive-table denylist — and stay admin-only (ADR-130). Wiring
+  :php:`TableReadAccessService` into the picker would also restrict
+  administrators, which is its own decision, not a side effect of this
+  module.
+- **``tasks_manage`` still does not exist.** This module adds no
+  management surface, so the grant would still have no enforcement point.
+- **"Own runs" for editors is mostly the approver's view.** Task
+  executions do not create agent runs (they are usage rows); agent runs
+  are currently started from admin surfaces. The ownership filter matters
+  the moment any non-admin path starts runs, and costs nothing now.
+
+Consequences
+============
+
+- Both ADR-130 grants become observable: ``tasks_use`` through the task
+  list/run form, ``agent_approve`` through the shared approvals inbox
+  (previously doubly unreachable for non-admins).
+- The inbox infobox no longer claims to be admin-only; it states the
+  actual visibility rule for the current actor.
+- Admin discovery: the overview's Tasks card links to the editor module.
+- The gate primitive for HTML module actions
+  (:php:`denyWithoutGrantHtml()`) complements the AJAX JSON variant from
+  ADR-130.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -428,3 +428,4 @@ Tools
    Adr128ProviderNativeStructuredOutput
    Adr129StructuredConsumers
    Adr130BackendUserGrants
+   Adr131EditorModule

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -22,9 +22,10 @@ keys, or implement caching and streaming. Add AI
 capabilities to your extension with three lines
 of dependency injection.
 
-**For administrators**, it provides a single backend module to manage all AI
-connections, encrypted API keys, and provider
-configurations. Switch from OpenAI to Anthropic
+**For administrators**, it provides a backend module tree to manage all AI
+connections, encrypted API keys, and provider configurations — plus a
+dedicated **AI Tasks** module in the Web area where editors run prepared
+tasks and decide pending approvals, gated by explicit permissions. Switch from OpenAI to Anthropic
 without touching any extension code.
 
 **For agencies**, it means consistent AI architecture across client projects, no

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -238,6 +238,42 @@
                 <source>This action requires a permission your backend account does not hold. Please contact your site administrator.</source>
                 <target>Diese Aktion erfordert eine Berechtigung, die Ihr Backend-Konto nicht besitzt. Bitte wenden Sie sich an Ihren Website-Administrator.</target>
             </trans-unit>
+            <trans-unit id="task.card.editorModule">
+                <source>Editor module</source>
+                <target>Redakteurs-Modul</target>
+            </trans-unit>
+            <trans-unit id="aitasks.title">
+                <source>AI tasks</source>
+                <target>KI-Aufgaben</target>
+            </trans-unit>
+            <trans-unit id="aitasks.intro">
+                <source>Run an AI task your administrators prepared. Every run counts against your personal usage budget.</source>
+                <target>Führen Sie eine von Ihren Administratoren vorbereitete KI-Aufgabe aus. Jede Ausführung zählt gegen Ihr persönliches Nutzungsbudget.</target>
+            </trans-unit>
+            <trans-unit id="aitasks.btn.run">
+                <source>Run</source>
+                <target>Ausführen</target>
+            </trans-unit>
+            <trans-unit id="aitasks.btn.approvals">
+                <source>Approvals</source>
+                <target>Freigaben</target>
+            </trans-unit>
+            <trans-unit id="aitasks.empty">
+                <source>No tasks are available to run yet. Ask your administrator to create and activate AI tasks.</source>
+                <target>Es sind noch keine ausführbaren Aufgaben verfügbar. Bitten Sie Ihren Administrator, KI-Aufgaben anzulegen und zu aktivieren.</target>
+            </trans-unit>
+            <trans-unit id="aitasks.notAvailable">
+                <source>This task is not available.</source>
+                <target>Diese Aufgabe ist nicht verfügbar.</target>
+            </trans-unit>
+            <trans-unit id="runs.ownOnly">
+                <source>You see only the runs you started. Deciding other users' runs requires the approval permission.</source>
+                <target>Sie sehen nur die Läufe, die Sie selbst gestartet haben. Läufe anderer Benutzer zu entscheiden erfordert die Freigabe-Berechtigung.</target>
+            </trans-unit>
+            <trans-unit id="runs.allVisible">
+                <source>You see every run. Approving or denying continues the run under its owner's identity; your decision is recorded.</source>
+                <target>Sie sehen alle Läufe. Freigeben oder Ablehnen setzt den Lauf unter der Identität seines Eigentümers fort; Ihre Entscheidung wird protokolliert.</target>
+            </trans-unit>
             <trans-unit id="grants.header">
                 <source>AI (nr_llm) permissions</source>
                 <target>KI-Berechtigungen (nr_llm)</target>

--- a/Resources/Private/Language/de.locallang_mod_aitasks.xlf
+++ b/Resources/Private/Language/de.locallang_mod_aitasks.xlf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="de" datatype="plaintext" original="messages">
+        <body>
+            <trans-unit id="mlang_labels_tablabel">
+                <source>AI Tasks</source>
+                <target>KI-Aufgaben</target>
+            </trans-unit>
+            <trans-unit id="mlang_tabs_tab">
+                <source>AI Tasks</source>
+                <target>KI-Aufgaben</target>
+            </trans-unit>
+            <trans-unit id="mlang_labels_tabdescr">
+                <source>Run AI tasks prepared by your administrators and decide agent runs waiting for your approval</source>
+                <target>Von Ihren Administratoren vorbereitete KI-Aufgaben ausführen und Agent-Läufe entscheiden, die auf Ihre Freigabe warten</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -181,6 +181,33 @@
             <trans-unit id="error.grantRequired">
                 <source>This action requires a permission your backend account does not hold. Please contact your site administrator.</source>
             </trans-unit>
+            <trans-unit id="task.card.editorModule">
+                <source>Editor module</source>
+            </trans-unit>
+            <trans-unit id="aitasks.title">
+                <source>AI tasks</source>
+            </trans-unit>
+            <trans-unit id="aitasks.intro">
+                <source>Run an AI task your administrators prepared. Every run counts against your personal usage budget.</source>
+            </trans-unit>
+            <trans-unit id="aitasks.btn.run">
+                <source>Run</source>
+            </trans-unit>
+            <trans-unit id="aitasks.btn.approvals">
+                <source>Approvals</source>
+            </trans-unit>
+            <trans-unit id="aitasks.empty">
+                <source>No tasks are available to run yet. Ask your administrator to create and activate AI tasks.</source>
+            </trans-unit>
+            <trans-unit id="aitasks.notAvailable">
+                <source>This task is not available.</source>
+            </trans-unit>
+            <trans-unit id="runs.ownOnly">
+                <source>You see only the runs you started. Deciding other users' runs requires the approval permission.</source>
+            </trans-unit>
+            <trans-unit id="runs.allVisible">
+                <source>You see every run. Approving or denying continues the run under its owner's identity; your decision is recorded.</source>
+            </trans-unit>
             <trans-unit id="grants.header">
                 <source>AI (nr_llm) permissions</source>
             </trans-unit>

--- a/Resources/Private/Language/locallang_mod_aitasks.xlf
+++ b/Resources/Private/Language/locallang_mod_aitasks.xlf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="messages">
+        <body>
+            <trans-unit id="mlang_labels_tablabel">
+                <source>AI Tasks</source>
+            </trans-unit>
+            <trans-unit id="mlang_tabs_tab">
+                <source>AI Tasks</source>
+            </trans-unit>
+            <trans-unit id="mlang_labels_tabdescr">
+                <source>Run AI tasks prepared by your administrators and decide agent runs waiting for your approval</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Templates/Backend/AgentRun/List.html
+++ b/Resources/Private/Templates/Backend/AgentRun/List.html
@@ -12,9 +12,18 @@
     <div>
         <h1><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_runs.xlf:mod_runs.title" default="Agent Runs" /></h1>
 
-        <f:be.infobox state="-1">
-            <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:module.adminOnly" default="This module is admin-only. Records and actions here affect every editor using LLM features." /></p>
-        </f:be.infobox>
+        <f:if condition="{restrictedView}">
+            <f:then>
+                <f:be.infobox state="-1">
+                    <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:runs.ownOnly" default="You see only the runs you started. Deciding other users' runs requires the approval permission." /></p>
+                </f:be.infobox>
+            </f:then>
+            <f:else>
+                <f:be.infobox state="-1">
+                    <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:runs.allVisible" default="You see every run. Approving or denying continues the run under its owner's identity; your decision is recorded." /></p>
+                </f:be.infobox>
+            </f:else>
+        </f:if>
 
         <f:if condition="{dataLoadError}">
             <f:be.infobox state="2" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:runs.dataLoadError', default: 'Runs could not be loaded. Some waiting runs may be hidden.')}">

--- a/Resources/Private/Templates/Backend/AiTask/Execute.html
+++ b/Resources/Private/Templates/Backend/AiTask/Execute.html
@@ -1,0 +1,185 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+<!--
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+-->
+
+<f:layout name="Module" />
+
+<f:comment>
+    The editor sibling of Backend/Task/Execute.html (ADR-131): same
+    data-task-execute contract for TaskExecute.js, but WITHOUT the
+    management affordances — no FormEngine edit links, no database record
+    picker (its endpoints have no read boundary yet and stay admin-only),
+    and only a compact configuration summary.
+</f:comment>
+
+<f:section name="Content">
+    <div data-task-execute data-task-uid="{task.uid}">
+
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h1>
+                <core:icon identifier="actions-play" size="medium" />
+                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.title" default="Execute" />: {task.name}
+            </h1>
+            <f:link.action action="list" controller="Backend\AiTask" class="btn btn-secondary btn-sm">
+                <core:icon identifier="actions-view-go-back" size="small" />
+                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.btn.backToList" default="Back to List" />
+            </f:link.action>
+        </div>
+
+        <f:comment>Compact, read-only configuration summary</f:comment>
+        <f:if condition="{effectiveConfig}">
+            <p class="text-muted small mb-4">
+                <core:icon identifier="actions-system-extension-configure" size="small" />
+                {effectiveConfig.name}
+                <f:if condition="{effectiveConfig.llmModel}">
+                    &middot; {effectiveConfig.llmModel.name}
+                </f:if>
+                <f:if condition="{isUsingDefaultConfig}">
+                    <span class="badge text-bg-secondary ms-1"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.config.usingDefault" default="Using system default" /></span>
+                </f:if>
+            </p>
+        </f:if>
+
+        <div class="row">
+            <div class="col-lg-6">
+                <div class="card mb-4">
+                    <div class="card-header">
+                        <h2 class="card-title mb-0">
+                            <core:icon identifier="actions-upload" size="small" />
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.input.title" default="Input" />
+                        </h2>
+                    </div>
+                    <div class="card-body">
+                        <f:if condition="{task.description}">
+                            <p class="text-muted mb-3">{task.description}</p>
+                        </f:if>
+
+                        <div class="mb-3">
+                            <label for="taskInput" class="form-label">
+                                <f:if condition="{requiresManualInput}">
+                                    <f:then><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.input.enterInput" default="Enter your input:" /></f:then>
+                                    <f:else>
+                                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.input.autoFetched" default="Auto-fetched data" /> ({task.inputType}):
+                                        <span class="badge text-bg-info"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.input.autoPopulated" default="Auto-populated" /></span>
+                                    </f:else>
+                                </f:if>
+                            </label>
+                            <textarea class="form-control font-monospace" id="taskInput" rows="15"
+                                      placeholder="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.input.placeholder', default: 'Enter the data to analyze...')}">{inputData}</textarea>
+
+                            <f:if condition="!{requiresManualInput}">
+                                <div id="emptyDataWarning" class="alert alert-warning mt-2 {f:if(condition: inputData, then: 'd-none')}">
+                                    <core:icon identifier="actions-exclamation-triangle" size="small" />
+                                    <strong><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.input.noData" default="No data available." /></strong>
+                                    <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.input.noData.manual" default="You can still enter data manually above." />
+                                </div>
+                            </f:if>
+                        </div>
+
+                        <div class="d-flex gap-2">
+                            <button type="button" class="btn btn-success btn-lg" id="executeBtn">
+                                <span class="btn-content">
+                                    <core:icon identifier="actions-play" size="small" />
+                                    <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.btn.execute" default="Execute Task" />
+                                </span>
+                                <span class="btn-loading d-none">
+                                    <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
+                                    <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.btn.executing" default="Executing..." />
+                                </span>
+                            </button>
+                            <f:if condition="!{requiresManualInput}">
+                                <button type="button" class="btn btn-secondary" id="refreshInputBtn">
+                                    <core:icon identifier="actions-refresh" size="small" />
+                                    <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.btn.refreshData" default="Refresh Data" />
+                                </button>
+                            </f:if>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-lg-6">
+                <div class="card">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <h2 class="card-title mb-0">
+                            <core:icon identifier="actions-download" size="small" />
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.output.title" default="Output" />
+                            <span class="badge text-bg-secondary ms-2">{task.outputFormat}</span>
+                        </h2>
+                        <div id="outputStatus" class="d-none">
+                            <span class="spinner-border spinner-border-sm text-primary" role="status">
+                                <span class="visually-hidden"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.output.processing" default="Processing..." /></span>
+                            </span>
+                            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.output.processing" default="Processing..." />
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div id="outputPlaceholder" class="text-center text-muted py-5">
+                            <core:icon identifier="actions-play" size="large" />
+                            <p class="mt-3"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.output.placeholder" default="Click &quot;Execute Task&quot; to run this task" /></p>
+                        </div>
+
+                        <div id="outputLoading" class="d-none text-center py-5">
+                            <div class="spinner-border text-primary mb-3" style="width: 3rem; height: 3rem;" role="status">
+                                <span class="visually-hidden"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.output.processing" default="Processing..." /></span>
+                            </div>
+                            <h4 class="text-primary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.output.loading.title" default="Processing request..." /></h4>
+                            <p class="text-muted mb-2"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.output.loading.message" default="Sending to LLM and waiting for response" /></p>
+                            <div class="progress mx-auto" style="width: 200px; height: 4px;">
+                                <div class="progress-bar progress-bar-striped progress-bar-animated bg-primary" style="width: 100%"></div>
+                            </div>
+                            <p class="text-muted mt-3 small">
+                                <span id="elapsedTime">0</span>s elapsed
+                            </p>
+                        </div>
+
+                        <div id="outputError" class="d-none">
+                            <div class="alert alert-danger">
+                                <strong><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.output.error" default="Error:" /></strong>
+                                <span id="errorMessage"></span>
+                            </div>
+                        </div>
+
+                        <div id="outputResult" class="d-none">
+                            <div class="d-flex justify-content-between align-items-center mb-2">
+                                <div class="btn-group btn-group-sm" role="group" aria-label="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.output.formatAria', default: 'Output format')}" id="outputFormatToggle">
+                                    <button type="button" class="btn btn-outline-secondary active" data-format="plain" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.output.format.plainTitle', default: 'Plain text')}">
+                                        <core:icon identifier="actions-code" size="small" />
+                                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.output.format.plain" default="Plain" />
+                                    </button>
+                                    <button type="button" class="btn btn-outline-secondary" data-format="html" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.output.format.htmlTitle', default: 'Rendered HTML')}">
+                                        <core:icon identifier="actions-template-new" size="small" />
+                                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.output.format.html" default="HTML" />
+                                    </button>
+                                    <button type="button" class="btn btn-outline-secondary" data-format="markdown" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.output.format.markdownTitle', default: 'Rendered Markdown')}">
+                                        <core:icon identifier="actions-file" size="small" />
+                                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.output.format.markdown" default="Markdown" />
+                                    </button>
+                                </div>
+                                <small class="text-muted">
+                                    <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.output.modelLabel" default="Model:" /> <span id="outputModel">-</span>
+                                    &middot;
+                                    <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.output.tokensLabel" default="Tokens:" /> <span id="outputTokens">-</span>
+                                </small>
+                            </div>
+                            <div id="outputContent" class="bg-light p-3 rounded" style="max-height: 500px; overflow-y: auto;"></div>
+
+                            <div class="mt-3">
+                                <button type="button" class="btn btn-sm btn-secondary" id="copyOutputBtn">
+                                    <core:icon identifier="actions-clipboard" size="small" />
+                                    <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.output.copy" default="Copy to Clipboard" />
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</f:section>
+
+</html>

--- a/Resources/Private/Templates/Backend/AiTask/List.html
+++ b/Resources/Private/Templates/Backend/AiTask/List.html
@@ -1,0 +1,63 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+<!--
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+-->
+
+<f:layout name="Module" />
+
+<f:section name="Content">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h1>
+            <core:icon identifier="module-nrllm-task" size="medium" />
+            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:aitasks.title" default="AI tasks" />
+        </h1>
+        <f:if condition="{showApprovals}">
+            <f:link.action action="list" controller="Backend\AgentRun" class="btn btn-secondary">
+                <core:icon identifier="module-nrllm-runs" size="small" />
+                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:aitasks.btn.approvals" default="Approvals" />
+            </f:link.action>
+        </f:if>
+    </div>
+
+    <p class="text-muted">
+        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:aitasks.intro" default="Run an AI task your administrators prepared. Every run counts against your personal usage budget." />
+    </p>
+
+    <f:if condition="{tasks}">
+        <f:then>
+            <f:for each="{tasks}" as="categoryTasks" key="category">
+                <h2 class="mt-4 text-capitalize">{category}</h2>
+                <div class="row">
+                    <f:for each="{categoryTasks}" as="task">
+                        <div class="col-md-6 col-xl-4 mb-3">
+                            <div class="card h-100">
+                                <div class="card-body">
+                                    <h3 class="card-title h5">{task.name}</h3>
+                                    <f:if condition="{task.description}">
+                                        <p class="card-text text-muted small">{task.description}</p>
+                                    </f:if>
+                                </div>
+                                <div class="card-footer">
+                                    <f:link.action action="executeForm" controller="Backend\AiTask" arguments="{uid: task.uid}" class="btn btn-primary btn-sm">
+                                        <core:icon identifier="actions-play" size="small" />
+                                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:aitasks.btn.run" default="Run" />
+                                    </f:link.action>
+                                </div>
+                            </div>
+                        </div>
+                    </f:for>
+                </div>
+            </f:for>
+        </f:then>
+        <f:else>
+            <div class="callout callout-info">
+                <p><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:aitasks.empty" default="No tasks are available to run yet. Ask your administrator to create and activate AI tasks." /></p>
+            </div>
+        </f:else>
+    </f:if>
+</f:section>
+
+</html>

--- a/Resources/Private/Templates/Backend/Index.html
+++ b/Resources/Private/Templates/Backend/Index.html
@@ -235,6 +235,7 @@ when the module has entries but none is the default; nothing when empty.</f:comm
                     <f:if condition="{statuses.providers.stateValue} == 'ready'">
                         <a href="{taskWizardUrl}"><core:icon identifier="actions-bolt" size="small" /> <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:taskAi.createWithAi" default="Create with AI" /></a>
                     </f:if>
+                    <a href="{be:moduleLink(route: 'nrllm_aitasks')}"><core:icon identifier="actions-user" size="small" /> <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.card.editorModule" default="Editor module" /></a>
                 </div>
             </div>
 

--- a/Tests/Functional/Controller/Backend/AiTaskControllerTest.php
+++ b/Tests/Functional/Controller/Backend/AiTaskControllerTest.php
@@ -1,0 +1,182 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;
+
+use Netresearch\NrLlm\Controller\Backend\AiTaskController;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Domain\Repository\TaskRepository;
+use Netresearch\NrLlm\Service\Task\TaskInputResolverInterface;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+use TYPO3\CMS\Backend\Routing\Route;
+use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
+use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Http\NormalizedParams;
+use TYPO3\CMS\Core\Http\RedirectResponse;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Messaging\FlashMessageService;
+use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
+use TYPO3\CMS\Extbase\Mvc\Request as ExtbaseRequest;
+use TYPO3\CMS\Extbase\Service\ExtensionService;
+
+/**
+ * Renders the editor task module (ADR-131) through the real ModuleTemplate +
+ * Fluid stack: the list must filter out TABLE-input tasks (no record-picker
+ * read boundary yet, ADR-130), the execute form must bounce a TABLE task's
+ * uid with a redirect instead of a form, and the grant gate must answer a
+ * grantless non-admin with the HTML 403.
+ *
+ * The controller is instantiated directly with container services and its
+ * Extbase request is set via reflection — the module-route dispatch itself is
+ * not exercised (same harness as {@see AgentRunControllerTest}).
+ */
+#[CoversClass(AiTaskController::class)]
+final class AiTaskControllerTest extends AbstractFunctionalTestCase
+{
+    private const TABLE_TASK_UID = 10;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importFixture('LlmConfigurations.csv');
+        $this->importFixture('Tasks.csv');
+        $this->importFixture('BeUsers.csv');
+
+        // Tasks.csv carries no TABLE-input task; add an ACTIVE one so the
+        // filter has something real to hide.
+        $this->getConnectionPool()->getConnectionForTable('tx_nrllm_task')->insert('tx_nrllm_task', [
+            'uid'               => self::TABLE_TASK_UID,
+            'pid'               => 0,
+            'identifier'        => 'test-table-task',
+            'name'              => 'Test Table Task',
+            'description'       => 'An active task reading records from a table',
+            'category'          => 'general',
+            'configuration_uid' => 1,
+            'prompt_template'   => 'Analyze: {{input}}',
+            'input_type'        => 'table',
+            'input_source'      => '{"table":"pages"}',
+            'output_format'     => 'markdown',
+            'is_active'         => 1,
+        ]);
+    }
+
+    #[Test]
+    public function listActionShowsActiveManualTasksButNeverTableOnes(): void
+    {
+        $this->logInBackendUser(1); // admin passes the grant gate
+
+        $controller = $this->makeController();
+        $this->setRequest($controller, 'list');
+
+        $response = $controller->listAction();
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = (string)$response->getBody();
+        // The active MANUAL task is offered ...
+        self::assertStringContainsString('Test Manual Task', $body);
+        // ... the active TABLE task is filtered out (ADR-130: no record-picker
+        // read boundary yet), as are inactive and deleted tasks.
+        self::assertStringNotContainsString('Test Table Task', $body);
+        self::assertStringNotContainsString('Test Inactive Task', $body);
+        self::assertStringNotContainsString('Test Deleted Task', $body);
+    }
+
+    #[Test]
+    public function executeFormActionRedirectsForATableTaskInsteadOfRenderingTheForm(): void
+    {
+        $this->logInBackendUser(1);
+
+        $controller = $this->makeController();
+        $this->setRequest($controller, 'executeForm');
+
+        $response = $controller->executeFormAction(self::TABLE_TASK_UID);
+
+        // Same bounce as an unknown uid — a guessed uid leaks nothing.
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame(302, $response->getStatusCode());
+        self::assertNotSame('', $response->getHeaderLine('location'));
+        // The user gets an explanation via the flash queue.
+        $messages = $this->getService(FlashMessageService::class)
+            ->getMessageQueueByIdentifier('extbase.flashmessages.tx_nrllm_')
+            ->getAllMessagesAndFlush();
+        self::assertNotEmpty($messages);
+    }
+
+    #[Test]
+    public function listActionAnswersAGrantlessNonAdminWithAnHtmlForbidden(): void
+    {
+        $this->logInBackendUser(2); // editor without groups: no tasks_use, no agent_approve
+
+        $controller = $this->makeController();
+        $this->setRequest($controller, 'list');
+
+        $response = $controller->listAction();
+
+        self::assertSame(403, $response->getStatusCode());
+        self::assertStringContainsString('text/html', $response->getHeaderLine('Content-Type'));
+        self::assertStringNotContainsString('Test Manual Task', (string)$response->getBody());
+    }
+
+    // --- helpers -----------------------------------------------------------
+
+    private function logInBackendUser(int $uid): void
+    {
+        $backendUser     = $this->setUpBackendUser($uid);
+        $GLOBALS['LANG'] = $this->getService(LanguageServiceFactory::class)->createFromUserPreferences($backendUser);
+    }
+
+    private function makeController(): AiTaskController
+    {
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+
+        $controller = new AiTaskController(
+            $this->getService(ModuleTemplateFactory::class),
+            $this->getService(TaskRepository::class),
+            $this->getService(LlmConfigurationRepository::class),
+            $this->getService(TaskInputResolverInterface::class),
+            $this->getService(BackendUriBuilder::class),
+            $this->getService(PageRenderer::class),
+        );
+
+        // getFlashMessageQueue()/addFlashMessage() need the two internal
+        // Extbase controller services a direct construction skips.
+        $controller->injectInternalFlashMessageService($this->getService(FlashMessageService::class));
+        $controller->injectInternalExtensionService($this->getService(ExtensionService::class));
+
+        return $controller;
+    }
+
+    private function setRequest(AiTaskController $controller, string $action): void
+    {
+        $extbaseParameters = new ExtbaseRequestParameters();
+        $extbaseParameters->setControllerName('Backend\AiTask');
+        $extbaseParameters->setControllerActionName($action);
+        $extbaseParameters->setControllerExtensionName('NrLlm');
+
+        $serverRequest = (new ServerRequest('https://typo3-testing.local/typo3/', 'GET'))
+            ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE)
+            ->withAttribute('route', new Route('/module/web/nrllm-aitasks', ['packageName' => 'netresearch/nr-llm']))
+            ->withAttribute('extbase', $extbaseParameters);
+        $serverRequest            = $serverRequest->withAttribute('normalizedParams', NormalizedParams::createFromRequest($serverRequest));
+        $GLOBALS['TYPO3_REQUEST'] = $serverRequest;
+
+        $reflection     = new ReflectionClass($controller);
+        $extbaseRequest = new ExtbaseRequest($serverRequest);
+        $reflection->getProperty('request')->setValue($controller, $extbaseRequest);
+    }
+}

--- a/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
+++ b/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
@@ -795,4 +795,50 @@ final class AgentRunPersisterTest extends AbstractFunctionalTestCase
         self::assertContains($cancelled->uuid, $uuids);
         self::assertNotContains($waiting->uuid, $uuids);
     }
+
+    #[Test]
+    public function findAwaitingScopedToABackendUserReturnsOnlyThatUsersRuns(): void
+    {
+        // ADR-131: the editor module's restricted runs view lists only the
+        // caller's own runs; the unscoped call stays the admin/approver view.
+        $mine = $this->persister->begin(null, 5);
+        self::assertNotNull($mine);
+        self::assertTrue($this->persister->suspend(
+            $mine,
+            new SuspendedRunState([], [ToolCall::function('c1', 'delete_thing', [])->toArray()], 1, 0, 0),
+        ));
+
+        $theirs = $this->persister->begin(null, 7);
+        self::assertNotNull($theirs);
+        self::assertTrue($this->persister->suspend(
+            $theirs,
+            new SuspendedRunState([], [ToolCall::function('c2', 'delete_thing', [])->toArray()], 1, 0, 0),
+        ));
+
+        $own = $this->repository->findAwaiting(beUser: 5);
+        self::assertSame([$mine->uuid], array_map(static fn(AgentRun $run): string => $run->uuid, $own));
+
+        $all = array_map(static fn(AgentRun $run): string => $run->uuid, $this->repository->findAwaiting());
+        self::assertContains($mine->uuid, $all);
+        self::assertContains($theirs->uuid, $all);
+    }
+
+    #[Test]
+    public function findRecentTerminalScopedToABackendUserReturnsOnlyThatUsersRuns(): void
+    {
+        $mine = $this->persister->begin(null, 5);
+        self::assertNotNull($mine);
+        $this->persister->settleCompleted($mine, new ToolLoopResult('x', [], 1, false, UsageStatistics::fromTokens(1, 1)));
+
+        $theirs = $this->persister->begin(null, 7);
+        self::assertNotNull($theirs);
+        $this->persister->settleFailed($theirs, new RuntimeException('boom', 1754500001));
+
+        $own = $this->repository->findRecentTerminal(beUser: 5);
+        self::assertSame([$mine->uuid], array_map(static fn(AgentRun $run): string => $run->uuid, $own));
+
+        $all = array_map(static fn(AgentRun $run): string => $run->uuid, $this->repository->findRecentTerminal());
+        self::assertContains($mine->uuid, $all);
+        self::assertContains($theirs->uuid, $all);
+    }
 }

--- a/Tests/Unit/Command/Fixture/InMemoryAgentRunRepository.php
+++ b/Tests/Unit/Command/Fixture/InMemoryAgentRunRepository.php
@@ -160,12 +160,12 @@ final class InMemoryAgentRunRepository implements AgentRunRepositoryInterface
         return null;
     }
 
-    public function findAwaiting(int $limit = 100): array
+    public function findAwaiting(int $limit = 100, ?int $beUser = null): array
     {
         return [];
     }
 
-    public function findRecentTerminal(int $limit = 20): array
+    public function findRecentTerminal(int $limit = 20, ?int $beUser = null): array
     {
         return [];
     }

--- a/Tests/Unit/Controller/Backend/RequiresBackendAdminTraitTest.php
+++ b/Tests/Unit/Controller/Backend/RequiresBackendAdminTraitTest.php
@@ -178,4 +178,79 @@ final class RequiresBackendAdminTraitTest extends TestCase
         self::assertInstanceOf(ResponseInterface::class, $response);
         self::assertSame(403, $response->getStatusCode());
     }
+
+    /**
+     * Run the HTML grant guard via an anonymous class exposing the private method.
+     */
+    private function grantGuardHtmlResult(): ?ResponseInterface
+    {
+        $subject = new class {
+            use RequiresBackendAdminTrait;
+
+            public function expose(): ?ResponseInterface
+            {
+                return $this->denyWithoutGrantHtml(BackendUserGrant::TASKS_USE);
+            }
+        };
+
+        return $subject->expose();
+    }
+
+    #[Test]
+    public function denyWithoutGrantHtmlPassesAdminsWithoutAnyGrant(): void
+    {
+        $backendUser = self::createStub(BackendUserAuthentication::class);
+        $backendUser->method('isAdmin')->willReturn(true);
+        $backendUser->method('check')->willReturn(false);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        self::assertNull($this->grantGuardHtmlResult());
+    }
+
+    #[Test]
+    public function denyWithoutGrantHtmlPassesANonAdminHoldingTheGrant(): void
+    {
+        $backendUser = self::createStub(BackendUserAuthentication::class);
+        $backendUser->method('isAdmin')->willReturn(false);
+        $backendUser->method('check')->willReturnCallback(
+            static fn(string $type, string $value): bool => $type === 'custom_options'
+                && $value === BackendUserGrant::TASKS_USE->permissionValue(),
+        );
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        self::assertNull($this->grantGuardHtmlResult());
+    }
+
+    #[Test]
+    public function denyWithoutGrantHtmlReturnsAnHtmlForbiddenForAGrantlessNonAdmin(): void
+    {
+        $backendUser = self::createStub(BackendUserAuthentication::class);
+        $backendUser->method('isAdmin')->willReturn(false);
+        $backendUser->method('check')->willReturn(false);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $response = $this->grantGuardHtmlResult();
+
+        self::assertInstanceOf(ResponseInterface::class, $response);
+        self::assertSame(403, $response->getStatusCode());
+        // Module-route actions render into a page, so the guard must answer
+        // with an HTML fragment — not the JSON shape of the AJAX guards.
+        self::assertStringContainsString('text/html', $response->getHeaderLine('Content-Type'));
+        $body = (string)$response->getBody();
+        self::assertStringStartsWith('<div', $body);
+        self::assertNull(json_decode($body), 'the body is a page fragment, not a JSON payload');
+        self::assertStringContainsStringIgnoringCase('permission', $body);
+    }
+
+    #[Test]
+    public function denyWithoutGrantHtmlReturnsForbiddenWhenNoBackendUserIsPresent(): void
+    {
+        unset($GLOBALS['BE_USER']);
+
+        $response = $this->grantGuardHtmlResult();
+
+        self::assertInstanceOf(ResponseInterface::class, $response);
+        self::assertSame(403, $response->getStatusCode());
+        self::assertStringContainsString('text/html', $response->getHeaderLine('Content-Type'));
+    }
 }

--- a/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
+++ b/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
@@ -369,14 +369,22 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
         return $this->staleRunning;
     }
 
-    public function findAwaiting(int $limit = 100): array
+    public function findAwaiting(int $limit = 100, ?int $beUser = null): array
     {
-        return $this->awaiting;
+        if ($beUser === null) {
+            return $this->awaiting;
+        }
+
+        return array_values(array_filter($this->awaiting, static fn(AgentRun $run): bool => $run->beUser === $beUser));
     }
 
-    public function findRecentTerminal(int $limit = 20): array
+    public function findRecentTerminal(int $limit = 20, ?int $beUser = null): array
     {
-        return $this->recentTerminal;
+        if ($beUser === null) {
+            return $this->recentTerminal;
+        }
+
+        return array_values(array_filter($this->recentTerminal, static fn(AgentRun $run): bool => $run->beUser === $beUser));
     }
 
     /** Simulates a run reclaimed by a heartbeat between SELECT and UPDATE. */


### PR DESCRIPTION
## What

The surface that makes the ADR-130 grants observable ([#610](https://github.com/netresearch/t3x-nr-llm/pull/610) shipped them into an admin-only UI): one new backend module, **`nrllm_aitasks`** ("AI Tasks", Web area), containing exactly what the editing role holds — run a prepared task, and decide agent runs waiting for approval. Everything else stays admin-only.

Structural choices, each forced by a verified platform constraint (details in ADR-131):

- **Top-level in the `web` group**, not a child of `nrllm` — the module menu drops every top-level module whose own access check fails, so a child of the admin-only tree would be invisible to non-admins.
- **`access => 'user'`, never `'user,group'`** — TYPO3 v14 resolves the access string through a gate registry that knows only `user`/`admin`/`systemMaintainer`; an unknown string denies **everyone**, admins included. Two switches, both required and documented: the be_groups module tick AND the grant, checked per action.
- **The approvals inbox is the SAME `AgentRunController` in both modules**, not a copy — the stale-review digest, schema coercion and exception map stay in one place. Visibility is actor-scoped in `renderList()`: an admin or `agent_approve` holder sees every run, everyone else only their own (new optional `beUser` filter on the run queries). The filter is a viewport; the security boundary stays `mayActOnRun()` per run.
- **The task surface is a NEW slim `AiTaskController` + templates** — the admin execute form renders FormEngine edit links and the record picker, neither of which belongs in front of an editor. The editor templates share the `data-task-execute` contract, so `TaskExecute.js` is reused unchanged.

## Deliberately out (reasons in ADR-131)

- **Table-input tasks**: the record picker reads arbitrary tables without a read boundary and stays admin-only; the editor list filters them and the execute form redirects for a TABLE uid exactly like an unknown uid (a guessed id leaks nothing).
- **`tasks_manage`**: this module adds no management surface, so the grant would still have no enforcement point.
- **Restricting the admin picker** via `TableReadAccessService`: would also restrict administrators — its own decision.

## UX/Docs

Runs infobox states the actual visibility rule instead of "admin-only"; overview Tasks card links to the editor module (admin discovery); `Permissions.rst` "Current reach" rewritten; module counts in Introduction/Administration corrected; module labels + UI strings EN+DE. **Known gap, deliberate:** documentation screenshots of the new module need this branch deployed into the ddev instance and follow separately.

## Tests

- Trait: 4 `denyWithoutGrantHtml` states (HTML 403, explicitly not JSON).
- Repository: `beUser` filter on `findAwaiting`/`findRecentTerminal` (functional, real rows).
- `AiTaskControllerTest` (functional, direct-call harness like the AgentRunController tests): TABLE task absent from the rendered list while MANUAL task present; 302 redirect + flash for a TABLE uid; non-admin without grant → 403 with no task names in the body.
- All six pre-push suites green locally on PHP 8.2 (unit, fuzzy, functional sqlite full run, phpstan, cgl, rector -n).

🤖 Generated with [Claude Code](https://claude.com/claude-code)