### PR TITLE
fix(agent): fail closed on an unrecorded write approval and bind the reviewed turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The approval of a write is fail-closed and bound to the turn that was
+  reviewed** (ADR-132). Two defects on the same path:
+  `AgentRunPersister::recordApproval()` swallowed a store error and
+  `ResumeCoordinator::approve()` executed anyway, so a write could run with no
+  record of who authorised it; and the stale-review digest existed only in the
+  `AgentRunController`, so the Tool Playground could approve a turn it had never
+  displayed. `recordApproval()` now returns `bool` (same shape as
+  `recordStep()`), and `approve()` refuses to execute a turn declaring a write
+  whose decision could not be recorded. The verified digest moved into
+  `ApprovalDecision` and is compared — timing-safe — against the state loaded
+  AFTER the resume claim, so a decision made on a turn a concurrent approval
+  already replaced is refused as well. Read-only turns stay fail-soft
+  (deliberately), and a denial still passes: it executes nothing, so refusing it
+  would only leave the write pending. A refused decision RELEASES the run back
+  to `WAITING_FOR_APPROVAL` — nothing runs, nothing settles, the operator can
+  re-review and decide again. The playground's `awaiting_approval` payload and
+  streaming event now carry `turnDigest`, and `resumeAction()` reads it back.
+  **Breaking:** `ApprovalDecision`'s constructor takes a third argument,
+  `?string $turnDigest`. It is optional in the signature for source
+  compatibility but MANDATORY at runtime — a `null` is refused exactly like a
+  wrong digest, so any third-party caller that constructs the decision itself
+  must supply the digest of the turn it displayed or every approval will fail
+  with `StaleApprovalTurnException`. `WaitingRunViewFactory::pendingTurnDigest()`
+  is gone; the computation lives in the new `PendingTurnDigest` service.
+
 ## [0.26.0] - 2026-08-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   wrong digest, so any third-party caller that constructs the decision itself
   must supply the digest of the turn it displayed or every approval will fail
   with `StaleApprovalTurnException`. `WaitingRunViewFactory::pendingTurnDigest()`
-  is gone; the computation lives in the new `PendingTurnDigest` service.
+  and `WaitingRunViewFactory::turnDigestForRun()` are gone; the computation lives
+  in the new `PendingTurnDigest` service, and the rendered card is the only
+  carrier of the value. (Neither was tracked public API.)
+  A run whose `suspended_state` is already unreadable is still refused BEFORE
+  the resume claim, so it stays `WAITING_FOR_APPROVAL` with its state intact
+  instead of being claimed and settled `FAILED` — the guarded terminal settle
+  clears `suspended_state`, which would destroy the only copy a repair could
+  work from. The decode after the claim remains and now covers only the race it
+  is there for: the state CHANGED between the two reads and the row the claim
+  won is the unreadable one.
 
 ## [0.26.0] - 2026-08-06
 

--- a/Classes/Controller/Backend/AgentRunController.php
+++ b/Classes/Controller/Backend/AgentRunController.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Service\Agent\AgentRunResult;
 use Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface;
 use Netresearch\NrLlm\Service\Agent\ApprovalDecision;
+use Netresearch\NrLlm\Service\Agent\Exception\ApprovalNotAuditableException;
 use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
 use Netresearch\NrLlm\Service\Agent\Exception\InvalidInputSubmissionException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunAlreadyResumingException;
@@ -22,6 +23,7 @@ use Netresearch\NrLlm\Service\Agent\Exception\RunConfigurationGoneException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingApprovalException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingInputException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunStateUnavailableException;
+use Netresearch\NrLlm\Service\Agent\Exception\StaleApprovalTurnException;
 use Netresearch\NrLlm\Service\Agent\Inbox\WaitingRunViewFactory;
 use Netresearch\NrLlm\Service\Agent\InputSubmission;
 use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
@@ -110,33 +112,16 @@ final class AgentRunController extends ActionController
             return $this->redirect('list');
         }
 
-        // Stale-review guard: reload the CURRENT state and refuse to approve a
-        // turn the operator did not review (a stale tab or a second admin).
-        $run = $this->persister->findRun($runUuid);
-        if (!$run instanceof AgentRun) {
-            $this->flash('runs.flash.error', ContextualFeedbackSeverity::ERROR);
-
-            return $this->redirect('list');
-        }
-
-        $currentDigest = $this->viewFactory->turnDigestForRun($run);
-        if ($currentDigest === null) {
-            $this->flash('runs.unreadable', ContextualFeedbackSeverity::ERROR);
-
-            return $this->redirect('list');
-        }
-
-        if ($currentDigest !== $turnDigest) {
-            $this->flash('runs.error.staleReview', ContextualFeedbackSeverity::WARNING);
-
-            return $this->redirect('list');
-        }
-
         try {
+            // The stale-review guard is NOT re-implemented here (ADR-132): the
+            // digest the card carried travels with the decision and is verified
+            // against the freshly CLAIMED state inside the runtime. A check here
+            // would read the row before the claim and could pass on a turn the
+            // winner of a concurrent approval has already replaced.
             $result = $this->agentRuntime->approve(
                 $this->currentActor(),
                 $runUuid,
-                new ApprovalDecision($approve, $this->currentBackendUserUid()),
+                new ApprovalDecision($approve, $this->currentBackendUserUid(), $turnDigest),
             );
         } catch (RunNotAwaitingApprovalException) {
             return $this->flashRedirect('runs.flash.error', ContextualFeedbackSeverity::WARNING);
@@ -144,6 +129,11 @@ final class AgentRunController extends ActionController
             return $this->flashRedirect('runs.flash.configGone', ContextualFeedbackSeverity::ERROR);
         } catch (RunAlreadyResumingException) {
             return $this->flashRedirect('runs.flash.alreadyResuming', ContextualFeedbackSeverity::WARNING);
+        } catch (StaleApprovalTurnException) {
+            // The run was released, not consumed — re-review and decide again.
+            return $this->flashRedirect('runs.error.staleReview', ContextualFeedbackSeverity::WARNING);
+        } catch (ApprovalNotAuditableException) {
+            return $this->flashRedirect('runs.error.notAuditable', ContextualFeedbackSeverity::ERROR);
         } catch (CorruptSuspendedStateException|RunStateUnavailableException) {
             return $this->flashRedirect('runs.unreadable', ContextualFeedbackSeverity::ERROR);
         }

--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -28,6 +28,7 @@ use Netresearch\NrLlm\Service\Agent\AgentRunResult;
 use Netresearch\NrLlm\Service\Agent\AgentRuntime;
 use Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface;
 use Netresearch\NrLlm\Service\Agent\ApprovalDecision;
+use Netresearch\NrLlm\Service\Agent\Exception\ApprovalNotAuditableException;
 use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
 use Netresearch\NrLlm\Service\Agent\Exception\InvalidInputSubmissionException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunAlreadyResumingException;
@@ -35,7 +36,9 @@ use Netresearch\NrLlm\Service\Agent\Exception\RunConfigurationGoneException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingApprovalException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingInputException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunStateUnavailableException;
+use Netresearch\NrLlm\Service\Agent\Exception\StaleApprovalTurnException;
 use Netresearch\NrLlm\Service\Agent\InputSubmission;
+use Netresearch\NrLlm\Service\Agent\PendingTurnDigest;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Tool\RunAugmentation;
 use Netresearch\NrLlm\Service\Tool\ToolAvailabilityServiceInterface;
@@ -101,6 +104,9 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         private readonly ToolAvailabilityServiceInterface $toolAvailability,
         private readonly SkillRepository $skillRepository,
         private readonly PromptSnippetRepository $promptSnippetRepository,
+        // The ONE digest definition (ADR-132): the pause payload shows a turn,
+        // so it must also hand out the value that proves which turn was shown.
+        private readonly PendingTurnDigest $turnDigest,
     ) {}
 
     public function listAction(): ResponseInterface
@@ -229,17 +235,41 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
         $body     = $request->getParsedBody();
         $runUuid  = trim($this->stringFromBody($body, 'runUuid'));
         $approved = $this->boolFromBody($body, 'approve');
