### PR TITLE
chore(deps): require nr-vault ^0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **`netresearch/nr-vault` is now required at `^0.14.0`** (was `^0.13.0`). 0.14
+  extends `VaultServiceInterface` with `retrieveForFrontend()`,
+  `assertDeletable()` and `setEnabled()`, adds `$includeDisabled` to `list()`
+  and removes `clearCache()`. No production class here implements that
+  interface, so only the in-memory test double changed. Operators upgrading a
+  site: 0.14 replaces nr-vault's admin-only model with grantable operation
+  permissions — backend users who reach an API key through nr-llm need
+  `tx_nrvault:secret.use`, and `secret.create` to store one. See nr-vault's
+  0.14.0 migration notes.
 - **BREAKING for external `completeStructured()` callers:** the schema is now
   validated against a named strict subset (ADR-126). Every subset keyword —
   enum, pattern, bounds, `oneOf` and friends — is enforced on the response,

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -42,7 +42,7 @@ Ensure your system meets these requirements:
 - PHP 8.2 or higher.
 - TYPO3 v13.4 LTS or v14.3 LTS.
 - Composer 2.x.
-- :composer:`netresearch/nr-vault` ^0.10.0 (required for
+- :composer:`netresearch/nr-vault` ^0.14.0 (required for
   API key encryption; installed automatically via
   Composer).
 

--- a/Tests/Unit/Fixture/InMemoryVaultService.php
+++ b/Tests/Unit/Fixture/InMemoryVaultService.php
@@ -55,6 +55,11 @@ final class InMemoryVaultService implements VaultServiceInterface
         return $this->secrets[$identifier] ?? null;
     }
 
+    public function retrieveForFrontend(string $identifier): ?string
+    {
+        throw new RuntimeException('not needed by these tests', 1754467301);
+    }
+
     public function exists(string $identifier): bool
     {
         return isset($this->secrets[$identifier]);
@@ -63,6 +68,13 @@ final class InMemoryVaultService implements VaultServiceInterface
     public function delete(string $identifier, string $reason = ''): void
     {
         unset($this->secrets[$identifier], $this->storeOptions[$identifier]);
+    }
+
+    public function assertDeletable(string $identifier): void {}
+
+    public function setEnabled(string $identifier, bool $enabled, string $reason = ''): void
+    {
+        throw new RuntimeException('not needed by these tests', 1754467302);
     }
 
     public function rotate(string $identifier, #[SensitiveParameter] string $newSecret, string $reason = ''): void
@@ -78,7 +90,7 @@ final class InMemoryVaultService implements VaultServiceInterface
     /**
      * @return list<SecretMetadata>
      */
-    public function list(?string $pattern = null): array
+    public function list(?string $pattern = null, bool $includeDisabled = false): array
     {
         // The command never enumerates secrets; assert against $secrets instead.
         return [];
@@ -88,8 +100,6 @@ final class InMemoryVaultService implements VaultServiceInterface
     {
         throw new RuntimeException('not needed by these tests', 9452800525);
     }
-
-    public function clearCache(): void {}
 
     public function http(): VaultHttpClientInterface
     {

--- a/Tests/Unit/Fixture/InMemoryVaultService.php
+++ b/Tests/Unit/Fixture/InMemoryVaultService.php
@@ -37,6 +37,9 @@ final class InMemoryVaultService implements VaultServiceInterface
     /** @var list<array{identifier: string, reason: string}> */
     public array $rotateCalls = [];
 
+    /** @var array<string, bool> */
+    public array $enabledState = [];
+
     public ?string $throwOn = null;
 
     public function store(string $identifier, #[SensitiveParameter] string $secret, array $options = []): void
@@ -57,7 +60,8 @@ final class InMemoryVaultService implements VaultServiceInterface
 
     public function retrieveForFrontend(string $identifier): ?string
     {
-        throw new RuntimeException('not needed by these tests', 1754467301);
+        // The double carries no frontend allow-set, so nothing is published.
+        return null;
     }
 
     public function exists(string $identifier): bool
@@ -70,11 +74,14 @@ final class InMemoryVaultService implements VaultServiceInterface
         unset($this->secrets[$identifier], $this->storeOptions[$identifier]);
     }
 
-    public function assertDeletable(string $identifier): void {}
+    public function assertDeletable(string $identifier): void
+    {
+        // The double has no ACL or permission layer, so everything is deletable.
+    }
 
     public function setEnabled(string $identifier, bool $enabled, string $reason = ''): void
     {
-        throw new RuntimeException('not needed by these tests', 1754467302);
+        $this->enabledState[$identifier] = $enabled;
     }
 
     public function rotate(string $identifier, #[SensitiveParameter] string $newSecret, string $reason = ''): void

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require": {
         "php": "^8.2",
-        "netresearch/nr-vault": "^0.13.0",
+        "netresearch/nr-vault": "^0.14.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/log": "^2.0 || ^3.0",


### PR DESCRIPTION
Moves the nr-vault floor from `^0.13.0` to [`^0.14.0`](https://github.com/netresearch/t3x-nr-vault/releases/tag/v0.14.0).

0.14 changes `VaultServiceInterface`: it adds `retrieveForFrontend()`, `assertDeletable()` and `setEnabled()`, adds `$includeDisabled` to `list()`, and removes `clearCache()`. `Tests/Unit/Fixture/InMemoryVaultService` is the only implementation in this repo and follows. No production class implements the interface, and `AgentStateEnvelopeRotator`'s `ForeignEnvelopeRotatorInterface` is unchanged in 0.14.

## Verified against a local build of nr-vault 0.14.0
- PHPStan (level 10, PHP 8.4): 1155 files, no errors
- Unit: 6003 tests, 0 failures
- Code style: clean

Rector was not run locally — the gate pins PHP 8.2 while the local resolve was 8.4, which trips the platform check. CI runs it.

## Operator note
0.14 replaces nr-vault's admin-only model with grantable operation permissions. Backend users who reach an API key through nr-llm need `tx_nrvault:secret.use`, and `secret.create` to store one. Covered in the CHANGELOG entry.