### PR TITLE
docs(adr): mark ADR-021's streaming scope line as overtaken

### DIFF
--- a/Documentation/Adr/Adr021ProviderFallbackChain.rst
+++ b/Documentation/Adr/Adr021ProviderFallbackChain.rst
@@ -6,7 +6,8 @@
 ADR-021: Provider Fallback Chain
 ==========================================
 
-:Status: Accepted
+:Status: Accepted (the streaming scope limitation is overtaken — see
+         :ref:`adr-021-scope`)
 :Date: 2026-04
 :Authors: Netresearch DTT GmbH
 
@@ -53,6 +54,14 @@ Scope limitations (v1)
   cannot swap providers mid-stream. :php:`streamChatWithConfiguration()`
   calls the primary adapter directly.
 
+  .. note::
+
+     Overtaken. :php:`StreamingDispatcher::openWithFallback()` walks the same
+     chain before the first chunk, so a primary that fails to open is no
+     longer fatal for a streamed call. The sentence that still holds is the
+     narrower one: no swap is possible *after* the first chunk has been
+     yielded, which is why the streaming chain is tried at open time only.
+
 * **Shallow only.** A fallback configuration's own chain is ignored. This
   prevents both cycles (``a -> b -> a``) and exponential blow-up of attempts.
 
@@ -84,6 +93,14 @@ Alternatives considered
   too invasive for a single-feature change. The middleware pattern remains
   on the roadmap as a v1.0 refactor; a fallback chain is the most valuable
   pipeline step users ask for and works fine as a standalone service.
+
+  .. note::
+
+     Lifted. This rejection was scoped to one release ("for this release"),
+     and :ref:`adr-026` built the pipeline it deferred. Fallback runs as a
+     middleware step today. Cite this ADR against a *recursive* chain or a
+     *per-link* retry policy — the two rejections below, which stand
+     unconditionally — not against pipeline work as such.
 
 * **Recursive chain resolution** (fallback's fallback). Rejected as the
   cost (cycle detection, attempt amplification) outweighs the benefit;


### PR DESCRIPTION
## Description

`Adr021ProviderFallbackChain.rst` said streaming is not wrapped by the fallback chain. `StreamingDispatcher::openWithFallback()` (`Classes/Service/Streaming/StreamingDispatcher.php:278`) walks the same chain before the first chunk, so that scope line no longer describes the code. Marked as overtaken; the narrower sentence that still holds — no swap *after* the first chunk — is stated explicitly.

The three remaining scope limitations stay verbatim. Two of them (inactive fallbacks skipped, missing identifiers skipped) are the semantics the candidate-resolution refactor will codify.

Second correction: the "fat middleware pipeline" rejection was scoped "Rejected for this release" and was lifted by ADR-026 — fallback runs as a middleware step today. A program audit cited this ADR as a blocker against pipeline work; the note prevents the next reader from doing the same. The rejections that stand unconditionally are recursive chains and per-link retry policy.

Status stays Accepted.

## Related Issue

Closes #631

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have run `composer ci` and all checks pass — not applicable, no code touched; CI renders the docs
- [ ] I have added tests that prove my fix/feature works — not applicable, documentation only
- [x] I have updated the documentation accordingly
- [ ] I have added a `CHANGELOG.md` entry under `## [Unreleased]` — not applicable, no user-facing change
- [x] I have added an ADR under `Documentation/Adr/` if this changes the public surface — amendment inside ADR-021, no new number
- [x] My changes generate no new warnings