### PR TITLE
fix(context): count the skill block against the conversation budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- The conversation context budget counts the skill block (#625).
+  `ConversationService` fitted the transcript and then dispatched into
+  `LlmServiceManager::chatForConfiguration()`, which prepends up to 24 000
+  bytes of skill block to the first user message — the fitted list and the
+  sent list were different lists. A criteria-mode configuration has no model
+  relation, so its window falls back to 8192 tokens, of which a full block is
+  roughly 7 900 estimated tokens against a budget of 6 946 (8192 minus the
+  1000-token response reserve minus the 3 % safety margin): the whole
+  configuration class overran. `ContextWindowManagerInterface::fit()` takes an
+  optional trailing `$injectedText` for payload that reaches the wire outside
+  the message list, and the conversation path composes the block once and
+  passes it. The injection stays where it is — the first user turn is the
+  never-droppable head, so injecting before the fit would drop the entire
+  history and still overflow. Known limit: a session opened without a
+  configuration resolves the installation default inside the manager, so its
+  block is still unaccounted for.
+
 ## [0.26.0] - 2026-08-06
 
 ### Added

--- a/Classes/Service/Context/ContextWindowManager.php
+++ b/Classes/Service/Context/ContextWindowManager.php
@@ -56,6 +56,7 @@ final class ContextWindowManager implements ContextWindowManagerInterface
         ?ChatOptions $options,
         ?UsageStatistics $lastUsage,
         array $toolSpecs = [],
+        string $injectedText = '',
     ): ContextFitResult {
         // A null $lastUsage marks the first send of a run's loop. Reset the
         // per-run calibration state here so a single shared manager instance
@@ -81,13 +82,21 @@ final class ContextWindowManager implements ContextWindowManagerInterface
             return $this->passthrough($messages);
         }
 
-        // The system prompt is prepended by MessageShaper AFTER fit() on the
-        // public path (ADR-093), so when the transcript has no leading system
-        // message its size must still be counted against the wire.
-        $systemPromptTokens = $this->missingSystemPromptTokens($messages, $configuration);
-        $estimate = function (array $msgs) use ($toolSpecs, $systemPromptTokens): int {
+        // Payload that reaches the wire without being in $messages, counted here
+        // because the budget binds the SEND, not this array:
+        // - the system prompt MessageShaper prepends AFTER fit() on the public
+        //   path (ADR-093), when the transcript has no leading system message;
+        // - $injectedText, prose a later stage prepends into the list — the
+        //   skill block LlmServiceManager injects on the configuration path.
+        // Both are charged to the estimate rather than deducted from the budget:
+        // a deduction large enough to push the budget to zero would trip the
+        // non-positive-budget passthrough below and disable pruning outright,
+        // which is the overflow this accounting exists to prevent.
+        $outsideTokens = $this->missingSystemPromptTokens($messages, $configuration)
+            + $this->injectedTokens($injectedText);
+        $estimate = function (array $msgs) use ($toolSpecs, $outsideTokens): int {
             /** @var list<ChatMessage|array<string, mixed>> $msgs the caller always passes the partitioned transcript */
-            return $this->estimator->estimate($msgs, $toolSpecs, $this->calibration) + $systemPromptTokens;
+            return $this->estimator->estimate($msgs, $toolSpecs, $this->calibration) + $outsideTokens;
         };
 
         [$head, $turns] = $this->partition($messages);
@@ -154,6 +163,23 @@ final class ContextWindowManager implements ContextWindowManagerInterface
         }
 
         return $this->estimator->estimate([ChatMessage::system($systemPrompt)], [], $this->calibration);
