### PR TITLE
feat(agent): an approver may only approve a write they could run themselves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,24 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   must supply the digest of the turn it displayed or every approval will fail
   with `StaleApprovalTurnException`. `WaitingRunViewFactory::pendingTurnDigest()`
   is gone; the computation lives in the new `PendingTurnDigest` service.
+- **An approver may only release a write they could run themselves** (ADR-133).
+  A resumed turn executes under the run OWNER's identity (ADR-083, unchanged),
+  but the approver was never checked against the tool they were releasing:
+  `mayActOnRun()` grants the decision on the `agent_approve` grant alone, so a
+  non-admin holding it could release an admin-only write that then ran with the
+  owner's privileges — a confused deputy. `ResumeCoordinator::approve()` now
+  resolves the APPROVER's live backend user and asks `ToolCallPolicy::decide()`
+  about every pending call that declares a write; a denial refuses the release
+  with `ApproverNotPermittedException` and RELEASES the run back to
+  `WAITING_FOR_APPROVAL`, so somebody who does hold the permission can still
+  decide it. A **service account may not release a write-declaring turn at
+  all**: it has no backend-user uid and `hasGrant()` is false for it, so
+  `decide()` would check only the `requiresAdmin` axis — refusing is the only
+  fail-closed variant. Read-only turns and denials are unaffected (they execute
+  nothing that needs the approver's authority), and no builtin declares a write
+  today (ADR-122), so the shipped catalogue behaves as before. The module shows
+  a new `runs.error.approverNotPermitted` flash; the playground answers 403 and
+  re-signals `awaiting_approval`.
 
 ## [0.26.0] - 2026-08-06
 

--- a/Classes/Controller/Backend/AgentRunController.php
+++ b/Classes/Controller/Backend/AgentRunController.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Service\Agent\AgentRunResult;
 use Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface;
 use Netresearch\NrLlm\Service\Agent\ApprovalDecision;
 use Netresearch\NrLlm\Service\Agent\Exception\ApprovalNotAuditableException;
+use Netresearch\NrLlm\Service\Agent\Exception\ApproverNotPermittedException;
 use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
 use Netresearch\NrLlm\Service\Agent\Exception\InvalidInputSubmissionException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunAlreadyResumingException;
@@ -132,6 +133,10 @@ final class AgentRunController extends ActionController
         } catch (StaleApprovalTurnException) {
             // The run was released, not consumed — re-review and decide again.
             return $this->flashRedirect('runs.error.staleReview', ContextualFeedbackSeverity::WARNING);
+        } catch (ApproverNotPermittedException) {
+            // ADR-133: the run was released, not consumed — someone who may run
+            // the pending write can still decide it.
+            return $this->flashRedirect('runs.error.approverNotPermitted', ContextualFeedbackSeverity::ERROR);
         } catch (ApprovalNotAuditableException) {
             return $this->flashRedirect('runs.error.notAuditable', ContextualFeedbackSeverity::ERROR);
         } catch (CorruptSuspendedStateException|RunStateUnavailableException) {

--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -29,6 +29,7 @@ use Netresearch\NrLlm\Service\Agent\AgentRuntime;
 use Netresearch\NrLlm\Service\Agent\AgentRuntimeInterface;
 use Netresearch\NrLlm\Service\Agent\ApprovalDecision;
 use Netresearch\NrLlm\Service\Agent\Exception\ApprovalNotAuditableException;
+use Netresearch\NrLlm\Service\Agent\Exception\ApproverNotPermittedException;
 use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
 use Netresearch\NrLlm\Service\Agent\Exception\InvalidInputSubmissionException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunAlreadyResumingException;
@@ -261,6 +262,17 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
                 'runUuid' => $runUuid,
                 'error'   => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.staleApproval', 'The pending action changed since you viewed it — please re-review.'),
             ], 409);
+        } catch (ApproverNotPermittedException) {
+            // ADR-133: the decider may not run the pending write themselves.
+            // Nothing was executed and the run is decidable again, so
+            // awaiting_approval is re-signalled — but 403, because the obstacle
+            // is who is asking, not the request or the store.
+            return $this->respondJson([
+                'success' => false,
+                'status'  => 'awaiting_approval',
+                'runUuid' => $runUuid,
+                'error'   => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.approverNotPermitted', 'You may not approve an action that runs a tool you are not permitted to use yourself.'),
+            ], 403);
         } catch (ApprovalNotAuditableException) {
             // Nothing was executed and the run is decidable again; 503, because
             // the obstacle is the audit store, not the request.

--- a/Classes/Service/Agent/AgentRuntime.php
+++ b/Classes/Service/Agent/AgentRuntime.php
@@ -18,6 +18,7 @@ use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
 use Netresearch\NrLlm\Service\Schema\JsonSchemaValidator;
 use Netresearch\NrLlm\Service\Tool\ActingBackendUserResolverInterface;
 use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
+use Netresearch\NrLlm\Service\Tool\ToolCallPolicyInterface;
 use Netresearch\NrLlm\Service\Tool\ToolEffectResolver;
 use Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface;
 use Psr\Log\LoggerInterface;
@@ -124,6 +125,10 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
         // one over the same persister, configuration repository, tool loop,
         // executor, schema validator and effect resolver.
         private ?ResumeCoordinator $resumeCoordinator = null,
+        // The composite tool gate (ADR-094), handed to the resume coordinator so
+        // an approver is checked against the writes they release (ADR-133). Held
+        // here only to pass down: this runtime never asks it anything itself.
+        private ?ToolCallPolicyInterface $toolPolicy = null,
     ) {}
 
     /**
@@ -139,6 +144,10 @@ final readonly class AgentRuntime implements AgentRuntimeInterface
             $this->runExecutor(),
             $this->schemaValidator,
             $this->toolEffectResolver,
+            null,
+            $this->toolPolicy,
+            $this->actingBackendUserResolver,
+            $this->logger,
         );
     }
 

--- a/Classes/Service/Agent/Exception/ApproverNotPermittedException.php
+++ b/Classes/Service/Agent/Exception/ApproverNotPermittedException.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent\Exception;
+
+use Netresearch\NrLlm\Domain\Enum\ToolDenialReason;
+use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
+
+/**
+ * The approver may not run the write they are releasing (ADR-133).
+ *
+ * A resumed turn executes under the RUN OWNER's identity (ADR-083), so an
+ * approver whose own permissions would not admit a pending write call would
+ * otherwise have that call executed on someone else's authority — a confused
+ * deputy. The decision therefore passes the same {@see \Netresearch\NrLlm\Service\Tool\ToolCallPolicy}
+ * the execution would, evaluated against the APPROVER's live backend user.
+ *
+ * Thrown BEFORE any execution and after the run has been released back to
+ * WAITING_FOR_APPROVAL: nothing ran, and someone who does hold the permission
+ * can still decide the turn. Only an APPROVAL is gated — a denial executes
+ * nothing.
+ *
+ * The message names the actor, the tool and the reason, so the refusal is
+ * recorded in the log line the coordinator writes and in the surface's own
+ * error path. It never carries tool arguments.
+ */
+final class ApproverNotPermittedException extends AgentRuntimeException
+{
+    /**
+     * The approver's own live permissions do not admit the pending write call.
+     */
+    public static function forDeniedTool(string $runUuid, AiActorContext $actor, string $toolName, ToolDenialReason $reason): self
+    {
+        return new self($runUuid, sprintf(
+            '%s may not run the write tool "%s" (%s) and therefore may not approve it. (run %s)',
+            ucfirst($actor->describe()),
+            $toolName !== '' ? $toolName : 'unknown',
+            $reason->value,
+            $runUuid !== '' ? $runUuid : 'unknown',
+        ));
+    }
+
+    /**
+     * The approver has no live backend user to evaluate the tool gate against: a
+     * service account (whose scopes carry no backend permissions at all), or a
+     * uid that no longer resolves to an enabled user. Both are refused rather
+     * than passed to the gate as "no user", which would only check the
+     * requiresAdmin axis and let every other write through.
+     */
+    public static function forApproverWithoutPermissions(string $runUuid, AiActorContext $actor, string $toolName): self
+    {
+        return new self($runUuid, sprintf(
+            '%s has no backend permissions to check the write tool "%s" against and therefore may not approve it. (run %s)',
+            ucfirst($actor->describe()),
+            $toolName !== '' ? $toolName : 'unknown',
+            $runUuid !== '' ? $runUuid : 'unknown',
+        ));
+    }
+
+    /**
+     * A pending entry too corrupt to yield a tool call cannot be classified and
+     * cannot be checked — the same fail-closed verdict the write classification
+     * gives it.
+     */
+    public static function forUnreadableCall(string $runUuid, AiActorContext $actor): self
+    {
+        return new self($runUuid, sprintf(
+            '%s may not approve a pending call that cannot be read, so its permissions cannot be checked. (run %s)',
+            ucfirst($actor->describe()),
+            $runUuid !== '' ? $runUuid : 'unknown',
+        ));
+    }
+}

