### PR TITLE
Extend the shared Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "github>netresearch/renovate-config"
   ]
 }


### PR DESCRIPTION
This repository's `renovate.json` extended bare `config:recommended`, so it inherited none of the organisation defaults.

## What it was missing

| setting from the shared preset | effect when absent |
|---|---|
| `stabilityDays: 3` | updates are proposed the moment they are published |
| `internalChecksFilter: strict` | PRs open before Renovate's own checks pass |
| axios deny-list | the versions from the 2026-03-31 supply-chain incident are not blocked |
| automerge for patch/minor/pin/digest | every dependency PR waits for a human |

The last one is what makes this visible: dependency PRs accumulate. In `t3x-nr-llm` three were open at once, the oldest 51 commits behind `main` and red only because its branch still carried the pre-rollout workflow set — not because the update was bad.

## The change

`github>netresearch/renovate-config` extends `config:recommended` itself, so nothing is lost; the repository gains the org defaults on top. Twelve t3x repositories already point at this preset, so this aligns with the majority rather than introducing a new convention.

The automerge default is being added to the preset in netresearch/renovate-config#5 — this PR is what makes this repository a consumer of it.

## Verification

`jq empty renovate.json` passes. One file, four lines, no other change.