+    }
+
+    /**
+     * Tokens for prose a later stage prepends into the send.
+     *
+     * Estimated as a user message, which charges the per-message overhead on
+     * top: the block is prepended INTO an existing message rather than added as
+     * one, so this errs high by that overhead — the direction this estimator
+     * errs in everywhere else.
+     */
+    private function injectedTokens(string $injectedText): int
+    {
+        if ($injectedText === '') {
+            return 0;
+        }
+
+        return $this->estimator->estimate([ChatMessage::user($injectedText)], [], $this->calibration);
     }
 
     /**

--- a/Classes/Service/Context/ContextWindowManagerInterface.php
+++ b/Classes/Service/Context/ContextWindowManagerInterface.php
@@ -34,8 +34,9 @@ interface ContextWindowManagerInterface
      * it (even the floor overflows).
      *
      * @param list<ChatMessage|array<string, mixed>> $messages
-     * @param list<array<string, mixed>>             $toolSpecs the tool schemas on the wire for THIS send; empty for a plain completion
-     * @param UsageStatistics|null                   $lastUsage the previous call's usage, to calibrate the estimator; null before the first call
+     * @param list<array<string, mixed>>             $toolSpecs    the tool schemas on the wire for THIS send; empty for a plain completion
+     * @param UsageStatistics|null                   $lastUsage    the previous call's usage, to calibrate the estimator; null before the first call
+     * @param string                                 $injectedText prose a LATER stage prepends into the message list for THIS send — the skill block; it is on the wire, so it is counted against the budget, but it is never added to the returned messages
      */
     public function fit(
         array $messages,
@@ -43,5 +44,6 @@ interface ContextWindowManagerInterface
         ?ChatOptions $options,
         ?UsageStatistics $lastUsage,
         array $toolSpecs = [],
+        string $injectedText = '',
     ): ContextFitResult;
 }

--- a/Classes/Service/Feature/ConversationService.php
+++ b/Classes/Service/Feature/ConversationService.php
@@ -24,6 +24,8 @@ use Netresearch\NrLlm\Service\Context\ContextWindowManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Service\Session\AiSessionRepositoryInterface;
+use Netresearch\NrLlm\Service\Skill\SkillComposer;
+use Netresearch\NrLlm\Service\Skill\SkillInjectionService;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Symfony\Component\Uid\Uuid;
@@ -58,6 +60,11 @@ final readonly class ConversationService implements ConversationServiceInterface
         // absent it a conversation grows unbounded exactly as before.
         private ?ContextWindowManagerInterface $contextWindow = null,
         private ?LoggerInterface $logger = null,
+        // Composes the same skill block LlmServiceManager injects after this
+        // service has already fitted the transcript, so its size can be counted
+        // against the budget. Optional for the same reason as the manager
+        // above; absent it the block is unaccounted for, exactly as before.
+        private ?SkillComposer $skillComposer = null,
     ) {}
 
     public function startSession(AiActorContext $actor, string $title = '', ?LlmConfiguration $configuration = null): AiSession
@@ -124,7 +131,14 @@ final readonly class ConversationService implements ConversationServiceInterface
             // lastUsage is null: each turn is a fresh assembly, so the
             // manager's calibration starts from its seed rather than carrying a
             // ratio over from an unrelated turn.
-            $fit          = $this->contextWindow->fit($messages, $configuration, $options, null, []);
+            //
+            // The skill block is composed ONCE here and passed as payload the
+            // send carries outside this list: LlmServiceManager injects it into
+            // the first user message AFTER this fit (#625). The injection stays
+            // there deliberately — the first user turn is the never-droppable
+            // HEAD, so injecting before the fit would spend the whole history
+            // on making room and still overflow.
+            $fit          = $this->contextWindow->fit($messages, $configuration, $options, null, [], $this->skillBlockFor($configuration));
             $messages     = $fit->messages;
             $droppedTurns = $fit->droppedTurns;
 
@@ -199,6 +213,33 @@ final readonly class ConversationService implements ConversationServiceInterface
         }
 
         return $this->llmManager->chatForConfiguration($messages, $configuration, $options);
