### PR TITLE
feat(tools): a builtin's declared write effect implies human approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- A builtin tool that declares a write effect (`ToolEffectInterface`,
+  ADR-111) now requires human approval in the agent loop even without the
+  `RequiresApprovalInterface` marker (ADR-134). Both write cases count;
+  `READ_ONLY` tools are unaffected, so nothing changes for the tools
+  shipped today — every builtin reads. Remote (MCP) tools are exempt:
+  `McpTool` declares `NON_IDEMPOTENT_WRITE` for every imported tool as a
+  fail-closed assumption about a body that cannot be inspected, so
+  coupling it to approval would suspend every remote call. The remote axis
+  gets an operator-declared server-level source separately.
+
 ## [0.26.0] - 2026-08-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   fail-closed assumption about a body that cannot be inspected, so
   coupling it to approval would suspend every remote call. The remote axis
   gets an operator-declared server-level source separately.
+  `ToolRegistry` now also rejects a non-remote tool that declares a write
+  **and** implements `RequiresInputInterface`: the approval scan runs before
+  the input scan, so such a tool would suspend for approval, be refused by
+  the approval resume for its missing input, and suspend again — never
+  executing. The existing `RequiresApprovalInterface` + `RequiresInputInterface`
+  ban (ADR-105) now covers the implicit form as well.
 
 ## [0.26.0] - 2026-08-06
 

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -722,6 +722,12 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
      * {@see ToolEffectResolver} exists to provide, and its unknown-tool fallback
      * (NON_IDEMPOTENT_WRITE) would turn every unregistered name into a suspend
      * instead of the refusal {@see self::invoke()} already gives it.