--- a/Classes/Service/Agent/ResumeCoordinator.php
+++ b/Classes/Service/Agent/ResumeCoordinator.php
@@ -13,6 +13,7 @@ use Closure;
 use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
 use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
 use Netresearch\NrLlm\Domain\Enum\ToolEffect;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
@@ -21,6 +22,7 @@ use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
 use Netresearch\NrLlm\Service\Agent\Exception\ApprovalNotAuditableException;
+use Netresearch\NrLlm\Service\Agent\Exception\ApproverNotPermittedException;
 use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
 use Netresearch\NrLlm\Service\Agent\Exception\InvalidInputSubmissionException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunAccessDeniedException;
@@ -31,14 +33,19 @@ use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingInputException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunStateUnavailableException;
 use Netresearch\NrLlm\Service\Agent\Exception\StaleApprovalTurnException;
 use Netresearch\NrLlm\Service\Schema\JsonSchemaValidator;
+use Netresearch\NrLlm\Service\Tool\ActingBackendUserResolver;
+use Netresearch\NrLlm\Service\Tool\ActingBackendUserResolverInterface;
 use Netresearch\NrLlm\Service\Tool\AgentRunHandle;
 use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
 use Netresearch\NrLlm\Service\Tool\InputSchema;
 use Netresearch\NrLlm\Service\Tool\RunTrace;
+use Netresearch\NrLlm\Service\Tool\ToolCallPolicyInterface;
 use Netresearch\NrLlm\Service\Tool\ToolEffectResolver;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 
 /**
  * Picks a suspended run back up: an approval decision (ADR-084) or a submitted
@@ -62,7 +69,9 @@ use RuntimeException;
  *
  * Both refuse a caller that may not act on the run, and both resume tools under
  * the RUN OWNER's identity rather than the approver's or the submitter's
- * (ADR-083).
+ * (ADR-083). Because the owner's identity is what executes, the APPROVER is
+ * checked against the pending writes separately (ADR-133) — an approver who
+ * could not run the call themselves may not have it run for them.
  */
 final readonly class ResumeCoordinator
 {
@@ -87,6 +96,27 @@ final readonly class ResumeCoordinator
         // The ONE digest definition (ADR-132), shared with the inbox view
         // factory so what is rendered and what is verified cannot drift.
         private ?PendingTurnDigest $turnDigest = null,
+        // The composite tool gate (ADR-094), asked whether the APPROVER could
+        // run the writes they are releasing (ADR-133). Optional for the
+        // positional test wiring like the collaborators above; production
+        // autowires it, and AgentRuntime hands its own down.
+        //
+        // A null is the ONE arm in which this gate does not run. Deliberately
+        // not "refuse every write": without a gate there is no verdict to fail
+        // closed ON, and refusing would make the bare positional construction
+        // unable to approve anything at all rather than merely unchecked. The
+        // arm is unreachable from the container, where the interface is aliased.
+        private ?ToolCallPolicyInterface $toolPolicy = null,
+        // Turns the APPROVER's uid into a live backend user for that gate
+        // (ADR-083's resolver, used here on the deciding identity rather than
+        // the executing one). A null falls back to a fresh default instance,
+        // exactly as in AgentRunExecutor — the fallback resolves from the
+        // database and is not a weakening.
+        private ?ActingBackendUserResolverInterface $actingBackendUserResolver = null,
+        // Records a refused approval (ADR-133): who was turned away, on which
+        // tool, for which reason. The exception carries the same facts to the
+        // surface; the log line is what survives the request.
+        private ?LoggerInterface $logger = null,
     ) {}
 
     /**
@@ -96,7 +126,8 @@ final readonly class ResumeCoordinator
      * tool loop under the run OWNER's identity. Throws rather than returning a
      * failed result when the run is not resumable: the caller distinguishes
      * "wrong state", "not yours", "already resuming", "corrupt state", "you
-     * reviewed a different turn" and "the decision could not be recorded".
+     * reviewed a different turn", "you may not run that write" and "the decision
+     * could not be recorded".
      *
      * The state that is resumed is the one loaded AFTER the claim, never the one
      * read before it. Lose the race and the run does not simply stay put: the
@@ -106,28 +137,42 @@ final readonly class ResumeCoordinator
      * write classification and the execution all have to use the fresh state or
      * they judge a turn that is no longer pending.
      *
-     * Two fail-closed gates sit between the claim and the execution, and both
-     * RELEASE the run (suspend it back to WAITING_FOR_APPROVAL, which clears the
-     * claim and the lease and writes the state back) rather than settling it:
-     * the decision was refused, nothing ran, and the operator can decide again.
+     * Three fail-closed gates sit between the claim and the execution, and all
+     * three RELEASE the run (suspend it back to WAITING_FOR_APPROVAL, which
+     * clears the claim and the lease and writes the state back) rather than
+     * settling it: the decision was refused, nothing ran, and the operator can
+     * decide again.
      *
      * 1. The decision must name the turn it was made on. A null digest and a
      *    mismatching digest both mean "the reviewed turn is not known", so both
      *    are refused. This is the ONLY place the invariant lives — the surfaces
      *    just carry the value through.
-     * 2. An approval whose APPROVAL event could not be stored may not execute
+     * 2. The APPROVER must be permitted to run every pending call that declares
+     *    a write (ADR-133). Execution stays the owner's (ADR-083), which is
+     *    precisely why: without this, a non-admin holding the `agent_approve`
+     *    grant could release an admin-only write and have it executed on the
+     *    owner's authority.
+     * 3. An approval whose APPROVAL event could not be stored may not execute
      *    a turn that declares a write. A read-only turn
      *    stays fail-soft (logged, and it continues): the audit gap is real but
      *    nothing changes state, and refusing would strand a harmless run.
      *
+     * Gate 2 sits between them on purpose. After gate 1, because it judges the
+     * calls of the turn that was actually reviewed and there is no point
+     * resolving a backend user for a decision already known to be stale; before
+     * gate 3, because a refused approval must not be written into the audit
+     * stream as a decision that stood — the same reason gate 1 releases before
+     * anything is recorded.
+     *
      * A DENIAL passes gate 1 — it is a decision on a turn like any other, and
      * denying a turn the operator never saw is exactly as wrong as approving it
-     * — but deliberately NOT gate 2. Gate 2 exists to stop an unaudited WRITE
-     * from executing; a denial executes nothing, so there is nothing to stop.
-     * Refusing it would only leave the write-declaring turn pending and
-     * approvable while the operator who wanted it gone is turned away — a worse
-     * state than a logged, unrecorded "no". The "who denied" record is still
-     * lost, which is why the failure is logged rather than silent.
+     * — but deliberately NOT gates 2 and 3. Both exist to stop a WRITE from
+     * executing (unauthorised or unaudited); a denial executes nothing, so there
+     * is nothing to stop. Refusing it would only leave the write-declaring turn
+     * pending and approvable while the operator who wanted it gone is turned
+     * away — a worse state than a logged, unrecorded "no". The "who denied"
+     * record is still lost, which is why the failure is logged rather than
+     * silent.
      *
      * @param (Closure(RunStep): void)|null $onStep
      */
