### PR TITLE
chore(release): 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-08-06
+
 ### Added
 
 - An editor-facing **AI Tasks** backend module in the Web area (ADR-131).
@@ -2024,7 +2026,12 @@ setting now either works or is gone. Three breaking changes — see below.
 
 Initial public release. See git history for prior commits.
 
-[Unreleased]: https://github.com/netresearch/t3x-nr-llm/compare/v0.23.0...HEAD
+[Unreleased]: https://github.com/netresearch/t3x-nr-llm/compare/v0.26.0...HEAD
+[0.26.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.25.1...v0.26.0
+[0.25.1]: https://github.com/netresearch/t3x-nr-llm/compare/v0.25.0...v0.25.1
+[0.25.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.24.0...v0.25.0
+[0.24.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.23.1...v0.24.0
+[0.23.1]: https://github.com/netresearch/t3x-nr-llm/compare/v0.23.0...v0.23.1
 [0.23.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.20.0...v0.21.0

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -11,8 +11,8 @@
 >
     <project
         title="TYPO3 LLM Extension"
-        version="0.25.1"
-        release="0.25.1"
+        version="0.26.0"
+        release="0.26.0"
         copyright="since 2025 by Netresearch DTT GmbH"
     />
 

--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
                 "providesPackages": {}
             },
             "extension-key": "nr_llm",
-            "version": "0.25.1",
+            "version": "0.26.0",
             "web-dir": ".Build/Web"
         }
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => '',
     'author_company' => 'Netresearch DTT GmbH',
     'state' => 'beta',
-    'version' => '0.25.1',
+    'version' => '0.26.0',
     'constraints' => [
         // composer.json is the authoritative dependency constraint
         // ("typo3/cms-core": "^13.4 || ^14.3"). The TER `depends` format only


### PR DESCRIPTION
Release preparation for v0.26.0. 56 pull requests since [v0.25.1](https://github.com/netresearch/t3x-nr-llm/releases/tag/v0.25.1).

Minor bump under the 0.x SemVer convention this project uses — the release carries breaking changes for external `completeStructured()` callers and raises the nr-vault floor.

## Version files
- `ext_emconf.php`: 0.25.1 -> 0.26.0
- `composer.json` (`extra.typo3/cms.version`): 0.25.1 -> 0.26.0
- `Documentation/guides.xml`: version + release -> 0.26.0
- `CHANGELOG.md`: `[Unreleased]` -> `[0.26.0] - 2026-08-06`

## Changelog footer repair
The footer's `[Unreleased]` reference pointed at `v0.23.0`, and the back-references for 0.23.1, 0.24.0, 0.25.0 and 0.25.1 were missing entirely — the links for those four releases resolved to nothing. Added them alongside `[0.26.0]` and repointed `[Unreleased]`.

## Issue gate
The only open issue is #80, Renovate's Dependency Dashboard (bot infrastructure). The two bugs filed during this work stream — #568 (DeepL JSON booleans) and #570 (translator priority) — are both fixed and closed by #569 and #571, which are in this release.