+     *
+     * {@see ToolRegistry} mirrors this predicate to reject a tool that is
+     * approval-bound AND {@see RequiresInputInterface}: this scan runs before
+     * the input scan, so that tool would suspend for approval and never reach
+     * the input flow (ADR-134). Narrowing the remote exemption here means
+     * narrowing it there too.
      */
     private function requiresHumanApproval(?ToolInterface $tool): bool
     {

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -244,11 +244,11 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
 
                 $messages[] = ChatMessage::assistantToolCalls($resp->toolCalls ?? [], $resp->content);
 
-                // Human-in-the-loop (ADR-084): if any call in this turn opts into
+                // Human-in-the-loop (ADR-084/134): if any call in this turn needs
                 // approval, suspend BEFORE executing any of the turn's calls so a
-                // multi-call turn stays consistent. Existing read-only tools never
-                // implement the marker, so this loop is inert for them and the
-                // synchronous path below is unchanged.
+                // multi-call turn stays consistent. Existing read-only tools
+                // neither carry the marker nor declare a write, so this loop is
+                // inert for them and the synchronous path below is unchanged.
                 foreach ($resp->toolCalls ?? [] as $call) {
                     // Fail-closed like invoke()/resolveOfferedNames(): only an
                     // OFFERED approval tool suspends. A registered-but-not-offered
@@ -256,7 +256,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                     // falls through to invoke(), which refuses it — no spurious
                     // pending-approval prompt for a tool the run never allowed.
                     if (in_array($call->name, $allowedNames, true)
-                        && $this->registry->get($call->name) instanceof RequiresApprovalInterface) {
+                        && $this->requiresHumanApproval($this->registry->get($call->name))) {
                         throw ToolApprovalRequiredException::fromState(new SuspendedRunState(
                             array_map(static fn(ChatMessage|array $m): array => $m instanceof ChatMessage ? $m->toArray() : $m, $messages),
                             array_map(static fn(ToolCall $c): array => $c->toArray(), $resp->toolCalls ?? []),
@@ -689,6 +689,51 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
     private function elapsedMs(int $startNs): float
     {
         return (hrtime(true) - $startNs) / 1_000_000;
+    }
+
+    /**
+     * Whether a human must approve this tool before the loop executes it
+     * (ADR-084/134).
+     *
+     * Two ways in, and the second is what ADR-134 adds: the explicit
+     * {@see RequiresApprovalInterface} marker, or a declared write effect. A
+     * builtin whose {@see \Netresearch\NrLlm\Domain\Enum\ToolEffect} is a write
+     * is describing a change to the installation that the operator cannot undo
+     * by reading the transcript, so it must not run unattended merely because
+     * nobody remembered the marker. The declaration is a property of the code
+     * (ADR-111) and cannot be relabelled by configuration, which is what makes
+     * it usable as an authorisation input.
+     *
+     * A {@see RemoteToolInterface} is exempt, and the exemption is load-bearing
+     * rather than convenient. {@see \Netresearch\NrLlm\Service\Tool\Mcp\McpTool}
+     * returns NON_IDEMPOTENT_WRITE for EVERY imported tool, a pure search
+     * included: a remote body is not ours to inspect, so the value is a
+     * fail-closed assumption about an unknown, not the tool's statement about
+     * itself. Treating it as one would suspend every MCP tool on every call and
+     * leave the shipped client unusable. The remote axis needs its own,
+     * operator-declared source — a server-level column, tracked separately. It
+     * will NOT come from the server: the `readOnlyHint` annotation is recorded
+     * verbatim and read by no resolver, because a remote server must not
+     * influence its own authorisation
+     * (see {@see \Netresearch\NrLlm\Domain\ValueObject\McpToolRecord}).
+     *
+     * The check is an `instanceof` on the tool the caller already fetched — no
+     * resolver, no new dependency: nothing here needs the registry-wide view a
+     * {@see ToolEffectResolver} exists to provide, and its unknown-tool fallback
+     * (NON_IDEMPOTENT_WRITE) would turn every unregistered name into a suspend
+     * instead of the refusal {@see self::invoke()} already gives it.
+     */
+    private function requiresHumanApproval(?ToolInterface $tool): bool
+    {
+        if ($tool instanceof RequiresApprovalInterface) {
+            return true;
+        }
+
+        if ($tool instanceof RemoteToolInterface) {
+            return false;
+        }
+
+        return $tool instanceof ToolEffectInterface && $tool->getEffect()->isWrite();
     }
 
     /**

--- a/Classes/Service/Tool/ToolRegistry.php
+++ b/Classes/Service/Tool/ToolRegistry.php
@@ -89,6 +89,36 @@ final class ToolRegistry
                 );
             }
 
+            // ADR-134 extends that ban to the IMPLICIT form of approval-gating.
+            // A declared write on a non-remote tool binds the approval scan
+            // exactly as the marker does, and that scan runs BEFORE the input
+            // scan (ToolLoopService): such a tool suspends AWAITING_APPROVAL,
+            // resume() then refuses it for the input it never received, the
+            // model re-requests, and it suspends again — unexecutable, one
+            // operator decision per cycle, with submitInput() unreachable
+            // because the status is never WAITING_FOR_INPUT. A combined
+            // approval+input pause is what would be needed, and ADR-105 banned
+            // the combination rather than build one; until it exists it is
+            // unsupported however it is expressed, so it fails at the container
+            // boot rather than silently at runtime.
+            //
+            // The predicate mirrors ToolLoopService::requiresHumanApproval(),
+            // including the remote exemption: narrowing the exemption there
+            // means narrowing it here, or a tool the loop would suspend becomes
+            // registrable again.
+            if ($tool instanceof RequiresInputInterface
+                && !$tool instanceof RemoteToolInterface
+                && $tool instanceof ToolEffectInterface
+                && $tool->getEffect()->isWrite()) {
+                throw new LogicException(
+                    sprintf(
+                        'Tool "%s" may not declare a write effect and implement RequiresInputInterface; a declared write binds the approval scan (ADR-134), which runs before the input scan, so the tool would suspend for approval and never receive its input.',
+                        $name,
+                    ),
+                    1786226400,
+                );
+            }
+
             $this->byName[$name] = $tool;
         }
 

--- a/Documentation/Adr/Adr105TypedInputSuspension.rst
+++ b/Documentation/Adr/Adr105TypedInputSuspension.rst
@@ -6,7 +6,7 @@
 ADR-105: Typed user-input suspension (WAITING_FOR_INPUT)
 ============================================================================
 
-:Status: Accepted
+:Status: Accepted (the approval+input registration ban is widened by :ref:`adr-134`)
 :Date: 2026-07-22
 :Authors: Netresearch DTT GmbH
 
@@ -71,6 +71,12 @@ Fail-closed rules
   combination is rejected at tool registration, and — defence in depth —
   ``resume()`` refuses an input-requiring pending call rather than fail-open
   executing it.
+
+  :ref:`adr-134` widened the ban without changing this reasoning: a declared
+  write effect became a second way to be approval-bound, so a non-remote,
+  write-declaring tool may not implement ``RequiresInputInterface`` either. The
+  ``resume()`` refusal named above is what makes that combination permanently
+  unexecutable, not what handles it. Read ADR-134 for the ban in force.
 - **An unstorable suspension fails closed** as ``SUSPEND_FAILED`` (as approval
   does): promising an input flow that cannot be resumed would strand the client.
 - **Submitted values are untrusted content** entering the model context; the

--- a/Documentation/Adr/Adr134WriteEffectImpliesApproval.rst
+++ b/Documentation/Adr/Adr134WriteEffectImpliesApproval.rst
@@ -1,0 +1,133 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-134:
+
+============================================================================
+ADR-134: A builtin's declared write effect implies human approval
+============================================================================
+
+:Status: Accepted
+:Date: 2026-08-09
+:Authors: Netresearch DTT GmbH
+
+.. _adr-134-context:
+
+Context
+=======
+
+Two declarations describe a tool that changes something, and until now they were
+unconnected.
+
+:php:`ToolEffectInterface` (:ref:`adr-111`) says what a tool does to the world.
+It feeds the write fence, the lease, the audit step and the retry decision — four
+readers, none of them about authorisation.
+
+:php:`RequiresApprovalInterface` (:ref:`adr-084`) says a human must approve the
+call before the loop executes it. It is the only thing the approval scan in
+:php:`ToolLoopService` looks for, and **no production class implements it**: the
+sole implementers are two anonymous test classes.
+
+A tool could therefore declare ``NON_IDEMPOTENT_WRITE`` and still run
+unattended. The two statements would have to be made in the same commit by
+someone who knew both existed, and nothing failed if only one of them was.
+
+The effect declaration is the better of the two to key on. It is a property of
+the code and deliberately not configurable (:ref:`adr-111`): an administrator
+cannot relabel a write as a read to dodge the audit, which is exactly the
+property an authorisation input needs. The marker is an opt-in nobody has yet
+opted into.
+
+.. _adr-134-decision:
+
+Decision
+========
+
+A tool counts as approval-bound in the loop's approval scan when it implements
+:php:`RequiresApprovalInterface`, **or** it implements
+:php:`ToolEffectInterface`, its ``getEffect()`` is a write, and it is **not** a
+:php:`RemoteToolInterface`.
+
+Both write cases qualify. ``isWrite()`` is the predicate, not idempotency —
+whether a repeat compounds governs retry, not whether a human should have seen
+the call in the first place.
+
+The check is an :php:`instanceof` on the tool the scan already fetched. No
+resolver, no new dependency: nothing here needs the registry-wide view
+:php:`ToolEffectResolver` exists to provide, and its unknown-tool fallback
+(``NON_IDEMPOTENT_WRITE``) would turn every unregistered name into a suspend
+instead of the refusal the invocation path already gives it.
+
+The pre-existing fail-closed rule is unchanged: only an **offered** tool
+suspends. A registered-but-not-offered tool named by a model steered through
+injected prose still falls through to the invocation gate, which refuses it —
+there is no spurious approval prompt for a tool the run never allowed.
+
+Remote tools are exempt
+-----------------------
+
+The exemption is load-bearing, not a convenience.
+
+:php:`McpTool::getEffect()` returns ``NON_IDEMPOTENT_WRITE`` for **every**
+imported tool, a pure search tool included. That value is a fail-closed
+assumption about a body this codebase cannot inspect (:ref:`adr-116`), not the
+tool's statement about itself. Treating it as one would suspend every MCP tool
+on every call and leave the shipped MCP client unusable.
+
+The remote axis needs a source of its own, and it will not be the server: the
+``readOnlyHint`` annotation is stored verbatim for display and read by no
+resolver, because a remote server must not be able to influence its own
+authorisation. An operator-declared, server-level column is the shape that
+works, and it is tracked separately from this decision.
+
+Registration stays as it is
+---------------------------
+
+:php:`ToolRegistry` refuses a tool that implements both
+:php:`RequiresApprovalInterface` and :php:`RequiresInputInterface`
+(:ref:`adr-105`). That ban is **not** extended to effect-declaring tools. It
+would be a registration refusal with no reader: the runtime already refuses an
+input-requiring pending call on the approval-resume path, fail-closed, because
+that path carries no user input. Widening a compile-time ban to cover a case the
+runtime already handles buys nothing and would reject a legitimate tool that
+needs both a human's data and a human's consent.
+
+.. _adr-134-consequences:
+
+Consequences
+============
+
+●● A write that ships without the approval marker still pauses for a human. The
+declaration that already had to be right for the audit and the retry now also
+carries the authorisation, so the two cannot drift apart.
+
+● Nothing changes for the tools shipped today. Every builtin reads — which
+:php:`ToolEffectCoverageTest` pins — so the new branch is inert until the first
+writer lands. That test stays the builtin list; its scope over
+:php:`ToolRegistry::builtinNames()` is untouched, because a provider-supplied
+tool must not be able to satisfy or break a guarantee about code in this
+repository.
+
+◐ The reasoning is in one place. A tool author declares an effect for
+:ref:`adr-111`'s reasons and gets the human-in-the-loop pause without knowing the
+marker exists.
+
+✕ Remote tools remain outside the coupling. An MCP tool that genuinely writes
+runs without a pause today, exactly as it did before this decision — the gap is
+named rather than closed, and closing it needs the operator-declared server
+column.
+
+.. _adr-134-revisit:
+
+Revisit when
+============
+
+The operator-declared remote effect column lands. At that point a remote tool
+has a statement about itself that did not come from the server, and the
+exemption here should narrow to "remote **and** undeclared" rather than
+"remote".
+
+Also revisit if a builtin ever needs to write without a pause. Today that is not
+expressible, deliberately: the way out is to not declare a write, which the
+audit and the retry would immediately make wrong. A real case for a
+write-without-approval builtin is a case for a third declaration, not for
+loosening this one.

--- a/Documentation/Adr/Adr134WriteEffectImpliesApproval.rst
+++ b/Documentation/Adr/Adr134WriteEffectImpliesApproval.rst
@@ -79,17 +79,45 @@ resolver, because a remote server must not be able to influence its own
 authorisation. An operator-declared, server-level column is the shape that
 works, and it is tracked separately from this decision.
 
-Registration stays as it is
----------------------------
+Registration bans the implicit combination too
+----------------------------------------------
 
-:php:`ToolRegistry` refuses a tool that implements both
+:php:`ToolRegistry` already refuses a tool that implements both
 :php:`RequiresApprovalInterface` and :php:`RequiresInputInterface`
-(:ref:`adr-105`). That ban is **not** extended to effect-declaring tools. It
-would be a registration refusal with no reader: the runtime already refuses an
-input-requiring pending call on the approval-resume path, fail-closed, because
-that path carries no user input. Widening a compile-time ban to cover a case the
-runtime already handles buys nothing and would reject a legitimate tool that
-needs both a human's data and a human's consent.
+(:ref:`adr-105`): the approval-resume path carries no user input, so the
+combination is unsupported. This decision makes a declared write a second way to
+be approval-bound, and the ban therefore extends to it — a **non-remote,
+write-declaring** tool may not implement :php:`RequiresInputInterface` either.
+
+The extension is not defensive tidying. Without it the combination is not
+"handled by the runtime", it is dead:
+
+#. The approval scan runs **before** the input scan, so the tool suspends
+   ``AWAITING_APPROVAL``, never ``WAITING_FOR_INPUT``.
+#. :php:`ToolLoopService::resume()` refuses an input-requiring pending call
+   ("requires user input that was not provided") — correctly, since the approval
+   path carries no data.
+#. The model re-requests, the approval scan binds again, and the cycle repeats:
+   one operator decision spent per turn and the tool never executes.
+#. ``submitInput()`` is unreachable. It requires status ``WAITING_FOR_INPUT``,
+   and the approval suspension's :php:`SuspendedRunState` carries neither
+   ``inputToolName`` nor ``inputSchema``.
+
+The refusal in step 2 is the mechanism of the defect, not its handling: it is
+what makes the cycle permanent. Nothing in the run reports the cause, and the
+operator sees only a tool that asks and asks. A registration failure at
+container boot names it.
+
+What this costs is real and is the cost :ref:`adr-105` already accepted: a tool
+that needs both a human's data and a human's consent cannot be built. The
+runtime has no combined approval+input pause — ADR-105 banned the combination
+rather than build one — so allowing the declaration would promise a flow that
+does not exist.
+
+The registration predicate mirrors the loop's, remote exemption included, so it
+can never reject a tool the approval scan would have let through. It sits in the
+constructor, which sees only the compile-time builtins; provider-supplied tools
+(the remote ones) are exempt from the coupling anyway.
 
 .. _adr-134-consequences:
 
@@ -111,6 +139,11 @@ repository.
 :ref:`adr-111`'s reasons and gets the human-in-the-loop pause without knowing the
 marker exists.
 
+✕ A builtin can no longer both declare a write and ask the user for typed input.
+The combination has no working runtime path, so it now fails at registration
+instead of livelocking at run time — but a genuine case for it has no workaround
+short of the combined pause below.
+
 ✕ Remote tools remain outside the coupling. An MCP tool that genuinely writes
 runs without a pause today, exactly as it did before this decision — the gap is
 named rather than closed, and closing it needs the operator-declared server
@@ -125,6 +158,11 @@ The operator-declared remote effect column lands. At that point a remote tool
 has a statement about itself that did not come from the server, and the
 exemption here should narrow to "remote **and** undeclared" rather than
 "remote".
+
+Also revisit when a tool genuinely needs both a human's data and a human's
+consent. That needs a combined pause — one suspension that collects the input
+and the decision together — which :ref:`adr-105` deferred. When it exists, the
+registration ban above drops for tools that use it.
 
 Also revisit if a builtin ever needs to write without a pause. Today that is not
 expressible, deliberately: the way out is to not declare a write, which the

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -429,3 +429,4 @@ Tools
    Adr129StructuredConsumers
    Adr130BackendUserGrants
    Adr131EditorModule
+   Adr134WriteEffectImpliesApproval

--- a/Tests/Functional/Service/Tool/ToolLoopServiceBuiltinTest.php
+++ b/Tests/Functional/Service/Tool/ToolLoopServiceBuiltinTest.php
@@ -9,32 +9,50 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
 
+use Netresearch\NrLlm\Domain\Enum\ToolDataClass;
+use Netresearch\NrLlm\Domain\Enum\ToolEffect;
 use Netresearch\NrLlm\Domain\Enum\TrustZone;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\McpServerRecord;
+use Netresearch\NrLlm\Domain\ValueObject\McpToolRecord;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Skill\SkillComposer;
 use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
 use Netresearch\NrLlm\Service\Tool\Builtin\FetchLogsTool;
+use Netresearch\NrLlm\Service\Tool\Exception\ToolApprovalRequiredException;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpClient;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpHttpTransport;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpTool;
 use Netresearch\NrLlm\Service\Tool\ToolAvailabilityService;
 use Netresearch\NrLlm\Service\Tool\ToolCallPolicy;
 use Netresearch\NrLlm\Service\Tool\ToolDataClassResolver;
+use Netresearch\NrLlm\Service\Tool\ToolEffectInterface;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolGroupStateRepository;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Service\Tool\ToolLoopService;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 use Netresearch\NrLlm\Service\Tool\ToolStateRepository;
 use Netresearch\NrLlm\Service\Tool\TrustZoneResolver;
+use Netresearch\NrLlm\Tests\Fixtures\Mcp\McpTestServer;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use Netresearch\NrVault\Http\SecureHttpClientFactory;
+use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use RuntimeException;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Http\Client\GuzzleClientFactory;
+use TYPO3\CMS\Core\Http\RequestFactory;
+use TYPO3\CMS\Core\Http\StreamFactory;
 
 /**
  * End-to-end agent loop over a REAL builtin tool.
@@ -156,12 +174,185 @@ final class ToolLoopServiceBuiltinTest extends AbstractFunctionalTestCase
     }
 
     /**
-     * Wire the loop with the real registry + real DB-backed availability service
-     * over the single real {@see FetchLogsTool}.
+     * A tool that declares a write and carries NO approval marker suspends the
+     * run through the REAL gate stack (ADR-134). No builtin writes today — that
+     * is what {@see ToolEffectCoverageTest} pins — so the first one that does is
+     * modelled here rather than waited for: the guarantee has to hold on the day
+     * it lands, not after someone remembers the marker.
      */
-    private function buildService(LlmServiceManagerInterface $mgr): ToolLoopService
+    #[Test]
+    public function aWriteDeclaringToolWithoutTheMarkerSuspendsEndToEnd(): void
     {
-        $registry     = new ToolRegistry([new FetchLogsTool($this->connectionPool)]);
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturn($this->response('', [new ToolCall('call_1', 'write_thing', ['id' => 7])]));
+
+        $service = $this->buildService($mgr, [$this->writeTool()]);
+
+        $this->expectException(ToolApprovalRequiredException::class);
+        $service->runLoop([$this->userTurn('write it')], $this->localConfiguration(), $this->contextFor($this->actingUser), null);
+    }
+
+    /**
+     * The remote exemption, over the REAL {@see McpTool} rather than a stand-in
+     * for it (ADR-134).
+     *
+     * `McpTool::getEffect()` is NON_IDEMPOTENT_WRITE for every imported tool,
+     * this scripted `search` included. That value is a fail-closed assumption
+     * about a body this codebase cannot inspect, not the tool's own statement,
+     * so it must not double as an approval trigger: if it did, every MCP tool
+     * would suspend on every call and the shipped client would be unusable.
+     */
+    #[Test]
+    public function aRemoteMcpToolWithAWriteEffectDoesNotSuspendEndToEnd(): void
+    {
+        $tool = $this->mcpTool('mcp_srv_search');
+        // An imported tool is inert until an operator enables it, so the real
+        // availability service would otherwise never offer it.
+        (new ToolStateRepository($this->connectionPool))->setEnabled('mcp_srv_search', true);
+
+        $queue = [
+            $this->response('', [new ToolCall('call_1', 'mcp_srv_search', ['q' => 'typo3'])]),
+            $this->response('Found it.'),
+        ];
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturnCallback(function () use (&$queue): CompletionResponse {
+                $next = array_shift($queue);
+                if (!$next instanceof CompletionResponse) {
+                    throw new RuntimeException('Scripted response queue underflow.', 1799990002);
+                }
+
+                return $next;
+            });
+
+        $service = $this->buildService($mgr, [$tool]);
+        $result  = $service->runLoop([$this->userTurn('search for typo3')], $this->localConfiguration(), $this->contextFor($this->actingUser), null);
+
+        // It ran synchronously — no suspension — and the remote text came back
+        // through the real client and transport.
+        self::assertSame('Found it.', $result->finalContent);
+        self::assertCount(1, $result->trace);
+        self::assertSame('mcp_srv_search', $result->trace[0]->name);
+        self::assertSame('REMOTE OK', $result->trace[0]->result);
+    }
+
+    /**
+     * A tool that declares a write effect and nothing else — no approval marker,
+     * no remote provenance.
+     */
+    private function writeTool(): ToolInterface
+    {
+        return new class implements ToolInterface, ToolEffectInterface {
+            public function getEffect(): ToolEffect
+            {
+                return ToolEffect::NON_IDEMPOTENT_WRITE;
+            }
+
+            public function getSpec(): ToolSpec
+            {
+                return ToolSpec::function('write_thing', 'changes a thing', ['type' => 'object', 'properties' => []]);
+            }
+
+            /**
+             * @param array<string, mixed> $arguments
+             */
+            public function execute(array $arguments, ToolExecutionContext $context): ToolResult
+            {
+                return ToolResult::text('WROTE');
+            }
+
+            public function isEnabledByDefault(): bool
+            {
+                return true;
+            }
+
+            public function requiresAdmin(): bool
+            {
+                return false;
+            }
+
+            public function getGroup(): string
+            {
+                return 'test';
+            }
+        };
+    }
+
+    /**
+     * A real {@see McpTool} over a scripted server: only the HTTP client is
+     * faked, so the client, the transport and the tool itself are production
+     * code.
+     */
+    private function mcpTool(string $localName): McpTool
+    {
+        $server = new McpServerRecord(
+            1,
+            0,
+            'srv',
+            'A server',
+            '',
+            'https://mcp.example.com/rpc',
+            '',
+            'bearer',
+            '',
+            'publicContent',
+            true,
+            'ok',
+            '',
+            0,
+            1,
+            0,
+            0,
+        );
+
+        $record = new McpToolRecord(
+            1,
+            0,
+            $server->uid,
+            $localName,
+            'search',
+            'searches the server',
+            '{"type":"object","properties":{}}',
+            // The server calls itself read-only. No resolver reads this, and the
+            // approval scan must not start doing so: a remote server cannot be
+            // allowed to decide its own authorisation.
+            '{"readOnlyHint":true}',
+            false,
+            0,
+            0,
+        );
+
+        $fake = (new McpTestServer())
+            ->willHandshake()
+            ->willReturn(['content' => [['type' => 'text', 'text' => 'REMOTE OK']]]);
+
+        $transport = new McpHttpTransport(
+            self::createStub(VaultServiceInterface::class),
+            new SecureHttpClientFactory(),
+            new RequestFactory(new GuzzleClientFactory()),
+            new StreamFactory(),
+        );
+        $transport->setHttpClient($fake);
+
+        return new McpTool(
+            $server,
+            $record,
+            ['type' => 'object', 'properties' => []],
+            ToolDataClass::PUBLIC_CONTENT,
+            new McpClient($transport),
+        );
+    }
+
+    /**
+     * Wire the loop with the real registry + real DB-backed availability service
+     * over the single real {@see FetchLogsTool}, or over the given tools.
+     *
+     * @param list<ToolInterface>|null $tools
+     */
+    private function buildService(LlmServiceManagerInterface $mgr, ?array $tools = null): ToolLoopService
+    {
+        $registry     = new ToolRegistry($tools ?? [new FetchLogsTool($this->connectionPool)]);
         $availability = new ToolAvailabilityService($registry, new ToolStateRepository($this->connectionPool), new ToolGroupStateRepository($this->connectionPool));
 
         // The REAL composite gate (ADR-094), not a double: this test exists to

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
 
 use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
 use Netresearch\NrLlm\Domain\Enum\ArtifactType;
+use Netresearch\NrLlm\Domain\Enum\ToolEffect;
 use Netresearch\NrLlm\Domain\Enum\TrustZone;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
@@ -45,6 +46,7 @@ use Netresearch\NrLlm\Service\Tool\RunAugmentation;
 use Netresearch\NrLlm\Service\Tool\RunTrace;
 use Netresearch\NrLlm\Service\Tool\ToolCallPolicy;
 use Netresearch\NrLlm\Service\Tool\ToolDataClassResolver;
+use Netresearch\NrLlm\Service\Tool\ToolEffectInterface;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Service\Tool\ToolLoopService;
@@ -55,6 +57,7 @@ use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeInputTool;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeToolAvailability;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -1027,6 +1030,97 @@ final class ToolLoopServiceTest extends TestCase
         };
     }
 
+    /**
+     * ADR-134: a declared write effect is itself the approval trigger, so a
+     * builtin that mutates cannot run unattended because nobody remembered the
+     * marker. Both write cases qualify — {@see ToolEffect::isWrite()} is the
+     * predicate, not idempotency, which governs retry and nothing else.
+     */
+    #[Test]
+    #[DataProvider('writeEffects')]
+    public function suspendsForAWriteDeclaringBuiltinWithoutTheApprovalMarker(ToolEffect $effect): void
+    {
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturn($this->response('', [new ToolCall('call_1', 'write_thing', ['id' => 7])], 5, 2));
+        $service = $this->service($mgr, new ToolRegistry([$this->writeTool('write_thing', $effect)]));
+
+        $state = $this->suspend($service);
+
+        self::assertCount(1, $state->pendingCalls);
+        self::assertSame('write_thing', $state->toolCalls()[0]->name);
+        // Captured BEFORE the write ran: the transcript is the user turn plus
+        // the assistant's tool-call turn, and no tool result.
+        self::assertCount(2, $state->messages);
+    }
+
+    /**
+     * @return iterable<string, array{ToolEffect}>
+     */
+    public static function writeEffects(): iterable
+    {
+        yield 'non-idempotent write' => [ToolEffect::NON_IDEMPOTENT_WRITE];
+        yield 'idempotent write'     => [ToolEffect::IDEMPOTENT_WRITE];
+    }
+
+    /**
+     * The other side of ADR-134: coupling effect to approval must not turn the
+     * forty-odd read-only builtins into pauses.
+     */
+    #[Test]
+    public function doesNotSuspendForAToolThatDeclaresReadOnly(): void
+    {
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturnCallback($this->queueCallback([
+            $this->response('', [new ToolCall('call_1', 'read_thing', [])]),
+            $this->response('read and done'),
+        ]));
+        $service = $this->service($mgr, new ToolRegistry([$this->writeTool('read_thing', ToolEffect::READ_ONLY)]));
+
+        $result = $service->runLoop([$this->userTurn('go')], $this->localConfiguration(), ToolExecutionContext::none(), null);
+
+        self::assertSame('read and done', $result->finalContent);
+        self::assertCount(1, $result->trace);
+        self::assertSame('WROTE', $result->trace[0]->result, 'the read-only tool ran synchronously');
+    }
+
+    /**
+     * The load-bearing exemption (ADR-134). Every imported MCP tool declares
+     * NON_IDEMPOTENT_WRITE — a fail-closed assumption about a body this codebase
+     * cannot inspect, not the tool's own statement — so coupling effect to
+     * approval globally would suspend every remote call and leave the shipped
+     * MCP client unusable. A remote tool therefore never suspends on its effect
+     * alone.
+     */
+    #[Test]
+    public function doesNotSuspendForARemoteToolThatDeclaresAWrite(): void
+    {
+        $remote = $this->remoteTool();
+        self::assertInstanceOf(ToolEffectInterface::class, $remote);
+        self::assertTrue($remote->getEffect()->isWrite(), 'the fixture must declare a write, or this proves nothing');
+
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturnCallback($this->queueCallback([
+            $this->response('', [new ToolCall('call_1', 'remote_thing', [])]),
+            $this->response('remote done'),
+        ]));
+        $service = $this->service($mgr, new ToolRegistry([$remote]));
+
+        $result = $service->runLoop([$this->userTurn('go')], $this->localConfiguration(), ToolExecutionContext::none(), null);
+
+        self::assertSame('remote done', $result->finalContent);
+        self::assertCount(1, $result->trace);
+        self::assertSame('remote ok', $result->trace[0]->result);
+    }
+
+    /**
+     * A tool that declares an effect and nothing else — no approval marker.
+     */
+    private function writeTool(string $name, ToolEffect $effect): ToolInterface
+    {
+        return new FakeTool($name, 'WROTE', true, false, 'test', [], $effect);
+    }
+
     #[Test]
     public function theConfigurationsToolGroupGateAppliesInsideTheLoopNotOnlyInThePlayground(): void
     {
@@ -1410,10 +1504,21 @@ final class ToolLoopServiceTest extends TestCase
     /**
      * A tool marked as living outside this codebase, which is the only thing
      * the budget keys on.
+     *
+     * It declares NON_IDEMPOTENT_WRITE like every
+     * {@see \Netresearch\NrLlm\Service\Tool\Mcp\McpTool} does — the
+     * fail-closed assumption about a body nobody here can inspect, not a
+     * statement the tool made about itself — so the approval scan's remote
+     * exemption (ADR-134) is exercised by the tests that use it.
      */
     private function remoteTool(): ToolInterface
     {
-        return new class implements ToolInterface, RemoteToolInterface {
+        return new class implements ToolInterface, RemoteToolInterface, ToolEffectInterface {
+            public function getEffect(): ToolEffect
+            {
+                return ToolEffect::NON_IDEMPOTENT_WRITE;
+            }
+
             public function getSpec(): ToolSpec
             {
                 return ToolSpec::function('remote_thing', "a tool on someone else's server", ['type' => 'object', 'properties' => []]);

--- a/Tests/Unit/Service/Tool/ToolRegistryTest.php
+++ b/Tests/Unit/Service/Tool/ToolRegistryTest.php
@@ -11,10 +11,13 @@ namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
 
 use LogicException;
 
+use Netresearch\NrLlm\Domain\Enum\ToolEffect;
 use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\RemoteToolInterface;
 use Netresearch\NrLlm\Service\Tool\RequiresApprovalInterface;
 use Netresearch\NrLlm\Service\Tool\RequiresInputInterface;
+use Netresearch\NrLlm\Service\Tool\ToolEffectInterface;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
@@ -101,5 +104,136 @@ final class ToolRegistryTest extends TestCase
 
         $this->expectException(LogicException::class);
         self::assertInstanceOf(ToolRegistry::class, new ToolRegistry([$dualMarker]));
+    }
+
+    #[Test]
+    public function aToolThatDeclaresAWriteAndRequiresInputIsRejected(): void
+    {
+        // ADR-134: a declared write binds the approval scan, which runs BEFORE
+        // the input scan. Registered, such a tool would suspend for approval,
+        // be refused by resume() for the input it never received, and suspend
+        // again on the model's next attempt — one operator decision per cycle
+        // and never an execution. Rejected at the container boot instead.
+        $this->expectException(LogicException::class);
+        $this->expectExceptionCode(1786226400);
+        self::assertInstanceOf(ToolRegistry::class, new ToolRegistry([$this->inputTool('create_page', ToolEffect::IDEMPOTENT_WRITE)]));
+    }
+
+    #[Test]
+    public function anInputToolThatDeclaresNoWriteStaysRegistrable(): void
+    {
+        // The control for the ban above: it keys on the WRITE, not on the input
+        // marker. A read-only tool that asks the user for data is the case
+        // ADR-105 was built for and must keep working.
+        $tool = $this->inputTool('ask_user', ToolEffect::READ_ONLY);
+
+        self::assertSame($tool, (new ToolRegistry([$tool]))->get('ask_user'));
+    }
+
+    #[Test]
+    public function aRemoteToolThatDeclaresAWriteAndRequiresInputStaysRegistrable(): void
+    {
+        // The ban mirrors ToolLoopService::requiresHumanApproval() including its
+        // remote exemption, so it can never reject a tool the approval scan
+        // would let through. McpTool declares NON_IDEMPOTENT_WRITE for every
+        // imported tool, a pure search included (ADR-134).
+        $remote = new class implements ToolInterface, RequiresInputInterface, ToolEffectInterface, RemoteToolInterface {
+            public function getSpec(): ToolSpec
+            {
+                return ToolSpec::function('remote_writer', 'a remote tool that asks for input', ['type' => 'object', 'properties' => []]);
+            }
+
+            /**
+             * @param array<string, mixed> $arguments
+             */
+            public function execute(array $arguments, ToolExecutionContext $context): ToolResult
+            {
+                return ToolResult::text('ok');
+            }
+
+            public function isEnabledByDefault(): bool
+            {
+                return true;
+            }
+
+            public function requiresAdmin(): bool
+            {
+                return false;
+            }
+
+            public function getGroup(): string
+            {
+                return 'test';
+            }
+
+            /**
+             * @return array<string, mixed>
+             */
+            public function getInputSchema(): array
+            {
+                return ['type' => 'object', 'properties' => ['x' => ['type' => 'string']]];
+            }
+
+            public function getEffect(): ToolEffect
+            {
+                return ToolEffect::NON_IDEMPOTENT_WRITE;
+            }
+        };
+
+        self::assertSame($remote, (new ToolRegistry([$remote]))->get('remote_writer'));
+    }
+
+    /**
+     * A local tool that asks the user for typed input and declares an effect.
+     */
+    private function inputTool(string $name, ToolEffect $effect): ToolInterface
+    {
+        return new class ($name, $effect) implements ToolInterface, RequiresInputInterface, ToolEffectInterface {
+            public function __construct(
+                private readonly string $name,
+                private readonly ToolEffect $effect,
+            ) {}
+
+            public function getSpec(): ToolSpec
+            {
+                return ToolSpec::function($this->name, 'asks the user for input', ['type' => 'object', 'properties' => []]);
+            }
+
+            /**
+             * @param array<string, mixed> $arguments
+             */
+            public function execute(array $arguments, ToolExecutionContext $context): ToolResult
+            {
+                return ToolResult::text('ok');
+            }
+
+            public function isEnabledByDefault(): bool
+            {
+                return true;
+            }
+
+            public function requiresAdmin(): bool
+            {
+                return false;
+            }
+
+            public function getGroup(): string
+            {
+                return 'test';
+            }
+
+            /**
+             * @return array<string, mixed>
+             */
+            public function getInputSchema(): array
+            {
+                return ['type' => 'object', 'properties' => ['x' => ['type' => 'string']]];
+            }
+
+            public function getEffect(): ToolEffect
+            {
+                return $this->effect;
+            }
+        };
     }
 }


### PR DESCRIPTION
## Description

Two declarations describe a tool that changes something, and they were unconnected.

`ToolEffectInterface` (ADR-111) feeds the write fence, the lease, the audit step and the retry decision — four readers, none about authorisation. `RequiresApprovalInterface` (ADR-084) is the only thing the approval scan looks for, and **no production class implements it**: the sole implementers are two anonymous test classes. A tool could therefore declare `NON_IDEMPOTENT_WRITE` and still run unattended.

The approval scan in `ToolLoopService` now also binds on a declared write. The effect is the better of the two to key on — it is a property of the code and deliberately not configurable (ADR-111), so an administrator cannot relabel a write as a read to dodge it.

### The remote exemption is load-bearing

`McpTool::getEffect()` returns `NON_IDEMPOTENT_WRITE` for **every** imported tool, a pure search included. That value is a fail-closed assumption about a body this codebase cannot inspect (ADR-116), not the tool's statement about itself. Treating it as one would suspend every MCP tool on every call and leave the shipped MCP client unusable. `readOnlyHint` is deliberately not consulted — a remote server must not influence its own authorisation. The remote axis gets an operator-declared, server-level column separately.

Precedence: an explicit marker wins over the remote exemption.

### The registration ban is extended

`ToolRegistry` already refuses a tool implementing both `RequiresApprovalInterface` and `RequiresInputInterface` (ADR-105). Since a declared write is now a second way to be approval-bound, the ban extends to it: a **non-remote, write-declaring** tool may not implement `RequiresInputInterface` either.

Not defensive tidying — without it the combination is dead rather than handled. The approval scan runs *before* the input scan, so such a tool suspends `AWAITING_APPROVAL` and never `WAITING_FOR_INPUT`; `resume()` then refuses it for the input it never received, the model re-requests, and it suspends again. One operator decision per cycle, `submitInput()` unreachable. Failing at container boot beats failing silently at runtime.

The predicate mirrors `ToolLoopService::requiresHumanApproval()`, remote exemption included — narrowing the exemption in one place means narrowing it in the other.

> **Korrektur (2026-08-09):** Diese Passage stand vorher als „Not done, on purpose" hier und behauptete das Gegenteil. Sie war veraltet — ADR-134 und der Code haben die Ausweitung von Anfang an, nur der PR-Text nicht. Aufgefallen beim manuellen Review, weil Copilots Kontingent erschöpft ist.

Nothing changes for the tools shipped today: every builtin reads, which `ToolEffectCoverageTest` pins. That test keeps its builtin scope — a provider-supplied tool must not be able to satisfy or break a guarantee about code in this repository.

## Related Issue

Closes #623

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `composer ci` and all checks pass — unit, PHPStan (level 10) and cgl re-run independently of the authoring pass: all SUCCESS. Rector was verified green under an 8.2 resolve, then the worktree was resolved back to 8.4; the two resolves cannot coexist locally, and CI pins the Rector job to 8.2 anyway.
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation accordingly
- [x] I have added a `CHANGELOG.md` entry under `## [Unreleased]`
- [x] I have added an ADR under `Documentation/Adr/` if this changes the public surface — ADR-134
- [x] My changes generate no new warnings

### Tests

- unit: a write-declaring builtin without the marker suspends (both `IDEMPOTENT_WRITE` and `NON_IDEMPOTENT_WRITE` via data provider); `READ_ONLY` runs synchronously; a remote tool declaring a write does **not** suspend; the marker path still suspends.
- functional through the real gate stack: a write-declaring tool suspends end to end, and a **real** `McpTool` — real `McpClient`, real `McpHttpTransport`, scripted server, `readOnlyHint: true` in the record that no resolver reads — runs without suspending.
- Control probe rather than plausibility: removing the effect branch fails exactly the two write tests; removing the remote exemption fails exactly the remote test.

### Note for reviewers

`Documentation/Adr/Index.rst` will show a gap at ADR-132/133 until the two sibling branches land.