@@ -205,7 +250,21 @@ final readonly class ResumeCoordinator
             throw StaleApprovalTurnException::forRun($runUuid);
         }
 
-        // Gate 2 — the decision is part of the run's audit stream (ADR-101):
+        // Gate 2 — the approver must be permitted to run what they release
+        // (ADR-133). Only an approval is checked: a denial executes nothing.
+        $refusal = $decision->approved ? $this->approverRefusal($actor, $configuration, $state, $runUuid) : null;
+        if ($refusal instanceof ApproverNotPermittedException) {
+            $this->logger?->warning('Approval refused: the approver may not run the pending write', [
+                'run'    => $runUuid,
+                'actor'  => $actor->describe(),
+                'reason' => $refusal->getMessage(),
+            ]);
+            $this->release($handle, $state, $runUuid);
+
+            throw $refusal;
+        }
+
+        // Gate 3 — the decision is part of the run's audit stream (ADR-101):
         // who approved or denied, before the continuation's own events. An
         // approval that authorises a write and could not be recorded does not
         // execute.
@@ -290,6 +349,76 @@ final readonly class ResumeCoordinator
     private function turnDigest(): PendingTurnDigest
     {
         return $this->turnDigest ?? new PendingTurnDigest();
+    }
+
+    /**
+     * Why this approver may not release this turn, or null when they may
+     * (ADR-133).
+     *
+     * Resume executes under the run OWNER's identity (ADR-083) — deliberately,
+     * and unchanged. That is exactly what makes the approver's own authority
+     * load-bearing: {@see AiActorContext::mayActOnRun()} grants the DECISION on
+     * the `agent_approve` grant alone, so without this the grant would let a
+     * non-admin release an admin-only write that then runs on the owner's
+     * authority. Every pending call that DECLARES a write is therefore put
+     * through the same gate the execution would pass, evaluated against the
+     * approver's live backend user. Read-only calls are not checked: nothing
+     * changes state, and the owner's own gate still governs what runs.
+     *
+     * Fail-closed in three places:
+     *
+     * - A SERVICE ACCOUNT may not release a write-declaring turn at all. Its
+     *   authority is scopes, not backend permissions:
+     *   {@see AiActorContext::hasGrant()} is false for it by construction and it
+     *   has no backend-user uid, so {@see ToolCallPolicyInterface::decide()} would
+     *   see `$user === null` and check only enabled/group/zone — the admin axis
+     *   bites solely on `requiresAdmin()`, so a write tool without that flag
+     *   would pass a gate that is effectively absent while a human is checked
+     *   properly. Refusing is the only variant that stays fail-closed without
+     *   inventing a second authorisation axis for service accounts.
+     * - A human whose uid no longer resolves to an enabled backend user is
+     *   refused for the same reason: there is no live permission surface to
+     *   check, and "no user" is not "permitted".
+     * - A pending entry too corrupt to yield a call is refused, mirroring
+     *   {@see self::turnDeclaresWrite()} — an unclassifiable call is the
+     *   dangerous case, not the harmless one.
+     *
+     * Observe mode is honoured as-is: the gate reports `allowed` there, and this
+     * check must not be stricter than the execution it mirrors.
+     */
+    private function approverRefusal(AiActorContext $actor, LlmConfiguration $configuration, SuspendedRunState $state, string $runUuid): ?ApproverNotPermittedException
+    {
+        if (!$this->toolPolicy instanceof ToolCallPolicyInterface) {
+            return null;
+        }
+
+        // A service account has no backend user by construction; resolving would
+        // return null anyway, but not asking says why.
+        $approver = $actor->isServiceAccount()
+            ? null
+            : ($this->actingBackendUserResolver ?? new ActingBackendUserResolver())->resolve($actor);
+
+        foreach ($state->pendingCalls as $raw) {
+            $call = ToolCall::tryFromArray($raw);
+            if (!$call instanceof ToolCall) {
+                return ApproverNotPermittedException::forUnreadableCall($runUuid, $actor);
+            }
+
+            if (!($this->toolEffectResolver?->effectFor($call->name) ?? ToolEffect::NON_IDEMPOTENT_WRITE)->isWrite()) {
+                continue;
+            }
+
+            if (!$approver instanceof BackendUserAuthentication) {
+                return ApproverNotPermittedException::forApproverWithoutPermissions($runUuid, $actor, $call->name);
+            }
+
+            $verdict = $this->toolPolicy->decide($call->name, $configuration, $approver);
+            if (!$verdict->allowed) {
+                return ApproverNotPermittedException::forDeniedTool($runUuid, $actor, $call->name, $verdict->reason);
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/Documentation/Adr/Adr133ApproverToolGate.rst
+++ b/Documentation/Adr/Adr133ApproverToolGate.rst
@@ -1,0 +1,125 @@
+.. _adr-133:
+
+=============================================================
+ADR-133: An approver may only release a write they could run
+=============================================================
+
+:Status: Accepted
+:Date: 2026-08-09
+
+Context
+=======
+
+A resumed run executes under the RUN OWNER's identity, deliberately
+(:ref:`ADR-083 <adr-083>`): the queued work acts for whoever started it, not
+for whoever happened to press *Approve*. The approver, however, was never
+checked against the tool they were releasing.
+
+:php:`AiActorContext::mayActOnRun()` grants the DECISION on the
+:php:`BackendUserGrant::AGENT_APPROVE` grant alone
+(:ref:`ADR-130 <adr-130>`) — a non-admin who holds it may decide other users'
+suspended runs. Combine the two and a non-admin can release an admin-only write
+tool, which then executes with the owner's privileges. That is a confused
+deputy: the authority that runs the call is not the authority that authorised
+it, and nothing compared the two.
+
+The suspension is worth exactly as much as the check behind it. An approval
+gate that any grant holder can satisfy for any tool is a queue, not a gate.
+
+Decision
+========
+
+**The approver passes the same gate the execution would.**
+:php:`ResumeCoordinator::approve()` resolves the APPROVER's live backend user —
+the :php:`ActingBackendUserResolver` of ADR-083, applied to the deciding
+identity rather than the executing one — and asks
+:php:`ToolCallPolicy::decide()` about every pending call that DECLARES a write
+(:php:`ToolEffectResolver`, ADR-111). A denial refuses the release.
+
+**Execution identity is unchanged.** ADR-083 stands: the turn still runs as the
+run owner. This adds a second, independent condition on the DECISION; it does
+not move the identity the tools authorise against, and a unit test asserts that
+the actor reaching the tool loop is still the owner's.
+
+**Read-only calls are not checked.** The gate exists because a write executes
+on someone else's authority. A read-only pending call changes nothing, and the
+owner's own gate still decides what actually runs when the turn resumes.
+
+**A service account may not release a write-declaring turn.** Its authority is
+scopes, not backend permissions: :php:`AiActorContext::hasGrant()` returns false
+for it by construction and it carries no backend-user uid. :php:`decide()` with
+:php:`$user === null` therefore checks only enabled / configuration group /
+trust zone — the admin axis bites solely on :php:`requiresAdmin()`, so a write
+tool without that flag would pass a gate that is effectively absent while a
+human is checked properly. Refusing is the only variant that stays fail-closed
+without inventing a second authorisation axis for service accounts. A service
+account may still release a read-only turn, so an automation that clears
+harmless pauses keeps working.
+
+**A human whose uid no longer resolves is refused too** — a deleted or disabled
+account has no live permission surface to check, and "no user" is not
+"permitted".
+
+**Placement: after the turn binding, before the audit write.** The gate is the
+second of the three between the claim and the execution
+(:ref:`ADR-132 <adr-132>` owns the first and the third):
+
+1. the decision must name the turn it was made on;
+2. **the approver must be permitted to run every write it releases**;
+3. an approval that authorises a write and could not be recorded does not
+   execute.
+
+After (1), because it judges the calls of the turn that was actually reviewed —
+and, like everything since ADR-132, it reads the state loaded AFTER the claim,
+never the pre-claim copy, which may be the previous turn. Before (3), because a
+refused approval must not enter the audit stream as a decision that stood; that
+is the same rule gate 1 already follows.
+
+**A refusal releases the run.** The existing :php:`release()` helper hands the
+run back to ``WAITING_FOR_APPROVAL``: nothing executed, nothing settled, and
+somebody who does hold the permission can still decide the turn. The refusal is
+logged with the actor, the tool and the policy's reason, and both surfaces map
+:php:`ApproverNotPermittedException` — the module to a flash, the playground to
+a 403 that re-signals ``awaiting_approval``.
+
+What this deliberately is not
+=============================
+
+- **Not a new grant.** :ref:`ADR-130 <adr-130>` admits a grant only together
+  with its consumer, and this needs none: the tool gate and the backend user's
+  own admin flag already carry the answer.
+- **Not a change to who may decide.** :php:`mayActOnRun()` is untouched. A
+  grant holder still reaches every suspended run; they are simply refused on
+  the writes they could not run themselves.
+- **Not applied to a denial.** The same asymmetry ADR-132 states for the audit
+  gate, for the same reason: the gate stops an unauthorised WRITE from
+  executing, and a denial executes nothing. Refusing it would only leave the
+  write pending and approvable while the operator who wanted it gone is turned
+  away.
+- **Not a scope for read-only exposure.** A non-admin approver can still
+  release a read-only call they could not run themselves, which lets its result
+  into the run's transcript. That is a smaller and different problem — the
+  approver cannot read another user's run events (``AGENT_READ`` has no grant
+  equivalent) — and widening the gate would refuse every read-only pause a
+  non-admin approves. Stated here so the limit is a decision, not an oversight.
+- **Not a per-call verdict.** One decision still covers the whole turn; the
+  gate refuses the turn when any write call in it fails.
+
+Consequences
+============
+
+- :php:`ResumeCoordinator` gained three optional collaborators: the tool policy,
+  the acting-user resolver and a logger. The policy is the one that switches
+  the gate on. A ``null`` policy does NOT refuse everything — without a gate
+  there is no verdict to fail closed on, and refusing would make the bare
+  positional construction unable to approve anything at all. The arm is
+  unreachable from the container, where :php:`ToolCallPolicyInterface` is
+  aliased, and :php:`AgentRuntime` hands its own policy down to the coordinator
+  it builds.
+- One new request-validation exception,
+  :php:`ApproverNotPermittedException`, joins the :php:`AgentRuntimeException`
+  family, with a message that names the actor, the tool and the policy reason.
+- No builtin tool declares a write today (:ref:`ADR-122 <adr-122>`), so nothing
+  in the shipped catalogue changes behaviour. The gate is in place for the
+  first write tool and for MCP-provided ones, and the tests construct a
+  write-declaring turn to exercise it.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -430,3 +430,4 @@ Tools
    Adr130BackendUserGrants
    Adr131EditorModule
    Adr132ApprovalAuditAndTurnBinding
+   Adr133ApproverToolGate

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -2786,6 +2786,10 @@
                 <source>The decision could not be recorded, so this write was not executed. The run is still waiting — please try again.</source>
                 <target>Die Entscheidung konnte nicht protokolliert werden, deshalb wurde der schreibende Aufruf nicht ausgeführt. Der Lauf wartet weiterhin – bitte erneut versuchen.</target>
             </trans-unit>
+            <trans-unit id="runs.error.approverNotPermitted">
+                <source>This action runs a tool you are not permitted to use yourself, so you may not approve it. The run is still waiting for someone who is.</source>
+                <target>Diese Aktion führt ein Werkzeug aus, das Sie selbst nicht verwenden dürfen; deshalb können Sie sie nicht freigeben. Der Lauf wartet weiterhin auf eine berechtigte Person.</target>
+            </trans-unit>
             <trans-unit id="runs.flash.approved">
                 <source>Approval recorded; the run continued.</source>
                 <target>Freigabe erfasst; der Lauf wurde fortgesetzt.</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -2104,6 +2104,9 @@
             <trans-unit id="runs.error.notAuditable">
                 <source>The decision could not be recorded, so this write was not executed. The run is still waiting — please try again.</source>
             </trans-unit>
+            <trans-unit id="runs.error.approverNotPermitted">
+                <source>This action runs a tool you are not permitted to use yourself, so you may not approve it. The run is still waiting for someone who is.</source>
+            </trans-unit>
             <trans-unit id="runs.flash.approved">
                 <source>Approval recorded; the run continued.</source>
             </trans-unit>

--- a/Tests/Functional/Service/Agent/ResumeCoordinatorApproverGateTest.php
+++ b/Tests/Functional/Service/Agent/ResumeCoordinatorApproverGateTest.php
@@ -1,0 +1,311 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Agent;
+
+use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
+use Netresearch\NrLlm\Domain\Enum\BackendUserGrant;
+use Netresearch\NrLlm\Domain\Enum\PrivacyLevel;
+use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
+use Netresearch\NrLlm\Domain\Enum\ToolEffect;
+use Netresearch\NrLlm\Domain\Enum\TrustZone;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\Provider;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
+use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
+use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
+use Netresearch\NrLlm\Service\Agent\AgentRunExecutor;
+use Netresearch\NrLlm\Service\Agent\ApprovalDecision;
+use Netresearch\NrLlm\Service\Agent\Exception\ApproverNotPermittedException;
+use Netresearch\NrLlm\Service\Agent\PendingTurnDigest;
+use Netresearch\NrLlm\Service\Agent\ResumeCoordinator;
+use Netresearch\NrLlm\Service\Skill\SkillComposer;
+use Netresearch\NrLlm\Service\Tool\ActingBackendUserResolver;
+use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
+use Netresearch\NrLlm\Service\Tool\AgentRunRepository;
+use Netresearch\NrLlm\Service\Tool\AgentStateCodec;
+use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
+use Netresearch\NrLlm\Service\Tool\ToolAvailabilityService;
+use Netresearch\NrLlm\Service\Tool\ToolCallPolicy;
+use Netresearch\NrLlm\Service\Tool\ToolDataClassResolver;
+use Netresearch\NrLlm\Service\Tool\ToolEffectResolver;
+use Netresearch\NrLlm\Service\Tool\ToolGroupStateRepository;
+use Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Service\Tool\ToolStateRepository;
+use Netresearch\NrLlm\Service\Tool\TrustZoneResolver;
+use Netresearch\NrLlm\Tests\Fixture\FixedPrivacyPolicy;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
+use RuntimeException;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * ADR-133: an approver may only release a write they could run themselves.
+ *
+ * The decision is made against the APPROVER's live backend user — the real
+ * {@see ActingBackendUserResolver} over real `be_users` rows — and the real
+ * composite gate ({@see ToolCallPolicy}), because both are the production code
+ * this guard rests on. The run itself lives in the functional database and goes
+ * through the real claim/release transitions, so "the run is decidable again" is
+ * asserted on the stored row rather than on a double.
+ *
+ * The tool catalogue is fake: no builtin declares a write today (ADR-122), so a
+ * write-declaring turn has to be constructed.
+ */
+#[CoversClass(ResumeCoordinator::class)]
+final class ResumeCoordinatorApproverGateTest extends AbstractFunctionalTestCase
+{
+    private AgentRunPersister $persister;
+
+    private bool $resumed = false;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // BeUsers.csv: uid 1 = admin (the run owner), uid 2 = non-admin editor.
+        $this->importFixture('BeUsers.csv');
+        $this->persister = new AgentRunPersister(
+            new AgentRunRepository($this->connectionPool(), $this->get(AgentStateCodec::class)),
+            FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL),
+            new NullLogger(),
+        );
+    }
+
+    #[Test]
+    public function aNonAdminWithTheApproveGrantMayNotReleaseAnAdminOnlyWrite(): void
+    {
+        // The confused deputy: the grant lets uid 2 DECIDE the admin's run, and
+        // the turn would then execute under the admin's identity (ADR-083).
+        $uuid = $this->suspendOn('delete_thing');
+
+        try {
+            $this->coordinator()->approve($this->grantedEditor(), $uuid, $this->decision(true, 2, 'delete_thing'));
+            self::fail('Expected ApproverNotPermittedException');
+        } catch (ApproverNotPermittedException $exception) {
+            self::assertStringContainsString('requiresAdmin', $exception->getMessage(), 'the refusal names the reason');
+            $this->assertStillWaiting($uuid);
+        }
+    }
+
+    #[Test]
+    public function theSameNonAdminReleasesAReadOnlyTurn(): void
+    {
+        // The other half: the gate judges write-declaring calls only, so the
+        // grant keeps working for everything that changes nothing.
+        $uuid = $this->suspendOn('list_pages');
+
+        $this->coordinator()->approve($this->grantedEditor(), $uuid, $this->decision(true, 2, 'list_pages'));
+
+        self::assertTrue($this->resumed, 'the turn was resumed');
+        $this->assertSettledCompleted($uuid);
+    }
+
+    #[Test]
+    public function aNonAdminReleasesAWriteTheyMayRunThemselves(): void
+    {
+        // The positive control: the gate is the tool policy's verdict about the
+        // approver, not a blanket "non-admins may not approve writes".
+        $uuid = $this->suspendOn('touch_thing');
+
+        $this->coordinator()->approve($this->grantedEditor(), $uuid, $this->decision(true, 2, 'touch_thing'));
+
+        self::assertTrue($this->resumed);
+        $this->assertSettledCompleted($uuid);
+    }
+
+    #[Test]
+    public function aServiceAccountMayNotReleaseAWriteDeclaringTurn(): void
+    {
+        // `touch_thing` has no admin flag, so the policy would ALLOW it for the
+        // "no user" a service account presents — which is exactly why the
+        // refusal cannot be left to the policy (ADR-133).
+        $uuid = $this->suspendOn('touch_thing');
+
+        try {
+            $this->coordinator()->approve($this->serviceAccount(), $uuid, $this->decision(true, 0, 'touch_thing'));
+            self::fail('Expected ApproverNotPermittedException');
+        } catch (ApproverNotPermittedException $exception) {
+            self::assertStringContainsString('Service account "nightly-approver"', $exception->getMessage());
+            $this->assertStillWaiting($uuid);
+        }
+    }
+
+    #[Test]
+    public function aServiceAccountReleasesAReadOnlyTurn(): void
+    {
+        $uuid = $this->suspendOn('list_pages');
+
+        $this->coordinator()->approve($this->serviceAccount(), $uuid, $this->decision(true, 0, 'list_pages'));
+
+        self::assertTrue($this->resumed);
+        $this->assertSettledCompleted($uuid);
+    }
+
+    // --- assertions --------------------------------------------------------
+
+    /**
+     * A refused decision leaves the run decidable: WAITING_FOR_APPROVAL with its
+     * suspended state intact, not RUNNING and not terminal — and nothing ran.
+     */
+    private function assertStillWaiting(string $uuid): void
+    {
+        self::assertFalse($this->resumed, 'nothing was executed');
+
+        $run = $this->persister->findRun($uuid);
+        self::assertInstanceOf(AgentRun::class, $run);
+        self::assertSame(AgentRunStatus::WAITING_FOR_APPROVAL, $run->statusEnum());
+        self::assertNotNull($run->suspendedState, 'the state is written back, so the turn can be re-reviewed');
+        self::assertSame(0, $run->finishedAt, 'a refused decision never settles the run');
+    }
+
+    private function assertSettledCompleted(string $uuid): void
+    {
+        $run = $this->persister->findRun($uuid);
+        self::assertInstanceOf(AgentRun::class, $run);
+        self::assertSame(AgentRunStatus::COMPLETED, $run->statusEnum());
+    }
+
+    // --- helpers -----------------------------------------------------------
+
+    /**
+     * A non-admin backend user (uid 2) who may decide the admin's run ONLY
+     * because of the ADR-130 grant — the principal ADR-133 is about.
+     */
+    private function grantedEditor(): AiActorContext
+    {
+        return AiActorContext::backendUser(2, grants: [BackendUserGrant::AGENT_APPROVE]);
+    }
+
+    private function serviceAccount(): AiActorContext
+    {
+        return AiActorContext::serviceAccount('nightly-approver', [ServiceAccountScope::AGENT_APPROVE]);
+    }
+
+    private function decision(bool $approved, int $decidedBy, string $tool): ApprovalDecision
+    {
+        return new ApprovalDecision($approved, $decidedBy, (new PendingTurnDigest())->forState($this->state($tool)));
+    }
+
+    /**
+     * Start a run owned by the ADMIN (uid 1) and pause it on one pending call.
+     *
+     * @return string the run uuid
+     */
+    private function suspendOn(string $tool): string
+    {
+        $handle = $this->persister->begin(null, 1);
+        self::assertNotNull($handle);
+        self::assertTrue($this->persister->suspend($handle, $this->state($tool)));
+
+        return $handle->uuid;
+    }
+
+    private function state(string $tool): SuspendedRunState
+    {
+        return new SuspendedRunState([], [ToolCall::function('c1', $tool, ['uid' => 42])->toArray()], 1, 0, 0);
+    }
+
+    /**
+     * The coordinator with the REAL gate and the REAL backend-user resolver; only
+     * the tool loop and the configuration lookup are doubled (this test is about
+     * who may release a call, not about what the call does).
+     */
+    private function coordinator(): ResumeCoordinator
+    {
+        $registry = new ToolRegistry([
+            new FakeTool('delete_thing', requiresAdmin: true, effect: ToolEffect::NON_IDEMPOTENT_WRITE),
+            new FakeTool('touch_thing', effect: ToolEffect::NON_IDEMPOTENT_WRITE),
+            new FakeTool('list_pages'),
+        ]);
+
+        $policy = new ToolCallPolicy(
+            $registry,
+            new ToolAvailabilityService($registry, new ToolStateRepository($this->connectionPool()), new ToolGroupStateRepository($this->connectionPool())),
+            new AllowedToolsResolver(new SkillComposer(), $registry),
+            new ToolDataClassResolver($registry),
+            new TrustZoneResolver(),
+        );
+
+        $configurationRepository = self::createStub(LlmConfigurationRepository::class);
+        $configurationRepository->method('findByUid')->willReturn($this->localConfiguration());
+
+        $loop = $this->toolLoop();
+
+        return new ResumeCoordinator(
+            $this->persister,
+            $configurationRepository,
+            $loop,
+            new AgentRunExecutor($loop, $this->persister),
+            null,
+            new ToolEffectResolver($registry),
+            new PendingTurnDigest(),
+            $policy,
+            new ActingBackendUserResolver(),
+            new NullLogger(),
+        );
+    }
+
+    /**
+     * A loop that records whether the turn was resumed at all — the assertion
+     * behind "nothing was executed" — and otherwise completes immediately.
+     */
+    private function toolLoop(): ToolLoopServiceInterface
+    {
+        $loop = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method('resume')->willReturnCallback(function (): ToolLoopResult {
+            $this->resumed = true;
+
+            return new ToolLoopResult('continued', [], 1, false, UsageStatistics::fromTokens(1, 1));
+        });
+        $loop->method('resumeWithInput')->willReturnCallback(static function (): ToolLoopResult {
+            throw new RuntimeException('resumeWithInput must not be reached', 1785400001);
+        });
+
+        return $loop;
+    }
+
+    /**
+     * A configuration whose provider sits in the LOCAL trust zone, so the
+     * trust-zone axis of the real gate permits the fake tools and the assertions
+     * are about the admin axis (see ToolLoopServiceBuiltinTest for the same
+     * reasoning).
+     */
+    private function localConfiguration(): LlmConfiguration
+    {
+        $provider = new Provider();
+        $provider->setTrustZoneEnum(TrustZone::LOCAL);
+
+        $model = new Model();
+        $model->setProvider($provider);
+
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('cfg-approver-gate');
+        $configuration->setLlmModel($model);
+
+        return $configuration;
+    }
+
+    private function connectionPool(): ConnectionPool
+    {
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+
+        return $connectionPool;
+    }
+}

