### PR TITLE
Read middleware priority from code, not from tag attributes

### DIFF
--- a/Classes/Provider/Middleware/BudgetMiddleware.php
+++ b/Classes/Provider/Middleware/BudgetMiddleware.php
@@ -70,9 +70,23 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  *                 CircuitBreaker <-- guards the provider call        (priority 20)
  *                   <terminal>
  */
-#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 75])]
+#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME)]
 final readonly class BudgetMiddleware implements ProviderMiddlewareInterface
 {
+    /**
+     * Pipeline priority, read by the tagged iterator via
+     * `defaultPriorityMethod` (ADR-085 ordering).
+     *
+     * It lives in code rather than in the AutoconfigureTag attribute
+     * because an attribute priority is lost when the same tag is
+     * declared on both the interface and the class and the container
+     * deduplicates the two — which silently unsorts the whole pipeline.
+     */
+    public static function getDefaultPriority(): int
+    {
+        return 75;
+    }
+
     public const METADATA_BE_USER_UID  = 'beUserUid';
 
     public const METADATA_PLANNED_COST = 'plannedCost';

--- a/Classes/Provider/Middleware/CacheMiddleware.php
+++ b/Classes/Provider/Middleware/CacheMiddleware.php
@@ -71,9 +71,23 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  * should assemble a custom pipeline with Cache *inside* those layers — it is
  * a pipeline-assembly choice, not a property of this middleware.
  */
-#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 100])]
+#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME)]
 final readonly class CacheMiddleware implements ProviderMiddlewareInterface
 {
+    /**
+     * Pipeline priority, read by the tagged iterator via
+     * `defaultPriorityMethod` (ADR-085 ordering).
+     *
+     * It lives in code rather than in the AutoconfigureTag attribute
+     * because an attribute priority is lost when the same tag is
+     * declared on both the interface and the class and the container
+     * deduplicates the two — which silently unsorts the whole pipeline.
+     */
+    public static function getDefaultPriority(): int
+    {
+        return 100;
+    }
+
     public const METADATA_CACHE_KEY  = 'cacheKey';
 
     public const METADATA_CACHE_TTL  = 'cacheTtl';

--- a/Classes/Provider/Middleware/CircuitBreakerMiddleware.php
+++ b/Classes/Provider/Middleware/CircuitBreakerMiddleware.php
@@ -73,9 +73,23 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
  * Disable via the `circuitBreaker.enabled` extension setting (default ON). When
  * disabled the middleware is a verbatim pass-through.
  */
-#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 20])]
+#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME)]
 final readonly class CircuitBreakerMiddleware implements ProviderMiddlewareInterface
 {
+    /**
+     * Pipeline priority, read by the tagged iterator via
+     * `defaultPriorityMethod` (ADR-085 ordering).
+     *
+     * It lives in code rather than in the AutoconfigureTag attribute
+     * because an attribute priority is lost when the same tag is
+     * declared on both the interface and the class and the container
+     * deduplicates the two — which silently unsorts the whole pipeline.
+     */
+    public static function getDefaultPriority(): int
+    {
+        return 20;
+    }
+
     private const DEFAULT_FAILURE_THRESHOLD = 5;
 
     private const DEFAULT_COOLDOWN_SECONDS  = 30;

--- a/Classes/Provider/Middleware/FallbackMiddleware.php
+++ b/Classes/Provider/Middleware/FallbackMiddleware.php
@@ -47,9 +47,23 @@ use Throwable;
  *                 CircuitBreaker <-- guards the provider call        (priority 20)
  *                   <terminal>
  */
-#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 50])]
+#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME)]
 final readonly class FallbackMiddleware implements ProviderMiddlewareInterface
 {
+    /**
+     * Pipeline priority, read by the tagged iterator via
+     * `defaultPriorityMethod` (ADR-085 ordering).
+     *
+     * It lives in code rather than in the AutoconfigureTag attribute
+     * because an attribute priority is lost when the same tag is
+     * declared on both the interface and the class and the container
+     * deduplicates the two — which silently unsorts the whole pipeline.
+     */
+    public static function getDefaultPriority(): int
+    {
+        return 50;
+    }
+
     public function __construct(
         private LlmConfigurationRepository $repository,
         private LoggerInterface $logger,

--- a/Classes/Provider/Middleware/GuardrailMiddleware.php
+++ b/Classes/Provider/Middleware/GuardrailMiddleware.php
@@ -55,9 +55,23 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
  * the whole pipeline (see ADR-085 / ADR-062), so streamed output is not screened
  * here.
  */
-#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 90])]
+#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME)]
 final readonly class GuardrailMiddleware implements ProviderMiddlewareInterface
 {
+    /**
+     * Pipeline priority, read by the tagged iterator via
+     * `defaultPriorityMethod` (ADR-085 ordering).
+     *
+     * It lives in code rather than in the AutoconfigureTag attribute
+     * because an attribute priority is lost when the same tag is
+     * declared on both the interface and the class and the container
+     * deduplicates the two — which silently unsorts the whole pipeline.
+     */
+    public static function getDefaultPriority(): int
+    {
+        return 90;
+    }
+
     /**
      * @param iterable<GuardrailInterface> $guardrails
      */

--- a/Classes/Provider/Middleware/IdempotencyMiddleware.php
+++ b/Classes/Provider/Middleware/IdempotencyMiddleware.php
@@ -69,9 +69,23 @@ use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
  * calls are not stored either — the exception propagates and a later retry with
  * the same key genuinely re-attempts.
  */
-#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 105])]
+#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME)]
 final class IdempotencyMiddleware implements ProviderMiddlewareInterface
 {
+    /**
+     * Pipeline priority, read by the tagged iterator via
+     * `defaultPriorityMethod` (ADR-085 ordering).
+     *
+     * It lives in code rather than in the AutoconfigureTag attribute
+     * because an attribute priority is lost when the same tag is
+     * declared on both the interface and the class and the container
+     * deduplicates the two — which silently unsorts the whole pipeline.
+     */
+    public static function getDefaultPriority(): int
+    {
+        return 105;
+    }
+
     public const METADATA_IDEMPOTENCY_KEY = 'idempotencyKey';
 
     private const CACHE_IDENTIFIER = 'nrllm_idempotency';

--- a/Classes/Provider/Middleware/MiddlewarePipeline.php
+++ b/Classes/Provider/Middleware/MiddlewarePipeline.php
@@ -17,8 +17,24 @@ use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
  *
  * Ordering follows the PSR-15 convention: the first-registered middleware is
  * the outermost layer of the onion -- it runs first on the way in and last on
- * the way out. Registration order comes from the service container's tagged
- * iterator; services can influence it with a `priority` tag attribute.
+ * the way out. Order comes from each middleware's static
+ * `getDefaultPriority()`, resolved by the tagged iterator below (highest
+ * first).
+ *
+ * The priority deliberately does NOT live in the `AutoconfigureTag` attribute.
+ * ProviderMiddlewareInterface carries the tag as well, so the container sees
+ * the tag declared twice for every middleware and deduplicates the pair — and
+ * the survivor is the interface's declaration, which has no priority. The
+ * effect is that the pipeline silently assembles UNSORTED, which for this
+ * stack is a privacy fault rather than a cosmetic one: GuardrailMiddleware
+ * (90) must unwind inside IdempotencyMiddleware (105), or an unredacted
+ * response is persisted to the nrllm_idempotency cache (ADR-085).
+ *
+ * Reading the priority from code instead of from tag attributes keeps the
+ * order a property of this extension rather than of container-internal tag
+ * merging. Observed as a live regression on 2026-08-08, when
+ * symfony/dependency-injection 7.4.16 changed when discovered interfaces are
+ * autoconfigured (symfony/symfony#65120) and the whole stack unsorted itself.
  *
  * The pipeline is side-effect-free on its own; every behavioural decision
  * (retry on rate-limit, skip cache, record usage, ...) lives in a concrete
@@ -35,7 +51,10 @@ final readonly class MiddlewarePipeline
      * @param iterable<ProviderMiddlewareInterface> $middleware
      */
     public function __construct(
-        #[AutowireIterator(ProviderMiddlewareInterface::TAG_NAME)]
+        #[AutowireIterator(
+            ProviderMiddlewareInterface::TAG_NAME,
+            defaultPriorityMethod: 'getDefaultPriority',
+        )]
         iterable $middleware,
     ) {
         $this->middleware = \is_array($middleware)

--- a/Classes/Provider/Middleware/ProviderMiddlewareInterface.php
+++ b/Classes/Provider/Middleware/ProviderMiddlewareInterface.php
@@ -26,9 +26,23 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
  *    tracking, budget accounting).
  *
  * Registered implementations are discovered via the `nr_llm.provider_middleware`
- * tag (auto-applied by AutoconfigureTag) and composed by MiddlewarePipeline in
- * registration order -- the first-registered middleware runs first on the
- * "before" half and last on the "after" half, classic onion ordering.
+ * tag (auto-applied by the AutoconfigureTag below) and composed by
+ * MiddlewarePipeline in priority order -- the highest priority runs first on
+ * the "before" half and last on the "after" half, classic onion ordering.
+ *
+ * ORDERING CONVENTION: declare the priority as a static method
+ *
+ *     public static function getDefaultPriority(): int { return 90; }
+ *
+ * and NOT as `attributes: ['priority' => 90]` on AutoconfigureTag. Because
+ * this interface carries the tag too, the container sees the tag twice per
+ * middleware and deduplicates; the survivor is this declaration, which has no
+ * priority, so an attribute priority is silently dropped and the pipeline
+ * assembles unsorted (symfony/symfony#65120, hit on 2026-08-08).
+ *
+ * The method is a convention, not an abstract member -- adding one here would
+ * break third-party implementations within a major version (ADR-127). A
+ * middleware that omits it simply sorts at priority 0, i.e. innermost.
  *
  * The return type is declared `mixed` because different operations return
  * different typed responses (CompletionResponse, EmbeddingResponse,

--- a/Classes/Provider/Middleware/TelemetryMiddleware.php
+++ b/Classes/Provider/Middleware/TelemetryMiddleware.php
@@ -69,9 +69,23 @@ use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
  * Disable via the `telemetry.enabled` extension setting (default ON). When
  * disabled the middleware is a verbatim pass-through.
  */
-#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 110])]
+#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME)]
 final readonly class TelemetryMiddleware implements ProviderMiddlewareInterface
 {
+    /**
+     * Pipeline priority, read by the tagged iterator via
+     * `defaultPriorityMethod` (ADR-085 ordering).
+     *
+     * It lives in code rather than in the AutoconfigureTag attribute
+     * because an attribute priority is lost when the same tag is
+     * declared on both the interface and the class and the container
+     * deduplicates the two — which silently unsorts the whole pipeline.
+     */
+    public static function getDefaultPriority(): int
+    {
+        return 110;
+    }
+
     public function __construct(
         private TelemetryRepositoryInterface $repository,
         private Context $context,

--- a/Classes/Provider/Middleware/UsageMiddleware.php
+++ b/Classes/Provider/Middleware/UsageMiddleware.php
@@ -80,9 +80,23 @@ use Throwable;
  *                 CircuitBreaker <-- guards the provider call        (priority 20)
  *                   <terminal>
  */
-#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME, attributes: ['priority' => 25])]
+#[AutoconfigureTag(name: ProviderMiddlewareInterface::TAG_NAME)]
 final readonly class UsageMiddleware implements ProviderMiddlewareInterface
 {
+    /**
+     * Pipeline priority, read by the tagged iterator via
+     * `defaultPriorityMethod` (ADR-085 ordering).
+     *
+     * It lives in code rather than in the AutoconfigureTag attribute
+     * because an attribute priority is lost when the same tag is
+     * declared on both the interface and the class and the container
+     * deduplicates the two — which silently unsorts the whole pipeline.
+     */
+    public static function getDefaultPriority(): int
+    {
+        return 25;
+    }
+
     public const METADATA_TASK_UID = 'task_uid';
 
     /**

--- a/Tests/Unit/Provider/Middleware/MiddlewarePriorityDeclarationTest.php
+++ b/Tests/Unit/Provider/Middleware/MiddlewarePriorityDeclarationTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Provider\Middleware;
+
+use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\CacheMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\CircuitBreakerMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\FallbackMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\GuardrailMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\IdempotencyMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\ProviderMiddlewareInterface;
+use Netresearch\NrLlm\Provider\Middleware\TelemetryMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * Guards HOW the pipeline order is declared, which
+ * {@see MiddlewarePipelineOrderTest} cannot: that test asserts the resulting
+ * order, and it passes with either declaration style — right up until the
+ * container stops honouring tag attributes, at which point the order silently
+ * inverts and an unredacted response reaches the idempotency cache (ADR-085).
+ *
+ * The attribute form is unsafe here because ProviderMiddlewareInterface
+ * carries the same tag: the container sees it twice per middleware and
+ * deduplicates, and the survivor is the interface's priority-less
+ * declaration. symfony/dependency-injection 7.4.16 made that path live
+ * (symfony/symfony#65120) and unsorted the whole stack.
+ */
+final class MiddlewarePriorityDeclarationTest extends AbstractUnitTestCase
+{
+    /**
+     * @return array<string, array{class-string, int}>
+     */
+    public static function middlewareProvider(): array
+    {
+        return [
+            'telemetry'       => [TelemetryMiddleware::class, 110],
+            'idempotency'     => [IdempotencyMiddleware::class, 105],
+            'cache'           => [CacheMiddleware::class, 100],
+            'guardrail'       => [GuardrailMiddleware::class, 90],
+            'budget'          => [BudgetMiddleware::class, 75],
+            'fallback'        => [FallbackMiddleware::class, 50],
+            'usage'           => [UsageMiddleware::class, 25],
+            'circuit breaker' => [CircuitBreakerMiddleware::class, 20],
+        ];
+    }
+
+    /**
+     * @param class-string $middleware
+     */
+    #[Test]
+    #[DataProvider('middlewareProvider')]
+    public function priorityIsDeclaredInCodeAndNotAsATagAttribute(string $middleware, int $expected): void
+    {
+        $reflection = new ReflectionClass($middleware);
+
+        self::assertTrue(
+            $reflection->hasMethod('getDefaultPriority'),
+            $middleware . ' must declare getDefaultPriority(); the tagged iterator reads the order from it.',
+        );
+
+        $method = $reflection->getMethod('getDefaultPriority');
+
+        // Symfony rejects a non-static or non-public method outright, so these
+        // two assertions are the difference between a wired pipeline and a
+        // container that refuses to compile.
+        self::assertTrue($method->isStatic(), $middleware . '::getDefaultPriority() must be static.');
+        self::assertTrue($method->isPublic(), $middleware . '::getDefaultPriority() must be public.');
+        self::assertSame($expected, $middleware::getDefaultPriority());
+
+        foreach ($reflection->getAttributes(AutoconfigureTag::class) as $attribute) {
+            $arguments = $attribute->getArguments();
+            $tagName   = $arguments['name'] ?? $arguments[0] ?? null;
+
+            if ($tagName !== ProviderMiddlewareInterface::TAG_NAME) {
+                continue;
+            }
+
+            /** @var array<string, mixed> $tagAttributes */
+            $tagAttributes = $arguments['attributes'] ?? $arguments[1] ?? [];
+
+            self::assertArrayNotHasKey(
+                'priority',
+                $tagAttributes,
+                $middleware . ' declares its priority as a tag attribute. An attribute priority wins over '
+                . 'getDefaultPriority() and is dropped when the interface-level tag survives deduplication, '
+                . 'which unsorts the pipeline without failing anything else.',
+            );
+        }
+    }
+}


### PR DESCRIPTION
The provider pipeline currently assembles **unsorted**, which places `GuardrailMiddleware` (90) outside `IdempotencyMiddleware` (105) instead of inside it. On that layout the idempotency cache persists the raw provider response — an API key echoed by the model is stored in plaintext. That is exactly the leak ADR-085 exists to prevent, and what `GuardrailIdempotencyLeakTest` asserts.

Both that test and `MiddlewarePipelineOrderTest` are red on the merge-queue ref today, which is why every entry in `t3x-nr-llm`'s merge queue is being dropped.

## Observed order

| position | expected | actual |
|---|---|---|
| 0 | Telemetry (110) | Telemetry |
| 1 | **Idempotency (105)** | Usage (25) |
| 2 | Cache (100) | Budget (75) |
| 3 | **Guardrail (90)** | Cache (100) |
| … | | |
| 6 | Usage (25) | **Guardrail (90)** |
| 7 | CircuitBreaker (20) | **Idempotency (105)** |

`110, 25, 75, 100, 20, 50, 90, 105` — no sorting is applied at all. All eight are registered; none is missing.

## Cause

Every middleware declared its priority as `AutoconfigureTag(attributes: ['priority' => N])`, and `ProviderMiddlewareInterface` carries the same tag. The container therefore sees the tag **twice** per middleware and deduplicates the pair — and the survivor is the interface's declaration, which has no priority.

That was harmless until **symfony/dependency-injection 7.4.16**. [symfony/symfony#65120](https://github.com/symfony/symfony/pull/65120) — a fix for `#[Autoconfigure]` being processed twice for PSR-4-discovered abstract types — removed the eager `processClass()` call for discovered interfaces. Its own description notes that "tags happen to be deduplicated later"; from this release that deduplication is what decides the priority.

Evidence, three runs, same tree:

| run | `symfony/dependency-injection` | functional tests |
|---|---|---|
| 2026-08-07 `merge_group` | 7.4.15 | green |
| 2026-08-08 `pull_request` | 7.4.15 (composer cache) | green |
| 2026-08-08 `merge_group` | **7.4.16** | red |

Twelve Symfony packages moved between the green and red runs; the four priority-relevant DI source files are byte-identical between 7.4.15 and 7.4.16, so the behaviour change comes from *when* interfaces are autoconfigured, not from the sorting code.

No upstream report exists for this side effect — worth filing separately; this PR does not depend on the outcome.

## The change

The priority moves into a static `getDefaultPriority()` on each middleware, read by the tagged iterator via `defaultPriorityMethod`. Order becomes a property of this extension rather than of container-internal tag merging, so it survives whatever the container does with duplicate tags. Values are unchanged: 110, 105, 100, 90, 75, 50, 25, 20.

`getDefaultPriority()` is a documented **convention, not an abstract member** — adding one to `ProviderMiddlewareInterface` would break third-party implementations within a major version (ADR-127). A middleware that omits it sorts at priority 0, i.e. innermost.

## New test

`MiddlewarePipelineOrderTest` asserts the resulting order and passes under **either** declaration style; it cannot see the fragile one until the container changes behaviour again. `MiddlewarePriorityDeclarationTest` locks the style itself: every middleware must expose a public static `getDefaultPriority()` returning its documented value, and must not carry a `priority` tag attribute.

Verified in position: re-adding `attributes: ['priority' => 90]` to `GuardrailMiddleware` fails exactly that case, and the file was restored afterwards.

## Local verification

| check | result |
|---|---|
| `composer ci:test:php:cgl` | SUCCESS |
| unit suite | 6028 tests, 16854 assertions, OK |
| PHPStan | No errors |
| `php -l` on all touched files | clean |

The two functional tests that prove the fix cannot run in this environment (SQLite bootstrap); CI is the authority on them.
