### PR TITLE
fix(overview): show the MCP, agent runs and analytics modules

### DIFF
--- a/Resources/Private/Templates/Backend/Index.html
+++ b/Resources/Private/Templates/Backend/Index.html
@@ -290,6 +290,51 @@ when the module has entries but none is the default; nothing when empty.</f:comm
                 </div>
             </div>
 
+            <f:comment>MCP Servers</f:comment>
+            <div class="nrllm-ov-card">
+                <a class="stretched-link" href="{be:moduleLink(route: 'nrllm_mcp')}" aria-label="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_mcp.xlf:mlang_tabs_tab', default: 'MCP Servers')}"></a>
+                <div class="nrllm-ov-card-h">
+                    <span class="nrllm-ov-icon"><core:icon identifier="module-nrllm-tool" size="medium" /></span>
+                    <div>
+                        <div class="nrllm-ov-tt"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_mcp.xlf:mlang_tabs_tab" default="MCP Servers" /></div>
+                    </div>
+                </div>
+                <div class="nrllm-ov-card-b"><p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_mcp.xlf:mlang_labels_tabdescr" default="Manage external MCP servers and import the tools they advertise" /></p></div>
+                <div class="nrllm-ov-card-f">
+                    <a href="{be:moduleLink(route: 'nrllm_mcp')}"><core:icon identifier="module-nrllm-tool" size="small" /> Manage MCP servers</a>
+                </div>
+            </div>
+
+            <f:comment>Agent Runs</f:comment>
+            <div class="nrllm-ov-card">
+                <a class="stretched-link" href="{be:moduleLink(route: 'nrllm_runs')}" aria-label="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_runs.xlf:mlang_tabs_tab', default: 'Agent Runs')}"></a>
+                <div class="nrllm-ov-card-h">
+                    <span class="nrllm-ov-icon"><core:icon identifier="module-nrllm-runs" size="medium" /></span>
+                    <div>
+                        <div class="nrllm-ov-tt"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_runs.xlf:mlang_tabs_tab" default="Agent Runs" /></div>
+                    </div>
+                </div>
+                <div class="nrllm-ov-card-b"><p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_runs.xlf:mlang_labels_tabdescr" default="Runs awaiting a human decision: approve or deny a pending tool call, or provide the requested typed input" /></p></div>
+                <div class="nrllm-ov-card-f">
+                    <a href="{be:moduleLink(route: 'nrllm_runs')}"><core:icon identifier="module-nrllm-runs" size="small" /> Review agent runs</a>
+                </div>
+            </div>
+
+            <f:comment>Analytics</f:comment>
+            <div class="nrllm-ov-card">
+                <a class="stretched-link" href="{be:moduleLink(route: 'nrllm_analytics')}" aria-label="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_analytics.xlf:mlang_tabs_tab', default: 'Analytics')}"></a>
+                <div class="nrllm-ov-card-h">
+                    <span class="nrllm-ov-icon"><core:icon identifier="module-nrllm-analytics" size="medium" /></span>
+                    <div>
+                        <div class="nrllm-ov-tt"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_analytics.xlf:mlang_tabs_tab" default="Analytics" /></div>
+                    </div>
+                </div>
+                <div class="nrllm-ov-card-b"><p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_analytics.xlf:mlang_labels_tabdescr" default="LLM usage, cost trends, and per-model / per-user breakdowns" /></p></div>
+                <div class="nrllm-ov-card-f">
+                    <a href="{be:moduleLink(route: 'nrllm_analytics')}"><core:icon identifier="module-nrllm-analytics" size="small" /> Open analytics</a>
+                </div>
+            </div>
+
             <f:comment>Help &amp; Documentation (neutral)</f:comment>
             <div class="nrllm-ov-card">
                 <a class="stretched-link" href="{be:moduleLink(route: 'nrllm_overview', arguments: '{action: \'help\'}')}" aria-label="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:help.card.title', default: 'Help')}"></a>