--- a/Tests/Unit/Service/Agent/AgentRuntimeTest.php
+++ b/Tests/Unit/Service/Agent/AgentRuntimeTest.php
@@ -12,9 +12,13 @@ namespace Netresearch\NrLlm\Tests\Unit\Service\Agent;
 use Netresearch\NrLlm\Domain\Enum\AgentRunOutcome;
 use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
 use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
+use Netresearch\NrLlm\Domain\Enum\BackendUserGrant;
 use Netresearch\NrLlm\Domain\Enum\PrivacyLevel;
 use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
+use Netresearch\NrLlm\Domain\Enum\ToolDataClass;
+use Netresearch\NrLlm\Domain\Enum\ToolDenialReason;
 use Netresearch\NrLlm\Domain\Enum\ToolEffect;
+use Netresearch\NrLlm\Domain\Enum\TrustZone;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
@@ -25,6 +29,7 @@ use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
+use Netresearch\NrLlm\Domain\ValueObject\ToolPolicyDecision;
 use Netresearch\NrLlm\Exception\GuardrailApprovalRequiredException;
 use Netresearch\NrLlm\Exception\GuardrailViolationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
@@ -33,6 +38,7 @@ use Netresearch\NrLlm\Service\Agent\AgentRunRequest;
 use Netresearch\NrLlm\Service\Agent\AgentRuntime;
 use Netresearch\NrLlm\Service\Agent\ApprovalDecision;
 use Netresearch\NrLlm\Service\Agent\Exception\ApprovalNotAuditableException;