+        // The digest of the turn the caller was shown (ADR-132). Passed through
+        // verbatim; the runtime compares it against the claimed state. An empty
+        // body value becomes null, which the runtime refuses like a mismatch —
+        // a client that does not send it cannot approve.
+        $digest = trim($this->stringFromBody($body, 'turnDigest'));
 
         try {
             $result = $this->agentRuntime->approve(
                 $this->currentActor(),
                 $runUuid,
-                new ApprovalDecision($approved, $this->currentBackendUserUid()),
+                new ApprovalDecision($approved, $this->currentBackendUserUid(), $digest !== '' ? $digest : null),
             );
         } catch (RunNotAwaitingApprovalException) {
             return $this->respondJson(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.notAwaitingApproval', 'No run is awaiting approval for that id.')], 400);
         } catch (RunConfigurationGoneException) {
             return $this->respondJson(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.configGone', 'The run configuration no longer exists.')], 400);
+        } catch (StaleApprovalTurnException) {
+            // Retryable, like an invalid input submission: the run was released
+            // back to its approval pause, so re-signal awaiting_approval and let
+            // the client re-fetch and re-review the CURRENT turn.
+            return $this->respondJson([
+                'success' => false,
+                'status'  => 'awaiting_approval',
+                'runUuid' => $runUuid,
+                'error'   => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.staleApproval', 'The pending action changed since you viewed it — please re-review.'),
+            ], 409);
+        } catch (ApprovalNotAuditableException) {
+            // Nothing was executed and the run is decidable again; 503, because
+            // the obstacle is the audit store, not the request.
+            return $this->respondJson([
+                'success' => false,
+                'status'  => 'awaiting_approval',
+                'runUuid' => $runUuid,
+                'error'   => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.approvalNotAuditable', 'The decision could not be recorded, so this write was not executed. Please try again.'),
+            ], 503);
         } catch (CorruptSuspendedStateException|RunStateUnavailableException) {
             return $this->respondJson(['success' => false, 'error' => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.corruptState', 'The suspended run state could not be read.')], 500);
         } catch (RunAlreadyResumingException) {
@@ -371,7 +401,8 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
 
     /**
      * The JSON body for a run that suspended for approval: the pending tool calls
-     * the operator must approve, plus the steps recorded up to the pause.
+     * the operator must approve, the digest binding a later decision to exactly
+     * those calls (ADR-132), plus the steps recorded up to the pause.
      *
      * @return array<string, mixed>
      */
@@ -382,8 +413,22 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
             'status'       => 'awaiting_approval',
             'runUuid'      => $result->runUuid,
             'pendingTools' => $this->pendingTools($result),
+            'turnDigest'   => $this->turnDigestFor($result),
             'steps'        => array_map(static fn(RunStep $step): array => $step->toArray(), $result->steps),
         ];
+    }
+
+    /**
+     * The digest of the turn this pause is showing, or '' when the result
+     * carries no state (a suspension that failed to store never gets here, but
+     * the property is nullable). A client that echoes '' back is refused by the
+     * runtime exactly like a stale digest.
+     */
+    private function turnDigestFor(AgentRunResult $result): string
+    {
+        $state = $result->suspendedState;
+
+        return $state instanceof SuspendedRunState ? $this->turnDigest->forState($state) : '';
     }
 
     /**
@@ -524,6 +569,10 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
                     'success'      => true,
                     'runUuid'      => $result->runUuid,
                     'pendingTools' => $this->pendingTools($result),
+                    // The streamed pause carries the same binding as the batch
+                    // payload (ADR-132) — both surfaces show a turn, so both
+                    // must be able to prove which turn was shown.
+                    'turnDigest'   => $this->turnDigestFor($result),
                 ]);
 
                 return;

--- a/Classes/Service/Agent/AgentRuntime.php
+++ b/Classes/Service/Agent/AgentRuntime.php
@@ -122,7 +122,7 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         // Picks a suspended run back up on an approval or a submitted input
         // (ADR-084/105). Optional like the collaborators above; a null builds
         // one over the same persister, configuration repository, tool loop,
-        // executor and schema validator.
+        // executor, schema validator and effect resolver.
         private ?ResumeCoordinator $resumeCoordinator = null,
     ) {}
 
@@ -138,6 +138,7 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
             $this->toolLoop,
             $this->runExecutor(),
             $this->schemaValidator,
+            $this->toolEffectResolver,
         );
     }
 

--- a/Classes/Service/Agent/ApprovalDecision.php
+++ b/Classes/Service/Agent/ApprovalDecision.php
@@ -24,8 +24,25 @@ namespace Netresearch\NrLlm\Service\Agent;
  */
 final readonly class ApprovalDecision
 {
+    /**
+     * @param string|null $turnDigest the {@see PendingTurnDigest} of the turn the
+     *                                decider actually saw. It binds the decision
+     *                                to THAT turn: {@see ResumeCoordinator::approve()}
+     *                                recomputes the digest from the freshly
+     *                                claimed state and refuses a mismatch, so a
+     *                                stale tab — or a second decider whose
+     *                                approval already let the run suspend on a
+     *                                different turn — cannot authorise calls
+     *                                nobody reviewed (ADR-132). Optional in the
+     *                                SIGNATURE only, for source compatibility;
+     *                                a null is refused at runtime exactly like a
+     *                                wrong digest, because "no digest" and "the
+     *                                wrong digest" prove the same thing: the
+     *                                reviewed turn is not known.
+     */
     public function __construct(
         public bool $approved,
         public int $decidedByBeUser,
+        public ?string $turnDigest = null,
     ) {}
 }

--- a/Classes/Service/Agent/Exception/ApprovalNotAuditableException.php
+++ b/Classes/Service/Agent/Exception/ApprovalNotAuditableException.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent\Exception;
+
+/**
+ * A write-declaring turn was approved but the decision could not be recorded
+ * (ADR-132).
+ *
+ * {@see \Netresearch\NrLlm\Service\Tool\AgentRunPersister::recordApproval()} is
+ * fail-soft by default — a store hiccup on a read-only turn is logged and the
+ * run continues. That is unacceptable when the turn declares a write: executing
+ * it would change state on an authority no one can later point to. The write
+ * STEP is already fail-closed ({@see AuditPersistenceFailedException}); this
+ * closes the decision that authorised it.
+ *
+ * Thrown BEFORE any execution and after the run has been released back to
+ * WAITING_FOR_APPROVAL, so nothing ran and the decision can be retried once the
+ * store recovers.
+ */
+final class ApprovalNotAuditableException extends AgentRuntimeException
+{
+    public static function forRun(string $runUuid): self
+    {
+        return new self($runUuid, sprintf(
+            'The approval of a write-declaring turn could not be recorded; the run was released instead of executing over an unaudited decision. (run %s)',
+            $runUuid !== '' ? $runUuid : 'unknown',
+        ));
+    }
+}

--- a/Classes/Service/Agent/Exception/StaleApprovalTurnException.php
+++ b/Classes/Service/Agent/Exception/StaleApprovalTurnException.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent\Exception;
+
+/**
+ * The decision does not name the turn it was made on, or names a different one
+ * (ADR-132).
+ *
+ * Thrown by approve() AFTER the claim, when the digest carried by the
+ * {@see \Netresearch\NrLlm\Service\Agent\ApprovalDecision} is null or does not
+ * match the freshly loaded state's pending calls. A missing digest and a wrong
+ * digest are the same fact — the reviewed turn is not known — so both fail
+ * closed here rather than one of them being waved through.
+ *
+ * The run is released back to WAITING_FOR_APPROVAL before this is thrown: the
+ * decision was refused, not consumed, and the operator can re-review the CURRENT
+ * turn and decide again.
+ */
+final class StaleApprovalTurnException extends AgentRuntimeException
+{
+    public static function forRun(string $runUuid): self
+    {
+        return new self($runUuid, sprintf(
+            "The approval does not match the run's current pending turn; it was reviewed against a different (or no) turn. (run %s)",
+            $runUuid !== '' ? $runUuid : 'unknown',
+        ));
+    }
+}

--- a/Classes/Service/Agent/Inbox/WaitingRunViewFactory.php
+++ b/Classes/Service/Agent/Inbox/WaitingRunViewFactory.php
@@ -67,23 +67,6 @@ final readonly class WaitingRunViewFactory
     }
 
     /**
-     * The current pending-turn digest for a freshly-loaded run, or null when its
-     * state is unreadable or it is not an approval pause. The rendered card
-     * carries this value back with the decision, and
-     * {@see \Netresearch\NrLlm\Service\Agent\ResumeCoordinator::approve()}
-     * recomputes it from the claimed state and refuses a mismatch (ADR-132).
-     */
-    public function turnDigestForRun(AgentRun $run): ?string
-    {
-        $state = $this->decodeState($run);
-        if (!$state instanceof SuspendedRunState || $state->inputToolName !== null) {
-            return null;
-        }
-
-        return $this->digest->forState($state);
-    }
-
-    /**
      * The current input schema for a freshly-loaded run, or null when its state
      * is unreadable, it is not an input pause, or the schema cannot be rendered
      * as a form. The controller coerces the POST against THIS (current) schema

--- a/Classes/Service/Agent/Inbox/WaitingRunViewFactory.php
+++ b/Classes/Service/Agent/Inbox/WaitingRunViewFactory.php
@@ -12,22 +12,28 @@ namespace Netresearch\NrLlm\Service\Agent\Inbox;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Service\Agent\PendingTurnDigest;
 use Netresearch\NrLlm\Service\Tool\SchemaPropertyClassifier;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 
 /**
  * Turns persisted {@see AgentRun}s into the logic-free view models the approvals
- * inbox renders (ADR-109). All defensive decoding of the suspended-state blob,
- * the schema-to-field flattening and the stale-review turn digest live here, so
- * the Fluid template contains no logic and every branch is unit-testable without
- * an HTTP request.
+ * inbox renders (ADR-109). All defensive decoding of the suspended-state blob
+ * and the schema-to-field flattening live here, so the Fluid template contains
+ * no logic and every branch is unit-testable without an HTTP request. The turn
+ * digest a card carries is NOT computed here: it comes from
+ * {@see PendingTurnDigest}, the single definition the resume path verifies
+ * against (ADR-132).
  */
 final readonly class WaitingRunViewFactory
 {
     public function __construct(
         private ToolRegistry $registry,
         private SchemaPropertyClassifier $classifier,
+        // The ONE digest definition (ADR-132), shared with ResumeCoordinator so
+        // the value rendered here and the value verified there cannot drift.
+        private PendingTurnDigest $digest,
     ) {}
 
     /**
@@ -61,25 +67,11 @@ final readonly class WaitingRunViewFactory
     }
 
     /**
-     * The digest of a suspended run's pending turn — a stable hash of the pending
-     * tool calls the operator reviewed. The controller recomputes this from the
-     * freshly-loaded current state and refuses to approve on a mismatch, so a
-     * stale tab (or a second admin) cannot authorize a turn the operator never
-     * saw (ADR-109 stale-review guard). Same method on both paths ⇒ identical
-     * digest for identical pending calls.
-     */
-    public function pendingTurnDigest(SuspendedRunState $state): string
-    {
-        $json = json_encode($state->pendingCalls, JSON_INVALID_UTF8_SUBSTITUTE);
-
-        return hash('sha256', $json !== false ? $json : serialize($state->pendingCalls));
-    }
-
-    /**
      * The current pending-turn digest for a freshly-loaded run, or null when its
-     * state is unreadable or it is not an approval pause. The controller compares
-     * this against the digest the operator reviewed and refuses a stale approval
-     * on a mismatch (ADR-109 stale-review guard).
+     * state is unreadable or it is not an approval pause. The rendered card
+     * carries this value back with the decision, and
+     * {@see \Netresearch\NrLlm\Service\Agent\ResumeCoordinator::approve()}
+     * recomputes it from the claimed state and refuses a mismatch (ADR-132).
      */
     public function turnDigestForRun(AgentRun $run): ?string
     {
@@ -88,7 +80,7 @@ final readonly class WaitingRunViewFactory
             return null;
         }
 
-        return $this->pendingTurnDigest($state);
+        return $this->digest->forState($state);
     }
 
     /**
@@ -149,7 +141,7 @@ final readonly class WaitingRunViewFactory
             mode: WaitingRunView::MODE_APPROVAL,
             createdAt: $run->crdate,
             configLabel: $this->configLabel($run),
-            turnDigest: $this->pendingTurnDigest($state),
+            turnDigest: $this->digest->forState($state),
             pendingCalls: $calls,
         );
     }

--- a/Classes/Service/Agent/PendingTurnDigest.php
+++ b/Classes/Service/Agent/PendingTurnDigest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent;
+
+use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
+
+/**
+ * The digest that binds an approval decision to the turn the operator reviewed
+ * (ADR-132).
+ *
+ * A stable hash over a suspended run's pending tool calls. The reviewing surface
+ * renders it alongside the calls, the decision carries it back, and
+ * {@see ResumeCoordinator::approve()} recomputes it from the freshly-claimed
+ * state and refuses a mismatch — so a stale tab, or a second operator whose
+ * approval already let the run suspend on a DIFFERENT turn, cannot authorize a
+ * turn nobody looked at.
+ *
+ * ONE definition, deliberately: the digest is a comparison, and two
+ * implementations that drift apart would silently compare unequal things. The
+ * hash covers the pending calls only — the transcript and the counters change
+ * on every round and would make every digest stale.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
+final readonly class PendingTurnDigest
+{
+    /**
+     * The sha256 of a suspended state's pending calls. `serialize()` is the
+     * fallback for the (unreachable in practice) case of an unencodable value,
+     * so the method always yields a comparable digest instead of an empty hash.
+     */
+    public function forState(SuspendedRunState $state): string
+    {
+        $json = json_encode($state->pendingCalls, JSON_INVALID_UTF8_SUBSTITUTE);
+
+        return hash('sha256', $json !== false ? $json : serialize($state->pendingCalls));
+    }
+}

--- a/Classes/Service/Agent/ResumeCoordinator.php
+++ b/Classes/Service/Agent/ResumeCoordinator.php
@@ -224,9 +224,13 @@ final readonly class ResumeCoordinator
         /** @var array<string, mixed> $decoded */
         $state = SuspendedRunState::fromArray($decoded);
 
-        // Gate 1 — the decision must name THIS turn. hash_equals, not !==: the
-        // digest is attacker-supplied and compared against a server secret-ish
-        // value, and a timing-safe comparison costs nothing here.
+        // Gate 1 — the decision must name THIS turn. hash_equals rather than
+        // !== because comparing digests is what it is for, not because the
+        // digest is a secret: it is a sha256 of the pending calls and the card
+        // renders it, so anyone who can see the turn can compute it. What this
+        // catches is STALENESS — a tab left open, or a second operator whose
+        // approval already let the run suspend on a different turn — not
+        // forgery.
         $current = $this->turnDigest()->forState($state);
         if ($decision->turnDigest === null || !hash_equals($current, $decision->turnDigest)) {
             $this->release($handle, $state, $runUuid);

--- a/Classes/Service/Agent/ResumeCoordinator.php
+++ b/Classes/Service/Agent/ResumeCoordinator.php
@@ -12,12 +12,15 @@ namespace Netresearch\NrLlm\Service\Agent;
 use Closure;
 use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
 use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
+use Netresearch\NrLlm\Domain\Enum\ToolEffect;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
+use Netresearch\NrLlm\Service\Agent\Exception\ApprovalNotAuditableException;
 use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
 use Netresearch\NrLlm\Service\Agent\Exception\InvalidInputSubmissionException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunAccessDeniedException;
@@ -26,11 +29,13 @@ use Netresearch\NrLlm\Service\Agent\Exception\RunConfigurationGoneException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingApprovalException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingInputException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunStateUnavailableException;
+use Netresearch\NrLlm\Service\Agent\Exception\StaleApprovalTurnException;
 use Netresearch\NrLlm\Service\Schema\JsonSchemaValidator;
 use Netresearch\NrLlm\Service\Tool\AgentRunHandle;
 use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
 use Netresearch\NrLlm\Service\Tool\InputSchema;
 use Netresearch\NrLlm\Service\Tool\RunTrace;
+use Netresearch\NrLlm\Service\Tool\ToolEffectResolver;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface;
 use RuntimeException;
@@ -44,7 +49,10 @@ use RuntimeException;
  * claim so a second caller cannot resume the same run, then re-resolve the
  * event-stream position from a FRESH row — the claim moved it. A position that
  * cannot be resolved after the claim settles the run rather than leaving it
- * RUNNING with nowhere to write.
+ * RUNNING with nowhere to write. Since ADR-132 the approval path reads its
+ * SUSPENDED STATE from that fresh row too, not from the pre-claim read: a lost
+ * race lets the run suspend again on a different turn, and the pre-claim copy
+ * would be the previous one.
  *
  * The one deliberate divergence is ADR-105's: a submitted input is validated
  * against the tool's declared schema BEFORE anything is probed or claimed, so a
@@ -67,15 +75,59 @@ final readonly class ResumeCoordinator
         // (ADR-105). A null falls back to a fresh stateless validator;
         // submitInput() always validates.
         private ?JsonSchemaValidator $schemaValidator = null,
+        // Classifies the pending turn's calls so an unrecorded approval fails
+        // closed only where it must (ADR-132). Optional for the positional test
+        // wiring, like the validator above; production autowires it. A null
+        // resolver classifies EVERY turn as writing — the opposite of
+        // AgentRunExecutor's null arm, and deliberately so: there the null means
+        // "no write fence at all", here it would mean "waive the audit
+        // requirement", and this guard only ever fires when the audit write
+        // already failed.
+        private ?ToolEffectResolver $toolEffectResolver = null,
+        // The ONE digest definition (ADR-132), shared with the inbox view
+        // factory so what is rendered and what is verified cannot drift.
+        private ?PendingTurnDigest $turnDigest = null,
     ) {}
 
     /**
-     * Resume a run waiting on an approval decision (ADR-084).
+     * Resume a run waiting on an approval decision (ADR-084 / ADR-132).
      *
      * Claims first — an approval has nothing to validate — then continues the
      * tool loop under the run OWNER's identity. Throws rather than returning a
      * failed result when the run is not resumable: the caller distinguishes
-     * "wrong state", "not yours", "already resuming" and "corrupt state".
+     * "wrong state", "not yours", "already resuming", "corrupt state", "you
+     * reviewed a different turn" and "the decision could not be recorded".
+     *
+     * The state that is resumed is the one loaded AFTER the claim, never the one
+     * read before it. Lose the race and the run does not simply stay put: the
+     * winner runs the turn, the loop continues, and the run can suspend AGAIN on
+     * a DIFFERENT turn — which is exactly the row our claim then succeeds on.
+     * The pre-claim read would be the previous turn, so the digest check, the
+     * write classification and the execution all have to use the fresh state or
+     * they judge a turn that is no longer pending.
+     *
+     * Two fail-closed gates sit between the claim and the execution, and both
+     * RELEASE the run (suspend it back to WAITING_FOR_APPROVAL, which clears the
+     * claim and the lease and writes the state back) rather than settling it:
+     * the decision was refused, nothing ran, and the operator can decide again.
+     *
+     * 1. The decision must name the turn it was made on. A null digest and a
+     *    mismatching digest both mean "the reviewed turn is not known", so both
+     *    are refused. This is the ONLY place the invariant lives — the surfaces
+     *    just carry the value through.
+     * 2. An approval whose APPROVAL event could not be stored may not execute
+     *    a turn that declares a write. A read-only turn
+     *    stays fail-soft (logged, and it continues): the audit gap is real but
+     *    nothing changes state, and refusing would strand a harmless run.
+     *
+     * A DENIAL passes gate 1 — it is a decision on a turn like any other, and
+     * denying a turn the operator never saw is exactly as wrong as approving it
+     * — but deliberately NOT gate 2. Gate 2 exists to stop an unaudited WRITE
+     * from executing; a denial executes nothing, so there is nothing to stop.
+     * Refusing it would only leave the write-declaring turn pending and
+     * approvable while the operator who wanted it gone is turned away — a worse
+     * state than a logged, unrecorded "no". The "who denied" record is still
+     * lost, which is why the failure is logged rather than silent.
      *
      * @param (Closure(RunStep): void)|null $onStep
      */
@@ -94,14 +146,6 @@ final readonly class ResumeCoordinator
         if ($configuration === null) {
             throw RunConfigurationGoneException::forRun($runUuid);
         }
-
-        $decoded = json_decode($run->suspendedState, true);
-        if (!is_array($decoded)) {
-            throw CorruptSuspendedStateException::forRun($runUuid);
-        }
-
-        /** @var array<string, mixed> $decoded */
-        $state = SuspendedRunState::fromArray($decoded);
 
         // Probe the event-stream position BEFORE the claim: a failure here
         // refuses the resume while the run is still WAITING_FOR_APPROVAL, so
@@ -125,7 +169,7 @@ final readonly class ResumeCoordinator
         // run rather than stranding it RUNNING (fail-closed either way).
         $claimed = $this->persister->findRun($runUuid);
         $handle  = $claimed instanceof AgentRun ? $this->persister->resumeHandle($claimed) : null;
-        if (!$handle instanceof AgentRunHandle) {
+        if (!$claimed instanceof AgentRun || !$handle instanceof AgentRunHandle) {
             $this->persister->settleFailed(
                 new AgentRunHandle($run->uid, $run->uuid),
                 new RuntimeException('The event-stream position could not be determined after the resume claim'),
@@ -134,9 +178,43 @@ final readonly class ResumeCoordinator
             throw RunStateUnavailableException::forRun($runUuid);
         }
 
-        // The decision is part of the run's audit stream (best-effort, ADR-101):
-        // who approved or denied, before the continuation's own events.
-        $this->persister->recordApproval($handle, $decision->approved, $decision->decidedByBeUser);
+        // Decode the state the run is ACTUALLY suspended on, from that same
+        // fresh row. Corrupt here means the run cannot continue and cannot be
+        // released either — settle it rather than leave it RUNNING with a
+        // won claim and nowhere to go.
+        $decoded = $claimed->suspendedState !== null ? json_decode($claimed->suspendedState, true) : null;
+        if (!is_array($decoded)) {
+            $this->persister->settleFailed(
+                $handle,
+                new RuntimeException('The suspended run state could not be decoded after the resume claim'),
+            );
+
+            throw CorruptSuspendedStateException::forRun($runUuid);
+        }
+
+        /** @var array<string, mixed> $decoded */
+        $state = SuspendedRunState::fromArray($decoded);
+
+        // Gate 1 — the decision must name THIS turn. hash_equals, not !==: the
+        // digest is attacker-supplied and compared against a server secret-ish
+        // value, and a timing-safe comparison costs nothing here.
+        $current = $this->turnDigest()->forState($state);
+        if ($decision->turnDigest === null || !hash_equals($current, $decision->turnDigest)) {
+            $this->release($handle, $state, $runUuid);
+
+            throw StaleApprovalTurnException::forRun($runUuid);
+        }
+
+        // Gate 2 — the decision is part of the run's audit stream (ADR-101):
+        // who approved or denied, before the continuation's own events. An
+        // approval that authorises a write and could not be recorded does not
+        // execute.
+        $recorded = $this->persister->recordApproval($handle, $decision->approved, $decision->decidedByBeUser);
+        if (!$recorded && $decision->approved && $this->turnDeclaresWrite($state)) {
+            $this->release($handle, $state, $runUuid);
+
+            throw ApprovalNotAuditableException::forRun($runUuid);
+        }
 
         // Tools resume under the RUN OWNER's identity (ADR-083), not whoever is
         // approving: the owner is who the queued work acts for. Reconstructed
@@ -157,6 +235,61 @@ final readonly class ResumeCoordinator
                 $decision->decidedByBeUser,
             ),
         );
+    }
+
+    /**
+     * Hand a claimed run back to the operator: the existing RUNNING ->
+     * WAITING_FOR_APPROVAL transition, which clears the claim and the lease and
+     * writes the (unchanged) state back, so the run is decidable again.
+     *
+     * A release that itself fails would leave the run RUNNING with no worker —
+     * invisible to the inbox and to the stale-run reaper alike — so that case
+     * settles it failed instead. Either way nothing was executed.
+     */
+    private function release(AgentRunHandle $handle, SuspendedRunState $state, string $runUuid): void
+    {
+        if ($this->persister->suspend($handle, $state)) {
+            return;
+        }
+
+        $this->persister->settleFailed(
+            $handle,
+            new RuntimeException(sprintf('Run %s could not be released back to its approval pause after a refused decision', $runUuid !== '' ? $runUuid : 'unknown')),
+        );
+    }
+
+    /**
+     * Whether the pending turn contains at least one call that DECLARES a write
+     * (ADR-111 effects).
+     *
+     * Fail-closed twice over: an unknown tool name resolves to
+     * NON_IDEMPOTENT_WRITE inside {@see ToolEffectResolver::effectFor()}, and an
+     * entry too corrupt to yield a call at all is counted as a write here —
+     * an unclassifiable call is the dangerous case, not the harmless one.
+     * {@see ToolCall::tryFromArray()} rather than
+     * {@see SuspendedRunState::toolCalls()} for exactly that reason: toolCalls()
+     * throws on a corrupt entry, and this guard must return a verdict, not
+     * escalate a classification problem into an uncaught error on a claimed run.
+     */
+    private function turnDeclaresWrite(SuspendedRunState $state): bool
+    {
+        foreach ($state->pendingCalls as $raw) {
+            $call = ToolCall::tryFromArray($raw);
+            if (!$call instanceof ToolCall) {
+                return true;
+            }
+
+            if (($this->toolEffectResolver?->effectFor($call->name) ?? ToolEffect::NON_IDEMPOTENT_WRITE)->isWrite()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function turnDigest(): PendingTurnDigest
+    {
+        return $this->turnDigest ?? new PendingTurnDigest();
     }
 
     /**

--- a/Classes/Service/Agent/ResumeCoordinator.php
+++ b/Classes/Service/Agent/ResumeCoordinator.php
@@ -45,14 +45,17 @@ use RuntimeException;
  * input (ADR-105).
  *
  * Both follow the same claim protocol, and the order in it is the safety
- * property: probe that a resume handle can be built at all, win the atomic
- * claim so a second caller cannot resume the same run, then re-resolve the
- * event-stream position from a FRESH row — the claim moved it. A position that
- * cannot be resolved after the claim settles the run rather than leaving it
- * RUNNING with nowhere to write. Since ADR-132 the approval path reads its
- * SUSPENDED STATE from that fresh row too, not from the pre-claim read: a lost
- * race lets the run suspend again on a different turn, and the pre-claim copy
- * would be the previous one.
+ * property: refuse what can be refused without touching the row, probe that a
+ * resume handle can be built at all, win the atomic claim so a second caller
+ * cannot resume the same run, then re-resolve the event-stream position from a
+ * FRESH row — the claim moved it. A position that cannot be resolved after the
+ * claim settles the run rather than leaving it RUNNING with nowhere to write.
+ * Since ADR-132 the approval path reads the SUSPENDED STATE it executes from
+ * that fresh row, not from the pre-claim read: a lost race lets the run suspend
+ * again on a different turn, and the pre-claim copy would be the previous one.
+ * It still DECODES the pre-claim copy first, purely to reject a row that was
+ * already unreadable, because that rejection can be non-destructive and the
+ * post-claim one cannot.
  *
  * The one deliberate divergence is ADR-105's: a submitted input is validated
  * against the tool's declared schema BEFORE anything is probed or claimed, so a
@@ -106,6 +109,15 @@ final readonly class ResumeCoordinator
      * write classification and the execution all have to use the fresh state or
      * they judge a turn that is no longer pending.
      *
+     * The state is nevertheless DECODED twice, and the two decodes answer
+     * different questions. The pre-claim one asks "was this row readable when we
+     * found it" and refuses without claiming, so a row corrupted outside the
+     * extension stays WAITING_FOR_APPROVAL with its blob intact. The post-claim
+     * one asks "is the row we actually won readable" and must settle the run on
+     * a no, because by then the claim is held. Dropping the first would make the
+     * ordinary corrupt-row case terminal and erase the evidence with it;
+     * dropping the second would let the race resume an unverified turn.
+     *
      * Two fail-closed gates sit between the claim and the execution, and both
      * RELEASE the run (suspend it back to WAITING_FOR_APPROVAL, which clears the
      * claim and the lease and writes the state back) rather than settling it:
@@ -147,6 +159,19 @@ final readonly class ResumeCoordinator
             throw RunConfigurationGoneException::forRun($runUuid);
         }
 
+        // Reject an already-unreadable state BEFORE the claim, and do not carry
+        // the result forward — the decode after the claim is the authoritative
+        // one. This one exists so the common case (the row was corrupt before
+        // anyone clicked) is refused non-destructively: nothing is claimed, the
+        // run stays WAITING_FOR_APPROVAL and its suspended_state survives for
+        // repair. Without it the first Approve claims the run and the post-claim
+        // decode settles it FAILED, and settling clears suspended_state — the
+        // very blob a repair would need (compare AgentRunExecutor's rule against
+        // flipping a resumable run to FAILED and destroying its state).
+        if (!is_array(json_decode($run->suspendedState, true))) {
+            throw CorruptSuspendedStateException::forRun($runUuid);
+        }
+
         // Probe the event-stream position BEFORE the claim: a failure here
         // refuses the resume while the run is still WAITING_FOR_APPROVAL, so
         // the approval can simply be retried (nothing was claimed or executed).
@@ -179,9 +204,13 @@ final readonly class ResumeCoordinator
         }
 
         // Decode the state the run is ACTUALLY suspended on, from that same
-        // fresh row. Corrupt here means the run cannot continue and cannot be
-        // released either — settle it rather than leave it RUNNING with a
-        // won claim and nowhere to go.
+        // fresh row. The pre-claim decode already refused a row that was corrupt
+        // when we read it, so what is left here is the race: the state CHANGED
+        // between the two reads (a lost race let another approval run the turn
+        // and the run suspended again) and the new one is unreadable. Corrupt at
+        // this point means the run cannot continue and cannot be released either
+        // — an unreadable state cannot be written back — so settle it rather
+        // than leave it RUNNING with a won claim and nowhere to go.
         $decoded = $claimed->suspendedState !== null ? json_decode($claimed->suspendedState, true) : null;
         if (!is_array($decoded)) {
             $this->persister->settleFailed(

--- a/Classes/Service/Tool/AgentRunPersister.php
+++ b/Classes/Service/Tool/AgentRunPersister.php
@@ -31,12 +31,15 @@ use Throwable;
  * uses to stream steps, so persistence is purely additive — the tool loop is
  * untouched and unaware of it.
  *
- * Every method is fail-soft: a persistence error is logged and swallowed so a
- * database hiccup can never break an otherwise-successful run. {@see self::begin()}
- * returns null on failure, which the caller treats as "do not record" — exactly
- * as a null {@see RunTrace} callback would. {@see self::recordStep()} still never
- * throws, but returns whether it persisted so the runtime can fail-close a
- * WRITING tool's audit step (ADR-111) while leaving read-only steps fail-soft.
+ * No method throws: a persistence error is logged and swallowed so a database
+ * hiccup can never break an otherwise-successful run. Whether that is fail-SOFT
+ * is the caller's decision, and two methods hand it the evidence to decide.
+ * {@see self::begin()} returns null on failure, which the caller treats as "do
+ * not record" — exactly as a null {@see RunTrace} callback would.
+ * {@see self::recordStep()} and {@see self::recordApproval()} return whether
+ * they persisted, so the runtime can fail-close a WRITING tool's audit step
+ * (ADR-111) and the approval that authorised it (ADR-132) while leaving
+ * read-only steps and read-only turns fail-soft.
  *
  * What a step actually stores is governed by the central privacy level via
  * {@see RunStepPrivacyFilter}: metadata-only by default, so persistence does not
@@ -489,10 +492,17 @@ final readonly class AgentRunPersister
     /**
      * Persist an operator's approval decision as the next event in the run's
      * stream (ADR-101): kind {@see AgentEventKind::APPROVAL}, payload
-     * ``{approved, decidedBy}``. Best-effort like every event write — a failure
-     * is logged, never blocks the decided continuation.
+     * ``{approved, decidedBy}``.
+     *
+     * Returns whether the decision was durably persisted. The store hiccup is
+     * still logged and swallowed here (this method never throws), same shape as
+     * {@see self::recordStep()}, but the boolean lets the caller fail closed on
+     * the decision that AUTHORISES a write: {@see \Netresearch\NrLlm\Service\Agent\ResumeCoordinator::approve()}
+     * refuses to execute a write-declaring turn whose approval could not be
+     * recorded (ADR-132). A read-only turn's caller ignores the result,
+     * preserving the fail-soft behaviour of the rest of this class.
      */
-    public function recordApproval(AgentRunHandle $handle, bool $approved, int $decidedByBeUser): void
+    public function recordApproval(AgentRunHandle $handle, bool $approved, int $decidedByBeUser): bool
     {
         try {
             $payload = json_encode(
@@ -508,8 +518,12 @@ final readonly class AgentRunPersister
                 $payload,
             );
             ++$handle->sequence;
+
+            return true;
         } catch (Throwable $exception) {
             $this->logger?->warning('AgentRun approval decision could not be persisted', ['exception' => $exception]);
+
+            return false;
         }
     }
 

--- a/Documentation/Adr/Adr109AgentRunsApprovalsInbox.rst
+++ b/Documentation/Adr/Adr109AgentRunsApprovalsInbox.rst
@@ -6,7 +6,7 @@
 ADR-109: Agent Runs approvals inbox (backend module)
 ============================================================================
 
-:Status: Accepted
+:Status: Accepted (stale-review binding superseded by :ref:`ADR-132 <adr-132>`)
 :Date: 2026-07-22
 :Authors: Netresearch DTT GmbH
 
@@ -69,16 +69,25 @@ Four non-negotiable correctness/security properties
    schema with at least one property; anything else is classified ``unreadable``
    and shows a fail-closed notice, never an empty ``<form>``.
 
-3. **Stale-review binding.** ``approve()`` binds only to the run uuid and reloads
-   whatever suspended state is CURRENT — a deny/continuation can re-suspend the
-   SAME run with a NEW pending turn, so a stale tab (or a second admin) could
-   authorize a call the operator never reviewed. The reviewed turn's digest (a
-   SHA-256 of the pending calls) travels as a hidden field; the controller
-   recomputes it from the freshly-loaded current state and refuses ``approve()``
-   on a mismatch, re-rendering "the pending action changed, please re-review".
-   The narrow check→approve window is consciously accepted; eliminating it
-   entirely would require a runtime change to ``ApprovalDecision`` and is out of
-   scope.
+3. **Stale-review binding.** *(superseded — see the ADR-132 paragraph below)*
+   ``approve()`` binds only to the run uuid and reloads whatever suspended state
+   is CURRENT — a deny/continuation can re-suspend the SAME run with a NEW
+   pending turn, so a stale tab (or a second admin) could authorize a call the
+   operator never reviewed. The reviewed turn's digest (a SHA-256 of the pending
+   calls) travels as a hidden field; the controller recomputes it from the
+   freshly-loaded current state and refuses ``approve()`` on a mismatch,
+   re-rendering "the pending action changed, please re-review". The narrow
+   check→approve window is consciously accepted; eliminating it entirely would
+   require a runtime change to ``ApprovalDecision`` and is out of scope.
+
+   ADR-132 took that runtime change and closed the window. The digest still
+   travels from the card, but the controller no longer verifies it: it hands the
+   value to ``ApprovalDecision`` and the verification happens inside
+   ``ResumeCoordinator::approve()`` against the state the resume CLAIM won. The
+   controller-side check is gone — it read the row before the claim, so it could
+   pass on a turn a concurrent approval had already replaced. A missing digest is
+   refused exactly like a mismatching one, which also closes the Tool Playground
+   endpoint that this ADR left unbound.
 
 4. **Honest load errors.** The two new persister queries return ``null`` strictly
    on a store error (an empty list only when there genuinely are none), so a DB
@@ -119,9 +128,11 @@ Consequences
   (``findAwaiting`` / ``findRecentTerminal``) and their fail-soft persister
   wrappers, Fluid templates/partials, the ``nrllm_runs`` module + icon + EN/DE
   XLIFF, and an enhancement JS module.
-- No change to ``AgentRuntime``, ``ApprovalDecision``, ``InputSubmission`` or the
-  DB schema/indexes — the existing ``status_lookup(status, crdate)`` index serves
-  the inbox queries.
+- No change to ``AgentRuntime``, ``InputSubmission`` or the DB schema/indexes —
+  the existing ``status_lookup(status, crdate)`` index serves the inbox queries.
+  ``ApprovalDecision`` was in this list too; :ref:`ADR-132 <adr-132>` gave it a
+  third constructor parameter (``?string $turnDigest``) to carry the reviewed
+  turn into the runtime *(superseded)*.
 - Non-goals: no run detail/inspector page, no cancel control, no
   pagination/filter/search, no per-call approval verdicts (approval is
   turn-level), no nested-object input widget (rendered "unsupported"), no JSON

--- a/Documentation/Adr/Adr132ApprovalAuditAndTurnBinding.rst
+++ b/Documentation/Adr/Adr132ApprovalAuditAndTurnBinding.rst
@@ -1,0 +1,111 @@
+.. _adr-132:
+
+==========================================================
+ADR-132: Fail-closed approval audit and turn binding
+==========================================================
+
+:Status: Accepted
+:Date: 2026-08-09
+
+Context
+=======
+
+Two defects sat on the same code path, :php:`ResumeCoordinator::approve()`.
+
+**The decision that authorises a write was not audited.**
+:php:`AgentRunPersister::recordApproval()` caught every :php:`Throwable`,
+logged a warning and returned :php:`void`. The coordinator called it unchecked
+and continued into the execution. A destructive tool call could therefore be
+approved and executed with nothing anywhere recording who approved it. The
+write *step* audit has been fail-closed since :ref:`ADR-111 <adr-111>` —
+:php:`AuditPersistenceFailedException` fails a run whose WRITING tool executed
+but whose step could not be stored. The decision that authorised the write was
+not covered by anything.
+
+**The reviewed turn was bound on one surface only.** The stale-review digest
+introduced with :ref:`ADR-109 <adr-109>` lived in
+:php:`AgentRunController::approveAction()`. The Tool Playground's
+``awaiting_approval`` payload returned no digest and its resume endpoint read
+only ``runUuid`` and ``approve`` — so the playground could approve a turn it had
+never displayed. Worse, the module's own check ran *before* the atomic claim,
+against the row as it was then.
+
+Decision
+========
+
+**One digest definition.** The computation moved out of the inbox view factory
+into :php:`PendingTurnDigest`, a small ``@internal`` service both the rendering
+side and the verifying side use. A digest is a comparison; two implementations
+that drift apart silently compare different things. The hash covers the pending
+calls only — the transcript and the counters change every round and would make
+every digest stale.
+
+**The digest travels with the decision.** :php:`ApprovalDecision` carries a
+third property, ``turnDigest``. Both surfaces hand it through; neither compares
+anything. The comparison happens once, inside the coordinator.
+
+**The verified state is the state loaded after the claim.** Losing the claim
+race does not leave the run untouched: the winner runs the turn, the loop
+continues, and the run can suspend *again* on a different turn — which is
+exactly the row the next claim succeeds on. The pre-claim read would be the
+previous turn, so the digest check, the write classification and the execution
+all read the freshly claimed row.
+
+**Two gates between the claim and the execution.**
+
+1. The decision must name the turn it was made on. A ``null`` digest and a
+   mismatching digest both mean "the reviewed turn is not known", so both are
+   refused; the comparison is :php:`hash_equals()`.
+2. An approval whose APPROVAL event could not be stored may not execute a turn
+   that declares a write. "Declares a write" is
+   :php:`ToolEffectResolver::effectFor()` (ADR-111), which already resolves an
+   unknown name to ``NON_IDEMPOTENT_WRITE``; a pending entry too corrupt to
+   yield a call at all counts as a write too.
+
+**A refused decision releases the run.** Both gates suspend the run back to
+``WAITING_FOR_APPROVAL`` — the existing RUNNING → WAITING transition, which
+clears the claim and the lease and writes the state back. Nothing executed and
+nothing settled, so the operator re-reviews the current turn and decides again.
+A release that itself fails settles the run instead, because a run left RUNNING
+with no worker is invisible to the inbox and to the reaper alike.
+
+What this deliberately is not
+=============================
+
+- **Not fail-closed for read-only turns.** A read-only turn whose decision
+  could not be stored continues, with the failure logged. The audit gap is
+  real, but nothing changes state, and refusing would strand a harmless run
+  behind an unavailable audit store.
+- **Not fail-closed for a denial.** A denial passes gate 1 — deciding on a turn
+  nobody reviewed is as wrong when the answer is "no" — but not gate 2. Gate 2
+  exists to stop an unaudited *write* from executing, and a denial executes
+  nothing. Refusing it would leave the write-declaring turn pending and
+  approvable while the operator who wanted it gone is turned away. "Who denied"
+  is still lost, which is why the failure is logged rather than silent.
+- **Not a new repository method.** The release reuses
+  :php:`AgentRunPersister::suspend()`. The transition it needs already exists.
+- **Not a per-call verdict.** One decision still covers the whole pending turn;
+  the digest binds the turn, not individual calls.
+
+Consequences
+============
+
+- :php:`AgentRunPersister::recordApproval()` returns :php:`bool`, the same shape
+  as :php:`recordStep()`. The class is no longer uniformly "fail-soft": it never
+  throws, but two methods hand the caller the evidence to fail closed.
+- Two new request-validation exceptions,
+  :php:`StaleApprovalTurnException` and :php:`ApprovalNotAuditableException`,
+  join the :php:`AgentRuntimeException` family. Both surfaces map them: the
+  module to the existing ``runs.error.staleReview`` and a new
+  ``runs.error.notAuditable`` flash, the playground to a 409 and a 503 that
+  both re-signal ``awaiting_approval``.
+- :php:`ApprovalDecision`'s constructor gained a third argument. It is optional
+  in the signature for source compatibility only — a ``null`` is refused at
+  runtime — so a third party constructing the decision itself must supply the
+  digest of the turn it displayed.
+- The playground carries ``turnDigest`` in both its batch pause payload and its
+  streamed ``awaiting_approval`` event. It ships no approval UI of its own
+  today, so no client code consumes it yet; the value is there for the first
+  one that does.
+- The controller-side stale check in :php:`AgentRunController` is gone. One
+  definition of the invariant, in the one place that holds the claim.

--- a/Documentation/Adr/Adr132ApprovalAuditAndTurnBinding.rst
+++ b/Documentation/Adr/Adr132ApprovalAuditAndTurnBinding.rst
@@ -51,6 +51,19 @@ exactly the row the next claim succeeds on. The pre-claim read would be the
 previous turn, so the digest check, the write classification and the execution
 all read the freshly claimed row.
 
+**The state is nevertheless decoded twice, and the two decodes answer different
+questions.** The pre-claim decode asks "was this row readable when we found
+it" and refuses without claiming — a row corrupted outside the extension stays
+``WAITING_FOR_APPROVAL`` with its blob intact, so an operator can inspect and
+repair it. The post-claim decode asks "is the row we actually won readable" and
+must *settle* the run on a no, because the claim is already held and an
+unreadable state cannot be written back. Both are needed. Dropping the pre-claim
+one would make the ordinary corrupt-row case terminal on the first Approve
+click, and the guarded terminal settle clears ``suspended_state`` — destroying
+the evidence along with the run, the outcome
+:php:`AgentRunExecutor` already names as the one to avoid. Dropping the
+post-claim one would let the race resume a turn nobody verified.
+
 **Two gates between the claim and the execution.**
 
 1. The decision must name the turn it was made on. A ``null`` digest and a
@@ -108,4 +121,9 @@ Consequences
   today, so no client code consumes it yet; the value is there for the first
   one that does.
 - The controller-side stale check in :php:`AgentRunController` is gone. One
-  definition of the invariant, in the one place that holds the claim.
+  definition of the invariant, in the one place that holds the claim. Its
+  unreadable-state pre-filter is gone with it, but the operator sees the same
+  ``runs.unreadable`` flash: the coordinator's pre-claim decode throws
+  :php:`CorruptSuspendedStateException`, which that action already maps. The Tool
+  Playground, which never had such a pre-filter, gains the guard for the first
+  time.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -429,3 +429,4 @@ Tools
    Adr129StructuredConsumers
    Adr130BackendUserGrants
    Adr131EditorModule
+   Adr132ApprovalAuditAndTurnBinding

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -2782,6 +2782,10 @@
                 <source>The pending action changed since you viewed it — please re-review.</source>
                 <target>Die ausstehende Aktion hat sich seit Ihrer Ansicht geändert – bitte erneut prüfen.</target>
             </trans-unit>
+            <trans-unit id="runs.error.notAuditable">
+                <source>The decision could not be recorded, so this write was not executed. The run is still waiting — please try again.</source>
+                <target>Die Entscheidung konnte nicht protokolliert werden, deshalb wurde der schreibende Aufruf nicht ausgeführt. Der Lauf wartet weiterhin – bitte erneut versuchen.</target>
+            </trans-unit>
             <trans-unit id="runs.flash.approved">
                 <source>Approval recorded; the run continued.</source>
                 <target>Freigabe erfasst; der Lauf wurde fortgesetzt.</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -2101,6 +2101,9 @@
             <trans-unit id="runs.error.staleReview">
                 <source>The pending action changed since you viewed it — please re-review.</source>
             </trans-unit>
+            <trans-unit id="runs.error.notAuditable">
+                <source>The decision could not be recorded, so this write was not executed. The run is still waiting — please try again.</source>
+            </trans-unit>
             <trans-unit id="runs.flash.approved">
                 <source>Approval recorded; the run continued.</source>
             </trans-unit>

--- a/Tests/Functional/Controller/Backend/AgentRunControllerTest.php
+++ b/Tests/Functional/Controller/Backend/AgentRunControllerTest.php
@@ -11,11 +11,17 @@ namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;
 
 use Netresearch\NrLlm\Controller\Backend\AgentRunController;
 use Netresearch\NrLlm\Domain\Enum\PrivacyLevel;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
+use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Service\Agent\AgentRunResult;
 use Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface;
+use Netresearch\NrLlm\Service\Agent\ApprovalDecision;
 use Netresearch\NrLlm\Service\Agent\Exception\InvalidInputSubmissionException;
+use Netresearch\NrLlm\Service\Agent\Exception\StaleApprovalTurnException;
 use Netresearch\NrLlm\Service\Agent\Inbox\WaitingRunViewFactory;
+use Netresearch\NrLlm\Service\Agent\PendingTurnDigest;
 use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
 use Netresearch\NrLlm\Service\Tool\AgentRunRepository;
 use Netresearch\NrLlm\Service\Tool\AgentStateCodec;
@@ -29,6 +35,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\NullLogger;
 use ReflectionClass;
+use ReflectionProperty;
 use TYPO3\CMS\Backend\Routing\Route;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
@@ -36,9 +43,14 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Messaging\FlashMessage;
+use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Mvc\ExtbaseRequestParameters;
 use TYPO3\CMS\Extbase\Mvc\Request as ExtbaseRequest;
+use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder as ExtbaseUriBuilder;
+use TYPO3\CMS\Extbase\Service\ExtensionService;
 
 /**
  * Renders the approvals inbox through the real ModuleTemplate + Fluid stack and
@@ -109,7 +121,88 @@ final class AgentRunControllerTest extends AbstractFunctionalTestCase
         self::assertStringContainsString('tabindex="-1"', $body);
     }
 
+    #[Test]
+    public function approveActionHandsTheReviewedTurnDigestToTheRuntimeAndRefusesAStaleOne(): void
+    {
+        // ADR-132: the module no longer decides staleness itself — it carries
+        // the digest the card rendered into the decision, and the runtime
+        // verifies it against the CLAIMED state. Two things are asserted: the
+        // value travels through unchanged, and the refusal is surfaced with the
+        // stale-review message rather than a generic error.
+        $this->suspendApproval('delete_thing', ['uid' => 42]);
+        $uuid = $this->lastUuid();
+
+        $seen    = null;
+        $runtime = $this->createMock(AgentRuntimeInterface::class);
+        $runtime->method('approve')->willReturnCallback(
+            static function (AiActorContext $actor, string $runUuid, ApprovalDecision $decision) use (&$seen, $uuid): AgentRunResult {
+                $seen = $decision;
+
+                throw StaleApprovalTurnException::forRun($uuid);
+            },
+        );
+
+        $controller = $this->makeController(new ToolRegistry([new FakeTool('delete_thing')]), $runtime);
+        $this->setRequest($controller, 'approve');
+
+        $response = $controller->approveAction($uuid, true, 'a-digest-of-some-other-turn');
+
+        self::assertSame(303, $response->getStatusCode(), 'the refusal ends in the POST-redirect-GET flush');
+        self::assertInstanceOf(ApprovalDecision::class, $seen);
+        self::assertSame('a-digest-of-some-other-turn', $seen->turnDigest);
+        self::assertTrue($seen->approved);
+        self::assertSame(
+            $this->localizedFlashMessages(),
+            ['The pending action changed since you viewed it — please re-review.'],
+        );
+    }
+
+    #[Test]
+    public function theDigestTheCardRendersIsTheOneTheRuntimeWillRecompute(): void
+    {
+        // The whole guard rests on both sides computing the same value from the
+        // same pending calls (ADR-132) — one definition, asserted across the
+        // render side and the verification side.
+        $this->suspendApproval('delete_thing', ['uid' => 42]);
+        $run = $this->persister->findRun($this->lastUuid());
+        self::assertInstanceOf(AgentRun::class, $run);
+        self::assertNotNull($run->suspendedState);
+
+        $decoded = json_decode($run->suspendedState, true);
+        self::assertIsArray($decoded);
+
+        $factory = new WaitingRunViewFactory(new ToolRegistry([new FakeTool('delete_thing')]), new SchemaPropertyClassifier(), new PendingTurnDigest());
+
+        self::assertSame(
+            (new PendingTurnDigest())->forState(SuspendedRunState::fromArray($decoded)),
+            $factory->turnDigestForRun($run),
+        );
+    }
+
     // --- helpers -----------------------------------------------------------
+
+    /**
+     * The rendered text of every flash message the action queued.
+     *
+     * @return list<string>
+     */
+    private function localizedFlashMessages(): array
+    {
+        $flashMessageService = $this->get(FlashMessageService::class);
+        self::assertInstanceOf(FlashMessageService::class, $flashMessageService);
+        $extensionService = $this->get(ExtensionService::class);
+        self::assertInstanceOf(ExtensionService::class, $extensionService);
+
+        // The identifier ActionController::getFlashMessageQueue() derives.
+        $queue = $flashMessageService->getMessageQueueByIdentifier(
+            'extbase.flashmessages.' . $extensionService->getPluginNamespace('NrLlm', null),
+        );
+
+        return array_values(array_map(
+            static fn(FlashMessage $message): string => $message->getMessage(),
+            $queue->getAllMessagesAndFlush(),
+        ));
+    }
 
     private ?string $lastUuid = null;
 
@@ -166,7 +259,7 @@ final class AgentRunControllerTest extends AbstractFunctionalTestCase
         return new AgentRunController(
             $moduleTemplateFactory,
             $this->persister,
-            new WaitingRunViewFactory($registry, new SchemaPropertyClassifier()),
+            new WaitingRunViewFactory($registry, new SchemaPropertyClassifier(), new PendingTurnDigest()),
             new SchemaInputCoercer(new SchemaPropertyClassifier()),
             $runtime,
             $pageRenderer,
@@ -193,13 +286,30 @@ final class AgentRunControllerTest extends AbstractFunctionalTestCase
 
         // The render-only actions we test (list + the 422 in-place re-render)
         // need the moduleTemplate property. We set it directly rather than via
-        // initializeAction(), whose getFlashMessageQueue()/doc-header calls need
-        // Extbase controller services a direct-call harness cannot provide — the
-        // flash queue and doc menu are display-only and irrelevant to the card
-        // markup we assert. Actions that use redirect()/flash are covered by the
-        // WaitingRunViewFactory/SchemaInputCoercer unit tests instead.
+        // initializeAction(), whose doc-header call needs Extbase controller
+        // services a direct-call harness cannot provide.
         $moduleTemplateFactory = $this->get(ModuleTemplateFactory::class);
         self::assertInstanceOf(ModuleTemplateFactory::class, $moduleTemplateFactory);
         $reflection->getProperty('moduleTemplate')->setValue($controller, $moduleTemplateFactory->create($extbaseRequest));
+
+        // The three collaborators an ActionController normally receives through
+        // its inject* methods. Set here so the POST-redirect-GET actions
+        // (flash + redirect) are reachable too — the approval decision is one,
+        // and testing it against a double instead would leave the surface's
+        // actual behaviour unasserted.
+        $uriBuilder = $this->get(ExtbaseUriBuilder::class);
+        self::assertInstanceOf(ExtbaseUriBuilder::class, $uriBuilder);
+        $uriBuilder->setRequest($extbaseRequest);
+        $reflection->getProperty('uriBuilder')->setValue($controller, $uriBuilder);
+
+        // These two are PRIVATE on ActionController, so they are reachable only
+        // through the declaring class, not the subclass reflection above.
+        $flashMessageService = $this->get(FlashMessageService::class);
+        self::assertInstanceOf(FlashMessageService::class, $flashMessageService);
+        (new ReflectionProperty(ActionController::class, 'internalFlashMessageService'))->setValue($controller, $flashMessageService);
+
+        $extensionService = $this->get(ExtensionService::class);
+        self::assertInstanceOf(ExtensionService::class, $extensionService);
+        (new ReflectionProperty(ActionController::class, 'internalExtensionService'))->setValue($controller, $extensionService);
     }
 }

