### PR TITLE
feat(routing): match the resolved model against the operation in criteria mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Criteria-mode configurations no longer resolve a model that cannot serve
+  the running operation (ADR-138). The operation is merged into the criteria
+  before selection, so a tool call picks a tool-capable model instead of
+  failing later as a provider error. Only `chat`, `vision` and `tools` are
+  enforced — no model discoverer writes `completion` or `embeddings`, and
+  only four of seven write `streaming`, so requiring those would refuse
+  working models. A model whose capability field is empty counts as
+  undeclared and always passes. New extension setting
+  `routing.operationCapabilityEnforcement` (default `enforce`, fail-closed
+  like ADR-113) switches the axis to `observe`, which logs the mismatch and
+  leaves selection untouched. Fixed-mode configurations are unaffected.
+- `Model::$capabilities` was dropped on every load from the database.
+  Extbase resolved the property as an array (Symfony PropertyInfo infers a
+  collection from the `addCapability()` / `removeCapability()` pair) and its
+  DataMapper has no array mapping, so every repository-loaded model came
+  back with an empty capability set — which also made every `capabilities`
+  selection criterion match nothing. Anything reading `getCapabilities()`
+  off a repository-loaded model now sees the persisted value.
+- The embedding cache key and the embedding call can no longer resolve
+  different models for the same call. `embedForConfiguration()` resolves
+  twice — once outside the pipeline for the key, once inside the terminal —
+  and both now pass the same operation.
+
+### Changed
+
+- Internal signature change: `ModelSelectionServiceInterface::resolveModel()`
+  and `ConfigurationCallPlanner::resolveModel()` take a required
+  `?ProviderOperation`; `ConfigurationCallPlanner::adapterFor()` likewise.
+  Neither class is part of the frozen `@api` surface. Callers with no
+  operation pass `null` explicitly.
+
 ## [0.26.0] - 2026-08-06
 
 ### Added

--- a/Classes/Controller/Backend/ConfigurationController.php
+++ b/Classes/Controller/Backend/ConfigurationController.php
@@ -23,6 +23,7 @@ use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\Analytics\AnalyticsPeriod;
 use Netresearch\NrLlm\Service\LlmConfigurationServiceInterface;
@@ -384,7 +385,11 @@ final class ConfigurationController extends ActionController
             // returns the directly configured model unchanged for fixed-mode
             // records, is what the runtime does; testing only getLlmModel()
             // reported "has no model assigned" for a configuration that works.