+use Netresearch\NrLlm\Service\Agent\Exception\ApproverNotPermittedException;
 use Netresearch\NrLlm\Service\Agent\Exception\AuditPersistenceFailedException;
 use Netresearch\NrLlm\Service\Agent\Exception\CorruptSuspendedStateException;
 use Netresearch\NrLlm\Service\Agent\Exception\InvalidInputSubmissionException;
@@ -56,6 +62,7 @@ use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
 use Netresearch\NrLlm\Service\Tool\Exception\ToolApprovalRequiredException;
 use Netresearch\NrLlm\Service\Tool\Exception\ToolInputRequiredException;
 use Netresearch\NrLlm\Service\Tool\RunTrace;
+use Netresearch\NrLlm\Service\Tool\ToolCallPolicyInterface;
 use Netresearch\NrLlm\Service\Tool\ToolEffectResolver;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface;
@@ -71,6 +78,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Throwable;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 
 #[CoversClass(AgentRuntime::class)]
 #[CoversClass(AgentRunExecutor::class)]
@@ -585,6 +593,206 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
             ->approve($this->actor(), 'run-uuid-1', $this->decision(false, 7, 'send_mail'));
 
         self::assertSame(AgentRunOutcome::COMPLETED, $result->outcome);
+    }
+
+    #[Test]
+    public function anApproverWhoMayNotRunTheWriteMayNotReleaseIt(): void
+    {
+        // ADR-133: the confused deputy. A non-admin holding the agent_approve
+        // grant may DECIDE another user's run (ADR-130), but the turn executes
+        // under the OWNER's identity (ADR-083) — so an admin-only write would run
+        // on the owner's authority. The gate the execution would pass is asked
+        // about the APPROVER, and its denial refuses the release.
+        $this->repository->findResult = $this->suspendedRun(tool: 'send_mail');
+
+        try {
+            $this->runtime(
+                $this->loopNeverResuming(),
+                effectResolver: new ToolEffectResolver(new ToolRegistry([
+                    new FakeTool('send_mail', requiresAdmin: true, effect: ToolEffect::NON_IDEMPOTENT_WRITE),
+                ])),
+                toolPolicy: $this->policyDeciding(false, ToolDenialReason::REQUIRES_ADMIN),
+                actingBackendUserResolver: $this->resolverReturningALiveUser(),
+            )->approve($this->approver(), 'run-uuid-1', $this->decision(true, 5, 'send_mail'));
+            self::fail('Expected ApproverNotPermittedException');
+        } catch (ApproverNotPermittedException) {
+            $this->assertReleasedNotSettled();
+            // The gate sits BEFORE the audit write: a refused approval must not
+            // land in the stream as a decision that stood.
+            self::assertSame([], array_values(array_filter(
+                $this->repository->events,
+                static fn(array $event): bool => $event['kind'] === 'approval',
+            )));
+        }
+    }
+
+    #[Test]
+    public function anApproverWhoMayRunTheWriteReleasesItUnderTheRunOwnersIdentity(): void
+    {
+        // The positive control for the gate AND the ADR-083 regression: the
+        // approver (uid 5) passes the gate, and what reaches the tool loop is
+        // still the run OWNER's actor (uid 9) — the deputy check must not have
+        // turned into an identity switch. The approver's uid travels only as the
+        // decider, for the continuation's budget check.
+        $this->repository->findResult = $this->suspendedRun(tool: 'send_mail');
+
+        $seenActor  = null;
+        $seenDecider = null;
+        $loop        = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method('resume')->willReturnCallback(
+            function (SuspendedRunState $state, bool $approved, LlmConfiguration $config, ToolExecutionContext $context, ?int $max, ?RunTrace $trace, ?int $beUserUid) use (&$seenActor, &$seenDecider): ToolLoopResult {
+                $seenActor   = $context->actor;
+                $seenDecider = $beUserUid;
+
+                return $this->loopResult('continued');
+            },
+        );
+
+        $result = $this->runtime(
+            $loop,
+            effectResolver: new ToolEffectResolver(new ToolRegistry([
+                new FakeTool('send_mail', effect: ToolEffect::NON_IDEMPOTENT_WRITE),
+            ])),
+            toolPolicy: $this->policyDeciding(true),
+            actingBackendUserResolver: $this->resolverReturningALiveUser(),
+        )->approve($this->approver(), 'run-uuid-1', $this->decision(true, 5, 'send_mail'));
+
+        self::assertSame(AgentRunOutcome::COMPLETED, $result->outcome);
+        self::assertInstanceOf(AiActorContext::class, $seenActor);
+        self::assertSame(9, $seenActor->backendUserUid, 'the resumed turn runs as the run owner, not the approver');
+        self::assertSame(5, $seenDecider);
+    }
+
+    #[Test]
+    public function theApproverGateOnlyJudgesWriteDeclaringCalls(): void
+    {
+        // The other half of the DoD: the same non-admin still releases a
+        // read-only turn. The policy double would deny EVERY tool it is asked
+        // about, so a green result proves the gate never asked.
+        $this->repository->findResult = $this->suspendedRun(tool: 'list_pages');
+
+        $result = $this->runtime(
+            $this->loopReturning($this->loopResult('continued')),
+            effectResolver: new ToolEffectResolver(new ToolRegistry([new FakeTool('list_pages')])),
+            toolPolicy: $this->policyDeciding(false, ToolDenialReason::REQUIRES_ADMIN),
+            actingBackendUserResolver: $this->resolverReturningALiveUser(),
+        )->approve($this->approver(), 'run-uuid-1', $this->decision(true, 5, 'list_pages'));
+
+        self::assertSame(AgentRunOutcome::COMPLETED, $result->outcome);
+    }
+
+    #[Test]
+    public function aServiceAccountMayNotReleaseAWriteDeclaringTurn(): void
+    {
+        // ADR-133 decision E5(a): a service account has no backend permissions
+        // at all — hasGrant() is false for it by construction and it has no uid —
+        // so decide() would see "no user" and check only the requiresAdmin axis.
+        // A write tool without that flag would pass a gate that is effectively
+        // absent. The policy double ALLOWS everything here, so the refusal can
+        // only come from the missing identity, not from the gate.
+        $this->repository->findResult = $this->suspendedRun(tool: 'send_mail');
+
+        try {
+            $this->runtime(
+                $this->loopNeverResuming(),
+                effectResolver: new ToolEffectResolver(new ToolRegistry([
+                    new FakeTool('send_mail', effect: ToolEffect::NON_IDEMPOTENT_WRITE),
+                ])),
+                toolPolicy: $this->policyDeciding(true),
+            )->approve(
+                AiActorContext::serviceAccount('nightly-approver', [ServiceAccountScope::AGENT_APPROVE]),
+                'run-uuid-1',
+                $this->decision(true, 0, 'send_mail'),
+            );
+            self::fail('Expected ApproverNotPermittedException');
+        } catch (ApproverNotPermittedException) {
+            $this->assertReleasedNotSettled();
+        }
+    }
+
+    #[Test]
+    public function aServiceAccountMayStillReleaseAReadOnlyTurn(): void
+    {
+        // The refusal is scoped to writes: an automation that clears read-only
+        // pauses keeps working (ADR-110's AGENT_APPROVE scope is not revoked).
+        $this->repository->findResult = $this->suspendedRun(tool: 'list_pages');
+
+        $result = $this->runtime(
+            $this->loopReturning($this->loopResult('continued')),
+            effectResolver: new ToolEffectResolver(new ToolRegistry([new FakeTool('list_pages')])),
+            toolPolicy: $this->policyDeciding(true),
+        )->approve(
+            AiActorContext::serviceAccount('nightly-approver', [ServiceAccountScope::AGENT_APPROVE]),
+            'run-uuid-1',
+            $this->decision(true, 0, 'list_pages'),
+        );
+
+        self::assertSame(AgentRunOutcome::COMPLETED, $result->outcome);
+    }
+
+    #[Test]
+    public function aDenialPassesTheApproverGate(): void
+    {
+        // The same asymmetry ADR-132 states for the audit gate, for the same
+        // reason: the gate exists to stop an unauthorised WRITE from executing,
+        // and a denial executes nothing. Refusing it would leave the write
+        // pending and approvable while the operator who wanted it gone is turned
+        // away.
+        $this->repository->findResult = $this->suspendedRun(tool: 'send_mail');
+
+        $result = $this->runtime(
+            $this->loopReturning($this->loopResult('refused and continued')),
+            effectResolver: new ToolEffectResolver(new ToolRegistry([
+                new FakeTool('send_mail', requiresAdmin: true, effect: ToolEffect::NON_IDEMPOTENT_WRITE),
+            ])),
+            toolPolicy: $this->policyDeciding(false, ToolDenialReason::REQUIRES_ADMIN),
+            actingBackendUserResolver: $this->resolverReturningALiveUser(),
+        )->approve($this->approver(), 'run-uuid-1', $this->decision(false, 5, 'send_mail'));
+
+        self::assertSame(AgentRunOutcome::COMPLETED, $result->outcome);
+    }
+
+    /**
+     * A non-owner, non-admin backend user who may decide the fixture's run only
+     * because of the ADR-130 grant — the exact principal ADR-133 is about.
+     */
+    private function approver(): AiActorContext
+    {
+        return AiActorContext::backendUser(5, grants: [BackendUserGrant::AGENT_APPROVE]);
+    }
+
+    /**
+     * A tool gate returning the same verdict for every tool it is asked about.
+     */
+    private function policyDeciding(bool $allowed, ToolDenialReason $reason = ToolDenialReason::NONE): ToolCallPolicyInterface
+    {
+        $policy = self::createStub(ToolCallPolicyInterface::class);
+        $policy->method('decide')->willReturnCallback(
+            static fn(string $toolName): ToolPolicyDecision => new ToolPolicyDecision(
+                $toolName,
+                $allowed,
+                ToolDataClass::EDITOR_CONTENT,
+                TrustZone::LOCAL,
+                ToolDataClass::SECRET_ADJACENT,
+                $reason,
+            ),
+        );
+
+        return $policy;
+    }
+
+    /**
+     * A resolver that hands back a live backend user for any actor — the "the
+     * approver exists" precondition, so a test asserts the GATE's verdict rather
+     * than the absence of a user. Resolution from the database is covered by the
+     * functional ActingBackendUserResolver test.
+     */
+    private function resolverReturningALiveUser(): ActingBackendUserResolverInterface
+    {
+        $resolver = self::createStub(ActingBackendUserResolverInterface::class);
+        $resolver->method('resolve')->willReturn(self::createStub(BackendUserAuthentication::class));
+
+        return $resolver;
     }
 
     /**
@@ -1290,6 +1498,10 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
         ?LlmConfiguration $configuration = new LlmConfiguration(),
         ?MessageBusInterface $bus = null,
         ?ToolEffectResolver $effectResolver = null,
+        // The approver gate (ADR-133) runs only when a policy is wired; the
+        // cases that are not about it leave both null and are unaffected.
+        ?ToolCallPolicyInterface $toolPolicy = null,
+        ?ActingBackendUserResolverInterface $actingBackendUserResolver = null,
     ): AgentRuntime {
         $configurationRepository = self::createStub(LlmConfigurationRepository::class);
         $configurationRepository->method('findByUid')->willReturn($configuration);
@@ -1304,8 +1516,9 @@ final class AgentRuntimeTest extends AbstractUnitTestCase
             // unit test — the real resolver would hit the database via
             // setBeUserByUid(). Tool authorization from a live user is covered by
             // the functional ActingBackendUserResolver and tool tests.
-            actingBackendUserResolver: self::createStub(ActingBackendUserResolverInterface::class),
+            actingBackendUserResolver: $actingBackendUserResolver ?? self::createStub(ActingBackendUserResolverInterface::class),
             toolEffectResolver: $effectResolver,
+            toolPolicy: $toolPolicy,
         );
     }
 


### PR DESCRIPTION
> **Stacked on #644.** Base is `fix/approval-audit-fail-closed`, not `main`. GitHub will retarget it when #644 merges.

## Description

A confused deputy. Resume executes under the run owner's identity, deliberately (ADR-083) — but the approver was never checked against the tool they release: `AiActorContext::mayActOnRun()` grants the decision on the `agent_approve` grant alone. A non-admin holding it could release an admin-only write tool, which then executed on someone else's authority.

`approve()` now resolves the **approver's** live backend user and asks `ToolCallPolicy::decide()` about every write-declaring pending call. Execution identity is unchanged.

### A service account may not approve a write-declaring turn

`hasGrant()` always returns false for a service account and it has no backend-user uid, so `decide()` with `$user === null` checks only registered/enabled/group/zone and bites on the admin axis solely through `requiresAdmin()`. A write tool with `requiresAdmin() === false` would pass a gate that is effectively absent — weaker than for any human. Refusing is the only variant that stays fail-closed without inventing a second authorisation axis.

No new `BackendUserGrant`: ADR-130 admits a grant only together with its consumer.

### Where the gate sits, and why

Between the digest check and the audit write — gate 2 of three.

- **After gate 1** (digest), because it judges the calls of the turn that was *actually reviewed*, and there is no point resolving a backend user for a decision already known to be stale.
- **Before gate 3** (audit), because a refused approval must not enter the audit stream as a decision that stood. Gate 1 already releases before anything is recorded; putting this one after the audit write would have broken that symmetry.

Refusal goes through the existing `release()`. A **denial** passes gates 2 and 3 — it executes nothing, so there is nothing to stop. A test pins that carve-out so it cannot be "fixed" by accident.

### Two limits made explicit rather than silently taken

- **Read-only pending calls are not gated.** A non-admin approver can still release an admin-only *read*, which puts its result into the run's transcript. Scoped per the issue ("every write-declaring pending call") and recorded in ADR-133's "deliberately is not" section as a decision, not an oversight.
- **The null-policy arm does not refuse everything.** Without a policy there is no verdict to fail closed *on*, and refusing would leave `AgentRuntime`'s own documented fallback construction unable to approve anything at all rather than merely unchecked. The arm is unreachable from the container (the interface is aliased) and `AgentRuntime` now hands its policy down. Documented at the constructor and in the ADR.

## Related Issue

Closes #622

Found while implementing this and filed separately, not fixed here: #649 — `submitInput()` has the same shape. It is currently unreachable (no production class implements `RequiresInputInterface`), and it cannot simply copy this fix: the input path has neither a write asymmetry to gate on nor a turn digest.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

Behaviour tightens for an approver who could not run the call themselves. No signature is broken; the new collaborators are optional constructor arguments on a non-`@api` class.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `composer ci` and all checks pass — unit, PHPStan (level 10) and cgl re-run independently of the authoring pass: all SUCCESS; the three functional classes executed for real (27 tests, 410 assertions). Rector green under an 8.2 resolve, then restored to 8.4 and the suites re-run on that tree.
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation accordingly
- [x] I have added a `CHANGELOG.md` entry under `## [Unreleased]`
- [x] I have added an ADR under `Documentation/Adr/` if this changes the public surface — ADR-133
- [x] My changes generate no new warnings

### Tests

`ResumeCoordinatorApproverGateTest` uses the real `ToolCallPolicy`, the real `ActingBackendUserResolver` over real `be_users` rows, a real DB run row and the real claim/release — not stand-ins for the thing under test.

- A non-admin with `agent_approve` cannot release an admin-only write turn; can release a read-only one.
- A service account is refused on a write-declaring turn.
- After a refusal the run is `WAITING_FOR_APPROVAL` again — not RUNNING, not terminal — and nothing executed.
- Execution identity remains the run owner (ADR-083 regression).
- The denial carve-out is asserted.

`Tests/Unit/Api/api-surface.txt` is unchanged and correct: the new constructor properties are `private` promoted on non-`@api` classes, and the new exception is not marked `@api` — nor are its siblings; only `AgentRuntimeException` is.