--- a/Tests/Functional/Controller/Backend/AgentRunControllerTest.php
+++ b/Tests/Functional/Controller/Backend/AgentRunControllerTest.php
@@ -173,9 +173,11 @@ final class AgentRunControllerTest extends AbstractFunctionalTestCase
 
         $factory = new WaitingRunViewFactory(new ToolRegistry([new FakeTool('delete_thing')]), new SchemaPropertyClassifier(), new PendingTurnDigest());
 
+        // The RENDERED card's value, not a convenience accessor beside it: what
+        // travels back with the decision is what the card carries.
         self::assertSame(
             (new PendingTurnDigest())->forState(SuspendedRunState::fromArray($decoded)),
-            $factory->turnDigestForRun($run),
+            $factory->buildWaiting([$run])[0]->turnDigest,
         );
     }
 

--- a/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
@@ -11,7 +11,9 @@ namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;
 
 use GuzzleHttp\Psr7\ServerRequest as GuzzleServerRequest;
 use Netresearch\NrLlm\Controller\Backend\ToolPlaygroundController;
+use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
 use Netresearch\NrLlm\Domain\Enum\PrivacyLevel;
+use Netresearch\NrLlm\Domain\Enum\ToolEffect;
 use Netresearch\NrLlm\Domain\Enum\TrustZone;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
