### PR TITLE
Assert the exact endpoint placeholder instead of a substring

### DIFF
--- a/Tests/E2E/Playwright/wizard.spec.ts
+++ b/Tests/E2E/Playwright/wizard.spec.ts
@@ -73,7 +73,10 @@ test.describe('Setup Wizard - 5-Step Provider Onboarding', () => {
       // Endpoint URL input
       const endpointInput = moduleFrame.locator('#wizard-endpoint');
       await expect(endpointInput).toBeVisible();
-      await expect(endpointInput).toHaveAttribute('placeholder', /api\.openai\.com/);
+      // Exact value, not a substring match: an unanchored /api\.openai\.com/
+      // also passes for https://evil.example/api.openai.com/, so it asserted
+      // far less than it appeared to.
+      await expect(endpointInput).toHaveAttribute('placeholder', 'https://api.openai.com/v1');
 
       // API Key input
       const apiKeyInput = moduleFrame.locator('#wizard-apikey');


### PR DESCRIPTION
Closes `js/regex/missing-regexp-anchor` (HIGH), live on `main`.

## What the assertion actually checked

The test matched a URL attribute against an unanchored pattern. A pattern without anchors matches **anywhere** in the string, so a host that merely contains the expected one satisfies it:

| value | old assertion |
|---|---|
| the real URL | passes ✓ |
| `https://evil.example/docs.typo3.org/` | **also passes** ✗ |

So the test asserted considerably less than it appeared to. CodeQL rates it HIGH because the same pattern in production code would be an origin check that can be bypassed; here the consequence is confined to test strength, which is why this is a test-quality fix rather than a vulnerability fix — worth saying plainly rather than dressing it up.

## The fix

Anchoring the regex would satisfy the rule while leaving a weaker test than intended. The expected value is a **fixed string in the product code**, so the assertion now compares against it exactly.

That also makes the test fail if the URL changes, which is the behaviour you want from an assertion about a documentation link.

## Scope

One assertion, one file. No change to product code.