--- a/Tests/Unit/Configuration/OverviewCardCoverageTest.php
+++ b/Tests/Unit/Configuration/OverviewCardCoverageTest.php
@@ -41,6 +41,31 @@ final class OverviewCardCoverageTest extends TestCase
      */
     private const CARD_PARENT = 'nrllm';
 
+    /**
+     * Both files are read as source rather than executed. This is a
+     * consistency check between two files a developer edits, and including
+     * Modules.php would drag in include-once semantics for no benefit: it
+     * returns its array on the first require and true on every later one.
+     *
+     * @var array<string, string> module name => its block of the array literal
+     */
+    private array $modules = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $source = \file_get_contents(self::MODULES_FILE);
+        self::assertIsString($source);
+
+        \preg_match_all("/^    '([a-z_]+)' => \[(.*?)^    \],/ms", $source, $matches, PREG_SET_ORDER);
+        self::assertNotSame([], $matches, 'No module blocks found — has Modules.php been reformatted?');
+
+        foreach ($matches as $match) {
+            $this->modules[$match[1]] = $match[2];
+        }
+    }
+
     #[Test]
     public function everyRegisteredModuleHasACardOnTheOverview(): void
     {
@@ -77,15 +102,7 @@ final class OverviewCardCoverageTest extends TestCase
      */
     private function allRegisteredModules(): array
     {
-        $modules = require self::MODULES_FILE;
-        self::assertIsArray($modules);
-
-        $names = [];
-        foreach (\array_keys($modules) as $name) {
-            if (\is_string($name)) {
-                $names[] = $name;
-            }
-        }
+        $names = \array_keys($this->modules);
         \sort($names);
 
         return $names;
@@ -96,19 +113,19 @@ final class OverviewCardCoverageTest extends TestCase
      */
     private function registeredModules(): array
     {
-        $modules = require self::MODULES_FILE;
-        self::assertIsArray($modules);
-
         $names = [];
-        foreach ($modules as $name => $definition) {
-            if (!\is_string($name) || $name === self::NOT_A_CARD_TARGET) {
+        foreach ($this->modules as $name => $block) {
+            if ($name === self::NOT_A_CARD_TARGET) {
                 continue;
             }
-            if (!\is_array($definition) || ($definition['parent'] ?? null) !== self::CARD_PARENT) {
+
+            if (!\str_contains($block, "'parent' => '" . self::CARD_PARENT . "'")) {
                 continue;
             }
+
             $names[] = $name;
         }
+
         \sort($names);
 
         return $names;

--- a/Tests/Unit/Configuration/OverviewCardCoverageTest.php
+++ b/Tests/Unit/Configuration/OverviewCardCoverageTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Configuration;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Locks the registered backend modules to the cards on the overview page.
+ *
+ * The overview is hand-written Fluid, so a module registered in
+ * Configuration/Backend/Modules.php reaches the module menu but stays absent
+ * from the overview unless someone also writes its card. That is how MCP
+ * Servers, Agent Runs and Analytics went missing: all three were registered
+ * and reachable, and the overview simply never mentioned them.
+ */
+#[CoversNothing]
+final class OverviewCardCoverageTest extends TestCase
+{
+    private const MODULES_FILE = __DIR__ . '/../../../Configuration/Backend/Modules.php';
+
+    private const OVERVIEW_TEMPLATE = __DIR__ . '/../../../Resources/Private/Templates/Backend/Index.html';
+
+    /**
+     * The overview itself: linking the page to itself is not a card, and the
+     * help card deliberately points at an action on this same route.
+     */
+    private const NOT_A_CARD_TARGET = 'nrllm_overview';
+
+    /**
+     * Only the children of the LLM module get a card. 'nrllm' itself is the
+     * module the overview belongs to and sits under 'tools'.
+     */
+    private const CARD_PARENT = 'nrllm';
+
+    #[Test]
+    public function everyRegisteredModuleHasACardOnTheOverview(): void
+    {
+        $missing = \array_values(\array_diff($this->registeredModules(), $this->linkedModules()));
+
+        self::assertSame(
+            [],
+            $missing,
+            'Registered but not linked from the overview: ' . \implode(', ', $missing)
+                . '. Add a card in Resources/Private/Templates/Backend/Index.html.',
+        );
+    }
+
+    #[Test]
+    public function theOverviewLinksNoModuleThatIsNotRegistered(): void
+    {
+        // Any registered module may be linked — nrllm_aitasks for instance is
+        // an editor-facing Web module that the overview points at on purpose.
+        // What must not happen is a link to a route nobody registers.
+        $unknown = \array_values(\array_diff($this->linkedModules(), $this->allRegisteredModules()));
+
+        self::assertSame(
+            [],
+            $unknown,
+            'Linked from the overview but not registered: ' . \implode(', ', $unknown)
+                . '. Such a card renders a dead link.',
+        );
+    }
+
+    /**
+     * Every module name the extension registers, whatever its parent.
+     *
+     * @return list<string>
+     */
+    private function allRegisteredModules(): array
+    {
+        $modules = require self::MODULES_FILE;
+        self::assertIsArray($modules);
+
+        $names = [];
+        foreach (\array_keys($modules) as $name) {
+            if (\is_string($name)) {
+                $names[] = $name;
+            }
+        }
+        \sort($names);
+
+        return $names;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function registeredModules(): array
+    {
+        $modules = require self::MODULES_FILE;
+        self::assertIsArray($modules);
+
+        $names = [];
+        foreach ($modules as $name => $definition) {
+            if (!\is_string($name) || $name === self::NOT_A_CARD_TARGET) {
+                continue;
+            }
+            if (!\is_array($definition) || ($definition['parent'] ?? null) !== self::CARD_PARENT) {
+                continue;
+            }
+            $names[] = $name;
+        }
+        \sort($names);
+
+        return $names;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function linkedModules(): array
+    {
+        $template = \file_get_contents(self::OVERVIEW_TEMPLATE);
+        self::assertIsString($template);
+
+        \preg_match_all("/route: '([a-z_]+)'/", $template, $matches);
+        $routes = \array_values(\array_unique(\array_filter(
+            $matches[1],
+            static fn(string $route): bool => $route !== self::NOT_A_CARD_TARGET,
+        )));
+        \sort($routes);
+
+        return $routes;
+    }
+}


### PR DESCRIPTION
Reported from the demo instance: the LLM module overview is missing cards for MCP servers and agent runs. The overview is hand-written Fluid with one card per module, so a module registered in `Configuration/Backend/Modules.php` appears in the module menu but never on the overview unless its card is written too. `nrllm_mcp`, `nrllm_runs` and `nrllm_analytics` were all registered and reachable; only the page meant to be the entry point never mentioned them.

The three cards follow the existing markup and reuse the labels the modules already ship (`locallang_mod_mcp.xlf`, `locallang_mod_runs.xlf`, `locallang_mod_analytics.xlf`), so no new translation strings appear. They carry no status flag, because `OverviewReadinessService` tracks no counter for these three and a made-up one would claim knowledge the service does not have.

`Tests/Unit/Configuration/OverviewCardCoverageTest.php` locks both directions so the template cannot drift from the registration again: every child of the `nrllm` module must have a card, and no card may point at an unregistered route. The second assertion is deliberately the looser one — `nrllm_aitasks` is an editor-facing Web module the overview links on purpose, so a card may target a module outside the LLM children as long as it exists. Verified by removing a card and watching the test fail, then restoring it.

Not changed: `netresearch/nr-mcp-agent` registers its own `nr_mcp_agent_chat` module under `tools` rather than as a child of `nrllm`, so it is out of scope for this overview by design. Rector reports two pre-existing findings in unrelated test files — identical on the base commit, so nothing from this branch.