@@ -25,11 +27,13 @@ use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Provider\Middleware\GuardrailMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\Agent\AgentRunRequest;
 use Netresearch\NrLlm\Service\Agent\AgentRuntime;
+use Netresearch\NrLlm\Service\Agent\PendingTurnDigest;
 use Netresearch\NrLlm\Service\CacheManagerInterface;
 use Netresearch\NrLlm\Service\Guardrail\GuardrailInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
@@ -50,6 +54,7 @@ use Netresearch\NrLlm\Service\Tool\TrustZoneResolver;
 use Netresearch\NrLlm\Tests\Fixture\FixedPrivacyPolicy;
 use Netresearch\NrLlm\Tests\Fixture\GuardrailIdentityDoubleTrait;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use Netresearch\NrLlm\Tests\Functional\Service\Fixtures\ApprovalEventFailingRunRepository;
 use Netresearch\NrLlm\Tests\Functional\Service\Fixtures\ScriptedToolAdapter;
 use Netresearch\NrLlm\Tests\LlmServiceManagerTestFactory;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
@@ -834,6 +839,134 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         self::assertFalse($payload['success']);
     }
 
+    #[Test]
+    public function resumeActionRefusesAStaleTurnDigestAndLeavesTheRunWaitingForApproval(): void
+    {
+        // ADR-132: the playground gets the turn binding for the first time. A
+        // decision made against a turn that is no longer pending is refused
+        // AFTER the claim and the run is handed back — not consumed, not
+        // terminal, and above all not executed.
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        [$controller, $persister, $uuid] = $this->suspendedApprovalController();
+
+        $response = $controller->resumeAction(
+            (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/resume'))
+                ->withParsedBody(['runUuid' => $uuid, 'approve' => '1', 'turnDigest' => 'a-digest-of-some-other-turn']),
+        );
+
+        self::assertSame(409, $response->getStatusCode());
+        $payload = json_decode((string)$response->getBody(), true);
+        self::assertIsArray($payload);
+        self::assertFalse($payload['success']);
+        // Re-signals the pause so the client re-fetches and re-reviews.
+        self::assertSame('awaiting_approval', $payload['status']);
+
+        $this->assertRunIsDecidableAgain($persister, $uuid);
+    }
+
+    #[Test]
+    public function resumeActionRefusesAnApprovalThatCarriesNoTurnDigest(): void
+    {
+        // A client that simply does not send the field must not be the one case
+        // that slips through — the signature default is not an escape hatch.
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        [$controller, $persister, $uuid] = $this->suspendedApprovalController();
+
+        $response = $controller->resumeAction(
+            (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/resume'))
+                ->withParsedBody(['runUuid' => $uuid, 'approve' => '1']),
+        );
+
+        self::assertSame(409, $response->getStatusCode());
+        $this->assertRunIsDecidableAgain($persister, $uuid);
+    }
+
+    #[Test]
+    public function resumeActionExecutesNothingWhenAWriteTurnsApprovalCannotBeRecorded(): void
+    {
+        // ADR-132: correct digest, correct claim — but the APPROVAL event cannot
+        // be stored and the turn declares a write. Nothing runs, and the run is
+        // decidable again once the store recovers.
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        [$controller, $persister, $uuid, $digest] = $this->suspendedApprovalController(failEventKind: 'approval');
+
+        $response = $controller->resumeAction(
+            (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/resume'))
+                ->withParsedBody(['runUuid' => $uuid, 'approve' => '1', 'turnDigest' => $digest]),
+        );
+
+        self::assertSame(503, $response->getStatusCode());
+        $payload = json_decode((string)$response->getBody(), true);
+        self::assertIsArray($payload);
+        self::assertFalse($payload['success']);
+
+        $this->assertRunIsDecidableAgain($persister, $uuid);
+    }
+
+    /**
+     * A run suspended for approval on ONE write-declaring call, in the real
+     * database, behind a controller whose provider must never be reached.
+     *
+     * @return array{0: ToolPlaygroundController, 1: AgentRunPersister, 2: string, 3: string}
+     */
+    private function suspendedApprovalController(?string $failEventKind = null): array
+    {
+        $repository = new AgentRunRepository($this->toolConnectionPool(), $this->get(AgentStateCodec::class));
+        $persister  = new AgentRunPersister(
+            $failEventKind === null ? $repository : new ApprovalEventFailingRunRepository($repository, $failEventKind),
+            FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL),
+            new NullLogger(),
+        );
+
+        $handle = $persister->begin(null, 1);
+        self::assertNotNull($handle);
+
+        $state = new SuspendedRunState(
+            [['role' => 'user', 'content' => 'delete it']],
+            [ToolCall::function('call_1', 'delete_thing', ['uid' => 42])->toArray()],
+            1,
+            5,
+            2,
+        );
+        self::assertTrue($persister->suspend($handle, $state));
+
+        $config = new LlmConfiguration();
+        $config->setIdentifier('cfg');
+
+        $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
+        $configurationRepository->method('findByUid')->willReturn($config);
+
+        // The refused decision must never reach a provider.
+        $manager = $this->createMock(LlmServiceManagerInterface::class);
+        $manager->expects(self::never())->method('chatWithToolsForConfiguration');
+        $manager->expects(self::never())->method('chatWithConfiguration');
+
+        $registry = new ToolRegistry([new FakeTool('delete_thing', effect: ToolEffect::NON_IDEMPOTENT_WRITE)]);
+
+        return [
+            $this->makeController($configurationRepository, $registry, $this->loopFor($manager, $registry, new NullLogger()), $persister),
+            $persister,
+            $handle->uuid,
+            (new PendingTurnDigest())->forState($state),
+        ];
+    }
+
+    private function assertRunIsDecidableAgain(AgentRunPersister $persister, string $uuid): void
+    {
+        $run = $persister->findRun($uuid);
+        self::assertInstanceOf(AgentRun::class, $run);
+        // Not RUNNING (the claim was handed back) and not terminal — the
+        // operator can review the current turn and decide again.
+        self::assertSame(AgentRunStatus::WAITING_FOR_APPROVAL, $run->statusEnum());
+        self::assertNotNull($run->suspendedState);
+    }
+
     /**
      * Build a controller wired to the scripted tool adapter (one tool call, then
      * a plain answer) over an in-memory configuration.
@@ -968,6 +1101,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
             $this->availabilityFor($toolRegistry),
             $skillRepository,
             $promptSnippetRepository,
+            new PendingTurnDigest(),
         );
     }
 

--- a/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
@@ -909,6 +909,47 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
         $this->assertRunIsDecidableAgain($persister, $uuid);
     }
 
+    #[Test]
+    public function resumeActionRefusesACorruptSuspendedStateWithoutClaimingOrClearingIt(): void
+    {
+        // A row that is already unreadable when the Approve click arrives — a
+        // hand-edit, a dump/restore, a non-strict overflow; the extension only
+        // ever writes it with JSON_THROW_ON_ERROR. It is refused BEFORE the
+        // claim, so the run stays decidable and, above all, keeps its blob: the
+        // post-claim decode would settle the run FAILED, and the guarded
+        // terminal settle clears suspended_state along with the claim.
+        //
+        // This surface has no other guard. The inbox controller can pre-filter
+        // an unreadable card, the playground's AJAX endpoint never could.
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        [$controller, , $uuid, $digest] = $this->suspendedApprovalController();
+
+        $connection = $this->toolConnectionPool()->getConnectionForTable('tx_nrllm_agentrun');
+        $connection->update('tx_nrllm_agentrun', ['suspended_state' => 'not-json{'], ['uuid' => $uuid]);
+
+        $response = $controller->resumeAction(
+            (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/resume'))
+                ->withParsedBody(['runUuid' => $uuid, 'approve' => '1', 'turnDigest' => $digest]),
+        );
+
+        self::assertSame(500, $response->getStatusCode());
+        $payload = json_decode((string)$response->getBody(), true);
+        self::assertIsArray($payload);
+        self::assertFalse($payload['success']);
+
+        // Assert against the ROW, not the value object: the point is that the
+        // column still holds the evidence. finishRun() would have emptied it.
+        $row = $connection
+            ->select(['status', 'suspended_state', 'claimed_by'], 'tx_nrllm_agentrun', ['uuid' => $uuid])
+            ->fetchAssociative();
+        self::assertIsArray($row);
+        self::assertSame(AgentRunStatus::WAITING_FOR_APPROVAL->value, $row['status']);
+        self::assertSame('not-json{', $row['suspended_state']);
+        self::assertSame('', $row['claimed_by']);
+    }
+
     /**
      * A run suspended for approval on ONE write-declaring call, in the real
      * database, behind a controller whose provider must never be reached.

--- a/Tests/Functional/Service/Fixtures/ApprovalEventFailingRunRepository.php
+++ b/Tests/Functional/Service/Fixtures/ApprovalEventFailingRunRepository.php
@@ -1,0 +1,173 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Fixtures;
+
+use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
+use Netresearch\NrLlm\Service\Tool\AgentRunRepositoryInterface;
+use RuntimeException;
+
+/**
+ * The real, database-backed repository with ONE fault injected: the event of a
+ * chosen kind cannot be written.
+ *
+ * Models the store hiccup that hits a single audit record rather than the whole
+ * connection, which is what {@see \Netresearch\NrLlm\Service\Tool\AgentRunPersister::recordApproval()}'s
+ * boolean is about (ADR-132). Everything else — the claim, the suspend, the
+ * status transitions the assertions read back — stays real, so the test asserts
+ * the row the operator would actually see.
+ */
+final readonly class ApprovalEventFailingRunRepository implements AgentRunRepositoryInterface
+{
+    public function __construct(
+        private AgentRunRepositoryInterface $inner,
+        private string $failingKind,
+    ) {}
+
+    public function recordEvent(int $runUid, int $sequence, string $kind, int $round, float $durationMs, string $payloadJson): void
+    {
+        if ($kind === $this->failingKind) {
+            throw new RuntimeException(sprintf('recordEvent(%s) failed', $kind), 1785200002);
+        }
+
+        $this->inner->recordEvent($runUid, $sequence, $kind, $round, $durationMs, $payloadJson);
+    }
+
+    public function startRun(string $uuid, int $configurationUid, string $configurationIdentifier, int $beUser): int
+    {
+        return $this->inner->startRun($uuid, $configurationUid, $configurationIdentifier, $beUser);
+    }
+
+    public function finishRun(
+        int $runUid,
+        string $status,
+        int $iterations,
+        bool $truncated,
+        int $promptTokens,
+        int $completionTokens,
+        int $totalTokens,
+        float $estimatedCost,
+        string $errorClass,
+        string $terminationReason = '',
+        ?string $ownedBy = null,
+    ): bool {
+        return $this->inner->finishRun($runUid, $status, $iterations, $truncated, $promptTokens, $completionTokens, $totalTokens, $estimatedCost, $errorClass, $terminationReason, $ownedBy);
+    }
+
+    public function suspendRun(int $runUid, string $stateJson): bool
+    {
+        return $this->inner->suspendRun($runUid, $stateJson);
+    }
+
+    public function suspendRunForInput(int $runUid, string $stateJson): bool
+    {
+        return $this->inner->suspendRunForInput($runUid, $stateJson);
+    }
+
+    public function claimForResume(int $runUid): bool
+    {
+        return $this->inner->claimForResume($runUid);
+    }
+
+    public function claimForResumeFromInput(int $runUid): bool
+    {
+        return $this->inner->claimForResumeFromInput($runUid);
+    }
+
+    public function enqueueRun(string $uuid, int $configurationUid, string $configurationIdentifier, int $beUser, string $requestJson): int
+    {
+        return $this->inner->enqueueRun($uuid, $configurationUid, $configurationIdentifier, $beUser, $requestJson);
+    }
+
+    public function claimQueued(int $runUid, string $claimedBy, int $leaseExpires): bool
+    {
+        return $this->inner->claimQueued($runUid, $claimedBy, $leaseExpires);
+    }
+
+    public function renewLease(int $runUid, string $claimedBy, int $leaseExpires): bool
+    {
+        return $this->inner->renewLease($runUid, $claimedBy, $leaseExpires);
+    }
+
+    public function markPendingEffect(int $runUid, string $claimedBy, string $effect, int $leaseExpires): bool
+    {
+        return $this->inner->markPendingEffect($runUid, $claimedBy, $effect, $leaseExpires);
+    }
+
+    public function requeue(int $runUid, string $claimedBy): bool
+    {
+        return $this->inner->requeue($runUid, $claimedBy);
+    }
+
+    public function findStaleRunning(int $now, int $limit = 50): array
+    {
+        return $this->inner->findStaleRunning($now, $limit);
+    }
+
+    public function requeueStale(int $runUid, int $now): bool
+    {
+        return $this->inner->requeueStale($runUid, $now);
+    }
+
+    public function deadLetterStale(int $runUid, int $now, string $terminationReason): bool
+    {
+        return $this->inner->deadLetterStale($runUid, $now, $terminationReason);
+    }
+
+    public function findByUuid(string $uuid): ?AgentRun
+    {
+        return $this->inner->findByUuid($uuid);
+    }
+
+    public function findAwaiting(int $limit = 100, ?int $beUser = null): array
+    {
+        return $this->inner->findAwaiting($limit, $beUser);
+    }
+
+    public function findRecentTerminal(int $limit = 20, ?int $beUser = null): array
+    {
+        return $this->inner->findRecentTerminal($limit, $beUser);
+    }
+
+    public function countByStatus(int $since = 0): array
+    {
+        return $this->inner->countByStatus($since);
+    }
+
+    public function countByTerminationReason(int $since = 0): array
+    {
+        return $this->inner->countByTerminationReason($since);
+    }
+
+    public function countInStatus(AgentRunStatus $status): int
+    {
+        return $this->inner->countInStatus($status);
+    }
+
+    public function findEvents(int $runUid, int $afterSequence = -1): array
+    {
+        return $this->inner->findEvents($runUid, $afterSequence);
+    }
+
+    public function maxEventSequence(int $runUid): int
+    {
+        return $this->inner->maxEventSequence($runUid);
+    }
+
+    public function purgeOlderThan(int $timestamp): int
+    {
+        return $this->inner->purgeOlderThan($timestamp);
+    }
+
+    public function purgeUnfinishedOlderThan(int $timestamp): int
+    {
+        return $this->inner->purgeUnfinishedOlderThan($timestamp);
+    }
+}

--- a/Tests/Unit/Api/api-surface.txt
+++ b/Tests/Unit/Api/api-surface.txt
@@ -1012,6 +1012,7 @@ Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface (interface)
 Netresearch\NrLlm\Service\Agent\ApprovalDecision (class)
   property readonly approved: bool
   property readonly decidedByBeUser: int
+  property readonly turnDigest: ?string
 
 Netresearch\NrLlm\Service\Agent\Exception\AgentRuntimeException (class)
   property readonly runUuid: string

--- a/Tests/Unit/Service/Agent/AgentRuntimeTest.php
+++ b/Tests/Unit/Service/Agent/AgentRuntimeTest.php
@@ -411,18 +411,39 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
     }
 
     #[Test]
-    public function approveThrowsOnCorruptSuspendedStateAndSettlesTheClaimedRun(): void
+    public function approveRefusesACorruptSuspendedStateWithoutClaimingOrSettlingTheRun(): void
     {
+        // A row that was ALREADY unreadable when we found it is refused before
+        // the claim, non-destructively: nothing is claimed, nothing is settled,
+        // and the run stays approvable with its state intact. Settling here
+        // would be terminal AND would clear suspended_state — erasing exactly
+        // the blob a repair needs.
         $this->repository->findResult = $this->suspendedRun(stateJson: 'not-json{');
 
         try {
             $this->runtime($this->loopReturning($this->loopResult('x')))->approve($this->actor(), 'run-uuid-1', $this->decision(true, 1));
             self::fail('Expected CorruptSuspendedStateException');
         } catch (CorruptSuspendedStateException) {
-            // Since ADR-132 the state is decoded from the CLAIMED row, so the
-            // claim is already won when corruption is found. The run must not be
-            // left RUNNING with nowhere to go — it is settled, not released
-            // (an unreadable state cannot be written back).
+            self::assertSame(0, $this->repository->claimsGranted);
+            self::assertNull($this->repository->finished);
+            self::assertNull($this->repository->suspended);
+        }
+    }
+
+    #[Test]
+    public function approveSettlesTheClaimedRunWhenTheStateTurnsUnreadableAfterTheClaim(): void
+    {
+        // The other decode, and the other verdict. Here the row was readable
+        // when we found it and the row the claim actually won is not — the race
+        // the post-claim decode exists for. The claim is held at that point, so
+        // the run cannot be left RUNNING and an unreadable state cannot be
+        // written back: settling is the only remaining move.
+        $this->repository->findResults = [$this->suspendedRun(), $this->suspendedRun(stateJson: 'not-json{')];
+
+        try {
+            $this->runtime($this->loopReturning($this->loopResult('x')))->approve($this->actor(), 'run-uuid-1', $this->decision(true, 1));
+            self::fail('Expected CorruptSuspendedStateException');
+        } catch (CorruptSuspendedStateException) {
             self::assertSame(1, $this->repository->claimsGranted);
             self::assertIsArray($this->repository->finished);
             self::assertSame('failed', $this->repository->finished['status']);

--- a/Tests/Unit/Service/Agent/AgentRuntimeTest.php
+++ b/Tests/Unit/Service/Agent/AgentRuntimeTest.php
@@ -32,6 +32,7 @@ use Netresearch\NrLlm\Service\Agent\AgentRunExecutor;
 use Netresearch\NrLlm\Service\Agent\AgentRunRequest;
 use Netresearch\NrLlm\Service\Agent\AgentRuntime;
 use Netresearch\NrLlm\Service\Agent\ApprovalDecision;
+use Netresearch\NrLlm\Service\Agent\Exception\ApprovalNotAuditableException;
 use Netresearch\NrLlm\Service\Agent\Exception\AuditPersistenceFailedException;
 use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
 use Netresearch\NrLlm\Service\Agent\Exception\InvalidInputSubmissionException;
@@ -42,7 +43,9 @@ use Netresearch\NrLlm\Service\Agent\Exception\RunEnqueueFailedException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingApprovalException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingInputException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunStateUnavailableException;
+use Netresearch\NrLlm\Service\Agent\Exception\StaleApprovalTurnException;
 use Netresearch\NrLlm\Service\Agent\InputSubmission;
+use Netresearch\NrLlm\Service\Agent\PendingTurnDigest;
 use Netresearch\NrLlm\Service\Agent\Queue\AgentRunQueuedMessage;
 use Netresearch\NrLlm\Service\Agent\QueuedRunCoordinator;
 use Netresearch\NrLlm\Service\Agent\QueuedRunFailureRecovery;
@@ -346,7 +349,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
             },
         );
 
-        $result = $this->runtime($loop)->approve($this->actor(), 'run-uuid-1', new ApprovalDecision(true, 42));
+        $result = $this->runtime($loop)->approve($this->actor(), 'run-uuid-1', $this->decision(true, 42));
 
         self::assertSame(AgentRunOutcome::COMPLETED, $result->outcome);
         self::assertSame($loopResult, $result->loopResult);
@@ -374,7 +377,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         $this->repository->maxSequenceReturns = [4, 9];
 
         $this->runtime($this->loopReturning($this->loopResult('continued')))
-            ->approve($this->actor(), 'run-uuid-1', new ApprovalDecision(true, 1));
+            ->approve($this->actor(), 'run-uuid-1', $this->decision(true, 1));
 
         self::assertNotSame([], $this->repository->events);
         self::assertSame(10, $this->repository->events[0]['sequence']);
@@ -386,7 +389,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         $this->repository->findResult = null;
 
         $this->expectException(RunNotAwaitingApprovalException::class);
-        $this->runtime($this->loopReturning($this->loopResult('x')))->approve($this->actor(), 'unknown', new ApprovalDecision(true, 1));
+        $this->runtime($this->loopReturning($this->loopResult('x')))->approve($this->actor(), 'unknown', $this->decision(true, 1));
     }
 
     #[Test]