+    }
+
+    /**
+     * The skill block this turn's send will carry, composed once.
+     *
+     * {@see \Netresearch\NrLlm\Service\LlmServiceManager::chatForConfiguration()}
+     * prepends it to the first user message after this service has fitted the
+     * transcript, so the fit has to know its size or the budget binds a list
+     * that is never sent that way (#625). Composition is deterministic over the
+     * configuration's skills, so the manager's own composition of the same set
+     * yields the same block.
+     *
+     * Known limit: the null-configuration branch of {@see self::dispatch()} is
+     * not covered. There the manager resolves the installation default itself
+     * and injects that configuration's skills — this service never learns which
+     * configuration that is, so it cannot account for its block.
+     */
+    private function skillBlockFor(LlmConfiguration $configuration): string
+    {
+        if (!$this->skillComposer instanceof SkillComposer) {
+            return '';
+        }
+
+        return $this->skillComposer->composeBlock(
+            SkillInjectionService::toList($configuration->getSkills()),
+            [],
+        )->block;
     }
 
     /**

--- a/Tests/Functional/Service/Feature/ConversationSkillBudgetTest.php
+++ b/Tests/Functional/Service/Feature/ConversationSkillBudgetTest.php
@@ -1,0 +1,231 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Feature;
+
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Service\ConfigurationResolver;
+use Netresearch\NrLlm\Service\Context\ContextWindowManager;
+use Netresearch\NrLlm\Service\Context\TranscriptEstimator;
+use Netresearch\NrLlm\Service\Feature\ConversationService;
+use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Session\AiSessionRepository;
+use Netresearch\NrLlm\Service\Skill\SkillComposer;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * The conversation budget must bind the list that is actually SENT (#625).
+ *
+ * A criteria-mode configuration carries no model relation, so the window falls
+ * back to 8192 tokens — against which the skill block the manager injects after
+ * the fit is a large share. This exercises the real collaboration: the session
+ * store on the real schema, the real configuration↔skill MM relation, the real
+ * composer and the real context-window manager.
+ */
+#[CoversClass(ConversationService::class)]
+final class ConversationSkillBudgetTest extends AbstractFunctionalTestCase
+{
+    /** Unknown context length -> UNKNOWN_WINDOW_FALLBACK, minus the 1000 reserve and the 3 % safety. */
+    private const EXPECTED_BUDGET = 8192 - 1000 - 246;
+
+    private const HISTORY_TURNS = 8;
+
+    private const HISTORY_MESSAGE_BYTES = 800;
+
+    private const SKILL_BODY_BYTES = 12000;
+
+    private AiSessionRepository $sessions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sessions = new AiSessionRepository($this->getService(ConnectionPool::class));
+        $this->seedConfigurations();
+    }
+
+    #[Test]
+    public function aLongSessionWithALargeSkillBlockDropsTurnsInsteadOfOverflowing(): void
+    {
+        $sent = $this->runTurnAgainst('skill-budget-skilled');
+
+        // Turns were dropped from the send: 2 * n messages fewer than the
+        // 2 * HISTORY_TURNS history messages plus the new user turn.
+        self::assertLessThan(2 * self::HISTORY_TURNS + 1, count($sent));
+
+        // And it dropped ENOUGH: transcript plus the block the manager will
+        // inject now fits the window instead of overflowing it.
+        $estimator = new TranscriptEstimator();
+        $onTheWire = $estimator->estimate($sent, [], 1.15)
+            + $estimator->estimate([ChatMessage::user($this->composedBlockFor('skill-budget-skilled'))], [], 1.15);
+        self::assertLessThanOrEqual(self::EXPECTED_BUDGET, $onTheWire);
+    }
+
+    #[Test]
+    public function theSameTranscriptWithoutASkillBlockKeepsEveryTurn(): void
+    {
+        // The control: identical history, identical window — nothing is dropped
+        // when there is no block to make room for. Without it the first test
+        // would also pass on a manager that simply prunes too eagerly.
+        $sent = $this->runTurnAgainst('skill-budget-plain');
+
+        self::assertCount(2 * self::HISTORY_TURNS + 1, $sent);
+    }
+
+    #[Test]
+    public function theStoredHistoryIsNeverShortenedByTheFit(): void
+    {
+        $session = $this->openSeededSession('skill-budget-skilled');
+        $this->service()->send($this->actor(), $session['uuid'], 'and now?');
+
+        // Dropping applies to what the model sees, never to the audit record:
+        // the seeded history plus this turn's user and assistant rows.
+        self::assertCount(2 * self::HISTORY_TURNS + 2, $this->sessions->findMessages($session['uid']));
+    }
+
+    /**
+     * Run one turn against a seeded session and return what the provider saw.
+     *
+     * @return list<ChatMessage|array<string, mixed>>
+     */
+    private function runTurnAgainst(string $identifier): array
+    {
+        $session = $this->openSeededSession($identifier);
+        $sent    = [];
+
+        $this->service($sent)->send($this->actor(), $session['uuid'], 'and now?');
+
+        return $sent;
+    }
+
+    /**
+     * @param list<ChatMessage|array<string, mixed>> $sent captures what the provider was handed
+     */
+    private function service(array &$sent = []): ConversationService
+    {
+        $llmManager = $this->createMock(LlmServiceManagerInterface::class);
+        $llmManager->method('chatForConfiguration')->willReturnCallback(
+            static function (array $messages) use (&$sent): CompletionResponse {
+                $sent = $messages;
+
+                return new CompletionResponse('answered', 'test-model', UsageStatistics::fromTokens(5, 3));
+            },
+        );
+
+        return new ConversationService(
+            $llmManager,
+            $this->sessions,
+            new ConfigurationResolver($this->getService(LlmConfigurationRepository::class)),
+            new ContextWindowManager(),
+            null,
+            new SkillComposer(),
+        );
+    }
+
+    /**
+     * A session bound to the configuration, carrying a history long enough to
+     * fit the window on its own but not once the block is counted too.
+     *
+     * @return array{uid: int, uuid: string}
+     */
+    private function openSeededSession(string $identifier): array
+    {
+        $uuid = sprintf('%s-0000-4000-8000-000000000000', substr(md5($identifier), 0, 8));
+        $uid  = $this->sessions->startSession($uuid, 42, $identifier, 'long chat');
+
+        $sequence = 0;
+        for ($turn = 0; $turn < self::HISTORY_TURNS; ++$turn) {
+            $this->sessions->appendMessage($uid, $sequence++, 'user', str_repeat('u', self::HISTORY_MESSAGE_BYTES), '', 0, 0, 0);
+            $this->sessions->appendMessage($uid, $sequence++, 'assistant', str_repeat('a', self::HISTORY_MESSAGE_BYTES), 'test-model', 0, 0, 0);
+        }
+
+        $this->sessions->touch($uid, $sequence);
+
+        return ['uid' => $uid, 'uuid' => $uuid];
+    }
+
+    private function composedBlockFor(string $identifier): string
+    {
+        $configuration = $this->getService(LlmConfigurationRepository::class)->findOneByIdentifier($identifier);
+        self::assertInstanceOf(LlmConfiguration::class, $configuration);
+
+        $skills = [];
+        foreach ($configuration->getSkills() as $skill) {
+            $skills[] = $skill;
+        }
+
+        return (new SkillComposer())->composeBlock($skills, [])->block;
+    }
+
+    private function actor(): AiActorContext
+    {
+        return AiActorContext::backendUser(42);
+    }
+
+    /**
+     * Two configurations without a model relation (criteria mode, `model_uid`
+     * 0), one with a large skill attached and one without.
+     */
+    private function seedConfigurations(): void
+    {
+        $pool = $this->getService(ConnectionPool::class);
+
+        $pool->getConnectionForTable('tx_nrllm_configuration')->insert('tx_nrllm_configuration', [
+            'uid'                  => 620,
+            'pid'                  => 0,
+            'identifier'           => 'skill-budget-skilled',
+            'name'                 => 'Skilled conversation',
+            'model_uid'            => 0,
+            'model_selection_mode' => 'criteria',
+            'is_active'            => 1,
+            'skills'               => 1,
+        ]);
+        $pool->getConnectionForTable('tx_nrllm_configuration')->insert('tx_nrllm_configuration', [
+            'uid'                  => 621,
+            'pid'                  => 0,
+            'identifier'           => 'skill-budget-plain',
+            'name'                 => 'Plain conversation',
+            'model_uid'            => 0,
+            'model_selection_mode' => 'criteria',
+            'is_active'            => 1,
+            'skills'               => 0,
+        ]);
+
+        // Generated rather than kept in a fixture file: the body has to be big
+        // enough to matter against the 8192 fallback, and its checksum must
+        // match or the composer fails closed and drops it.
+        $body = str_repeat('Answer in short, verifiable sentences. ', (int)ceil(self::SKILL_BODY_BYTES / 38));
+        $pool->getConnectionForTable('tx_nrllm_skill')->insert('tx_nrllm_skill', [
+            'uid'           => 610,
+            'pid'           => 0,
+            'source'        => 1,
+            'identifier'    => 'cfg:budget',
+            'name'          => 'Budget Skill',
+            'body'          => $body,
+            'body_checksum' => hash('sha256', $body),
+            'enabled'       => 1,
+            'orphaned'      => 0,
+        ]);
+
+        $pool->getConnectionForTable('tx_nrllm_configuration_skill_mm')->insert('tx_nrllm_configuration_skill_mm', [
+            'uid_local'       => 620,
+            'uid_foreign'     => 610,
+            'sorting'         => 1,
+            'sorting_foreign' => 0,
+        ]);
+    }
+}