-            $model = $this->modelSelectionService->resolveModel($configuration);
+            // The test below dispatches complete(), so the resolution is scoped
+            // to that operation (ADR-138) — testing a criteria-mode
+            // configuration must exercise the model a completion call would
+            // actually pick, not a differently-capable sibling.
+            $model = $this->modelSelectionService->resolveModel($configuration, ProviderOperation::Completion);
             if (!$model instanceof Model || !$model->getProvider() instanceof Provider) {
                 $response = new JsonResponse((new ErrorResponse($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.config.noModel', 'Configuration has no model assigned')))->jsonSerialize(), 400);
             } else {

--- a/Classes/Domain/Model/Model.php
+++ b/Classes/Domain/Model/Model.php
@@ -40,6 +40,23 @@ class Model extends AbstractEntity
     /** Embedding vector dimensionality of the model (0 = unknown). */
     protected int $dimensions = 0;
 
+    /**
+     * The `@var` below is load-bearing and must not be removed as "redundant
+     * with the property type" — its description is what keeps PHP-CS-Fixer's
+     * `no_superfluous_phpdoc_tags` from stripping it.
+     *
+     * Extbase's ClassSchema resolves property types through Symfony's
+     * PropertyInfo, whose ReflectionExtractor infers a COLLECTION from an
+     * adder/remover pair: `addCapability()` / `removeCapability()` below inflect
+     * to this property and made it resolve as `array`. Extbase's DataMapper has
+     * no array mapping (`'array' => null` in `thawProperties()`), so the column
+     * was silently dropped on every load — every repository-loaded model came
+     * back with an EMPTY capability set, which in turn made every `capabilities`
+     * selection criterion match nothing. PhpDocExtractor runs before
+     * ReflectionExtractor, so the tag restores the declared type (ADR-138).
+     *
+     * @var string Comma-separated capability tokens, exactly as persisted
+     */
     protected string $capabilities = '';
 
     protected int $defaultTimeout = 120;

--- a/Classes/Service/ConfigurationCallPlanner.php
+++ b/Classes/Service/ConfigurationCallPlanner.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 
 /**
@@ -40,16 +41,26 @@ final readonly class ConfigurationCallPlanner
     /**
      * The adapter a configuration-driven call runs against — the single
      * adapter choke point (ADR-066).
+     *
+     * `$operation` is threaded through to the resolution so that two adapter
+     * lookups for the same call cannot land on different models (ADR-138).
      */
-    public function adapterFor(LlmConfiguration $configuration): ProviderInterface
+    public function adapterFor(LlmConfiguration $configuration, ?ProviderOperation $operation): ProviderInterface
     {
-        return $this->adapterRegistry->createAdapterFromModel($this->resolveModel($configuration));
+        return $this->adapterRegistry->createAdapterFromModel($this->resolveModel($configuration, $operation));
     }
 
     /**
      * Resolve the concrete Model entity an LlmConfiguration call runs against.
+     *
+     * `$operation` names the call being planned. In criteria mode it narrows
+     * the selection to models that declare the matching capability (ADR-138);
+     * pass null only where there is genuinely no operation. Two resolutions of
+     * the SAME call must pass the SAME operation — a cache key derived from one
+     * resolution and a terminal that resolves again would otherwise be able to
+     * disagree about which model the call runs on.
      */
-    public function resolveModel(LlmConfiguration $configuration): Model
+    public function resolveModel(LlmConfiguration $configuration, ?ProviderOperation $operation): Model
     {
         // Criteria-mode configurations carry no direct model relation (model_uid = 0);
         // their model is selected at call time from the stored criteria. Resolve
@@ -58,7 +69,7 @@ final readonly class ConfigurationCallPlanner
         // model here. Without this, every *ForConfiguration() call on a criteria-mode
         // configuration threw "has no model assigned".
         $llmModel = $this->modelSelectionService instanceof ModelSelectionServiceInterface
-            ? $this->modelSelectionService->resolveModel($configuration)
+            ? $this->modelSelectionService->resolveModel($configuration, $operation)
             : $configuration->getLlmModel();
         if (!$llmModel instanceof Model) {
             throw new ProviderException(

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -561,7 +561,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             ProviderOperation::Tools,
             function (ProviderCallContext $ctx) use ($normalisedMessages, $normalisedTools, $optionOverrides): CompletionResponse {
                 $config   = $this->planner->requireConfiguration($ctx);
-                $llmModel = $this->planner->resolveModel($config);
+                $llmModel = $this->planner->resolveModel($config, ProviderOperation::Tools);
                 $adapter  = $this->adapterRegistry->createAdapterFromModel($llmModel);
                 if (!$adapter instanceof ToolCapableInterface) {
                     throw new UnsupportedFeatureException(
@@ -627,11 +627,16 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         // case, or entries keyed under the empty id would be shared across
         // whatever model the criteria select over time. Fixed-mode configs
         // keep the relation's id without the extra resolution.
+        //
+        // This resolution sits OUTSIDE the terminal, which resolves again a few
+        // lines below. Both MUST pass the same ProviderOperation: if they could
+        // disagree, the key would name model A while the call ran on model B and
+        // cache entries would be served across models (ADR-138).
         $effectiveModel = is_string($optionOverrides['model'] ?? null)
             ? $optionOverrides['model']
             : ($configuration->getModelId() !== ''
                 ? $configuration->getModelId()
-                : $this->planner->resolveModel($configuration)->getModelId());
+                : $this->planner->resolveModel($configuration, ProviderOperation::Embedding)->getModelId());
         // EmbedCacheKeyBuilder sanitizes the scope tag: configuration
         // identifiers use the dotted preset scheme (nr_ai_search.embeddings),
         // and the cache frontend rejects a tag containing a dot with an
@@ -650,7 +655,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             ProviderCallContext::forConfiguration(ProviderOperation::Embedding, $configuration, $metadata),
             function (ProviderCallContext $ctx) use ($input, $optionOverrides): array {
                 $config   = $this->planner->requireConfiguration($ctx);
-                $llmModel = $this->planner->resolveModel($config);
+                $llmModel = $this->planner->resolveModel($config, ProviderOperation::Embedding);
                 $adapter  = $this->adapterRegistry->createAdapterFromModel($llmModel);
                 if (!$adapter->supportsFeature('embeddings')) {
                     throw new UnsupportedFeatureException(
@@ -728,7 +733,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
      */
     public function getAdapterFromConfiguration(LlmConfiguration $configuration): ProviderInterface
     {
-        return $this->planner->adapterFor($configuration);
+        return $this->planner->adapterFor($configuration, null);
     }
 
     /**
@@ -755,7 +760,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             ProviderOperation::Chat,
             function (ProviderCallContext $ctx) use ($normalisedMessages, $optionOverrides): CompletionResponse {
                 $config   = $this->planner->requireConfiguration($ctx);
-                $llmModel = $this->planner->resolveModel($config);
+                $llmModel = $this->planner->resolveModel($config, ProviderOperation::Chat);
                 $adapter  = $this->adapterRegistry->createAdapterFromModel($llmModel);
                 $options  = $this->planner->callOptions($config, $llmModel, $optionOverrides);
                 return $adapter->chatCompletion($this->applyAndScreenSystemPrompt($normalisedMessages, $options), $options);
@@ -781,7 +786,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             ProviderOperation::Completion,
             function (ProviderCallContext $ctx) use ($prompt, $optionOverrides): CompletionResponse {
                 $config   = $this->planner->requireConfiguration($ctx);
-                $llmModel = $this->planner->resolveModel($config);
+                $llmModel = $this->planner->resolveModel($config, ProviderOperation::Completion);
                 $adapter  = $this->adapterRegistry->createAdapterFromModel($llmModel);
                 $options  = $this->planner->callOptions($config, $llmModel, $optionOverrides);
                 return $adapter->complete($prompt, $options);
@@ -1009,7 +1014,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         $messages = $this->screenInput($messages);
 
         $open = function (LlmConfiguration $config) use ($messages, $optionOverrides): Generator {
-            $llmModel = $this->planner->resolveModel($config);
+            $llmModel = $this->planner->resolveModel($config, ProviderOperation::Stream);
             $adapter  = $this->adapterRegistry->createAdapterFromModel($llmModel);
             $options  = $this->planner->callOptions($config, $llmModel, $optionOverrides);
 
@@ -1029,7 +1034,12 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         // provider throws at call time, not lazily on the first iteration inside
         // the dispatcher; fallback candidates are still checked per-attempt in
         // the opener above.
-        $this->assertStreamingCapable($this->getAdapterFromConfiguration($configuration), 1735300101);
+        // Deliberately NOT getAdapterFromConfiguration(): that is the generic,
+        // operation-less entry point, and resolving without the operation here
+        // could pick a different model than the opener above resolves with
+        // ProviderOperation::Stream — the eager check would then assert against
+        // an adapter the stream never runs on (ADR-138).
+        $this->assertStreamingCapable($this->planner->adapterFor($configuration, ProviderOperation::Stream), 1735300101);
 
         $metadata[StreamingDispatcher::METADATA_PROMPT_CHARS] = $this->estimatePromptChars($messages);
 

--- a/Classes/Service/ModelSelectionService.php
+++ b/Classes/Service/ModelSelectionService.php
@@ -9,10 +9,16 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service;
 
+use Netresearch\NrLlm\Domain\Enum\ModelCapability;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
+use Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Psr\Log\LoggerInterface;
+use Throwable;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 /**
  * Service for dynamic model selection based on criteria.
@@ -22,35 +28,89 @@ use Netresearch\NrLlm\Domain\Repository\ModelRepository;
  * - Preferred adapter types (openai, anthropic, etc.)
  * - Minimum context length requirements
  * - Cost constraints and preferences
+ * - The capability the running operation itself requires (ADR-138)
  */
 final readonly class ModelSelectionService implements ModelSelectionServiceInterface
 {
+    private const OBSERVE = 'observe';
+
     public function __construct(
         private ModelRepository $modelRepository,
+        private ?ExtensionConfiguration $extensionConfiguration = null,
+        private ?LoggerInterface $logger = null,
     ) {}
 
     /**
      * Resolve a model for the given configuration.
      *
      * If the configuration uses fixed mode, returns the configured model.
-     * If using criteria mode, finds the best matching model based on criteria.
+     * If using criteria mode, finds the best matching model based on criteria,
+     * constrained by the capability `$operation` requires (ADR-138). Pass null
+     * for a resolution that is not tied to one operation.
      */
-    public function resolveModel(LlmConfiguration $configuration): ?Model
+    public function resolveModel(LlmConfiguration $configuration, ?ProviderOperation $operation): ?Model
     {
         if (!$configuration->usesCriteriaSelection()) {
-            // Fixed mode: return the directly configured model
+            // Fixed mode: return the directly configured model. Nothing is
+            // being chosen here — the operator named this model — so there is
+            // nothing for the operation to constrain. A fixed model that cannot
+            // do the operation still fails at the adapter, exactly as before.
             return $configuration->getLlmModel();
         }
 
         // Criteria mode: find best matching model
         $criteria = $configuration->getModelSelectionCriteriaArray();
-        return $this->findMatchingModel($criteria);
+
+        $capability = $operation instanceof ProviderOperation
+            ? OperationCapabilityMap::capabilityFor($operation)
+            : null;
+        if (!$operation instanceof ProviderOperation || !$capability instanceof ModelCapability) {
+            return $this->findMatchingModel($criteria);
+        }
+
+        if (!$this->enforcingOperationCapability()) {
+            $model = $this->findMatchingModel($criteria);
+            $this->reportObservedMismatch($model, $capability, $operation, $configuration);
+
+            return $model;
+        }
+
+        $constrained                        = $criteria;
+        $constrained['operationCapability'] = $capability->value;
+
+        $model = $this->findMatchingModel($constrained);
+        if ($model instanceof Model) {
+            return $model;
+        }
+
+        // Distinguish the two ways of ending up with nothing. Criteria that
+        // match no model at all are the pre-existing "has no model assigned"
+        // condition and stay a null return. Criteria that DO match, but match
+        // only models declaring they cannot do this operation, are a
+        // misconfiguration worth naming — and naming it here is the point of
+        // the ticket, because the alternative is an opaque provider error.
+        if ($this->findMatchingModel($criteria) instanceof Model) {
+            throw new UnsupportedFeatureException(
+                sprintf(
+                    'Configuration "%s" selects its model by criteria, but every matching model declares '
+                    . 'capabilities without "%s", which the "%s" operation requires. '
+                    . 'Add the capability to the model record, widen the criteria, or set '
+                    . 'routing.operationCapabilityEnforcement = observe.',
+                    $configuration->getIdentifier(),
+                    $capability->value,
+                    $operation->value,
+                ),
+                1786100138,
+            );
+        }
+
+        return null;
     }
 
     /**
      * Find a model matching the given criteria.
      *
-     * @param array{capabilities?: string[], adapterTypes?: string[], minContextLength?: int, maxCostInput?: int, preferLowestCost?: bool} $criteria
+     * @param array{capabilities?: string[], operationCapability?: string, adapterTypes?: string[], minContextLength?: int, maxCostInput?: int, preferLowestCost?: bool} $criteria
      */
     public function findMatchingModel(array $criteria): ?Model
     {
@@ -70,7 +130,7 @@ final readonly class ModelSelectionService implements ModelSelectionServiceInter
     /**
      * Find all models matching the given criteria.
      *
-     * @param array{capabilities?: string[], adapterTypes?: string[], minContextLength?: int, maxCostInput?: int, preferLowestCost?: bool} $criteria
+     * @param array{capabilities?: string[], operationCapability?: string, adapterTypes?: string[], minContextLength?: int, maxCostInput?: int, preferLowestCost?: bool} $criteria
      *
      * @return Model[]
      */
@@ -96,20 +156,50 @@ final readonly class ModelSelectionService implements ModelSelectionServiceInter
     /**
      * Check if a model matches the given criteria.
      *
-     * @param array{capabilities?: string[], adapterTypes?: string[], minContextLength?: int, maxCostInput?: int, preferLowestCost?: bool} $criteria
+     * @param array{capabilities?: string[], operationCapability?: string, adapterTypes?: string[], minContextLength?: int, maxCostInput?: int, preferLowestCost?: bool} $criteria
      */
     public function modelMatchesCriteria(Model $model, array $criteria): bool
     {
         return $this->matchesCapabilities($model, $criteria)
+            && $this->matchesOperationCapability($model, $criteria)
             && $this->matchesAdapterTypes($model, $criteria)
             && $this->matchesMinContextLength($model, $criteria)
             && $this->matchesMaxCostInput($model, $criteria);
     }
 
     /**
+     * Check whether the model can serve the operation the call is running.
+     *
+     * A SEPARATE key from `capabilities`, deliberately, because the two answer
+     * different questions and need different treatment of an undeclared model.
+     * `capabilities` is what an operator asked for and is matched strictly; a
+     * model that declares nothing does not satisfy it. `operationCapability` is
+     * derived from the running call, and there an empty capability CSV means
+     * "undeclared", not "cannot" (ADR-138): the field is optional, plenty of
+     * installations never filled it, and refusing every such model would break
+     * them for a fact nobody ever stated.
+     *
+     * @param array{capabilities?: string[], operationCapability?: string, adapterTypes?: string[], minContextLength?: int, maxCostInput?: int, preferLowestCost?: bool} $criteria
+     */
+    private function matchesOperationCapability(Model $model, array $criteria): bool
+    {
+        $required = $criteria['operationCapability'] ?? null;
+        if (!is_string($required) || $required === '') {
+            return true;
+        }
+
+        $capabilities = $model->getCapabilitySet();
+        if ($capabilities->isEmpty()) {
+            return true;
+        }
+
+        return $capabilities->has($required);
+    }
+
+    /**
      * Check whether the model satisfies all required capabilities.
      *
-     * @param array{capabilities?: string[], adapterTypes?: string[], minContextLength?: int, maxCostInput?: int, preferLowestCost?: bool} $criteria
+     * @param array{capabilities?: string[], operationCapability?: string, adapterTypes?: string[], minContextLength?: int, maxCostInput?: int, preferLowestCost?: bool} $criteria
      */
     private function matchesCapabilities(Model $model, array $criteria): bool
     {
@@ -142,7 +232,7 @@ final readonly class ModelSelectionService implements ModelSelectionServiceInter
     /**
      * Check whether the model's provider adapter type is among the allowed types.
      *
-     * @param array{capabilities?: string[], adapterTypes?: string[], minContextLength?: int, maxCostInput?: int, preferLowestCost?: bool} $criteria
+     * @param array{capabilities?: string[], operationCapability?: string, adapterTypes?: string[], minContextLength?: int, maxCostInput?: int, preferLowestCost?: bool} $criteria
      */
     private function matchesAdapterTypes(Model $model, array $criteria): bool
     {
@@ -161,7 +251,7 @@ final readonly class ModelSelectionService implements ModelSelectionServiceInter
     /**
      * Check whether the model meets the minimum context length requirement.
      *
-     * @param array{capabilities?: string[], adapterTypes?: string[], minContextLength?: int, maxCostInput?: int, preferLowestCost?: bool} $criteria
+     * @param array{capabilities?: string[], operationCapability?: string, adapterTypes?: string[], minContextLength?: int, maxCostInput?: int, preferLowestCost?: bool} $criteria
      */
     private function matchesMinContextLength(Model $model, array $criteria): bool
     {
@@ -178,7 +268,7 @@ final readonly class ModelSelectionService implements ModelSelectionServiceInter
     /**
      * Check whether the model's input cost is within the allowed maximum.
      *
-     * @param array{capabilities?: string[], adapterTypes?: string[], minContextLength?: int, maxCostInput?: int, preferLowestCost?: bool} $criteria
+     * @param array{capabilities?: string[], operationCapability?: string, adapterTypes?: string[], minContextLength?: int, maxCostInput?: int, preferLowestCost?: bool} $criteria
      */
     private function matchesMaxCostInput(Model $model, array $criteria): bool
     {
@@ -270,6 +360,77 @@ final readonly class ModelSelectionService implements ModelSelectionServiceInter
         // already pre-orders by `sorting, name`, so this yields a deterministic
         // result without relying on usort() input-order preservation.
         return $a->getSorting() <=> $b->getSorting();
+    }
+
+    /**
+     * Whether the operation-capability axis is enforced or merely observed
+     * (ADR-138, following the ADR-113 switch shape).
+     *
+     * Fail-closed in the same sense as the tool gate: the axis observes ONLY on
+     * an explicit `observe`. An unreadable extension configuration, a malformed
+     * `routing` section, a missing value or a typo all enforce, so a broken
+     * setting cannot silently disable the check.
+     *
+     * Note what fail-closed does NOT mean here: an empty capability CSV on a
+     * model is still read as "undeclared" and passes. Refusing every model that
+     * never filled the optional field would break working installations without
+     * evidence that anything is actually wrong — see
+     * {@see self::matchesOperationCapability()}.
+     */
+    private function enforcingOperationCapability(): bool
+    {
+        try {
+            /** @var array<string, mixed> $config */
+            $config = $this->extensionConfiguration?->get('nr_llm') ?? [];
+        } catch (Throwable) {
+            return true;
+        }
+
+        $routing = $config['routing'] ?? null;
+        if (!is_array($routing)) {
+            return true;
+        }
+
+        $mode = $routing['operationCapabilityEnforcement'] ?? null;
+
+        return !is_string($mode) || strtolower(trim($mode)) !== self::OBSERVE;
+    }
+
+    /**
+     * Observe mode: selection is left untouched, but a model that declares it
+     * cannot serve the operation is reported, so an operator can see what
+     * enforcement would do before switching it on.
+     *
+     * Silent for an undeclared (empty) capability set — that is not a mismatch,
+     * it is an absent statement, and logging it on every call would bury the
+     * real findings.
+     */
+    private function reportObservedMismatch(
+        ?Model $model,
+        ModelCapability $capability,
+        ProviderOperation $operation,
+        LlmConfiguration $configuration,
+    ): void {
+        if (!$model instanceof Model) {
+            return;
+        }
+
+        $capabilities = $model->getCapabilitySet();
+        if ($capabilities->isEmpty() || $capabilities->has($capability)) {
+            return;
+        }
+
+        $this->logger?->warning(
+            'Criteria-mode selection resolved a model that does not declare the capability the operation requires. '
+            . 'Enforcement is set to observe, so the call proceeds.',
+            [
+                'configuration'       => $configuration->getIdentifier(),
+                'operation'           => $operation->value,
+                'requiredCapability'  => $capability->value,
+                'model'               => $model->getModelId(),
+                'declaredCapabilities' => $capabilities->toCsv(),
+            ],
+        );
     }
 
     /**

--- a/Classes/Service/ModelSelectionServiceInterface.php
+++ b/Classes/Service/ModelSelectionServiceInterface.php
@@ -11,6 +11,8 @@ namespace Netresearch\NrLlm\Service;
 
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 
 /**
  * Public surface of the dynamic model-selection service.
@@ -25,21 +27,32 @@ interface ModelSelectionServiceInterface
      * Resolve a model for the given configuration.
      *
      * If the configuration uses fixed mode, returns the configured model.
-     * If using criteria mode, finds the best matching model based on criteria.
+     * If using criteria mode, finds the best matching model based on criteria,
+     * additionally constrained by the capability `$operation` requires
+     * (ADR-138).
+     *
+     * `$operation` has no default on purpose. Every criteria-mode resolution
+     * that belongs to a concrete call must say which call it is, and the one
+     * caller that genuinely has no operation — a bare "give me the adapter" —
+     * has to say `null` out loud rather than inherit a silent skip.
+     *
+     * @throws UnsupportedFeatureException when enforcement is on and the
+     *                                     criteria match only models that
+     *                                     declare they cannot serve `$operation`
      */
-    public function resolveModel(LlmConfiguration $configuration): ?Model;
+    public function resolveModel(LlmConfiguration $configuration, ?ProviderOperation $operation): ?Model;
 
     /**
      * Find a model matching the given criteria.
      *
-     * @param array{capabilities?: string[], adapterTypes?: string[], minContextLength?: int, maxCostInput?: int, preferLowestCost?: bool} $criteria
+     * @param array{capabilities?: string[], operationCapability?: string, adapterTypes?: string[], minContextLength?: int, maxCostInput?: int, preferLowestCost?: bool} $criteria
      */
     public function findMatchingModel(array $criteria): ?Model;
 
     /**
      * Find all models matching the given criteria.
      *
-     * @param array{capabilities?: string[], adapterTypes?: string[], minContextLength?: int, maxCostInput?: int, preferLowestCost?: bool} $criteria
+     * @param array{capabilities?: string[], operationCapability?: string, adapterTypes?: string[], minContextLength?: int, maxCostInput?: int, preferLowestCost?: bool} $criteria
      *
      * @return Model[]
      */
@@ -48,7 +61,7 @@ interface ModelSelectionServiceInterface
     /**
      * Check if a model matches the given criteria.
      *
-     * @param array{capabilities?: string[], adapterTypes?: string[], minContextLength?: int, maxCostInput?: int, preferLowestCost?: bool} $criteria
+     * @param array{capabilities?: string[], operationCapability?: string, adapterTypes?: string[], minContextLength?: int, maxCostInput?: int, preferLowestCost?: bool} $criteria
      */
     public function modelMatchesCriteria(Model $model, array $criteria): bool;
 

--- a/Classes/Service/OperationCapabilityMap.php
+++ b/Classes/Service/OperationCapabilityMap.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service;
+
+use Netresearch\NrLlm\Domain\Enum\ModelCapability;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+
+/**
+ * Which model capability an operation requires (ADR-138).
+ *
+ * The two vocabularies were never connected: `ProviderOperation` labels the
+ * call the pipeline is running, `ModelCapability` labels what a `Model` record
+ * declares it can do. Criteria-mode selection matched only the stored criteria,
+ * so a configuration whose criteria never mention tools could resolve a model
+ * that cannot do tools, and the mismatch surfaced as a provider error.
+ *
+ * Pure and stateless — a static lookup, no state, no dependencies.
+ *
+ * **Null means "requires nothing", and the map is deliberately narrower than
+ * the vocabulary allows.** A requirement is only worth enforcing when the
+ * records it reads are actually written. Three capabilities pass that test:
+ * every model discoverer writes `chat`, and writes `vision` / `tools` when the
+ * model has them, so a record lacking one of those is a statement, not a gap.
+ *
+ * The rest do not, and enforcing them would refuse working models:
+ *
+ * - `completion` and `embeddings` are written by NO discoverer. The seven
+ *   wizard discoverers write `chat[,vision,tools,streaming,reasoning]` and
+ *   nothing else; `completion` appears only in hand-written records such as the
+ *   ddev seed. Requiring `completion` would break the primary completion path
+ *   for every wizard-created corpus, and requiring `embeddings` would break
+ *   every criteria-mode embedding configuration — for a fact nobody stated.
+ * - `streaming` is written by four of the seven discoverers (OpenAI, Anthropic,
+ *   Gemini, Mistral) and by none of Ollama, Groq or OpenRouter, whose models
+ *   stream perfectly well. Enforcing it would refuse a correct model because
+ *   its own discoverer never filled the field.
+ * - The image / speech / transcription capabilities describe specialized
+ *   services that do not reach criteria-mode selection at all (ADR-138 states
+ *   that boundary), so a mapping here would be inert.
+ * - `Translation` is served either by a chat/completion model — which arrives
+ *   here as `Chat` / `Completion` — or by DeepL, which is not a `Model` record.
+ *   There is no `ModelCapability` for it.
+ * - `Metadata` is a provider status/usage lookup, deliberately not an AI
+ *   generation (see the enum's own note), so it constrains nothing.
+ *
+ * Widen the map when the producers catch up, not before.
+ */
+final class OperationCapabilityMap
+{
+    /**
+     * The capability a model must declare to serve this operation, or null
+     * when the operation requires none.
+     */
+    public static function capabilityFor(ProviderOperation $operation): ?ModelCapability
+    {
+        return match ($operation) {
+            ProviderOperation::Chat   => ModelCapability::CHAT,
+            ProviderOperation::Vision => ModelCapability::VISION,
+            ProviderOperation::Tools  => ModelCapability::TOOLS,
+
+            // Not enforced — see the class docblock for the producer gap behind
+            // each one. Listed explicitly rather than swept into a default arm
+            // so adding a ProviderOperation case is a compile-time decision.
+            ProviderOperation::Completion,
+            ProviderOperation::Embedding,
+            ProviderOperation::Stream,
+            ProviderOperation::ImageGeneration,
+            ProviderOperation::ImageEdit,
+            ProviderOperation::ImageVariation,
+            ProviderOperation::Transcription,
+            ProviderOperation::SpeechSynthesis,
+            ProviderOperation::Translation,
+            ProviderOperation::Metadata => null,
+        };
+    }
+}

--- a/Classes/Service/OperationCapabilityMap.php
+++ b/Classes/Service/OperationCapabilityMap.php
@@ -25,22 +25,39 @@ use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
  *
  * **Null means "requires nothing", and the map is deliberately narrower than
  * the vocabulary allows.** A requirement is only worth enforcing when the
- * records it reads are actually written. Three capabilities pass that test:
- * every model discoverer writes `chat`, and writes `vision` / `tools` when the
- * model has them, so a record lacking one of those is a statement, not a gap.
+ * records it reads are actually written — and the honest answer is that they
+ * are written UNEVENLY. Since #671/#676 each discoverer seeds only what its
+ * provider's API substantiates, which is the right data but not uniform data:
  *
- * The rest do not, and enforcing them would refuse working models:
+ * - Mistral, OpenRouter and Ollama report `tools` and `vision` per model, so a
+ *   record from them lacking one is a statement.
+ * - Anthropic and the curated OpenAI/Gemini table entries write both because
+ *   the models have them; that is curated knowledge, not an API answer.
+ * - **Groq reports nothing.** Its listing has no capability field at all, so
+ *   its models are seeded `chat` alone. A record from Groq lacking `tools` is
+ *   a GAP, not a statement.
  *
- * - `completion` and `embeddings` are written by NO discoverer. The seven
- *   wizard discoverers write `chat[,vision,tools,streaming,reasoning]` and
- *   nothing else; `completion` appears only in hand-written records such as the
- *   ddev seed. Requiring `completion` would break the primary completion path
- *   for every wizard-created corpus, and requiring `embeddings` would break
- *   every criteria-mode embedding configuration — for a fact nobody stated.
- * - `streaming` is written by four of the seven discoverers (OpenAI, Anthropic,
- *   Gemini, Mistral) and by none of Ollama, Groq or OpenRouter, whose models
- *   stream perfectly well. Enforcing it would refuse a correct model because
- *   its own discoverer never filled the field.
+ * `chat` is therefore the only token every producer writes, and the reason the
+ * three enforced entries below still work is that `vision` and `tools` are
+ * requested by configurations that were authored against a specific model.
+ * Enforcing them against a Groq-discovered corpus refuses working models until
+ * the operator completes the checkboxes — which is why the enforcement switch
+ * exists and why `observe` is the safer default for an upgrade.
+ *
+ * The rest are not enforced at all, and enforcing them would refuse working
+ * models outright:
+ *
+ * - `completion` and `embeddings` are written by NO discoverer; `completion`
+ *   appears only in hand-written records such as the ddev seed. Requiring
+ *   `completion` would break the primary completion path for every
+ *   wizard-created corpus, and requiring `embeddings` would break every
+ *   criteria-mode embedding configuration — for a fact nobody stated.
+ * - `streaming` is written by Gemini (derived from `supportedGenerationMethods`)
+ *   and by the curated OpenAI / Anthropic / Gemini table entries, and by no one
+ *   else — not by Mistral, whose listing does not substantiate it, and not by
+ *   Ollama, Groq or OpenRouter, whose models stream perfectly well. Enforcing
+ *   it would refuse a correct model because its own discoverer never filled the
+ *   field.
  * - The image / speech / transcription capabilities describe specialized
  *   services that do not reach criteria-mode selection at all (ADR-138 states
  *   that boundary), so a mapping here would be inert.

--- a/Documentation/Adr/Adr138OperationCapabilityMatch.rst
+++ b/Documentation/Adr/Adr138OperationCapabilityMatch.rst
@@ -1,0 +1,159 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-138:
+
+============================================================================
+ADR-138: Criteria-mode selection matches the operation, not only the criteria
+============================================================================
+
+:Status: Accepted
+:Date: 2026-08-09
+:Authors: Netresearch DTT GmbH
+
+.. _adr-138-context:
+
+Context
+=======
+
+A criteria-mode :php:`LlmConfiguration` carries no model relation. Its model is
+chosen at call time from stored criteria — capabilities, adapter types, a
+context-length floor, a cost ceiling. Until now that was the whole input.
+:php:`ModelSelectionService::resolveModel()` never learned which call it was
+resolving for.
+
+So a configuration whose criteria say ``{"adapterTypes": ["ollama"]}`` could
+serve a tool call with a model whose own record states it cannot do tools. The
+selection succeeded, the adapter was built, and the request failed at the
+provider — as a transport-shaped error, several layers away from the
+configuration that caused it.
+
+Two related facts shaped the fix.
+
+**The same call resolves twice.** ``embedForConfiguration()`` resolves once
+outside the pipeline to build the embedding cache key and once inside the
+terminal to pick the adapter. Two resolutions that can disagree would let cache
+entries stored under model A serve a call that ran against model B. The eager
+streaming-capability check had the same shape.
+
+**The capability column never reached the entity.** Extbase resolves property
+types through Symfony's PropertyInfo, whose ``ReflectionExtractor`` infers a
+collection from an adder/remover pair. :php:`Model::addCapability()` /
+:php:`removeCapability()` inflect to ``$capabilities``, so the property resolved
+as ``array``; the DataMapper has no array mapping and dropped the column. Every
+repository-loaded model came back with an EMPTY capability set. The pre-existing
+``capabilities`` criterion therefore matched nothing in production either — the
+defect this ADR fixes was one of two, and the second one hid the first.
+
+.. _adr-138-decision:
+
+Decision
+========
+
+**Thread the operation into the resolution.**
+:php:`ModelSelectionServiceInterface::resolveModel()` and
+:php:`ConfigurationCallPlanner::resolveModel()` take a
+:php:`?ProviderOperation`. It has no default: every resolution belonging to a
+concrete call must name that call, and the one caller that genuinely has none —
+the bare ``adapterFor()`` lookup behind :php:`getAdapterFromConfiguration()` —
+says ``null`` out loud. In criteria mode the capability the operation requires is
+merged into the criteria under its own key before ``findMatchingModel()`` runs.
+Fixed mode is untouched: the operator named that model, so nothing is being
+chosen and there is nothing to constrain.
+
+**Both resolutions of one call pass the same operation.** The embedding
+cache-key site and the embedding terminal both pass ``Embedding``; the eager
+streaming check calls the planner directly with ``Stream`` rather than routing
+through the operation-less public entry point. A unit test asserts that the two
+embedding resolutions receive the same operation and return the same model.
+
+**Restore the capability mapping.** An explicit ``@var string`` on
+:php:`Model::$capabilities` puts ``PhpDocExtractor`` — which runs first — back in
+charge of the property type. Without it this ADR would ship decoration: every
+model would read as undeclared and the new check would never fire.
+
+**An empty capability CSV means undeclared, not "cannot".** The field is
+optional and many installations never filled it. The operation-derived check is
+therefore skipped for such a model, in both switch positions. This is a separate
+criteria key from ``capabilities`` precisely so the two can differ: what an
+operator explicitly asked for is still matched strictly, and a model that
+declares nothing still fails that.
+
+**Enforcement is a fail-closed switch, following ADR-113.**
+``routing.operationCapabilityEnforcement`` defaults to ``enforce``. Only a
+literal ``observe`` observes — a missing value, a malformed ``routing`` section,
+an unreadable extension configuration and a typo all enforce, so a broken
+setting cannot silently disable the axis. Fail-closed governs the SWITCH, not
+the empty CSV: reading an absent statement as a denial would break working
+installations for a fact nobody ever stated.
+
+**The map is narrower than the vocabulary.** Only ``chat``, ``vision`` and
+``tools`` are enforced, because only those are actually written. All seven model
+discoverers write ``chat`` and write ``vision`` / ``tools`` when the model has
+them, so a record lacking one of those is a statement. No discoverer writes
+``completion`` or ``embeddings`` at all, and only four of seven write
+``streaming`` — requiring those would refuse models that work, on the strength
+of a field their own discoverer never filled. A requirement no producer
+satisfies is not a check, it is an outage.
+
+**A misconfiguration is named, not disguised.** When enforcement is on and the
+criteria match models but none that can serve the operation, resolution throws
+:php:`UnsupportedFeatureException` naming the configuration, the capability and
+the operation. Criteria that match nothing at all still return ``null`` — that is
+the pre-existing "has no model assigned" condition and it keeps its behaviour.
+
+**UnsupportedFeatureException stays UNKNOWN in the failure classifier**, and
+therefore not retryable. This is deliberate and must not be "fixed": the
+exception now reports the installation's own misconfiguration. A retry cannot
+repair it, and a fallback that silently answered from another configuration
+would hide the very defect this ADR exists to surface. The operator would see a
+working system quietly running on the wrong model.
+
+.. _adr-138-boundary:
+
+Boundary: the generic path keeps its adapter checks
+===================================================
+
+``chat()``, ``complete()`` and ``streamChat()`` prefer the default DB
+configuration and reach ``resolveModel()`` through it — those calls get the
+check. Their ad-hoc branch does not, and neither do ``embed()``, ``vision()`` or
+``chatWithTools()``, which always run ad-hoc: they synthesize a transient
+configuration carrying only an identifier — no model, no provider, no criteria —
+and resolve a provider by key instead. There is no model record to match
+against, so there is nothing for this ADR to check.
+
+Those paths keep the adapter-level guards they already have
+(:php:`ToolCapableInterface`, :php:`VisionCapableInterface`,
+``supportsFeature('embeddings')``). This is stated as a boundary rather than
+papered over: making the generic path capability-aware means giving it a model
+record, which is a different change with a different blast radius.
+
+.. _adr-138-consequences:
+
+Consequences
+============
+
+Fixed-mode configurations — the majority — are unaffected.
+
+Criteria-mode configurations become stricter for chat, vision and tool calls,
+and the capability criterion starts working at all now that the column reaches
+the entity. An installation whose model records understate what their models can
+do will see a resolution refused where it previously succeeded and failed later
+at the provider. The escape hatch is one setting, and the real fix is one
+checkbox on the model record.
+
+Restoring the capability mapping is visible beyond selection: anything reading
+``getCapabilities()`` off a repository-loaded model saw an empty string before
+and now sees the persisted value.
+
+.. _adr-138-revisit:
+
+Revisit when
+============
+
+The discoverers write the capabilities they currently omit. ``streaming`` is the
+nearest: four of seven already write it, and closing the other three would make
+``Stream`` enforceable. ``embeddings`` and ``completion`` need a producer before
+they mean anything at all.
+
+Also revisit if the generic path ever gains a model record. The boundary above
+exists because it has none, not because operation matching is unwanted there.

--- a/Documentation/Adr/Adr138OperationCapabilityMatch.rst
+++ b/Documentation/Adr/Adr138OperationCapabilityMatch.rst
@@ -87,13 +87,39 @@ the empty CSV: reading an absent statement as a denial would break working
 installations for a fact nobody ever stated.
 
 **The map is narrower than the vocabulary.** Only ``chat``, ``vision`` and
-``tools`` are enforced, because only those are actually written. All seven model
-discoverers write ``chat`` and write ``vision`` / ``tools`` when the model has
-them, so a record lacking one of those is a statement. No discoverer writes
-``completion`` or ``embeddings`` at all, and only four of seven write
-``streaming`` — requiring those would refuse models that work, on the strength
-of a field their own discoverer never filled. A requirement no producer
-satisfies is not a check, it is an outage.
+``tools`` are enforced. ``chat`` is the only token every producer writes; the
+other two are written **unevenly**, and this decision rests on that being
+understood rather than glossed over.
+
+Since :ref:`#671 <adr-138-discoverer-note>` each discoverer seeds only what its
+provider's API substantiates. Mistral, OpenRouter and Ollama report ``tools``
+and ``vision`` per model, so a record from them lacking one is a statement.
+Anthropic and the curated OpenAI / Gemini entries write both from curated
+knowledge. **Groq reports nothing** — its listing carries no capability field,
+so its models are seeded ``chat`` alone and a missing ``tools`` there is a gap,
+not a statement.
+
+Enforcing ``vision`` / ``tools`` against a Groq-discovered corpus therefore
+refuses working models until an operator completes the checkboxes. That is the
+reason the enforcement switch exists, and the reason ``observe`` is the safer
+default for an upgraded installation.
+
+No discoverer writes ``completion`` or ``embeddings`` at all, and ``streaming``
+is written only by Gemini (derived from ``supportedGenerationMethods``) and the
+curated OpenAI / Anthropic / Gemini entries — requiring those would refuse
+models that work, on the strength of a field their own discoverer never filled.
+A requirement no producer satisfies is not a check, it is an outage.
+
+.. _adr-138-discoverer-note:
+
+.. note::
+
+   An earlier revision of this decision argued from "all seven model
+   discoverers write ``chat`` and write ``vision`` / ``tools`` when the model
+   has them". That was not true when written: Groq and OpenRouter wrote a flat
+   ``chat``, and Mistral ``chat, tools`` for every model including vision-only
+   ones. The producers were corrected in #671; this section now describes what
+   they actually write.
 
 **A misconfiguration is named, not disguised.** When enforcement is on and the
 criteria match models but none that can serve the operation, resolution throws
@@ -151,9 +177,15 @@ Revisit when
 ============
 
 The discoverers write the capabilities they currently omit. ``streaming`` is the
-nearest: four of seven already write it, and closing the other three would make
-``Stream`` enforceable. ``embeddings`` and ``completion`` need a producer before
-they mean anything at all.
+nearest, but "closing the gap" now means something different than it did before
+#671: a discoverer may only write a token its provider's API substantiates, so
+``Stream`` becomes enforceable when the remaining providers *report* streaming,
+not when someone fills the field in. Where an API stays silent — Groq's listing
+has no capability field at all — the gap closes through the operator's own
+checkboxes, which is a different mechanism and a slower one.
+
+``embeddings`` and ``completion`` need a producer before they mean anything at
+all.
 
 Also revisit if the generic path ever gains a model record. The boundary above
 exists because it has none, not because operation matching is unwanted there.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -429,3 +429,4 @@ Tools
    Adr129StructuredConsumers
    Adr130BackendUserGrants
    Adr131EditorModule
+   Adr138OperationCapabilityMatch

--- a/Tests/Functional/Fixtures/CapabilityRouting.csv
+++ b/Tests/Functional/Fixtures/CapabilityRouting.csv
@@ -1,0 +1,16 @@
+"tx_nrllm_provider"
+,"uid","pid","identifier","name","description","adapter_type","endpoint_url","api_key","organization_id","api_timeout","max_retries","options","priority","is_active","sorting","deleted","hidden"
+,101,0,"routing-ollama","Routing Ollama","Provider with a mixed model corpus","ollama","http://ollama:11434","","",30,3,"",50,1,1,0,0
+,102,0,"routing-openai","Routing OpenAI","Provider whose only model declares chat","openai","https://api.openai.com/v1","","",30,3,"",50,1,2,0,0
+,103,0,"routing-legacy","Routing Legacy","Provider whose model never filled the capability field","groq","http://ollama:11434","","",30,3,"",50,1,3,0,0
+"tx_nrllm_model"
+,"uid","pid","identifier","name","description","provider_uid","model_id","context_length","max_output_tokens","capabilities","default_timeout","cost_input","cost_output","is_active","is_default","sorting","deleted","hidden"
+,101,0,"routing-chat-only","Routing Chat Only","Sorted first, cannot do tools",101,"routing-chat-only",32000,4096,"chat",120,0,0,1,0,1,0,0
+,102,0,"routing-with-tools","Routing With Tools","Sorted second, can do tools",101,"routing-with-tools",32000,4096,"chat,tools",120,0,0,1,0,2,0,0
+,103,0,"routing-openai-chat","Routing OpenAI Chat","The only model of the openai routing provider",102,"routing-openai-chat",32000,4096,"chat",120,0,0,1,0,3,0,0
+,104,0,"routing-undeclared","Routing Undeclared","Capability field never filled",103,"routing-undeclared",32000,4096,"",120,0,0,1,0,4,0,0
+"tx_nrllm_configuration"
+,"uid","pid","identifier","name","description","model_uid","model_selection_mode","model_selection_criteria","translator","system_prompt","temperature","max_tokens","top_p","frequency_penalty","presence_penalty","options","max_requests_per_day","max_tokens_per_day","max_cost_per_day","is_active","is_default","allowed_groups","tstamp","crdate","deleted","hidden","sorting"
+,101,0,"routing-mixed","Routing Mixed","Criteria match a chat-only and a tool-capable model",0,"criteria","{""adapterTypes"":[""ollama""],""capabilities"":[""chat""]}","","",0.70,1000,1.00,0.00,0.00,"{}",0,0,0.00,1,0,0,1703347200,1703347200,0,0,1
+,102,0,"routing-no-tools","Routing No Tools","Criteria match only a model that declares it cannot do tools",0,"criteria","{""adapterTypes"":[""openai""]}","","",0.70,1000,1.00,0.00,0.00,"{}",0,0,0.00,1,0,0,1703347200,1703347200,0,0,2
+,103,0,"routing-undeclared","Routing Undeclared","Criteria match only a model whose capability field is empty",0,"criteria","{""adapterTypes"":[""groq""]}","","",0.70,1000,1.00,0.00,0.00,"{}",0,0,0.00,1,0,0,1703347200,1703347200,0,0,3

--- a/Tests/Functional/Service/ModelSelectionOperationCapabilityTest.php
+++ b/Tests/Functional/Service/ModelSelectionOperationCapabilityTest.php
@@ -1,0 +1,178 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Service\ModelSelectionService;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+/**
+ * Criteria-mode selection against a real model corpus (ADR-138).
+ *
+ * The unit tests pin the decision table; this one pins that the decision
+ * survives the persistence round-trip — a criteria JSON read from the database,
+ * a capability CSV read from a `tx_nrllm_model` row, and the repository's own
+ * active/deleted filtering.
+ */
+#[CoversClass(ModelSelectionService::class)]
+final class ModelSelectionOperationCapabilityTest extends AbstractFunctionalTestCase
+{
+    private LlmConfigurationRepository $configurations;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var LlmConfigurationRepository $configurations */
+        $configurations       = $this->get(LlmConfigurationRepository::class);
+        $this->configurations = $configurations;
+
+        $this->importFixture('CapabilityRouting.csv');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->storeEnforcement(null);
+        parent::tearDown();
+    }
+
+    /**
+     * Write `routing.operationCapabilityEnforcement` the way an operator's
+     * extension configuration would present it. Null removes the whole section.
+     */
+    private function storeEnforcement(?string $mode): void
+    {
+        $confVars = $GLOBALS['TYPO3_CONF_VARS'] ?? [];
+        if (!is_array($confVars)) {
+            $confVars = [];
+        }
+
+        $extensions = $confVars['EXTENSIONS'] ?? [];
+        if (!is_array($extensions)) {
+            $extensions = [];
+        }
+
+        $extensions['nr_llm'] = $mode === null
+            ? []
+            : ['routing' => ['operationCapabilityEnforcement' => $mode]];
+
+        $confVars['EXTENSIONS']  = $extensions;
+        $GLOBALS['TYPO3_CONF_VARS'] = $confVars;
+    }
+
+    private function subject(): ModelSelectionService
+    {
+        /** @var ModelSelectionService $subject */
+        $subject = $this->get(ModelSelectionService::class);
+
+        return $subject;
+    }
+
+    private function configuration(string $identifier): LlmConfiguration
+    {
+        $configuration = $this->configurations->findOneByIdentifier($identifier);
+        self::assertInstanceOf(LlmConfiguration::class, $configuration, 'Fixture configuration missing: ' . $identifier);
+        self::assertTrue($configuration->usesCriteriaSelection(), $identifier . ' must be a criteria-mode fixture');
+
+        return $configuration;
+    }
+
+    #[Test]
+    public function aToolsCallResolvesTheToolCapableModel(): void
+    {
+        $this->storeEnforcement('enforce');
+
+        $configuration = $this->configuration('routing-mixed');
+
+        // Without the operation the corpus order wins and the chat-only model
+        // is picked — that is the reported defect.
+        $withoutOperation = $this->subject()->resolveModel($configuration, null);
+        self::assertInstanceOf(Model::class, $withoutOperation);
+        self::assertSame('routing-chat-only', $withoutOperation->getModelId());
+
+        $forTools = $this->subject()->resolveModel($configuration, ProviderOperation::Tools);
+        self::assertInstanceOf(Model::class, $forTools);
+        self::assertSame('routing-with-tools', $forTools->getModelId());
+    }
+
+    #[Test]
+    public function enforceModeRefusesWhenNoMatchingModelCanDoTools(): void
+    {
+        $this->storeEnforcement('enforce');
+
+        $configuration = $this->configuration('routing-no-tools');
+
+        // The same configuration still resolves for a chat call.
+        $forChat = $this->subject()->resolveModel($configuration, ProviderOperation::Chat);
+        self::assertInstanceOf(Model::class, $forChat);
+        self::assertSame('routing-openai-chat', $forChat->getModelId());
+
+        $this->expectException(UnsupportedFeatureException::class);
+        $this->expectExceptionCode(1786100138);
+
+        $this->subject()->resolveModel($configuration, ProviderOperation::Tools);
+    }
+
+    #[Test]
+    public function observeModeKeepsResolvingTheModelThatCannotDoTools(): void
+    {
+        $this->storeEnforcement('observe');
+
+        $resolved = $this->subject()->resolveModel(
+            $this->configuration('routing-no-tools'),
+            ProviderOperation::Tools,
+        );
+
+        self::assertInstanceOf(Model::class, $resolved);
+        self::assertSame('routing-openai-chat', $resolved->getModelId());
+    }
+
+    #[Test]
+    public function anEmptyCapabilityColumnIsUndeclaredAndStillResolves(): void
+    {
+        // Enforce mode, a model row whose capability CSV was never filled: it
+        // passes, because an absent statement is not a denial. Fail-closed here
+        // would break every installation that ignored the optional field.
+        $this->storeEnforcement('enforce');
+
+        $resolved = $this->subject()->resolveModel(
+            $this->configuration('routing-undeclared'),
+            ProviderOperation::Tools,
+        );
+
+        self::assertInstanceOf(Model::class, $resolved);
+        self::assertSame('routing-undeclared', $resolved->getModelId());
+    }
+
+    #[Test]
+    public function theSettingIsReadableThroughTheRealExtensionConfiguration(): void
+    {
+        // Guards the wiring the three tests above depend on: the value written
+        // by storeEnforcement() is what ExtensionConfiguration hands the
+        // service. Without this, a rename of the setting key would leave those
+        // tests silently exercising the fail-closed default instead.
+        $this->storeEnforcement('observe');
+
+        /** @var ExtensionConfiguration $extensionConfiguration */
+        $extensionConfiguration = $this->get(ExtensionConfiguration::class);
+        $configuration          = $extensionConfiguration->get('nr_llm');
+
+        self::assertIsArray($configuration);
+        self::assertIsArray($configuration['routing'] ?? null);
+        self::assertSame('observe', $configuration['routing']['operationCapabilityEnforcement'] ?? null);
+    }
+}

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -623,7 +623,8 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $selection = $this->createMock(ModelSelectionServiceInterface::class);
         $selection->expects(self::once())
             ->method('resolveModel')
-            ->with($config)
+            // The generic adapter lookup has no operation and must say so.
+            ->with($config, null)
             ->willReturn($resolvedModel);
 
         $mockAdapter = self::createStub(ProviderInterface::class);
@@ -1521,6 +1522,88 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
 
         // Per-call options win over the configuration's stored model id.
         self::assertSame('override-model', $capturedOptions['model']);
+    }
+
+    #[Test]
+    public function embedForConfigurationResolvesTheSameModelForTheCacheKeyAndTheCall(): void
+    {
+        // A criteria-mode configuration is resolved TWICE per embedding call:
+        // once outside the pipeline to build the cache key, once inside the
+        // terminal to pick the adapter. Both must pass the same operation —
+        // if they could disagree, entries stored under model A would be served
+        // to a call that ran against model B (ADR-138).
+        $embeddingModel = self::createStub(Model::class);
+        $embeddingModel->method('getModelId')->willReturn('embedding-model');
+        $otherModel = self::createStub(Model::class);
+        $otherModel->method('getModelId')->willReturn('some-other-model');
+
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn(null);
+        $config->method('getIdentifier')->willReturn('nr_ai_search.embeddings');
+        // Criteria mode carries no model relation, so the cache key has to
+        // resolve rather than read the id off the configuration.
+        $config->method('getModelId')->willReturn('');
+        $config->method('toOptionsArray')->willReturn([]);
+
+        $resolutions = [];
+        $selection   = self::createStub(ModelSelectionServiceInterface::class);
+        $selection->method('resolveModel')->willReturnCallback(
+            static function (LlmConfiguration $configuration, ?ProviderOperation $operation) use (
+                &$resolutions,
+                $embeddingModel,
+                $otherModel,
+            ): Model {
+                // Distinct models per operation, so a site that forgets to pass
+                // the operation resolves visibly differently.
+                $model         = $operation === ProviderOperation::Embedding ? $embeddingModel : $otherModel;
+                $resolutions[] = ['operation' => $operation, 'model' => $model];
+
+                return $model;
+            },
+        );
+
+        $adapterModels = [];
+        $mockAdapter   = $this->createMock(ProviderInterface::class);
+        $mockAdapter->method('supportsFeature')->willReturnCallback(
+            static fn(string $feature): bool => $feature === 'embeddings',
+        );
+        $mockAdapter->method('embeddings')->willReturn(new EmbeddingResponse(
+            embeddings: [[0.1]],
+            model: 'embedding-model',
+            usage: new UsageStatistics(1, 0, 1),
+            provider: 'openai',
+        ));
+
+        $registryStub = self::createStub(ProviderAdapterRegistryInterface::class);
+        $registryStub->method('createAdapterFromModel')->willReturnCallback(
+            static function (Model $model) use (&$adapterModels, $mockAdapter): ProviderInterface {
+                $adapterModels[] = $model;
+
+                return $mockAdapter;
+            },
+        );
+
+        $manager = $this->createLlmServiceManager($this->extensionConfigStub, $this->loggerStub, $registryStub, $this->emptyMiddlewarePipeline(), self::createStub(CacheManagerInterface::class), null, null, $selection);
+
+        $manager->embedForConfiguration('text', $config, new EmbeddingOptions(cacheTtl: 600));
+
+        self::assertCount(2, $resolutions, 'Expected the cache-key resolution and the terminal resolution.');
+        self::assertSame(
+            ProviderOperation::Embedding,
+            $resolutions[0]['operation'],
+            'The cache-key resolution ran without the operation.',
+        );
+        self::assertSame(
+            ProviderOperation::Embedding,
+            $resolutions[1]['operation'],
+            'The terminal resolution ran without the operation.',
+        );
+        self::assertSame(
+            $resolutions[0]['model'],
+            $resolutions[1]['model'],
+            'The cache key names a different model than the call runs on.',
+        );
+        self::assertSame([$embeddingModel], $adapterModels);
     }
 
     /**

--- a/Tests/Unit/Service/ModelSelectionServiceTest.php
+++ b/Tests/Unit/Service/ModelSelectionServiceTest.php
@@ -14,11 +14,17 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
+use Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Service\ModelSelectionService;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use ReflectionClass;
+use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 
@@ -207,7 +213,7 @@ final class ModelSelectionServiceTest extends TestCase
         $config = $this->createConfiguration(LlmConfiguration::SELECTION_MODE_FIXED);
         $config->setLlmModel($model);
 
-        $result = $this->subject->resolveModel($config);
+        $result = $this->subject->resolveModel($config, null);
 
         self::assertSame($model, $result);
     }
@@ -225,7 +231,7 @@ final class ModelSelectionServiceTest extends TestCase
         $config = $this->createConfiguration(LlmConfiguration::SELECTION_MODE_CRITERIA);
         $config->setModelSelectionCriteriaArray(['capabilities' => ['vision']]);
 
-        $result = $this->subject->resolveModel($config);
+        $result = $this->subject->resolveModel($config, null);
 
         self::assertSame($model2, $result);
     }
@@ -526,7 +532,7 @@ final class ModelSelectionServiceTest extends TestCase
             'capabilities' => ['chat'],
         ]);
 
-        $result = $this->subject->resolveModel($configuration);
+        $result = $this->subject->resolveModel($configuration, null);
 
         self::assertSame($model, $result);
     }
@@ -561,5 +567,287 @@ final class ModelSelectionServiceTest extends TestCase
         self::assertArrayHasKey(LlmConfiguration::SELECTION_MODE_CRITERIA, $modes);
         self::assertSame('Fixed Model', $modes[LlmConfiguration::SELECTION_MODE_FIXED]);
         self::assertSame('Dynamic (Criteria)', $modes[LlmConfiguration::SELECTION_MODE_CRITERIA]);
+    }
+
+    // ==================== operation capability (ADR-138) ====================
+
+    /**
+     * A subject wired to a specific enforcement setting.
+     *
+     * `$mode` is what the extension configuration returns for
+     * `routing.operationCapabilityEnforcement`; null omits the key entirely.
+     */
+    private function subjectWithEnforcement(?string $mode, ?LoggerInterface $logger = null): ModelSelectionService
+    {
+        $extensionConfiguration = self::createStub(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn(
+            $mode === null ? [] : ['routing' => ['operationCapabilityEnforcement' => $mode]],
+        );
+
+        return new ModelSelectionService($this->modelRepository, $extensionConfiguration, $logger);
+    }
+
+    private function criteriaConfiguration(): LlmConfiguration
+    {
+        $config = $this->createConfiguration(LlmConfiguration::SELECTION_MODE_CRITERIA);
+        $config->setIdentifier('criteria-config');
+
+        return $config;
+    }
+
+    #[Test]
+    public function criteriaModeRefusesAModelThatCannotDoTheRunningOperation(): void
+    {
+        // The reported defect: criteria that never mention tools happily
+        // resolved a chat-only model, and the failure surfaced as a provider
+        // error mid-call.
+        $chatOnly = $this->createModel(1, 'chat');
+
+        $this->modelRepository
+            ->method('findActive')
+            ->willReturn($this->createQueryResult([$chatOnly]));
+
+        $config = $this->criteriaConfiguration();
+        $config->setModelSelectionCriteriaArray(['capabilities' => ['chat']]);
+
+        $this->expectException(UnsupportedFeatureException::class);
+        $this->expectExceptionMessage('criteria-config');
+
+        $this->subjectWithEnforcement('enforce')->resolveModel($config, ProviderOperation::Tools);
+    }
+
+    #[Test]
+    public function criteriaModePrefersTheModelThatCanDoTheRunningOperation(): void
+    {
+        // Both satisfy the stored criteria; only one can do tools. Without the
+        // operation the chat-only model wins on sorting order.
+        $chatOnly  = $this->createModel(1, 'chat', 'openai', 8000, 100, 200, 50, true, 1);
+        $withTools = $this->createModel(2, 'chat,tools', 'openai', 8000, 100, 200, 50, false, 2);
+
+        $this->modelRepository
+            ->method('findActive')
+            ->willReturn($this->createQueryResult([$chatOnly, $withTools]));
+
+        $config = $this->criteriaConfiguration();
+        $config->setModelSelectionCriteriaArray(['capabilities' => ['chat']]);
+
+        $subject = $this->subjectWithEnforcement('enforce');
+
+        self::assertSame($chatOnly, $subject->resolveModel($config, ProviderOperation::Chat));
+        self::assertSame($withTools, $subject->resolveModel($config, ProviderOperation::Tools));
+    }
+
+    #[Test]
+    public function theOperationCapabilityDoesNotOverwriteTheStoredCriteria(): void
+    {
+        // The stored criteria must survive the merge intact — a wide-context
+        // Anthropic model is still required, the operation only adds to that.
+        $wrongAdapter = $this->createModel(1, 'chat,tools', 'openai', 200000);
+        $tooSmall     = $this->createModel(2, 'chat,tools', 'anthropic', 4000);
+        $wanted       = $this->createModel(3, 'chat,tools', 'anthropic', 200000);
+
+        $this->modelRepository
+            ->method('findActive')
+            ->willReturn($this->createQueryResult([$wrongAdapter, $tooSmall, $wanted]));
+
+        $config = $this->criteriaConfiguration();
+        $config->setModelSelectionCriteriaArray([
+            'capabilities'     => ['chat'],
+            'adapterTypes'     => ['anthropic'],
+            'minContextLength' => 100000,
+        ]);
+
+        self::assertSame(
+            $wanted,
+            $this->subjectWithEnforcement('enforce')->resolveModel($config, ProviderOperation::Tools),
+        );
+    }
+
+    #[Test]
+    public function nullOperationLeavesTheSelectionUntouched(): void
+    {
+        $chatOnly = $this->createModel(1, 'chat');
+
+        $this->modelRepository
+            ->method('findActive')
+            ->willReturn($this->createQueryResult([$chatOnly]));
+
+        $config = $this->criteriaConfiguration();
+        $config->setModelSelectionCriteriaArray(['capabilities' => ['chat']]);
+
+        self::assertSame(
+            $chatOnly,
+            $this->subjectWithEnforcement('enforce')->resolveModel($config, null),
+        );
+    }
+
+    #[Test]
+    public function anOperationThatRequiresNoCapabilityLeavesTheSelectionUntouched(): void
+    {
+        // Completion is deliberately unmapped (no discoverer writes the
+        // capability), so a chat-only model stays eligible.
+        $chatOnly = $this->createModel(1, 'chat');
+
+        $this->modelRepository
+            ->method('findActive')
+            ->willReturn($this->createQueryResult([$chatOnly]));
+
+        $config = $this->criteriaConfiguration();
+        $config->setModelSelectionCriteriaArray(['capabilities' => ['chat']]);
+
+        self::assertSame(
+            $chatOnly,
+            $this->subjectWithEnforcement('enforce')->resolveModel($config, ProviderOperation::Completion),
+        );
+    }
+
+    #[Test]
+    public function fixedModeIsNotConstrainedByTheOperation(): void
+    {
+        // The operator named this model. Nothing is being chosen, so there is
+        // nothing to constrain — it still fails at the adapter, as before.
+        $chatOnly = $this->createModel(1, 'chat');
+        $config   = $this->createConfiguration(LlmConfiguration::SELECTION_MODE_FIXED);
+        $config->setLlmModel($chatOnly);
+
+        self::assertSame(
+            $chatOnly,
+            $this->subjectWithEnforcement('enforce')->resolveModel($config, ProviderOperation::Tools),
+        );
+    }
+
+    #[Test]
+    public function criteriaMatchingNothingAtAllStillReturnsNull(): void
+    {
+        // Pre-existing "has no model assigned" condition: the criteria match
+        // nothing, with or without the operation. That must stay a null return
+        // rather than become an UnsupportedFeatureException.
+        $chatOnly = $this->createModel(1, 'chat', 'openai');
+
+        $this->modelRepository
+            ->method('findActive')
+            ->willReturn($this->createQueryResult([$chatOnly]));
+
+        $config = $this->criteriaConfiguration();
+        $config->setModelSelectionCriteriaArray(['adapterTypes' => ['anthropic']]);
+
+        self::assertNull(
+            $this->subjectWithEnforcement('enforce')->resolveModel($config, ProviderOperation::Tools),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{?string}>
+     */
+    public static function enforcementSettingProvider(): iterable
+    {
+        yield 'enforce'        => ['enforce'];
+        yield 'observe'        => ['observe'];
+        yield 'missing key'    => [null];
+        yield 'typo enforces'  => ['observ'];
+    }
+
+    #[Test]
+    #[DataProvider('enforcementSettingProvider')]
+    public function anEmptyCapabilityCsvIsUndeclaredAndSkipsTheCheck(?string $enforcement): void
+    {
+        // The decision that keeps this shippable: an empty capability field is
+        // an absent statement, not "cannot". Refusing every model that never
+        // filled the optional field would break working installations, so the
+        // check is skipped in BOTH switch positions.
+        $undeclared = $this->createModel(1, '');
+
+        $this->modelRepository
+            ->method('findActive')
+            ->willReturn($this->createQueryResult([$undeclared]));
+
+        $config = $this->criteriaConfiguration();
+        $config->setModelSelectionCriteriaArray([]);
+
+        self::assertSame(
+            $undeclared,
+            $this->subjectWithEnforcement($enforcement)->resolveModel($config, ProviderOperation::Tools),
+        );
+    }
+
+    #[Test]
+    public function observeModeKeepsTheModelAndReportsTheMismatch(): void
+    {
+        $chatOnly = $this->createModel(1, 'chat');
+
+        $this->modelRepository
+            ->method('findActive')
+            ->willReturn($this->createQueryResult([$chatOnly]));
+
+        $config = $this->criteriaConfiguration();
+        $config->setModelSelectionCriteriaArray(['capabilities' => ['chat']]);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('warning');
+
+        self::assertSame(
+            $chatOnly,
+            $this->subjectWithEnforcement('observe', $logger)->resolveModel($config, ProviderOperation::Tools),
+        );
+    }
+
+    #[Test]
+    public function observeModeIsSilentForAnUndeclaredModel(): void
+    {
+        // An empty capability set is not a mismatch, it is an absent statement.
+        // Reporting it on every call would bury the real findings.
+        $undeclared = $this->createModel(1, '');
+
+        $this->modelRepository
+            ->method('findActive')
+            ->willReturn($this->createQueryResult([$undeclared]));
+
+        $config = $this->criteriaConfiguration();
+        $config->setModelSelectionCriteriaArray([]);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())->method('warning');
+
+        $this->subjectWithEnforcement('observe', $logger)->resolveModel($config, ProviderOperation::Tools);
+    }
+
+    #[Test]
+    public function anUnreadableExtensionConfigurationEnforces(): void
+    {
+        // Fail-closed like the tool gate (ADR-113): a broken setting must not
+        // silently disable the axis.
+        $chatOnly = $this->createModel(1, 'chat');
+
+        $this->modelRepository
+            ->method('findActive')
+            ->willReturn($this->createQueryResult([$chatOnly]));
+
+        $extensionConfiguration = self::createStub(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willThrowException(new ExtensionConfigurationExtensionNotConfiguredException());
+
+        $config = $this->criteriaConfiguration();
+        $config->setModelSelectionCriteriaArray(['capabilities' => ['chat']]);
+
+        $this->expectException(UnsupportedFeatureException::class);
+
+        (new ModelSelectionService($this->modelRepository, $extensionConfiguration))
+            ->resolveModel($config, ProviderOperation::Tools);
+    }
+
+    #[Test]
+    public function noExtensionConfigurationAtAllEnforces(): void
+    {
+        $chatOnly = $this->createModel(1, 'chat');
+
+        $this->modelRepository
+            ->method('findActive')
+            ->willReturn($this->createQueryResult([$chatOnly]));
+
+        $config = $this->criteriaConfiguration();
+        $config->setModelSelectionCriteriaArray(['capabilities' => ['chat']]);
+
+        $this->expectException(UnsupportedFeatureException::class);
+
+        $this->subject->resolveModel($config, ProviderOperation::Tools);
     }
 }

--- a/Tests/Unit/Service/OperationCapabilityMapTest.php
+++ b/Tests/Unit/Service/OperationCapabilityMapTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service;
+
+use Netresearch\NrLlm\Domain\Enum\ModelCapability;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Service\OperationCapabilityMap;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The operation → capability map (ADR-138).
+ *
+ * Pinned case by case rather than asserted as a rule, because the map is a set
+ * of individual judgements: which capability a `Model` record must declare
+ * before it may serve an operation, and — for the majority of operations —
+ * why nothing may be required at all. A new `ProviderOperation` case makes the
+ * `match` non-exhaustive and the coverage test below fail, so neither half can
+ * be added silently.
+ */
+#[CoversClass(OperationCapabilityMap::class)]
+final class OperationCapabilityMapTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{ProviderOperation, ?ModelCapability}>
+     */
+    public static function operationCapabilityProvider(): iterable
+    {
+        // Enforced: every discoverer writes `chat`, and writes `vision` /
+        // `tools` when the model has them, so a record without one of these
+        // states an absence rather than leaving a gap.
+        yield 'chat requires chat'     => [ProviderOperation::Chat, ModelCapability::CHAT];
+        yield 'vision requires vision' => [ProviderOperation::Vision, ModelCapability::VISION];
+        yield 'tools requires tools'   => [ProviderOperation::Tools, ModelCapability::TOOLS];
+
+        // Not enforced: no discoverer writes `completion` or `embeddings`, and
+        // only four of seven write `streaming`. Requiring them would refuse
+        // models that work, for a fact nobody stated.
+        yield 'completion requires nothing' => [ProviderOperation::Completion, null];
+        yield 'embedding requires nothing'  => [ProviderOperation::Embedding, null];
+        yield 'stream requires nothing'     => [ProviderOperation::Stream, null];
+
+        // Not enforced: specialized services never reach criteria-mode
+        // selection, so a mapping would be inert (the ADR-138 boundary).
+        yield 'image generation requires nothing' => [ProviderOperation::ImageGeneration, null];
+        yield 'image edit requires nothing'       => [ProviderOperation::ImageEdit, null];
+        yield 'image variation requires nothing'  => [ProviderOperation::ImageVariation, null];
+        yield 'transcription requires nothing'    => [ProviderOperation::Transcription, null];
+        yield 'speech synthesis requires nothing' => [ProviderOperation::SpeechSynthesis, null];
+
+        // Not enforced: no ModelCapability describes translation, and metadata
+        // is not an AI generation at all.
+        yield 'translation requires nothing' => [ProviderOperation::Translation, null];
+        yield 'metadata requires nothing'    => [ProviderOperation::Metadata, null];
+    }
+
+    #[Test]
+    #[DataProvider('operationCapabilityProvider')]
+    public function mapsOperationToTheCapabilityItRequires(
+        ProviderOperation $operation,
+        ?ModelCapability $expected,
+    ): void {
+        self::assertSame($expected, OperationCapabilityMap::capabilityFor($operation));
+    }
+
+    #[Test]
+    public function everyProviderOperationIsAccountedFor(): void
+    {
+        $covered = [];
+        foreach (self::operationCapabilityProvider() as $case) {
+            $covered[] = $case[0];
+        }
+
+        self::assertEqualsCanonicalizing(
+            ProviderOperation::cases(),
+            $covered,
+            'A ProviderOperation case is missing from the map coverage above. '
+            . 'Decide explicitly whether it requires a capability — silence is the bug this ADR fixed.',
+        );
+    }
+}

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -122,6 +122,13 @@ telemetry.enabled = 1
 tools.dataClassEnforcement = enforce
 
 # =============================================================================
+# Model routing (ADR-138)
+# =============================================================================
+
+# cat=routing; type=options[Enforce=enforce,Observe (log only)=observe]; label=Operation capability enforcement: Whether a criteria-mode configuration may resolve a model that does not declare the capability the running operation needs (chat, vision, tool calling). "Enforce" removes such models from the candidate set and reports a misconfiguration when nothing is left. "Observe" leaves the selection untouched and only logs the mismatch. The read is fail-closed, so a missing or mistyped value also enforces. A model whose capability field is EMPTY is treated as undeclared and always passes — the field is optional and refusing every model that never filled it would break working installations. Fixed-mode configurations are unaffected: the operator named the model there, so nothing is being chosen.
+routing.operationCapabilityEnforcement = enforce
+
+# =============================================================================
 # Privacy & data retention (ADR-064)
 # =============================================================================
 


### PR DESCRIPTION
## Description

Criteria mode matched capabilities only against **stored** criteria, never against the operation actually running. A configuration whose criteria do not mention tools could resolve a model that cannot do tools, and the failure surfaced as a provider error rather than a configuration one.

A `ProviderOperation → ModelCapability` map is merged into the criteria before `findMatchingModel()`.

### It carries a pre-existing bug fix it cannot work without — #652

**`Model::$capabilities` never reached the entity.** Extbase resolves property types through Symfony PropertyInfo; `ReflectionExtractor` infers a *collection* from an adder/remover pair, and `addCapability()` / `removeCapability()` inflect to `$capabilities`, so it resolved as `array`. `DataMapper::thawProperties()` has no array mapping, so the column was silently dropped on every load.

Every repository-loaded model came back with an **empty** capability set — which means **every `capabilities` selection criterion has been matching nothing in production**, long before this ticket. Unit tests could not catch it: they construct `Model` with setters, the one path that bypasses the DataMapper.

Fixed with an explicit `@var string`. **The tag needs its description** — PHP-CS-Fixer's `no_superfluous_phpdoc_tags` strips a bare `@var string` as redundant, which would silently reintroduce the bug. The docblock says so.

Verified as a controlled before/after on the same tree rather than by inference: docblock removed → 2 failures (`null is not an instance of Model`); docblock restored → 5 tests, 23 assertions, SUCCESS.

Filed as #652 so the defect has its own record; it is older and wider than this feature.

### Three deviations from the issue text

1. **Only `chat`, `vision` and `tools` are enforced** — not "every operation that implies a capability". No model discoverer writes `completion` or `embeddings`; all seven write `chat[,vision,tools,streaming,reasoning]`. Only four of seven write `streaming` (Ollama, Groq and OpenRouter do not, and their models stream fine). Enforcing those would refuse every wizard-created model on the *primary* completion path and break every criteria-mode embedding configuration. That is an outage, not a check. Recorded in ADR-138 with a revisit condition.
2. **The derived capability goes into its own criteria key**, not into `capabilities`. "Empty CSV means undeclared" and strict matching of operator-stated criteria are incompatible in one list: a model declaring nothing must pass the *derived* check while still failing an *explicit* requirement.
3. **`chat()` / `complete()` / `streamChat()` do reach `resolveModel()`** — the issue says the generic path never does. They prefer the default DB configuration and delegate to `*WithConfiguration()`. Only their ad-hoc pinned-provider branch, plus `embed()`, `vision()` and `chatWithTools()`, bypass it. The boundary is real but narrower than stated, and ADR-138 states it precisely. Those paths are untouched.

### As instructed and confirmed unchanged

`UnsupportedFeatureException` still falls to `FailureClass::UNKNOWN` (`FailureClassifier.php:45`) and is therefore not retryable — a misconfiguration must not be masked by a fallback. The reason is in the ADR so nobody "fixes" it later.

`LlmServiceManager.php:634` and `:653` both pass `ProviderOperation::Embedding`, with a unit test asserting the two resolutions receive the same operation and return the same model — the cache-key trap the issue warned about.

## Related Issue

Closes #635 · fixes #652

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

Internal signatures change (`ModelSelectionServiceInterface::resolveModel()`, `ConfigurationCallPlanner::resolveModel()`/`adapterFor()`); neither is in the frozen `api-surface.txt`, and no new type enters a frozen signature.

Note that #652's fix makes `capabilities` criteria **start working**. An installation with criteria that were silently ignored will now see them applied — the new `routing.operationCapabilityEnforcement` switch (ADR-113/115 shape, only a literal `observe` observes) exists for the derived check; the pre-existing criterion has no such switch because it was always meant to apply.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `composer ci` and all checks pass — unit, PHPStan (level 10), cgl and fuzzy re-run independently of the authoring pass: all SUCCESS; the functional classes executed for real (45 tests, 485 assertions). Rector green under an 8.2 resolve, then restored to 8.4 and the suites re-run on that tree.
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation accordingly
- [x] I have added a `CHANGELOG.md` entry under `## [Unreleased]`
- [x] I have added an ADR under `Documentation/Adr/` if this changes the public surface — ADR-138
- [x] My changes generate no new warnings

### Named, not fixed

`ConfigurationController::testConfigurationAction()` catches `ProviderException` — the parent of `UnsupportedFeatureException` — and answers 502 "LLM provider error". An admin testing a misconfigured criteria configuration now gets a provider-shaped message for a configuration-shaped problem. Fixing it needs new locallang keys and is a separate change; naming it here rather than claiming it is filed.