@@ -395,7 +398,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         $this->repository->findResult = $this->suspendedRun(status: 'completed');
 
         $this->expectException(RunNotAwaitingApprovalException::class);
-        $this->runtime($this->loopReturning($this->loopResult('x')))->approve($this->actor(), 'run-uuid-1', new ApprovalDecision(true, 1));
+        $this->runtime($this->loopReturning($this->loopResult('x')))->approve($this->actor(), 'run-uuid-1', $this->decision(true, 1));
     }
 
     #[Test]
@@ -404,16 +407,27 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         $this->repository->findResult = $this->suspendedRun();
 
         $this->expectException(RunConfigurationGoneException::class);
-        $this->runtime($this->loopReturning($this->loopResult('x')), configuration: null)->approve($this->actor(), 'run-uuid-1', new ApprovalDecision(true, 1));
+        $this->runtime($this->loopReturning($this->loopResult('x')), configuration: null)->approve($this->actor(), 'run-uuid-1', $this->decision(true, 1));
     }
 
     #[Test]
-    public function approveThrowsOnCorruptSuspendedState(): void
+    public function approveThrowsOnCorruptSuspendedStateAndSettlesTheClaimedRun(): void
     {
         $this->repository->findResult = $this->suspendedRun(stateJson: 'not-json{');
 
-        $this->expectException(CorruptSuspendedStateException::class);
-        $this->runtime($this->loopReturning($this->loopResult('x')))->approve($this->actor(), 'run-uuid-1', new ApprovalDecision(true, 1));
+        try {
+            $this->runtime($this->loopReturning($this->loopResult('x')))->approve($this->actor(), 'run-uuid-1', $this->decision(true, 1));
+            self::fail('Expected CorruptSuspendedStateException');
+        } catch (CorruptSuspendedStateException) {
+            // Since ADR-132 the state is decoded from the CLAIMED row, so the
+            // claim is already won when corruption is found. The run must not be
+            // left RUNNING with nowhere to go — it is settled, not released
+            // (an unreadable state cannot be written back).
+            self::assertSame(1, $this->repository->claimsGranted);
+            self::assertIsArray($this->repository->finished);
+            self::assertSame('failed', $this->repository->finished['status']);
+            self::assertNull($this->repository->suspended);
+        }
     }
 
     #[Test]