--- a/Tests/Unit/Service/Context/ContextWindowManagerTest.php
+++ b/Tests/Unit/Service/Context/ContextWindowManagerTest.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Service\Context\ContextWindowManager;
+use Netresearch\NrLlm\Service\Context\TranscriptEstimator;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -150,6 +151,93 @@ final class ContextWindowManagerTest extends TestCase
         self::assertFalse($result->overflowAtFloor);
         self::assertSame(0, $result->droppedTurns);
         self::assertSame($messages, $result->messages);
+    }
+
+    #[Test]
+    public function injectedTextIsChargedToTheEstimateWithoutJoiningTheMessages(): void
+    {
+        // The skill block is prepended into the send AFTER fit() returns, so it
+        // is on the wire without being in this list. Counting it shrinks the
+        // headroom by exactly its own estimate; the list itself is untouched.
+        $messages = [ChatMessage::system('sys'), ChatMessage::user('hi'), ...$this->turn('call_1', 'small')];
+        $block    = str_repeat('s', 4000);
+
+        $without = (new ContextWindowManager())->fit($messages, $this->config(128000), null, null);
+        $with    = (new ContextWindowManager())->fit($messages, $this->config(128000), null, null, [], $block);
+
+        $blockTokens = (new TranscriptEstimator())->estimate([ChatMessage::user($block)], [], 1.15);
+        self::assertGreaterThan(0, $blockTokens);
+        self::assertSame($without->budget, $with->budget);
+        self::assertSame($without->estimatedTokens + $blockTokens, $with->estimatedTokens);
+        self::assertSame($messages, $with->messages);
+    }
+
+    #[Test]
+    public function noInjectedTextLeavesTheCalculationExactlyAsItWas(): void
+    {
+        $messages = [ChatMessage::system('sys'), ChatMessage::user('hi'), ...$this->turn('call_1', str_repeat('x', 3000))];
+
+        $implicit = (new ContextWindowManager())->fit($messages, $this->config(4000), null, null);
+        $explicit = (new ContextWindowManager())->fit($messages, $this->config(4000), null, null, [], '');
+
+        self::assertSame($implicit->budget, $explicit->budget);
+        self::assertSame($implicit->estimatedTokens, $explicit->estimatedTokens);
+        self::assertSame($implicit->droppedTurns, $explicit->droppedTurns);
+        self::assertSame($implicit->messages, $explicit->messages);
+    }
+
+    #[Test]
+    public function aTranscriptThatFitsAloneIsPrunedOnceTheInjectedBlockCountsToo(): void
+    {
+        // The defect this guards (#625): an unknown context length falls back to
+        // 8192, and a skill block of a few thousand bytes is a large share of
+        // that budget. Unaccounted, the transcript "fits" and the send overflows.
+        $messages = [
+            ChatMessage::system('sys'),
+            ChatMessage::user('the task'),
+            ...$this->turn('call_1', str_repeat('a', 3000)),
+            ...$this->turn('call_2', str_repeat('b', 3000)),
+            ...$this->turn('call_3', str_repeat('c', 3000)),
+        ];
+
+        $alone = (new ContextWindowManager())->fit($messages, $this->config(0), null, null);
+        self::assertFalse($alone->pruned);
+        self::assertSame(0, $alone->droppedTurns);
+
+        $withBlock = (new ContextWindowManager())->fit($messages, $this->config(0), null, null, [], str_repeat('s', 12000));
+
+        self::assertTrue($withBlock->pruned);
+        self::assertGreaterThanOrEqual(1, $withBlock->droppedTurns);
+        // Dropping turns was enough — it prunes into the budget instead of
+        // handing the provider an oversized send.
+        self::assertFalse($withBlock->overflowAtFloor);
+        self::assertLessThanOrEqual($withBlock->budget, $withBlock->estimatedTokens);
+    }
+
+    #[Test]
+    public function theInjectedBlockIsAccountedForWithoutEnteringTheUndroppableHead(): void
+    {
+        // The block is prepended to the FIRST user message downstream, and
+        // partition() counts everything up to and including that message as the
+        // never-droppable head. Injecting it before the fit would grow the head
+        // by the block and pay for it with the whole history — and still
+        // overflow. fit() therefore accounts for it and leaves the list alone.
+        $messages = [
+            ChatMessage::system('the system prompt'),
+            ChatMessage::user('the task'),
+            ...$this->turn('call_1', str_repeat('y', 8000)),
+            ...$this->turn('call_2', str_repeat('y', 8000)),
+        ];
+
+        $result = (new ContextWindowManager())->fit($messages, $this->config(0), null, null, [], str_repeat('s', 20000));
+
+        $system = $result->messages[0];
+        $task   = $result->messages[1];
+        self::assertInstanceOf(ChatMessage::class, $system);
+        self::assertInstanceOf(ChatMessage::class, $task);
+        self::assertSame('system', $this->roleOf($system));
+        self::assertSame('user', $this->roleOf($task));
+        self::assertSame('the task', $this->contentOf($task));
     }
 
     /**

--- a/Tests/Unit/Service/Feature/ConversationServiceTest.php
+++ b/Tests/Unit/Service/Feature/ConversationServiceTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\Unit\Service\Feature;
 use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Skill;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
@@ -25,6 +26,7 @@ use Netresearch\NrLlm\Service\Context\ContextWindowManagerInterface;
 use Netresearch\NrLlm\Service\Feature\ConversationService;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
+use Netresearch\NrLlm\Service\Skill\SkillComposer;
 use Netresearch\NrLlm\Tests\Unit\Service\Session\Fixtures\RecordingAiSessionRepository;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -475,6 +477,102 @@ final class ConversationServiceTest extends TestCase
         $session = $service->startSession($actor, '', $configuration);
 
         self::assertSame('answered anyway', $service->send($actor, $session->uuid, 'a very long turn')->content);
+    }
+
+    #[Test]
+    public function theSkillBlockTheManagerWillInjectIsHandedToTheFit(): void
+    {
+        // The manager prepends the configuration's skill block to the first user
+        // message AFTER this fit (#625). Unless the fit is told about it, the
+        // budget binds a list that is never sent that way.
+        $repository    = new RecordingAiSessionRepository();
+        $configuration = $this->configuration('editorial');
+        $configuration->getSkills()->attach($this->skill('cfg:budget', 'Budget Skill', 'Answer in short sentences.'));
+
+        $injected      = null;
+        $contextWindow = $this->createMock(ContextWindowManagerInterface::class);
+        $contextWindow->method('fit')->willReturnCallback(
+            function (
+                array $messages,
+                LlmConfiguration $configuration,
+                ?ChatOptions $options,
+                ?UsageStatistics $lastUsage,
+                array $toolSpecs = [],
+                string $injectedText = '',
+            ) use (&$injected): ContextFitResult {
+                $injected = $injectedText;
+
+                return new ContextFitResult([ChatMessage::user('hi')], false, 0, 1, 10, 1000, false, 1.15);
+            },
+        );
+
+        $llmManager = $this->createMock(LlmServiceManagerInterface::class);
+        $llmManager->method('chatForConfiguration')->willReturn($this->response('ok'));
+
+        $service = new ConversationService(
+            $llmManager,
+            $repository,
+            $this->resolverReturning($configuration),
+            $contextWindow,
+            null,
+            new SkillComposer(),
+        );
+        $actor   = $this->owner();
+        $session = $service->startSession($actor, '', $configuration);
+        $service->send($actor, $session->uuid, 'hi');
+
+        self::assertIsString($injected);
+        self::assertStringContainsString('### Skill: Budget Skill', $injected);
+        self::assertStringContainsString('Answer in short sentences.', $injected);
+    }
+
+    #[Test]
+    public function withoutASkillComposerNothingIsReservedAndTheFitIsUnchanged(): void
+    {
+        $repository    = new RecordingAiSessionRepository();
+        $configuration = $this->configuration('editorial');
+        $configuration->getSkills()->attach($this->skill('cfg:budget', 'Budget Skill', 'Answer in short sentences.'));
+
+        $injected      = 'not called';
+        $contextWindow = $this->createMock(ContextWindowManagerInterface::class);
+        $contextWindow->method('fit')->willReturnCallback(
+            function (
+                array $messages,
+                LlmConfiguration $configuration,
+                ?ChatOptions $options,
+                ?UsageStatistics $lastUsage,
+                array $toolSpecs = [],
+                string $injectedText = '',
+            ) use (&$injected): ContextFitResult {
+                $injected = $injectedText;
+
+                return new ContextFitResult([ChatMessage::user('hi')], false, 0, 1, 10, 1000, false, 1.15);
+            },
+        );
+
+        $llmManager = $this->createMock(LlmServiceManagerInterface::class);
+        $llmManager->method('chatForConfiguration')->willReturn($this->response('ok'));
+
+        $service = new ConversationService($llmManager, $repository, $this->resolverReturning($configuration), $contextWindow);
+        $actor   = $this->owner();
+        $session = $service->startSession($actor, '', $configuration);
+        $service->send($actor, $session->uuid, 'hi');
+
+        self::assertSame('', $injected);
+    }
+
+    private function skill(string $identifier, string $name, string $body): Skill
+    {
+        $skill = new Skill();
+        $skill->setSource(1);
+        $skill->setIdentifier($identifier);
+        $skill->setName($name);
+        $skill->setBody($body);
+        $skill->setBodyChecksum(hash('sha256', $body));
+        $skill->setEnabled(true);
+        $skill->setOrphaned(false);
+
+        return $skill;
     }
 
     /**


### PR DESCRIPTION
## Description

`ConversationService::send()` computed the context budget and then dispatched through `LlmServiceManager::chatForConfiguration()`, which injects up to 24 kB of skill block **after** the fit. The budget bound a message list that was never sent that way.

Not a corner case: a criteria-mode configuration has `model_uid = 0`, so `getLlmModel()` is null and `fit()` always falls back to `UNKNOWN_WINDOW_FALLBACK = 8192`. A full block is ~7 900 estimated tokens against a budget of `8192 − 1000 reserve − 246 safety = 6 946`.

`ContextWindowManagerInterface::fit()` gains an optional trailing `string $injectedText` — payload that reaches the wire without being in the message list, the same shape `$toolSpecs` already has. `ConversationService` composes the block once and passes it.

### Deviation from the issue text — please read

The issue says "passes it as a **reserve**", i.e. deduct it from the budget. **That was wrong and is not what this does.**

For exactly the case the issue describes, a deduction pushes the budget non-positive (`6946 − 7896 < 0`), which trips the guard at `Classes/Service/Context/ContextWindowManager.php:78` and returns `passthrough()` — no pruning at all. The fix would have disabled pruning for precisely the class of run it exists for.

The block is therefore charged to the **estimate**, which is what the file already does for the system prompt `MessageShaper` prepends after `fit()`. Drop decisions, `overflowAtFloor` and the recalibration input are identical to a deduction except in that degenerate case; `budget` keeps meaning "window headroom" and `estimatedTokens` keeps meaning "what goes on the wire".

### What was deliberately not done

The injection was **not** moved before the fit. `SkillInjectionService::augmentMessages()` prepends to the *first user message*, and `ContextWindowManager::partition()` counts everything up to and including the first user turn as the never-droppable HEAD. Injecting before the fit would drop the entire history making room and still overflow.

### Known limits, named rather than papered over

- The null-configuration branch of `dispatch()` is not covered — there the manager resolves the installation default itself, and this service never learns which configuration that is.
- The block is composed twice per turn: once here for the estimate, once in the manager for the injection. Both go through the same shared `SkillComposer` DI service (`Configuration/Services.yaml:339`) with identical arguments (`composeBlock($configSkills, [])`), so they agree. Removing the second composition would mean restructuring the injection point, which is a larger change than this fix.

## Related Issue

Closes #625

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `composer ci` and all checks pass — unit, PHPStan (level 10), cgl, fuzzy and the new functional class re-run independently of the authoring pass: all SUCCESS. Rector was verified green under an 8.2 resolve, then the worktree was restored to 8.4; the two resolves cannot coexist locally and CI pins the Rector job to 8.2.
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation accordingly — docblocks; no user-facing doc change
- [x] I have added a `CHANGELOG.md` entry under `## [Unreleased]`
- [ ] I have added an ADR under `Documentation/Adr/` if this changes the public surface — not needed: `ContextWindowManagerInterface` carries no `@api` marker and is not in `Tests/Unit/Api/api-surface.txt`; `ConversationService` is in the snapshot but constructors are excluded from it by design
- [x] My changes generate no new warnings

### Tests

- unit (`ContextWindowManagerTest`): the block is charged exactly — budget untouched, estimate grows by exactly the block's estimate, message list untouched; an empty block is byte-identical to before (regression); a transcript that fits alone gets pruned once the block counts, and still fits after dropping; the block never enters the undroppable HEAD (guard against the rejected solution).
- unit (`ConversationServiceTest`): the composed block reaches `fit()`; without a composer, `''` is passed.
- functional (`ConversationSkillBudgetTest`, new): real DB session store, real MM-loaded skill, real composer, real `ContextWindowManager`, criteria-mode configuration. 8 seeded turns and a ~12 kB skill body → turns are dropped and the send stays under budget; a control configuration without skills keeps every turn; the stored history is never shortened.