@@ -423,7 +437,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         $this->repository->throwOnMaxSequence = true;
 
         try {
-            $this->runtime($this->loopReturning($this->loopResult('x')))->approve($this->actor(), 'run-uuid-1', new ApprovalDecision(true, 1));
+            $this->runtime($this->loopReturning($this->loopResult('x')))->approve($this->actor(), 'run-uuid-1', $this->decision(true, 1));
             self::fail('Expected RunStateUnavailableException');
         } catch (RunStateUnavailableException) {
             // Fail-closed BEFORE the claim: the run is still suspended, so the
@@ -445,7 +459,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         });
 
         $this->expectException(RunAlreadyResumingException::class);
-        $this->runtime($loop)->approve($this->actor(), 'run-uuid-1', new ApprovalDecision(true, 1));
+        $this->runtime($loop)->approve($this->actor(), 'run-uuid-1', $this->decision(true, 1));
     }
 
     #[Test]
@@ -463,7 +477,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
             },
         );
 
-        $result = $this->runtime($loop)->approve($this->actor(), 'run-uuid-1', new ApprovalDecision(false, 7));
+        $result = $this->runtime($loop)->approve($this->actor(), 'run-uuid-1', $this->decision(false, 7));
 
         // A denial does not terminate the run: the loop continues from the
         // refusal message (ADR-084) — and the denial is on the audit stream.
@@ -474,13 +488,139 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function approveWithoutATurnDigestIsRefusedAndTheRunIsReleased(): void
+    {
+        // ADR-132: a decision that does not name the turn it was made on cannot
+        // be checked against anything. "No digest" is refused exactly like the
+        // wrong digest — the signature default must not be an escape hatch.
+        $this->repository->findResult = $this->suspendedRun();
+
+        try {
+            $this->runtime($this->loopNeverResuming())->approve($this->actor(), 'run-uuid-1', new ApprovalDecision(true, 1));
+            self::fail('Expected StaleApprovalTurnException');
+        } catch (StaleApprovalTurnException) {
+            $this->assertReleasedNotSettled();
+        }
+    }
+
+    #[Test]
+    public function approveWithAStaleTurnDigestIsRefusedAndTheRunIsReleased(): void
+    {
+        // The operator reviewed some other turn (a stale tab, or a second
+        // approver whose continuation already suspended the run on a different
+        // turn). Nothing runs, and the run goes back to WAITING_FOR_APPROVAL so
+        // the CURRENT turn can be re-reviewed.
+        $this->repository->findResult = $this->suspendedRun();
+
+        try {
+            $this->runtime($this->loopNeverResuming())
+                ->approve($this->actor(), 'run-uuid-1', new ApprovalDecision(true, 1, 'a-digest-of-some-other-turn'));
+            self::fail('Expected StaleApprovalTurnException');
+        } catch (StaleApprovalTurnException) {
+            $this->assertReleasedNotSettled();
+        }
+    }
+
+    #[Test]
+    public function approvingAWriteTurnWhoseDecisionCannotBeRecordedExecutesNothing(): void
+    {
+        // ADR-132: the write STEP audit is fail-closed (ADR-111); so is the
+        // decision that authorised it. The approval event cannot be stored, the
+        // turn declares a write — nothing executes and the run is decidable
+        // again once the store recovers.
+        $this->repository->findResult       = $this->suspendedRun(tool: 'send_mail');
+        $this->repository->throwOnRecordKind = 'approval';
+
+        $resolver = new ToolEffectResolver(new ToolRegistry([
+            new FakeTool('send_mail', effect: ToolEffect::NON_IDEMPOTENT_WRITE),
+        ]));
+
+        try {
+            $this->runtime($this->loopNeverResuming(), effectResolver: $resolver)
+                ->approve($this->actor(), 'run-uuid-1', $this->decision(true, 1, 'send_mail'));
+            self::fail('Expected ApprovalNotAuditableException');
+        } catch (ApprovalNotAuditableException) {
+            $this->assertReleasedNotSettled();
+        }
+    }
+
+    #[Test]
+    public function approvingAReadOnlyTurnContinuesEvenWhenTheDecisionCannotBeRecorded(): void
+    {
+        // The deliberate other half: a read-only turn stays fail-soft. The audit
+        // gap is logged, but refusing would strand a run that changes nothing.
+        $this->repository->findResult        = $this->suspendedRun(tool: 'list_pages');
+        $this->repository->throwOnRecordKind = 'approval';
+
+        $resolver = new ToolEffectResolver(new ToolRegistry([new FakeTool('list_pages')]));
+
+        $result = $this->runtime($this->loopReturning($this->loopResult('continued')), effectResolver: $resolver)
+            ->approve($this->actor(), 'run-uuid-1', $this->decision(true, 1, 'list_pages'));
+
+        self::assertSame(AgentRunOutcome::COMPLETED, $result->outcome);
+        // The approval event is genuinely missing — this is a real audit gap,
+        // not a silently retried write.
+        self::assertSame([], array_values(array_filter(
+            $this->repository->events,
+            static fn(array $event): bool => $event['kind'] === 'approval',
+        )));
+    }
+
+    #[Test]
+    public function denyingAWriteTurnWhoseDecisionCannotBeRecordedStillResumes(): void
+    {
+        // ADR-132's asymmetry, asserted so it cannot be "fixed" by accident: the
+        // write fence exists to stop an unaudited WRITE from executing. A denial
+        // executes nothing, so refusing it would only leave the write-declaring
+        // turn pending and approvable while the operator who wanted it gone is
+        // turned away.
+        $this->repository->findResult        = $this->suspendedRun(tool: 'send_mail');
+        $this->repository->throwOnRecordKind = 'approval';
+
+        $resolver = new ToolEffectResolver(new ToolRegistry([
+            new FakeTool('send_mail', effect: ToolEffect::NON_IDEMPOTENT_WRITE),
+        ]));
+
+        $result = $this->runtime($this->loopReturning($this->loopResult('refused and continued')), effectResolver: $resolver)
+            ->approve($this->actor(), 'run-uuid-1', $this->decision(false, 7, 'send_mail'));
+
+        self::assertSame(AgentRunOutcome::COMPLETED, $result->outcome);
+    }
+
+    /**
+     * A refused decision releases the run — back to WAITING_FOR_APPROVAL with
+     * the state written back — instead of settling it terminal. The claim was
+     * consumed, so the release is what makes the run decidable again.
+     */
+    private function assertReleasedNotSettled(): void
+    {
+        self::assertSame(1, $this->repository->claimsGranted, 'the claim was won and must be handed back');
+        self::assertIsArray($this->repository->suspended, 'the run was released, not left RUNNING');
+        self::assertNull($this->repository->finished, 'a refused decision never settles the run');
+    }
+
+    /**
+     * A loop whose resume() is a hard failure: any test that expects nothing to
+     * execute fails loudly rather than silently passing on a stub's default.
+     */
+    private function loopNeverResuming(): ToolLoopServiceInterface
+    {
+        $loop = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method('resume')->willReturnCallback(static function (): ToolLoopResult {
+            throw new RuntimeException('resume must not be reached', 1785200001);
+        });
+
+        return $loop;
+    }
+
+    #[Test]
     public function aResumedRunMaySuspendAgain(): void
     {
         $this->repository->findResult = $this->suspendedRun();
         $again = $this->suspendedState();
 
         $runtime = $this->runtime($this->loopThrowing(ToolApprovalRequiredException::fromState($again), onResume: true));
-        $result  = $runtime->approve($this->actor(), 'run-uuid-1', new ApprovalDecision(true, 1));
+        $result  = $runtime->approve($this->actor(), 'run-uuid-1', $this->decision(true, 1));
 
         self::assertSame(AgentRunOutcome::AWAITING_APPROVAL, $result->outcome);
         self::assertSame($again, $result->suspendedState);
@@ -1273,7 +1413,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
 
         $this->expectException(RunAccessDeniedException::class);
         $this->runtime($this->loopReturning($this->loopResult('x')))
-            ->approve(AiActorContext::backendUser(5), 'run-uuid-1', new ApprovalDecision(true, 5));
+            ->approve(AiActorContext::backendUser(5), 'run-uuid-1', $this->decision(true, 5));
     }
 
     #[Test]
@@ -1321,7 +1461,7 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         $this->repository->findResult = $this->suspendedRun();
         $this->expectException(RunAccessDeniedException::class);
         $this->runtime($this->loopReturning($this->loopResult('x')))
-            ->approve($cancelOnly, 'run-uuid-1', new ApprovalDecision(true, 5));
+            ->approve($cancelOnly, 'run-uuid-1', $this->decision(true, 5));
     }
 
     #[Test]
@@ -1383,11 +1523,21 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         return $loop;
     }
 
-    private function suspendedState(): SuspendedRunState
+    /**
+     * A decision on the fixture's pending turn, digest included (ADR-132).
+     * Anything else is refused before the run is resumed, so a test that means
+     * "a valid decision" has to name the turn it decides on.
+     */
+    private function decision(bool $approved, int $decidedBy, string $tool = 'delete_thing'): ApprovalDecision
+    {
+        return new ApprovalDecision($approved, $decidedBy, (new PendingTurnDigest())->forState($this->suspendedState($tool)));
+    }
+
+    private function suspendedState(string $tool = 'delete_thing'): SuspendedRunState
     {
         return new SuspendedRunState(
             [['role' => 'user', 'content' => 'delete it']],
-            [['id' => 'call_1', 'type' => 'function', 'function' => ['name' => 'delete_thing', 'arguments' => '{}']]],
+            [['id' => 'call_1', 'type' => 'function', 'function' => ['name' => $tool, 'arguments' => '{}']]],
             1,
             5,
             2,
@@ -1444,9 +1594,9 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         );
     }
 
-    private function suspendedRun(string $status = 'waiting_for_approval', ?string $stateJson = null): AgentRun
+    private function suspendedRun(string $status = 'waiting_for_approval', ?string $stateJson = null, string $tool = 'delete_thing'): AgentRun
     {
-        $encoded = $stateJson ?? json_encode($this->suspendedState()->toArray());
+        $encoded = $stateJson ?? json_encode($this->suspendedState($tool)->toArray());
         \assert(is_string($encoded));
 
         return new AgentRun(

--- a/Tests/Unit/Service/Agent/Inbox/WaitingRunViewFactoryTest.php
+++ b/Tests/Unit/Service/Agent/Inbox/WaitingRunViewFactoryTest.php
@@ -177,23 +177,39 @@ final class WaitingRunViewFactoryTest extends TestCase
     }
 
     #[Test]
-    public function turnDigestForRunRecomputesTheSameDigestTheViewCarried(): void
+    public function theCardCarriesTheSharedDigestOfItsPendingTurn(): void
     {
-        $state   = $this->approvalState('delete_thing', ['uid' => 42]);
-        $run     = $this->makeRun('a', $state);
-        $factory = $this->factory(new FakeTool('delete_thing'));
+        // The card is the render side of the ADR-132 binding; ResumeCoordinator
+        // is the verify side. Asserted against PendingTurnDigest itself — the
+        // ONE definition both use — and across the JSON boundary the card's
+        // value crosses: the factory decodes the stored row, the digest must
+        // survive that round trip or the verify side would never match.
+        $stateJson = $this->approvalState('delete_thing', ['uid' => 42]);
+        $run       = $this->makeRun('a', $stateJson);
 
-        $viewDigest = $factory->buildWaiting([$run])[0]->turnDigest;
+        $view = $this->factory(new FakeTool('delete_thing'))->buildWaiting([$run])[0];
 
-        self::assertSame($viewDigest, $factory->turnDigestForRun($run));
+        // Decoded here on purpose: this is the step the verify side performs on
+        // the stored row, so the expectation is built the way it is built there.
+        $decoded = json_decode($stateJson, true);
+        self::assertIsArray($decoded);
+
+        /** @var array<string, mixed> $decoded */
+        self::assertSame(
+            (new PendingTurnDigest())->forState(SuspendedRunState::fromArray($decoded)),
+            $view->turnDigest,
+        );
     }
 
     #[Test]
-    public function turnDigestForRunIsNullForAnInputPause(): void
+    public function anInputCardCarriesNoTurnDigest(): void
     {
+        // An input pause has no approval turn to bind, so there is nothing to
+        // digest — the field must stay null rather than carry a value that would
+        // look like a reviewed turn.
         $run = $this->makeRun('a', $this->inputState('ask', ['type' => 'object', 'properties' => ['x' => ['type' => 'string']]]));
 
-        self::assertNull($this->factory()->turnDigestForRun($run));
+        self::assertNull($this->factory()->buildWaiting([$run])[0]->turnDigest);
     }
 
     #[Test]

--- a/Tests/Unit/Service/Agent/Inbox/WaitingRunViewFactoryTest.php
+++ b/Tests/Unit/Service/Agent/Inbox/WaitingRunViewFactoryTest.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Service\Agent\Inbox\WaitingRunView;
 use Netresearch\NrLlm\Service\Agent\Inbox\WaitingRunViewFactory;
+use Netresearch\NrLlm\Service\Agent\PendingTurnDigest;
 use Netresearch\NrLlm\Service\Tool\SchemaPropertyClassifier;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
@@ -26,7 +27,7 @@ final class WaitingRunViewFactoryTest extends TestCase
 {
     private function factory(FakeTool ...$tools): WaitingRunViewFactory
     {
-        return new WaitingRunViewFactory(new ToolRegistry($tools), new SchemaPropertyClassifier());
+        return new WaitingRunViewFactory(new ToolRegistry($tools), new SchemaPropertyClassifier(), new PendingTurnDigest());
     }
 
     #[Test]

--- a/Tests/Unit/Service/Agent/PendingTurnDigestTest.php
+++ b/Tests/Unit/Service/Agent/PendingTurnDigestTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Agent;
+
+use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
+use Netresearch\NrLlm\Service\Agent\PendingTurnDigest;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Characterizes {@see PendingTurnDigest} against the computation it was
+ * extracted from (WaitingRunViewFactory::pendingTurnDigest, ADR-109).
+ *
+ * The digests already rendered into open backend tabs were produced by the old
+ * inline code; a byte difference here would silently invalidate every one of
+ * them, and the fail-closed guard would read as "everything is stale". The
+ * expected values below are therefore recomputed from the ORIGINAL expression,
+ * not copied from the new implementation.
+ */
+#[CoversClass(PendingTurnDigest::class)]
+final class PendingTurnDigestTest extends TestCase
+{
+    #[Test]
+    public function theDigestIsByteIdenticalToTheExtractedComputation(): void
+    {
+        $calls = [
+            ['id' => 'call_1', 'type' => 'function', 'function' => ['name' => 'delete_thing', 'arguments' => '{"uid":42}']],
+            ['id' => 'call_2', 'type' => 'function', 'function' => ['name' => 'send_mail', 'arguments' => '{}']],
+        ];
+
+        // The original expression, verbatim.
+        $json     = json_encode($calls, JSON_INVALID_UTF8_SUBSTITUTE);
+        $expected = hash('sha256', $json !== false ? $json : serialize($calls));
+
+        self::assertSame($expected, (new PendingTurnDigest())->forState($this->stateWith($calls)));
+    }
+
+    #[Test]
+    public function theDigestCoversOnlyThePendingCallsAndNotTheRestOfTheState(): void
+    {
+        // The transcript and the counters change on every round; binding them in
+        // would make every digest stale the moment the run moved at all.
+        $calls = [['id' => 'call_1', 'type' => 'function', 'function' => ['name' => 'delete_thing', 'arguments' => '{}']]];
+
+        $digest = new PendingTurnDigest();
+
+        self::assertSame(
+            $digest->forState(new SuspendedRunState([['role' => 'user', 'content' => 'a']], $calls, 1, 5, 2)),
+            $digest->forState(new SuspendedRunState([['role' => 'user', 'content' => 'b']], $calls, 9, 99, 77, ['x'], ['temperature' => 1])),
+        );
+    }
+
+    #[Test]
+    public function differentPendingCallsProduceDifferentDigests(): void
+    {
+        $digest = new PendingTurnDigest();
+
+        $one = $digest->forState($this->stateWith([['id' => 'call_1', 'type' => 'function', 'function' => ['name' => 'delete_thing', 'arguments' => '{"uid":42}']]]));
+        $two = $digest->forState($this->stateWith([['id' => 'call_1', 'type' => 'function', 'function' => ['name' => 'delete_thing', 'arguments' => '{"uid":43}']]]));
+
+        self::assertNotSame($one, $two);
+    }
+
+    #[Test]
+    public function anUnencodableTurnStillYieldsAComparableDigest(): void
+    {
+        // json_encode() fails on INF/NAN even with JSON_INVALID_UTF8_SUBSTITUTE.
+        // The serialize() fallback keeps the digest a comparable value instead of
+        // hashing the empty string — which would make every unencodable turn
+        // collide with every other one.
+        $calls = [['id' => 'call_1', 'type' => 'function', 'function' => ['name' => 'x', 'arguments' => ['n' => INF]]]];
+
+        $expected = hash('sha256', serialize($calls));
+
+        self::assertSame($expected, (new PendingTurnDigest())->forState($this->stateWith($calls)));
+    }
+
+    /**
+     * @param list<array<string, mixed>> $calls
+     */
+    private function stateWith(array $calls): SuspendedRunState
+    {
+        return new SuspendedRunState([['role' => 'user', 'content' => 'do it']], $calls, 1, 5, 2);
+    }
+}

--- a/Tests/Unit/Service/Tool/AgentRunPersisterTest.php
+++ b/Tests/Unit/Service/Tool/AgentRunPersisterTest.php
@@ -188,6 +188,37 @@ final class AgentRunPersisterTest extends TestCase
     }
 
     #[Test]
+    public function recordApprovalReportsWhetherTheDecisionWasStored(): void
+    {
+        // ADR-132: the caller has to be able to tell a stored decision from a
+        // swallowed one — a write-declaring turn is refused on false. Without
+        // the boolean the failure is invisible and the write runs unaudited.
+        $repository = new RecordingAgentRunRepository();
+        $persister  = new AgentRunPersister($repository, FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL));
+        $handle     = new AgentRunHandle(1, 'uuid');
+
+        self::assertTrue($persister->recordApproval($handle, true, 42));
+        self::assertSame(1, $handle->sequence);
+        self::assertCount(1, $repository->events);
+    }
+
+    #[Test]
+    public function recordApprovalReturnsFalseOnAStoreErrorWithoutThrowingOrAdvancing(): void
+    {
+        $repository                = new RecordingAgentRunRepository();
+        $repository->throwOnRecord = true;
+
+        $persister = new AgentRunPersister($repository, FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL));
+        $handle    = new AgentRunHandle(1, 'uuid');
+
+        // Still never throws (same shape as recordStep) — the decision is the
+        // caller's to make.
+        self::assertFalse($persister->recordApproval($handle, true, 42));
+        self::assertSame(0, $handle->sequence);
+        self::assertSame([], $repository->events);
+    }
+
+    #[Test]
     public function settleCompletedStoresTheLoopsTerminationReason(): void
     {
         $repository = new RecordingAgentRunRepository();

--- a/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
+++ b/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
@@ -28,6 +28,13 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
 
     public bool $throwOnRecord = false;
 
+    /**
+     * Fail only the event of this kind (e.g. `approval`), leaving every other
+     * write intact — the store hiccup that hits one audit record, not the whole
+     * connection. `null` = no kind-specific failure.
+     */
+    public ?string $throwOnRecordKind = null;
+
     public bool $throwOnFinish = false;
 
     /** @var list<array{uuid: string, configurationUid: int, configurationIdentifier: string, beUser: int}> */
@@ -57,7 +64,7 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
 
     public function recordEvent(int $runUid, int $sequence, string $kind, int $round, float $durationMs, string $payloadJson): void
     {
-        if ($this->throwOnRecord) {
+        if ($this->throwOnRecord || ($this->throwOnRecordKind !== null && $this->throwOnRecordKind === $kind)) {
             throw new RuntimeException('recordEvent failed', 9973913396);
         }
 

--- a/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
+++ b/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
@@ -254,8 +254,22 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
     /** Run returned by findByUuid() (default null = unknown). */
     public ?AgentRun $findResult = null;
 
+    /**
+     * Successive findByUuid() results, consumed one per call before falling back
+     * to $findResult. The resume paths read the row twice — once before the
+     * claim and once after — and the two reads can legitimately differ, so a
+     * single fixed result cannot express that race.
+     *
+     * @var list<AgentRun|null>
+     */
+    public array $findResults = [];
+
     public function findByUuid(string $uuid): ?AgentRun
     {
+        if ($this->findResults !== []) {
+            return array_shift($this->findResults);
+        }
+
         return $this->findResult;
     }
 


### PR DESCRIPTION
## Description

Two defects on the approval path, fixed together because both sit in `ResumeCoordinator::approve()`.

**The approval decision was not audited.** `AgentRunPersister::recordApproval()` caught `Throwable`, logged a warning and returned `void`; `ResumeCoordinator` called it unchecked and continued into `executeResume()`. A write could be approved and executed with the authorising decision recorded nowhere. The write *step* audit is fail-closed; the decision that authorised it was not.

**The reviewed turn was not bound on every surface.** The stale-review digest existed only in `AgentRunController::approveAction`. `ToolPlaygroundController::resumeAction()` is a registered AJAX route (`nrllm_tool_resume`) and read only `runUuid` and `approve` — nothing bound the decision to the turn under review.

### The subtle part: which state gets resumed

The decode now happens **after** the claim, from the freshly loaded row.

Losing the claim race does not leave the run untouched. The winner runs the turn, the loop continues, and the run can suspend **again on a different turn** — which is exactly the row our claim then succeeds on. The pre-claim read would be the previous turn, so the digest check, the write classification and the execution all have to use the fresh state or they judge a turn that is no longer pending.

### Two gates, both releasing rather than settling

1. The decision must name the turn it was made on. A null digest and a mismatching digest both mean "the reviewed turn is not known", so both are refused (`hash_equals`, not `!==`). This is now the **only** place the invariant lives — the controller comparison is gone.
2. An approval whose APPROVAL event could not be stored may not execute a turn that declares a write. Read-only turns stay fail-soft.

Both release the run back to `WAITING_FOR_APPROVAL` through the existing `suspend()` transition, which clears claim and lease. Nothing ran; the operator can decide again. A release that itself fails settles the run rather than stranding it RUNNING, invisible to both the inbox and the reaper.

**A denial passes gate 1 but deliberately not gate 2.** Gate 2 stops an unaudited *write* from executing, and a denial executes nothing. Refusing it would leave the write-declaring turn pending and approvable while the operator who wanted it gone is turned away. The lost "who denied" record is logged. A test pins the asymmetry.

### Corrections to the issue text — please read

- **`Tests/Unit/Api/api-surface.txt` does change.** The issue said constructors are exempt from the snapshot, so none was expected. Constructors are — *promoted properties* are not. Exactly one line was added: `property readonly turnDigest: ?string`. Regenerated the documented way.
- **The playground has no approval UI.** The issue asked for the playground JS to send the digest back. `Resources/Public/JavaScript/` contains no `approve`, `runUuid` or `resume` — the handler exists, the client does not. No JS was changed. The server now emits the digest in both pause shapes; binding the reachable endpoint is the point, and building an approval UI is a different task.
- `ResumeCoordinator` has no explicit `Services.yaml` entry; namespace autoregistration covers it, so the new collaborators autowire without a config change.

## Related Issue

Closes #621

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

`ApprovalDecision` is `@api` and constructed by third parties. The third parameter is optional in the signature but **mandatory in behaviour**: a null digest is refused. That is deliberate — silently accepting an unbound decision would defeat the gate — and it is called out in CHANGELOG.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `composer ci` and all checks pass — unit, PHPStan (level 10), cgl, fuzzy and both functional controller classes re-run independently of the authoring pass: all SUCCESS (functional: 22 tests, 364 assertions). Rector was verified green under an 8.2 resolve, then the worktree was restored to 8.4.
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation accordingly
- [x] I have added a `CHANGELOG.md` entry under `## [Unreleased]`
- [x] I have added an ADR under `Documentation/Adr/` if this changes the public surface — ADR-132
- [x] My changes generate no new warnings

### Tests

- unit: `PendingTurnDigest` is byte-identical to the previous inline computation, including the `serialize()` fallback (characterisation).
- unit: `recordApproval()` returns false when the event store throws.
- functional: a stale digest is refused on **both** surfaces and the run is `WAITING_FOR_APPROVAL` afterwards — not RUNNING, not terminal. A null digest is refused likewise.
- functional: a write turn whose approval event cannot be stored executes nothing and is decidable again (new `ApprovalEventFailingRunRepository` fixture — a real DB repository where only that one event kind fails).
- functional: a read-only turn continues despite a failed approval event; a **denied** write turn also continues, pinning the asymmetry.
- `AgentRunControllerTest` now drives `approveAction` including PRG and flash mapping, rather than deferring to unit tests.

### Note for reviewers

`Documentation/Adr/Index.rst` will show gaps around ADR-133..137 until the sibling branches land.