### PR TITLE
feat(governance): read-only effective-policy readout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- A read-only **Governance** tab on the LLM Overview showing the effective
+  value of the four governance keys that carry a decision —
+  `privacy.level`, `privacy.retentionDays`, `tools.dataClassEnforcement`
+  and `skills.minTrustLevel` — together with the FQCN of the resolver each
+  value came from (ADR-140). Every value is read through the same resolver
+  the runtime uses, so the view cannot drift from behaviour: a mistyped
+  `tools.dataClassEnforcement` reads as `enforce` because that is what the
+  gate applies. A resolver that cannot be asked yields "unknown", never a
+  substituted default. There is deliberately no apply path and no
+  provenance column — the Install Tool stays the place where instance-wide
+  keys are set; ADR-140 records why.
+
+### Changed
+
+- `ToolCallPolicy::enforcing()` moved verbatim into the new
+  `Service\Tool\DataClassEnforcementResolver`, which the tool gate and the
+  governance readout both ask. `ToolCallPolicy` no longer takes an optional
+  `ExtensionConfiguration` and instead requires the resolver; behaviour is
+  unchanged, including the fail-closed matrix of ADR-113.
+- `SkillComposerFactory::minTrustLevel()` is public so the readout can show
+  the level the composer is actually built with.
+
 ## [0.26.0] - 2026-08-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   gate applies. A resolver that cannot be asked yields "unknown", never a
   substituted default. There is deliberately no apply path and no
   provenance column — the Install Tool stays the place where instance-wide
-  keys are set; ADR-140 records why.
+  keys are set; ADR-140 records why. Two rows carry more than a value:
+  `tools.dataClassEnforcement = observe` is annotated as applying to
+  built-in tools only, because the gate enforces the trust-zone ceiling for
+  every MCP tool regardless (ADR-115), and each
+  `privacy.retention.<category>` override that deviates from
+  `privacy.retentionDays` gets its own row — the overrides left at the
+  shipped `0` resolve to the global window and stay out.
 
 ### Changed
 

--- a/Classes/Controller/Backend/LlmModuleController.php
+++ b/Classes/Controller/Backend/LlmModuleController.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Service\Analytics\AnalyticsPeriod;
+use Netresearch\NrLlm\Service\Governance\EffectivePolicyReadout;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Service\Overview\OverviewReadinessService;
@@ -51,6 +52,7 @@ final class LlmModuleController extends ActionController
         private readonly OverviewReadinessService $readinessService,
         private readonly ProviderReachabilityService $reachabilityService,
         private readonly UsageAnalyticsServiceInterface $analytics,
+        private readonly EffectivePolicyReadout $effectivePolicyReadout,
         private readonly PageRenderer $pageRenderer,
         private readonly LoggerInterface $logger,
     ) {}
@@ -251,6 +253,35 @@ final class LlmModuleController extends ActionController
         return $result;
     }
 
+    /**
+     * Read-only effective-policy readout (ADR-140).
+     *
+     * Shows the four governance keys that carry a decision, each read through
+     * the same resolver the runtime uses. There is deliberately no apply path
+     * and no provenance column — see ADR-140. Instance-wide keys are set in the
+     * Install Tool.
+     */
+    public function governanceAction(): ResponseInterface
+    {
+        $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
+        $moduleTemplate->makeDocHeaderModuleMenu();
+        $this->buildDocHeaderTabMenu($moduleTemplate, 'governance');
+
+        if (method_exists($moduleTemplate->getDocHeaderComponent(), 'setShortcutContext')) {
+            $moduleTemplate->getDocHeaderComponent()->setShortcutContext(
+                routeIdentifier: 'nrllm',
+                displayName: 'LLM - Governance',
+                arguments: ['action' => 'governance'],
+            );
+        }
+
+        $moduleTemplate->assignMultiple([
+            'policyRows' => $this->effectivePolicyReadout->rows(),
+        ]);
+
+        return $moduleTemplate->renderResponse('Backend/Governance');
+    }
+
     public function helpAction(): ResponseInterface
     {
         $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
@@ -266,7 +297,11 @@ final class LlmModuleController extends ActionController
     }
 
     /**
-     * Build a Dashboard/Help tab menu in the docheader.
+     * Build a Dashboard/Governance/Help tab menu in the docheader.
+     *
+     * These are links to real routes, not in-page tabs: the dashboard entry
+     * goes through the backend route, the other two through Extbase actions of
+     * this controller.
      */
     private function buildDocHeaderTabMenu(ModuleTemplate $moduleTemplate, string $activeTab): void
     {
@@ -282,6 +317,15 @@ final class LlmModuleController extends ActionController
         }
 
         $menu->addMenuItem($dashboardItem);
+
+        $governanceItem = $menu->makeMenuItem()
+            ->setTitle(LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:tab.governance', 'NrLlm') ?? 'Governance')
+            ->setHref($this->uriBuilder->reset()->uriFor('governance'));
+        if ($activeTab === 'governance') {
+            $governanceItem->setActive(true);
+        }
+
+        $menu->addMenuItem($governanceItem);
 
         $helpItem = $menu->makeMenuItem()
             ->setTitle(LocalizationUtility::translate('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:tab.help', 'NrLlm') ?? 'Help')

--- a/Classes/Service/Governance/EffectivePolicyReadout.php
+++ b/Classes/Service/Governance/EffectivePolicyReadout.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Governance;
+
+use Netresearch\NrLlm\Service\Privacy\PrivacyPolicyInterface;
+use Netresearch\NrLlm\Service\Skill\SkillComposerFactory;
+use Netresearch\NrLlm\Service\Tool\DataClassEnforcementResolver;
+use Throwable;
+
+/**
+ * The read-only effective-policy readout (ADR-140).
+ *
+ * Governance is spread over ``ext_conf_template.txt``, several TCA tables,
+ * ``be_groups`` and the dashboard widgets; there was no single place showing
+ * the *effective* state. This service assembles the four keys that carry an
+ * actual decision, each read through the SAME resolver the runtime uses, so the
+ * view cannot drift from behaviour:
+ *
+ * - ``privacy.level`` and ``privacy.retentionDays`` via {@see PrivacyPolicyInterface}
+ * - ``tools.dataClassEnforcement`` via {@see DataClassEnforcementResolver}
+ * - ``skills.minTrustLevel`` via {@see SkillComposerFactory}
+ *
+ * Every read is wrapped: a resolver that throws yields an "unknown" row rather
+ * than a value. A governance view that guesses is worse than one that admits it
+ * does not know, because an operator would act on the guess.
+ *
+ * There is no apply path — see ADR-140 for why.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
+final readonly class EffectivePolicyReadout
+{
+    public function __construct(
+        private PrivacyPolicyInterface $privacyPolicy,
+        private DataClassEnforcementResolver $enforcementResolver,
+        private SkillComposerFactory $skillComposerFactory,
+    ) {}
+
+    /**
+     * @return list<EffectivePolicyRow>
+     */
+    public function rows(): array
+    {
+        return [
+            $this->row(
+                'privacy.level',
+                $this->privacyPolicy::class,
+                fn(): string => $this->privacyPolicy->level()->value,
+            ),
+            $this->row(
+                'privacy.retentionDays',
+                $this->privacyPolicy::class,
+                fn(): string => (string)$this->privacyPolicy->retentionDays(),
+            ),
+            $this->row(
+                'tools.dataClassEnforcement',
+                $this->enforcementResolver::class,
+                fn(): string => $this->enforcementResolver->mode(),
+            ),
+            $this->row(
+                'skills.minTrustLevel',
+                $this->skillComposerFactory::class,
+                fn(): string => $this->skillComposerFactory->minTrustLevel()->value,
+            ),
+        ];
+    }
+
+    /**
+     * Ask one resolver. Anything thrown becomes "unknown" — the readout never
+     * substitutes a default for an answer it did not get.
+     *
+     * @param callable(): string $read
+     */
+    private function row(string $key, string $reader, callable $read): EffectivePolicyRow
+    {
+        try {
+            $value = $read();
+        } catch (Throwable) {
+            $value = null;
+        }
+
+        return new EffectivePolicyRow($key, $value, $reader);
+    }
+}

--- a/Classes/Service/Governance/EffectivePolicyReadout.php
+++ b/Classes/Service/Governance/EffectivePolicyReadout.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Governance;
 
+use Netresearch\NrLlm\Domain\Enum\PrivacyDataCategory;
 use Netresearch\NrLlm\Service\Privacy\PrivacyPolicyInterface;
 use Netresearch\NrLlm\Service\Skill\SkillComposerFactory;
 use Netresearch\NrLlm\Service\Tool\DataClassEnforcementResolver;
@@ -27,6 +28,10 @@ use Throwable;
  * - ``tools.dataClassEnforcement`` via {@see DataClassEnforcementResolver}
  * - ``skills.minTrustLevel`` via {@see SkillComposerFactory}
  *
+ * Plus one row per ``privacy.retention.<category>`` override that actually
+ * deviates from the global window — never the seven that ship as ``0`` and
+ * resolve to it.
+ *
  * Every read is wrapped: a resolver that throws yields an "unknown" row rather
  * than a value. A governance view that guesses is worse than one that admits it
  * does not know, because an operator would act on the guess.
@@ -37,6 +42,14 @@ use Throwable;
  */
 final readonly class EffectivePolicyReadout
 {
+    /**
+     * Observe mode is not global: {@see \Netresearch\NrLlm\Service\Tool\ToolCallPolicy::decide()}
+     * enforces the ceiling for every {@see \Netresearch\NrLlm\Service\Tool\RemoteToolInterface}
+     * tool regardless of the setting (ADR-115). An unqualified `observe` would
+     * send an operator whose MCP tool is being dropped looking somewhere else.
+     */
+    private const NOTE_REMOTE_ALWAYS_ENFORCED = 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:governance.note.remoteAlwaysEnforced';
+
     public function __construct(
         private PrivacyPolicyInterface $privacyPolicy,
         private DataClassEnforcementResolver $enforcementResolver,
@@ -48,28 +61,86 @@ final readonly class EffectivePolicyReadout
      */
     public function rows(): array
     {
+        $retention = $this->row(
+            'privacy.retentionDays',
+            $this->privacyPolicy::class,
+            fn(): string => (string)$this->privacyPolicy->retentionDays(),
+        );
+
         return [
             $this->row(
                 'privacy.level',
                 $this->privacyPolicy::class,
                 fn(): string => $this->privacyPolicy->level()->value,
             ),
-            $this->row(
-                'privacy.retentionDays',
-                $this->privacyPolicy::class,
-                fn(): string => (string)$this->privacyPolicy->retentionDays(),
-            ),
-            $this->row(
-                'tools.dataClassEnforcement',
-                $this->enforcementResolver::class,
-                fn(): string => $this->enforcementResolver->mode(),
-            ),
+            $retention,
+            ...$this->retentionOverrideRows($retention),
+            $this->enforcementRow(),
             $this->row(
                 'skills.minTrustLevel',
                 $this->skillComposerFactory::class,
                 fn(): string => $this->skillComposerFactory->minTrustLevel()->value,
             ),
         ];
+    }
+
+    /**
+     * The enforcement mode, qualified where the gate does not apply it.
+     *
+     * `observe` is the mode for builtins only: the gate enforces the trust-zone
+     * ceiling for every remote tool whatever the setting says. The unqualified
+     * word would therefore be a true value and a false statement.
+     */
+    private function enforcementRow(): EffectivePolicyRow
+    {
+        $row = $this->row(
+            'tools.dataClassEnforcement',
+            $this->enforcementResolver::class,
+            fn(): string => $this->enforcementResolver->mode(),
+        );
+
+        if ($row->value !== DataClassEnforcementResolver::MODE_OBSERVE) {
+            return $row;
+        }
+
+        return new EffectivePolicyRow($row->key, $row->value, $row->reader, self::NOTE_REMOTE_ALWAYS_ENFORCED);
+    }
+
+    /**
+     * One row per `privacy.retention.<category>` override that actually moves a
+     * window, and none for the rest.
+     *
+     * The seven overrides ship as `0` and resolve to the global window, so on a
+     * stock install listing them adds seven rows reading "30" and informs
+     * nobody. Once one IS set, the opposite holds: `privacy.retentionDays` is
+     * then no longer the window that category is purged on, and a single number
+     * on a page promising what the install "actually applies" is read as the
+     * answer for everything.
+     *
+     * @return list<EffectivePolicyRow>
+     */
+    private function retentionOverrideRows(EffectivePolicyRow $globalRetention): array
+    {
+        if (!$globalRetention->isKnown()) {
+            // Nothing to deviate from — the global row already reads "unknown",
+            // and a category window without its baseline states nothing.
+            return [];
+        }
+
+        $rows = [];
+        foreach (PrivacyDataCategory::cases() as $category) {
+            $row = $this->row(
+                'privacy.retention.' . $category->configKey(),
+                $this->privacyPolicy::class,
+                fn(): string => (string)$this->privacyPolicy->retentionDaysFor($category),
+            );
+
+            if ($row->isKnown() && $row->value !== $globalRetention->value) {
+                $rows[] = $row;
+            }
+        }
+
+        return $rows;
     }
 
     /**

--- a/Classes/Service/Governance/EffectivePolicyRow.php
+++ b/Classes/Service/Governance/EffectivePolicyRow.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Governance;
+
+/**
+ * One line of the read-only effective-policy readout (ADR-140): a governance
+ * key, the value the runtime resolver actually returned, and the FQCN of the
+ * resolver that returned it.
+ *
+ * A null $value means the resolver could not be asked. The row then reads
+ * "unknown" — never a value, and never a guess reconstructed from the raw
+ * setting, because a value shown here must be one the runtime would apply.
+ *
+ * There is deliberately no provenance ("shipped default" vs "explicitly set"):
+ * no resolver exposes it, and TYPO3's own
+ * ExtensionConfiguration::synchronizeExtConfTemplateWithLocalConfigurationOfAllExtensions()
+ * merges the shipped template defaults into settings.php, so the distinction is
+ * not reconstructable from the stored configuration either.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
+final readonly class EffectivePolicyRow
+{
+    /**
+     * @param string      $key    The configuration key, e.g. `privacy.level`
+     * @param string|null $value  The effective value, or null when unknown
+     * @param string      $reader FQCN of the resolver the runtime reads through
+     */
+    public function __construct(
+        public string $key,
+        public ?string $value,
+        public string $reader,
+    ) {}
+
+    /**
+     * Whether the resolver answered. False renders as "unknown".
+     */
+    public function isKnown(): bool
+    {
+        return $this->value !== null;
+    }
+}

--- a/Classes/Service/Governance/EffectivePolicyRow.php
+++ b/Classes/Service/Governance/EffectivePolicyRow.php
@@ -18,6 +18,11 @@ namespace Netresearch\NrLlm\Service\Governance;
  * "unknown" — never a value, and never a guess reconstructed from the raw
  * setting, because a value shown here must be one the runtime would apply.
  *
+ * $noteKey carries the case where the effective value is right but incomplete:
+ * a setting the runtime applies to most, not all, of what the key names. The
+ * note is a translation key rather than prose so the view stays the only place
+ * that renders language.
+ *
  * There is deliberately no provenance ("shipped default" vs "explicitly set"):
  * no resolver exposes it, and TYPO3's own
  * ExtensionConfiguration::synchronizeExtConfTemplateWithLocalConfigurationOfAllExtensions()
@@ -29,14 +34,18 @@ namespace Netresearch\NrLlm\Service\Governance;
 final readonly class EffectivePolicyRow
 {
     /**
-     * @param string      $key    The configuration key, e.g. `privacy.level`
-     * @param string|null $value  The effective value, or null when unknown
-     * @param string      $reader FQCN of the resolver the runtime reads through
+     * @param string      $key     The configuration key, e.g. `privacy.level`
+     * @param string|null $value   The effective value, or null when unknown
+     * @param string      $reader  FQCN of the resolver the runtime reads through
+     * @param string|null $noteKey `LLL:` key of a qualification the value alone
+     *                             would misstate, or null when the value stands
+     *                             on its own. Rendered by Governance.html.
      */
     public function __construct(
         public string $key,
         public ?string $value,
         public string $reader,
+        public ?string $noteKey = null,
     ) {}
 
     /**

--- a/Classes/Service/Skill/SkillComposerFactory.php
+++ b/Classes/Service/Skill/SkillComposerFactory.php
@@ -37,10 +37,18 @@ final readonly class SkillComposerFactory
 
     public function create(): SkillComposer
     {
-        return new SkillComposer(minTrustLevel: $this->resolveMinTrustLevel());
+        return new SkillComposer(minTrustLevel: $this->minTrustLevel());
     }
 
-    private function resolveMinTrustLevel(): SkillTrustLevel
+    /**
+     * The effective minimum publisher-trust level every composer is built with.
+     *
+     * Public so the read-only governance readout (ADR-140) can show the value
+     * the runtime actually applies instead of re-reading and re-interpreting
+     * ``skills.minTrustLevel`` itself, which would let the view drift from the
+     * composer.
+     */
+    public function minTrustLevel(): SkillTrustLevel
     {
         try {
             /** @var array<string, mixed> $config */

--- a/Classes/Service/Tool/DataClassEnforcementResolver.php
+++ b/Classes/Service/Tool/DataClassEnforcementResolver.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+use Throwable;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+/**
+ * Resolves ``tools.dataClassEnforcement`` — whether the trust-zone axis of the
+ * tool gate is enforced or merely observed (ADR-113).
+ *
+ * Extracted verbatim from {@see ToolCallPolicy} so the runtime gate and the
+ * read-only governance readout (ADR-140) answer the same question through the
+ * same code. A second reader that re-implemented the parsing could drift from
+ * the gate and show an operator a mode the gate does not apply.
+ *
+ * Fail-closed: the axis observes ONLY on an explicit `observe`. Every other
+ * case enforces — an unreadable extension configuration, a malformed `tools`
+ * section, a missing value, or a typo (`observ`, `off`, ``). The gate is a
+ * security control, so an operator who cannot express a deliberate "only
+ * observe" gets the safe behaviour rather than a silently disabled gate.
+ * Turning the axis on never loosens anything (the four pre-existing gates
+ * always enforce), so failing closed here cannot over-permit.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
+final readonly class DataClassEnforcementResolver
+{
+    public const MODE_ENFORCE = 'enforce';
+
+    public const MODE_OBSERVE = 'observe';
+
+    public function __construct(
+        private ?ExtensionConfiguration $extensionConfiguration = null,
+    ) {}
+
+    /**
+     * Whether the trust-zone axis is enforced (true) or merely observed (false).
+     */
+    public function enforcing(): bool
+    {
+        try {
+            /** @var array<string, mixed> $config */
+            $config = $this->extensionConfiguration?->get('nr_llm') ?? [];
+        } catch (Throwable) {
+            return true;
+        }
+
+        $tools = $config['tools'] ?? null;
+        if (!is_array($tools)) {
+            return true;
+        }
+
+        $mode = $tools['dataClassEnforcement'] ?? null;
+
+        return !is_string($mode) || strtolower(trim($mode)) !== self::MODE_OBSERVE;
+    }
+
+    /**
+     * The effective mode as a label for the governance readout. Derived from
+     * {@see enforcing()} rather than from the raw setting, so what is shown is
+     * exactly what the gate applies — a typo reads as `enforce`, because that is
+     * what happens.
+     *
+     * @return self::MODE_*
+     */
+    public function mode(): string
+    {
+        return $this->enforcing() ? self::MODE_ENFORCE : self::MODE_OBSERVE;
+    }
+}

--- a/Classes/Service/Tool/ToolCallPolicy.php
+++ b/Classes/Service/Tool/ToolCallPolicy.php
@@ -14,9 +14,7 @@ use Netresearch\NrLlm\Domain\Enum\ToolDenialReason;
 use Netresearch\NrLlm\Domain\Enum\TrustZone;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\ValueObject\ToolPolicyDecision;
-use Throwable;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
-use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 /**
  * The composite tool gate (ADR-094).
@@ -29,23 +27,23 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
  * The zone gate ships in **observe** mode via the `tools.dataClassEnforcement`
  * extension setting: the decision is computed and reported, but the tool is
  * still offered. An operator sets it to any non-`observe` value (or the setting
- * is missing/unreadable) to enforce. The switch is fail-closed (ADR-113): only
- * a deliberate `observe` observes; everything else enforces, so a broken or
- * mistyped setting cannot silently disable the gate. The four pre-existing
+ * is missing/unreadable) to enforce. The switch is read by
+ * {@see DataClassEnforcementResolver}, which the governance readout (ADR-140)
+ * asks as well so the view cannot drift from this gate. It is fail-closed
+ * (ADR-113): only a deliberate `observe` observes; everything else enforces, so
+ * a broken or mistyped setting cannot silently disable the gate. The four pre-existing
  * gates always enforce — the switch governs only the new axis, so turning it on
  * (or failing closed) cannot loosen anything.
  */
 final readonly class ToolCallPolicy implements ToolCallPolicyInterface
 {
-    private const OBSERVE = 'observe';
-
     public function __construct(
         private ToolRegistry $registry,
         private ToolAvailabilityServiceInterface $availability,
         private AllowedToolsResolver $allowedTools,
         private ToolDataClassResolver $dataClasses,
         private TrustZoneResolver $trustZones,
-        private ?ExtensionConfiguration $extensionConfiguration = null,
+        private DataClassEnforcementResolver $enforcement,
     ) {}
 
     public function decide(string $toolName, LlmConfiguration $configuration, ?BackendUserAuthentication $user): ToolPolicyDecision
@@ -80,7 +78,7 @@ final readonly class ToolCallPolicy implements ToolCallPolicyInterface
             // worked (ADR-115); no remote tool worked before, so there is
             // nothing to preserve, and an upgraded install must not end up more
             // permissive than a fresh one.
-            $enforcing = $this->enforcing() || $tool instanceof RemoteToolInterface;
+            $enforcing = $this->enforcement->enforcing() || $tool instanceof RemoteToolInterface;
 
             return new ToolPolicyDecision(
                 $toolName,
@@ -130,35 +128,5 @@ final readonly class ToolCallPolicy implements ToolCallPolicyInterface
         ToolDenialReason $reason,
     ): ToolPolicyDecision {
         return new ToolPolicyDecision($toolName, false, $dataClass, $zone, $ceiling, $reason);
-    }
-
-    /**
-     * Whether the trust-zone axis is enforced or merely observed (ADR-113).
-     *
-     * Fail-closed: the axis observes ONLY on an explicit `observe`. Every other
-     * case enforces — an unreadable extension configuration, a malformed
-     * `tools` section, a missing value, or a typo (`observ`, `off`, ``). The
-     * gate is a security control, so an operator who cannot express a deliberate
-     * "only observe" gets the safe behaviour rather than a silently disabled
-     * gate. Turning the axis on never loosens anything (the four pre-existing
-     * gates always enforce), so failing closed here cannot over-permit.
-     */
-    private function enforcing(): bool
-    {
-        try {
-            /** @var array<string, mixed> $config */
-            $config = $this->extensionConfiguration?->get('nr_llm') ?? [];
-        } catch (Throwable) {
-            return true;
-        }
-
-        $tools = $config['tools'] ?? null;
-        if (!is_array($tools)) {
-            return true;
-        }
-
-        $mode = $tools['dataClassEnforcement'] ?? null;
-
-        return !is_string($mode) || strtolower(trim($mode)) !== self::OBSERVE;
     }
 }

--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -63,6 +63,7 @@ return [
                 'index',
                 'test',
                 'executeTest',
+                'governance',
                 'help',
             ],
         ],
@@ -79,11 +80,16 @@ return [
         'path' => '/module/nrllm/overview',
         'labels' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_overview.xlf',
         'extensionName' => 'NrLlm',
+        // `governance` is the read-only effective-policy readout (ADR-140). It
+        // is an action of this module rather than a fourteenth flat submodule:
+        // ADR-119 already calls twelve entries a dumping ground, and the
+        // readout is a property of the overview, not a management surface.
         'controllerActions' => [
             LlmModuleController::class => [
                 'index',
                 'test',
                 'executeTest',
+                'governance',
                 'help',
             ],
         ],

--- a/Documentation/Administration/Index.rst
+++ b/Documentation/Administration/Index.rst
@@ -34,6 +34,20 @@ approvals in the separate :guilabel:`Web > AI Tasks` module
 - a **For developers** section showing how to call the same configuration from
   PHP via ``LlmServiceManager``.
 
+The Overview's docheader carries a :guilabel:`Governance` tab — the read-only
+**effective policy** readout (:ref:`ADR-140 <adr-140>`). It lists the four
+governance keys that carry a decision (``privacy.level``,
+``privacy.retentionDays``, ``tools.dataClassEnforcement``,
+``skills.minTrustLevel``) with the value the runtime applies right now and the
+class that resolved it. Two things it deliberately does not do: it never
+changes a value — instance-wide keys are set in the Install Tool under
+:guilabel:`Settings > Extension Configuration > nr_llm` — and it never shows a
+value it did not get from a resolver, so a row that cannot be answered reads
+``unknown`` rather than a default. Because the reads go through the runtime
+resolvers, the tab shows what is *in force*: a mistyped
+``tools.dataClassEnforcement`` reads ``enforce``, because the gate is
+fail-closed (:ref:`ADR-113 <adr-113>`).
+
 .. figure:: /Images/backend-dashboard.png
    :alt: The LLM Overview — a usage-and-cost band, a status-coloured module
        card grid, and a developer section

--- a/Documentation/Administration/Index.rst
+++ b/Documentation/Administration/Index.rst
@@ -48,6 +48,17 @@ resolvers, the tab shows what is *in force*: a mistyped
 ``tools.dataClassEnforcement`` reads ``enforce``, because the gate is
 fail-closed (:ref:`ADR-113 <adr-113>`).
 
+Two rows say more than their value alone:
+
+- ``tools.dataClassEnforcement = observe`` is annotated as applying to built-in
+  tools only. Tools reached through an MCP server are always enforced against
+  the trust-zone ceiling (:ref:`ADR-115 <adr-115>`), so an MCP tool can be
+  dropped while this row reads ``observe``.
+- Every ``privacy.retention.<category>`` override that deviates from
+  ``privacy.retentionDays`` gets its own row underneath it. Categories left at
+  ``0`` resolve to the global window and are not listed — see
+  :ref:`administration-data-retention` for the full set.
+
 .. figure:: /Images/backend-dashboard.png
    :alt: The LLM Overview — a usage-and-cost band, a status-coloured module
        card grid, and a developer section

--- a/Documentation/Adr/Adr140EffectivePolicyReadoutWithoutApplyPath.rst
+++ b/Documentation/Adr/Adr140EffectivePolicyReadoutWithoutApplyPath.rst
@@ -1,0 +1,144 @@
+.. _adr-140:
+
+=========================================================
+ADR-140: The effective-policy readout has no apply path
+=========================================================
+
+:Status: Accepted
+:Date: 2026-08-09
+
+Context
+=======
+
+Governance is spread over ``ext_conf_template.txt``, several TCA tables,
+``be_groups`` and three dashboard widgets. There was no single place where an
+operator could see the **effective** state — the values the runtime actually
+applies right now. Four keys carry real decision content:
+
+- ``privacy.level``
+- ``privacy.retentionDays``
+- ``tools.dataClassEnforcement``
+- ``skills.minTrustLevel``
+
+The obvious next step after showing a value is letting the operator change it
+there. That step is the decision this ADR records, and the answer is no.
+
+Decision
+========
+
+A read-only view, in an existing module, reading through the runtime resolvers.
+
+1. **Read through the same resolver as the runtime, never a second parser.**
+   :php:`ToolCallPolicy::enforcing()` moved verbatim into
+   :php:`Service\\Tool\\DataClassEnforcementResolver`, which both the gate and
+   the view now ask. :php:`SkillComposerFactory` exposes the previously private
+   :php:`minTrustLevel()`. Privacy keeps its existing
+   :php:`PrivacyPolicyInterface`. A view with its own copy of the parsing rules
+   would drift from behaviour on the first change to either side — and a
+   governance view that is *almost* right is worse than none, because an
+   operator acts on it.
+
+2. **The value shown is what the gate DOES, not the literal setting.**
+   ``tools.dataClassEnforcement`` is fail-closed (:ref:`ADR-113 <adr-113>`):
+   only a literal ``observe`` observes. A typo (``observ``) therefore reads as
+   ``enforce`` in the view, because that is what the runtime applies. Echoing
+   the raw string would tell an operator the axis is off while it is enforcing.
+
+3. **A resolver that cannot be asked yields "unknown", never a value.** No
+   substituted default, no reconstruction from the raw setting. A row that
+   admits it does not know is safe; a plausible wrong value is not.
+
+4. **No apply path.** See below — this is the actual decision.
+
+5. **No provenance column** ("shipped default" vs "explicitly set"). No
+   resolver exposes provenance, and it is not reconstructable from the stored
+   configuration either: TYPO3's own
+   :php:`ExtensionConfiguration::synchronizeExtConfTemplateWithLocalConfigurationOfAllExtensions()`
+   (``ExtensionConfiguration.php:197-218``) merges every ``ext_conf_template.txt``
+   default into ``settings.php`` whenever an unknown key is read or the Install
+   Tool is entered. By the time anything could ask, the shipped defaults are
+   already stored values.
+
+6. **No new backend module.** :ref:`ADR-119 <adr-119>` already calls twelve flat
+   entries a dumping ground. The readout is a **Governance** tab of the
+   Overview module (``nrllm_overview``, action ``governance``), not a
+   thirteenth admin entry. Overview rather than Analytics: Analytics answers
+   "what did this install spend and do over time" from usage rows; the readout
+   answers "what does this install allow right now" — a static property of the
+   install, which is what the Overview already reports through its readiness
+   cards. Because
+   :php:`LlmModuleController::buildDocHeaderTabMenu()` builds links to real
+   routes rather than in-page tabs, the tab needed a real action, a template,
+   registration in ``Configuration/Backend/Modules.php`` and XLIFF keys in both
+   language files.
+
+Why there is no apply path
+--------------------------
+
+The only API for writing extension configuration is
+:php:`ExtensionConfiguration::set()`. Three properties, each verified against
+the shipped core:
+
+- **It is ``@internal``** (``ExtensionConfiguration.php:150``) and documented as
+  *"Set a full extension configuration"* — it takes the whole array and calls
+  :php:`setLocalConfigurationValueByPath('EXTENSIONS/' . $extension, $value)`
+  (``:166``). There is no per-key write.
+- **It materialises every shipped default.** A caller has no source for the
+  array other than :php:`get()`, which returns the template-merged result. Our
+  own :php:`DataClassEnforcementDefaultUpdateWizard::executeUpdate()`
+  (``Classes/Updates/DataClassEnforcementDefaultUpdateWizard.php:77-85``) does
+  exactly this: ``get()`` → mutate one key → ``set()``. Every default in
+  ``ext_conf_template.txt`` becomes an explicitly stored value.
+  :php:`storedEnforcement()` (``:121-131``) — the "did the operator ever choose
+  a mode?" probe :ref:`ADR-115 <adr-115>`'s wizard depends on — could then never
+  return ``null`` again.
+- **``additional.php`` spoils it.** The core docblock says so outright
+  (``ExtensionConfiguration.php:145-146``): if that file overwrites a setting,
+  ``->set()`` "may not end up as expected". An apply button would report success
+  and the next request would serve the old value — the worst failure mode a
+  governance UI can have.
+
+The Install Tool stays the place where instance-wide keys are set. It owns the
+write, the synchronisation and the cache flush; a second writer in a module
+would only add a way to get them out of step.
+
+Constraints and honest limits
+-----------------------------
+
+- **The ADR-115 argument is weaker than it looks, and does not carry the
+  decision alone.** ``storedEnforcement()`` reads
+  ``$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']``, whose docblock calls it the raw
+  stored configuration "pre-template-merge". It is not: the core
+  synchronisation writes the merged template into ``settings.php`` and into that
+  same global. On an install that has entered the Install Tool since the default
+  flipped, the "default vs chosen" distinction is *already* gone without any
+  apply path. The apply path would guarantee the loss rather than cause it. The
+  ``@internal`` full-array write and the ``additional.php`` hazard are the
+  load-bearing reasons; ADR-115 is corroborating, not decisive.
+- **The seven ``privacy.retention.*`` overrides are not shown.** All ship as
+  ``0`` and resolve to the global window by design; eleven rows of which eight
+  read "30" inform nobody. They belong in the documentation.
+- **"Unknown" is a guarantee, not a common state.** All three current resolvers
+  are fail-closed and swallow their own read errors, so on a working install
+  every row is answered. The guarantee exists so a future resolver — or a
+  partially booted container — can never be rendered as a value it did not
+  return.
+- **Read-only means read-only.** The view has no state, no AJAX route, and no
+  write of any kind; it is registered as an ``admin``-only module action like
+  every other nr_llm admin surface.
+
+Consequences
+============
+
+- The enforcement read has exactly one implementation. The functional test
+  wires the gate and the view from the same container resolver and asserts that
+  flipping ``tools.dataClassEnforcement`` moves both — the view cannot drift.
+- :php:`ToolCallPolicy` no longer depends on :php:`ExtensionConfiguration`; it
+  takes :php:`DataClassEnforcementResolver` as a required constructor argument.
+  Behaviour is unchanged, including the "no configuration at all enforces" case
+  the old nullable dependency produced.
+- :php:`SkillComposerFactory::minTrustLevel()` is public. The composer is still
+  built through :php:`create()`; the accessor only exposes what it already
+  computed.
+- Operators still change these keys in the Install Tool. The readout links
+  nowhere and changes nothing; it tells them what is in force.

--- a/Documentation/Adr/Adr140EffectivePolicyReadoutWithoutApplyPath.rst
+++ b/Documentation/Adr/Adr140EffectivePolicyReadoutWithoutApplyPath.rst
@@ -44,6 +44,18 @@ A read-only view, in an existing module, reading through the runtime resolvers.
    ``enforce`` in the view, because that is what the runtime applies. Echoing
    the raw string would tell an operator the axis is off while it is enforcing.
 
+   The same rule forces a qualification on ``observe``. The gate computes
+   :php:`$this->enforcement->enforcing() || $tool instanceof RemoteToolInterface`
+   (:php:`ToolCallPolicy::decide()`), so observe mode covers builtins only —
+   an MCP tool above the ceiling is denied outright whatever the setting says
+   (:ref:`ADR-115 <adr-115>`). The row therefore carries a note saying so. The
+   scenario is not exotic: :php:`DataClassEnforcementDefaultUpdateWizard` pins
+   any upgraded install that already has providers and never chose a mode to
+   ``observe``, and a server whose trust zone is unset falls back to
+   ``EXTERNAL_GLOBAL`` — the lowest ceiling there is. An
+   unqualified ``observe`` would send the operator whose MCP tool is being
+   dropped looking anywhere but at the trust zone.
+
 3. **A resolver that cannot be asked yields "unknown", never a value.** No
    substituted default, no reconstruction from the raw setting. A row that
    admits it does not know is safe; a plausible wrong value is not.
@@ -115,9 +127,17 @@ Constraints and honest limits
   apply path. The apply path would guarantee the loss rather than cause it. The
   ``@internal`` full-array write and the ``additional.php`` hazard are the
   load-bearing reasons; ADR-115 is corroborating, not decisive.
-- **The seven ``privacy.retention.*`` overrides are not shown.** All ship as
-  ``0`` and resolve to the global window by design; eleven rows of which eight
-  read "30" inform nobody. They belong in the documentation.
+- **The seven ``privacy.retention.*`` overrides are shown only where they
+  deviate.** On the *shipped defaults* they all read ``0`` and resolve to the
+  global window, so listing them adds seven rows reading "30" and informs
+  nobody — that argument covers a stock install and nothing else. Once an
+  operator sets one, ``privacy.retentionDays`` is no longer the window that
+  category is purged on, and a page promising what the install "actually
+  applies" would carry a single retention number that is wrong for it. A
+  category whose :php:`PrivacyPolicyInterface::retentionDaysFor()` differs from
+  :php:`retentionDays()` therefore gets its own row, directly under the global
+  one; the rest stay in the documentation
+  (:ref:`administration-data-retention`).
 - **"Unknown" is a guarantee, not a common state.** All three current resolvers
   are fail-closed and swallow their own read errors, so on a working install
   every row is answered. The guarantee exists so a future resolver — or a

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -429,3 +429,4 @@ Tools
    Adr129StructuredConsumers
    Adr130BackendUserGrants
    Adr131EditorModule
+   Adr140EffectivePolicyReadoutWithoutApplyPath

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -362,9 +362,51 @@
                 <source>Dashboard</source>
                 <target>Dashboard</target>
             </trans-unit>
+            <trans-unit id="tab.governance">
+                <source>Governance</source>
+                <target>Governance</target>
+            </trans-unit>
             <trans-unit id="tab.help">
                 <source>Help</source>
                 <target>Hilfe</target>
+            </trans-unit>
+
+            <!-- Effective policy readout (ADR-140) -->
+            <trans-unit id="governance.page.title">
+                <source>Effective policy</source>
+                <target>Effektive Richtlinie</target>
+            </trans-unit>
+            <trans-unit id="governance.lead">
+                <source>The governance settings this installation actually applies right now, each read through the same resolver the runtime uses.</source>
+                <target>Die Governance-Einstellungen, die diese Installation gerade tatsächlich anwendet — jede über denselben Resolver gelesen, den auch die Laufzeit befragt.</target>
+            </trans-unit>
+            <trans-unit id="governance.readonly.title">
+                <source>Read-only</source>
+                <target>Nur lesend</target>
+            </trans-unit>
+            <trans-unit id="governance.readonly.text">
+                <source>These keys are instance-wide and are changed in the Install Tool under Settings &gt; Extension Configuration &gt; nr_llm. This page deliberately cannot change them: writing extension configuration rewrites the whole merged array and would materialise every shipped default (ADR-140).</source>
+                <target>Diese Schlüssel gelten instanzweit und werden im Install Tool unter Einstellungen &gt; Extension-Konfiguration &gt; nr_llm geändert. Diese Seite kann sie bewusst nicht ändern: ein Schreibvorgang auf die Extension-Konfiguration schreibt das ganze gemergte Array zurück und würde jeden ausgelieferten Default materialisieren (ADR-140).</target>
+            </trans-unit>
+            <trans-unit id="governance.column.key">
+                <source>Setting</source>
+                <target>Einstellung</target>
+            </trans-unit>
+            <trans-unit id="governance.column.value">
+                <source>Effective value</source>
+                <target>Effektiver Wert</target>
+            </trans-unit>
+            <trans-unit id="governance.column.reader">
+                <source>Read by</source>
+                <target>Gelesen von</target>
+            </trans-unit>
+            <trans-unit id="governance.value.unknown">
+                <source>unknown</source>
+                <target>unbekannt</target>
+            </trans-unit>
+            <trans-unit id="governance.unknown.note">
+                <source>A row reads "unknown" when its resolver could not be asked. It never falls back to a shipped default, because a value shown here must be one the runtime would apply.</source>
+                <target>Eine Zeile zeigt „unbekannt“, wenn ihr Resolver nicht befragt werden konnte. Sie fällt nie auf einen ausgelieferten Default zurück, denn ein hier gezeigter Wert muss einer sein, den die Laufzeit auch anwenden würde.</target>
             </trans-unit>
 
             <!-- Dashboard overview cards -->

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -408,6 +408,10 @@
                 <source>A row reads "unknown" when its resolver could not be asked. It never falls back to a shipped default, because a value shown here must be one the runtime would apply.</source>
                 <target>Eine Zeile zeigt „unbekannt“, wenn ihr Resolver nicht befragt werden konnte. Sie fällt nie auf einen ausgelieferten Default zurück, denn ein hier gezeigter Wert muss einer sein, den die Laufzeit auch anwenden würde.</target>
             </trans-unit>
+            <trans-unit id="governance.note.remoteAlwaysEnforced">
+                <source>Applies to built-in tools only. Tools provided by an MCP server are always enforced against the trust-zone ceiling, never observed.</source>
+                <target>Gilt nur für eingebaute Tools. Tools von einem MCP-Server werden immer gegen die Trust-Zone-Obergrenze durchgesetzt, nie nur beobachtet.</target>
+            </trans-unit>
 
             <!-- Dashboard overview cards -->
             <trans-unit id="snippet.card.title">

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -310,6 +310,9 @@
             <trans-unit id="governance.unknown.note">
                 <source>A row reads "unknown" when its resolver could not be asked. It never falls back to a shipped default, because a value shown here must be one the runtime would apply.</source>
             </trans-unit>
+            <trans-unit id="governance.note.remoteAlwaysEnforced">
+                <source>Applies to built-in tools only. Tools provided by an MCP server are always enforced against the trust-zone ceiling, never observed.</source>
+            </trans-unit>
 
             <!-- Dashboard overview cards -->
             <trans-unit id="snippet.card.title">

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -275,8 +275,40 @@
             <trans-unit id="tab.dashboard">
                 <source>Dashboard</source>
             </trans-unit>
+            <trans-unit id="tab.governance">
+                <source>Governance</source>
+            </trans-unit>
             <trans-unit id="tab.help">
                 <source>Help</source>
+            </trans-unit>
+
+            <!-- Effective policy readout (ADR-140) -->
+            <trans-unit id="governance.page.title">
+                <source>Effective policy</source>
+            </trans-unit>
+            <trans-unit id="governance.lead">
+                <source>The governance settings this installation actually applies right now, each read through the same resolver the runtime uses.</source>
+            </trans-unit>
+            <trans-unit id="governance.readonly.title">
+                <source>Read-only</source>
+            </trans-unit>
+            <trans-unit id="governance.readonly.text">
+                <source>These keys are instance-wide and are changed in the Install Tool under Settings &gt; Extension Configuration &gt; nr_llm. This page deliberately cannot change them: writing extension configuration rewrites the whole merged array and would materialise every shipped default (ADR-140).</source>
+            </trans-unit>
+            <trans-unit id="governance.column.key">
+                <source>Setting</source>
+            </trans-unit>
+            <trans-unit id="governance.column.value">
+                <source>Effective value</source>
+            </trans-unit>
+            <trans-unit id="governance.column.reader">
+                <source>Read by</source>
+            </trans-unit>
+            <trans-unit id="governance.value.unknown">
+                <source>unknown</source>
+            </trans-unit>
+            <trans-unit id="governance.unknown.note">
+                <source>A row reads "unknown" when its resolver could not be asked. It never falls back to a shipped default, because a value shown here must be one the runtime would apply.</source>
             </trans-unit>
 
             <!-- Dashboard overview cards -->

--- a/Resources/Private/Templates/Backend/Governance.html
+++ b/Resources/Private/Templates/Backend/Governance.html
@@ -43,6 +43,9 @@
                                     </span>
                                 </f:else>
                             </f:if>
+                            <f:if condition="{row.noteKey}">
+                                <span class="d-block small text-body-secondary"><f:translate key="{row.noteKey}" /></span>
+                            </f:if>
                         </td>
                         <td><code class="text-body-secondary">{row.reader}</code></td>
                     </tr>

--- a/Resources/Private/Templates/Backend/Governance.html
+++ b/Resources/Private/Templates/Backend/Governance.html
@@ -1,0 +1,58 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+<!--
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Read-only effective-policy readout (ADR-140).
+ *
+ * Every value comes from the resolver the runtime itself reads through, so the
+ * page cannot drift from behaviour. There is no apply path and no provenance
+ * column — see ADR-140.
+-->
+<f:layout name="Module" />
+<f:section name="Content">
+    <h1><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:governance.page.title" default="Effective policy" /></h1>
+    <p class="lead">
+        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:governance.lead" default="The governance settings this installation actually applies right now, each read through the same resolver the runtime uses." />
+    </p>
+
+    <f:be.infobox state="-1" title="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:governance.readonly.title', default: 'Read-only')}">
+        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:governance.readonly.text" default="These keys are instance-wide and are changed in the Install Tool under Settings > Extension Configuration > nr_llm. This page deliberately cannot change them: writing extension configuration rewrites the whole merged array and would materialise every shipped default (ADR-140)." />
+    </f:be.infobox>
+
+    <div class="table-fit">
+        <table class="table table-striped table-hover">
+            <thead>
+                <tr>
+                    <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:governance.column.key" default="Setting" /></th>
+                    <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:governance.column.value" default="Effective value" /></th>
+                    <th><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:governance.column.reader" default="Read by" /></th>
+                </tr>
+            </thead>
+            <tbody>
+                <f:for each="{policyRows}" as="row">
+                    <tr>
+                        <td><code>{row.key}</code></td>
+                        <td>
+                            <f:if condition="{row.known}">
+                                <f:then><strong>{row.value}</strong></f:then>
+                                <f:else>
+                                    <span class="text-warning">
+                                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:governance.value.unknown" default="unknown" />
+                                    </span>
+                                </f:else>
+                            </f:if>
+                        </td>
+                        <td><code class="text-body-secondary">{row.reader}</code></td>
+                    </tr>
+                </f:for>
+            </tbody>
+        </table>
+    </div>
+
+    <p class="text-body-secondary">
+        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:governance.unknown.note" default="A row reads &quot;unknown&quot; when its resolver could not be asked. It never falls back to a shipped default, because a value shown here must be one the runtime would apply." />
+    </p>
+</f:section>
+</html>

--- a/Tests/Architecture/ModuleSeamTest.php
+++ b/Tests/Architecture/ModuleSeamTest.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Command\PurgePrivacyDataCommand;
 use Netresearch\NrLlm\Command\ReapStaleAgentRunsCommand;
 use Netresearch\NrLlm\Form\Tca\ToolGroupItems;
 use Netresearch\NrLlm\Service\Evaluation\LexicalSearchRetriever;
+use Netresearch\NrLlm\Service\Governance\EffectivePolicyReadout;
 use Netresearch\NrLlm\Service\Overview\OverviewReadinessService;
 use PHPat\Selector\Selector;
 use PHPat\Test\Builder\Rule;
@@ -181,7 +182,7 @@ final class ModuleSeamTest
      * into `nr_llm_tools` would make the two packages mutually dependent.
      *
      * "Core" here is the remainder: everything that is not one of the mapped
-     * module namespaces above. Six classes are excluded BY NAME rather than by
+     * module namespaces above. Seven classes are excluded BY NAME rather than by
      * directory, because they are the tool module's own operational surface
      * living in shared directories — in a split each moves WITH its module,
      * so their coupling is ownership, not leakage:
@@ -197,6 +198,11 @@ final class ModuleSeamTest
      *   retrieval API (→ nr_llm_tools, retrieval scope)
      * - `OverviewReadinessService` — feeds the backend Overview module's
      *   readiness card (→ nr_llm_backend)
+     * - `EffectivePolicyReadout` — the read model behind the backend Overview
+     *   module's Governance tab (ADR-140). It asks each module's own resolver
+     *   so the view cannot drift from the runtime; that is precisely why it
+     *   crosses the seam, and in a split it moves with the view
+     *   (→ nr_llm_backend)
      *
      * A NEW core class that imports the tool module fails this rule; the
      * named list is the complete, deliberate exception set. Do not grow it
@@ -222,6 +228,7 @@ final class ModuleSeamTest
                     Selector::classname(ToolGroupItems::class),
                     Selector::classname(LexicalSearchRetriever::class),
                     Selector::classname(OverviewReadinessService::class),
+                    Selector::classname(EffectivePolicyReadout::class),
                 ),
             ))
             ->shouldNotDependOn()

--- a/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
@@ -39,6 +39,7 @@ use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
 use Netresearch\NrLlm\Service\Tool\AgentRunRepository;
 use Netresearch\NrLlm\Service\Tool\AgentStateCodec;
 use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
+use Netresearch\NrLlm\Service\Tool\DataClassEnforcementResolver;
 use Netresearch\NrLlm\Service\Tool\ToolAvailabilityService;
 use Netresearch\NrLlm\Service\Tool\ToolCallPolicy;
 use Netresearch\NrLlm\Service\Tool\ToolDataClassResolver;
@@ -999,6 +1000,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
                 new AllowedToolsResolver(new SkillComposer(), $registry),
                 new ToolDataClassResolver($registry),
                 new TrustZoneResolver(),
+                new DataClassEnforcementResolver(),
             ),
             $logger,
         );

--- a/Tests/Functional/Service/Governance/EffectivePolicyReadoutTest.php
+++ b/Tests/Functional/Service/Governance/EffectivePolicyReadoutTest.php
@@ -23,6 +23,7 @@ use Netresearch\NrLlm\Service\Tool\ToolDataClassResolver;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 use Netresearch\NrLlm\Service\Tool\TrustZoneResolver;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeRemoteTool;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeToolAvailability;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -97,6 +98,40 @@ final class EffectivePolicyReadoutTest extends AbstractFunctionalTestCase
 
         self::assertFalse($policy->decide('system_tool', $configuration, null)->allowed);
         self::assertSame('enforce', $this->enforcementRow($readout)->value);
+    }
+
+    #[Test]
+    public function observeNeverReachesARemoteToolAndTheRowSaysSo(): void
+    {
+        // ADR-115: the ceiling is enforced for every RemoteToolInterface tool
+        // whatever the setting says. An operator whose MCP tool is being dropped
+        // reads this page first, so the row must not claim the axis is observing.
+        $registry = new ToolRegistry([
+            new FakeTool('system_tool', 'ok', true, false, 'system'),
+            new FakeRemoteTool('remote_tool'),
+        ]);
+        $configuration = $this->externalConfiguration();
+        $policy        = $this->policyFromContainer($registry);
+        $readout       = $this->getService(EffectivePolicyReadout::class);
+
+        $this->setEnforcement('observe');
+
+        self::assertTrue(
+            $policy->decide('system_tool', $configuration, null)->allowed,
+            'observe still offers the builtin above the ceiling',
+        );
+
+        $remote = $policy->decide('remote_tool', $configuration, null);
+        self::assertFalse($remote->allowed, 'a remote tool above the ceiling is denied even in observe mode');
+        self::assertFalse($remote->observedOnly);
+
+        $row = $this->enforcementRow($readout);
+        self::assertSame('observe', $row->value);
+        self::assertSame(
+            'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:governance.note.remoteAlwaysEnforced',
+            $row->noteKey,
+            'the row must qualify a mode the gate does not apply to remote tools',
+        );
     }
 
     #[Test]

--- a/Tests/Functional/Service/Governance/EffectivePolicyReadoutTest.php
+++ b/Tests/Functional/Service/Governance/EffectivePolicyReadoutTest.php
@@ -1,0 +1,214 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Governance;
+
+use Netresearch\NrLlm\Domain\Enum\TrustZone;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\Provider;
+use Netresearch\NrLlm\Service\Governance\EffectivePolicyReadout;
+use Netresearch\NrLlm\Service\Governance\EffectivePolicyRow;
+use Netresearch\NrLlm\Service\Skill\SkillComposer;
+use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
+use Netresearch\NrLlm\Service\Tool\DataClassEnforcementResolver;
+use Netresearch\NrLlm\Service\Tool\ToolCallPolicy;
+use Netresearch\NrLlm\Service\Tool\ToolDataClassResolver;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Service\Tool\TrustZoneResolver;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeToolAvailability;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+/**
+ * The readout cannot drift from the runtime (ADR-140).
+ *
+ * Both the tool gate and the governance view are wired from the real DI
+ * container here, so they share one {@see DataClassEnforcementResolver}. The
+ * assertion is that flipping ``tools.dataClassEnforcement`` moves BOTH — a view
+ * that re-implemented the read would keep showing the old mode.
+ */
+#[CoversClass(EffectivePolicyReadout::class)]
+#[CoversClass(DataClassEnforcementResolver::class)]
+final class EffectivePolicyReadoutTest extends AbstractFunctionalTestCase
+{
+    /** @var array<string, mixed>|null */
+    private ?array $extensionConfigurationBackup = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extensionConfigurationBackup = $this->readExtensionConfiguration();
+    }
+
+    protected function tearDown(): void
+    {
+        // The tests patch the live extension configuration; put it back so no
+        // later test in this process inherits a mode it never set.
+        $this->writeExtensionConfiguration($this->extensionConfigurationBackup ?? []);
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function observeMovesTheToolGateAndTheViewTogether(): void
+    {
+        $registry      = new ToolRegistry([new FakeTool('system_tool', 'ok', true, false, 'system')]);
+        $configuration = $this->externalConfiguration();
+        $policy        = $this->policyFromContainer($registry);
+        $readout       = $this->getService(EffectivePolicyReadout::class);
+
+        $this->setEnforcement('observe');
+
+        $observed = $policy->decide('system_tool', $configuration, null);
+        self::assertTrue($observed->allowed, 'observe still offers the over-ceiling tool');
+        self::assertTrue($observed->observedOnly);
+        self::assertSame('observe', $this->enforcementRow($readout)->value, 'the view must report observe too');
+
+        $this->setEnforcement('enforce');
+
+        $enforced = $policy->decide('system_tool', $configuration, null);
+        self::assertFalse($enforced->allowed, 'enforce drops the over-ceiling tool');
+        self::assertSame('enforce', $this->enforcementRow($readout)->value, 'the view must follow to enforce');
+    }
+
+    #[Test]
+    public function aMistypedModeReadsAsEnforceInBothTheGateAndTheView(): void
+    {
+        // ADR-113 fail-closed. The view must show what the gate DOES, not the
+        // literal setting — otherwise an operator reads "observ" and believes
+        // the axis is off while it is enforcing.
+        $registry      = new ToolRegistry([new FakeTool('system_tool', 'ok', true, false, 'system')]);
+        $configuration = $this->externalConfiguration();
+        $policy        = $this->policyFromContainer($registry);
+        $readout       = $this->getService(EffectivePolicyReadout::class);
+
+        $this->setEnforcement('observ');
+
+        self::assertFalse($policy->decide('system_tool', $configuration, null)->allowed);
+        self::assertSame('enforce', $this->enforcementRow($readout)->value);
+    }
+
+    #[Test]
+    public function everyRowIsAnsweredByARealResolverOnAStockInstall(): void
+    {
+        $rows = $this->getService(EffectivePolicyReadout::class)->rows();
+
+        self::assertCount(4, $rows);
+        foreach ($rows as $row) {
+            self::assertTrue($row->isKnown(), sprintf('%s must not read "unknown" on a stock install', $row->key));
+            self::assertNotSame('', $row->reader);
+        }
+    }
+
+    /**
+     * The real gate, wired with the container's enforcement resolver — the same
+     * object the readout was built with, which is the point of the test.
+     */
+    private function policyFromContainer(ToolRegistry $registry): ToolCallPolicy
+    {
+        return new ToolCallPolicy(
+            $registry,
+            new FakeToolAvailability($registry->names()),
+            new AllowedToolsResolver(new SkillComposer(), $registry),
+            new ToolDataClassResolver($registry),
+            new TrustZoneResolver(),
+            $this->getService(DataClassEnforcementResolver::class),
+        );
+    }
+
+    private function enforcementRow(EffectivePolicyReadout $readout): EffectivePolicyRow
+    {
+        foreach ($readout->rows() as $row) {
+            if ($row->key === 'tools.dataClassEnforcement') {
+                return $row;
+            }
+        }
+
+        self::fail('the readout has no tools.dataClassEnforcement row');
+    }
+
+    /**
+     * Patch the one key in the live extension configuration, on top of the
+     * stock template-synchronised values the install already carries.
+     */
+    private function setEnforcement(string $mode): void
+    {
+        // Force the template synchronisation so the rest of the stock
+        // configuration is present and only this key differs.
+        $this->getService(ExtensionConfiguration::class)->get('nr_llm');
+
+        $nrLlm = $this->readExtensionConfiguration() ?? [];
+        $tools = $nrLlm['tools'] ?? [];
+        self::assertIsArray($tools);
+
+        $tools['dataClassEnforcement'] = $mode;
+        $nrLlm['tools']                = $tools;
+
+        $this->writeExtensionConfiguration($nrLlm);
+    }
+
+    /**
+     * The stored `nr_llm` extension configuration, or null when absent.
+     * Narrowed step by step because the $GLOBALS shape is untyped.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function readExtensionConfiguration(): ?array
+    {
+        $confVars   = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+        $extensions = is_array($confVars) ? ($confVars['EXTENSIONS'] ?? null) : null;
+        $nrLlm      = is_array($extensions) ? ($extensions['nr_llm'] ?? null) : null;
+
+        if (!is_array($nrLlm)) {
+            return null;
+        }
+
+        /** @var array<string, mixed> $nrLlm */
+        return $nrLlm;
+    }
+
+    /**
+     * @param array<string, mixed> $nrLlm
+     */
+    private function writeExtensionConfiguration(array $nrLlm): void
+    {
+        $confVars = $GLOBALS['TYPO3_CONF_VARS'] ?? [];
+        self::assertIsArray($confVars);
+        $extensions = $confVars['EXTENSIONS'] ?? [];
+        self::assertIsArray($extensions);
+
+        $extensions['nr_llm']       = $nrLlm;
+        $confVars['EXTENSIONS']     = $extensions;
+        $GLOBALS['TYPO3_CONF_VARS'] = $confVars;
+    }
+
+    /**
+     * A configuration whose provider sits in the EXTERNAL_GLOBAL trust zone, so
+     * the SYSTEM_DIAGNOSTICS tool is above its ceiling and the enforcement
+     * switch decides the outcome.
+     */
+    private function externalConfiguration(): LlmConfiguration
+    {
+        $provider = new Provider();
+        $provider->setTrustZoneEnum(TrustZone::EXTERNAL_GLOBAL);
+
+        $model = new Model();
+        $model->setProvider($provider);
+
+        $configuration = new LlmConfiguration();
+        $configuration->setLlmModel($model);
+
+        return $configuration;
+    }
+}

--- a/Tests/Functional/Service/Tool/ToolLoopServiceBuiltinTest.php
+++ b/Tests/Functional/Service/Tool/ToolLoopServiceBuiltinTest.php
@@ -20,6 +20,7 @@ use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Skill\SkillComposer;
 use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
 use Netresearch\NrLlm\Service\Tool\Builtin\FetchLogsTool;
+use Netresearch\NrLlm\Service\Tool\DataClassEnforcementResolver;
 use Netresearch\NrLlm\Service\Tool\ToolAvailabilityService;
 use Netresearch\NrLlm\Service\Tool\ToolCallPolicy;
 use Netresearch\NrLlm\Service\Tool\ToolDataClassResolver;
@@ -172,6 +173,7 @@ final class ToolLoopServiceBuiltinTest extends AbstractFunctionalTestCase
             new AllowedToolsResolver(new SkillComposer(), $registry),
             new ToolDataClassResolver($registry),
             new TrustZoneResolver(),
+            new DataClassEnforcementResolver(),
         );
 
         return new ToolLoopService($mgr, $registry, $policy);

--- a/Tests/Unit/Service/Governance/EffectivePolicyReadoutTest.php
+++ b/Tests/Unit/Service/Governance/EffectivePolicyReadoutTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Service\Governance;
 
+use Netresearch\NrLlm\Domain\Enum\PrivacyDataCategory;
 use Netresearch\NrLlm\Domain\Enum\PrivacyLevel;
 use Netresearch\NrLlm\Service\Governance\EffectivePolicyReadout;
 use Netresearch\NrLlm\Service\Governance\EffectivePolicyRow;
@@ -81,6 +82,9 @@ final class EffectivePolicyReadoutTest extends TestCase
         $unreadable = $this->createMock(PrivacyPolicyInterface::class);
         $unreadable->method('level')->willThrowException(new RuntimeException('privacy resolver unavailable', 1785200001));
         $unreadable->method('retentionDays')->willReturn(30);
+        // No category override: the interface guarantees at least 1 day and
+        // falls back to the global window, which an unstubbed mock (0) does not.
+        $unreadable->method('retentionDaysFor')->willReturn(30);
 
         $rows = $this->readout($unreadable, ['tools' => ['dataClassEnforcement' => 'observe']])->rows();
 
@@ -109,6 +113,115 @@ final class EffectivePolicyReadoutTest extends TestCase
 
         self::assertSame('enforce', $rows[2]->value);
         self::assertSame('untrusted', $rows[3]->value);
+    }
+
+    #[Test]
+    public function observeIsQualifiedBecauseItNeverAppliesToRemoteTools(): void
+    {
+        // The gate reads `enforcing() || $tool instanceof RemoteToolInterface`,
+        // so the word "observe" alone is a true value and a false statement.
+        $rows = $this->readout(
+            new FixedPrivacyPolicy(),
+            ['tools' => ['dataClassEnforcement' => 'observe']],
+        )->rows();
+
+        self::assertSame('observe', $rows[2]->value);
+        self::assertSame(
+            'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:governance.note.remoteAlwaysEnforced',
+            $rows[2]->noteKey,
+        );
+    }
+
+    #[Test]
+    public function enforceCarriesNoQualificationBecauseItHasNoException(): void
+    {
+        $rows = $this->readout(
+            new FixedPrivacyPolicy(),
+            ['tools' => ['dataClassEnforcement' => 'enforce']],
+        )->rows();
+
+        self::assertSame('enforce', $rows[2]->value);
+        self::assertNull($rows[2]->noteKey);
+    }
+
+    #[Test]
+    public function theShippedRetentionOverridesAddNoRowsBecauseTheyResolveToTheGlobalWindow(): void
+    {
+        $rows = $this->readoutOnConfiguration([
+            'privacy' => [
+                'retentionDays' => 30,
+                'retention'     => array_fill_keys(PrivacyDataCategory::values(), 0),
+            ],
+        ])->rows();
+
+        self::assertSame(
+            ['privacy.level', 'privacy.retentionDays', 'tools.dataClassEnforcement', 'skills.minTrustLevel'],
+            array_map(static fn(EffectivePolicyRow $row): string => $row->key, $rows),
+        );
+    }
+
+    #[Test]
+    public function aRetentionOverrideThatMovesAWindowGetsItsOwnRow(): void
+    {
+        // Without the row the page shows "30" as the only retention number
+        // while the purge command deletes transcripts after 7 days.
+        $rows = $this->readoutOnConfiguration([
+            'privacy' => [
+                'retentionDays' => 30,
+                'retention'     => ['conversation' => 7, 'telemetry' => 30],
+            ],
+        ])->rows();
+
+        self::assertSame(
+            [
+                'privacy.level',
+                'privacy.retentionDays',
+                'privacy.retention.conversation',
+                'tools.dataClassEnforcement',
+                'skills.minTrustLevel',
+            ],
+            array_map(static fn(EffectivePolicyRow $row): string => $row->key, $rows),
+        );
+        self::assertSame('30', $rows[1]->value);
+        self::assertSame('7', $rows[2]->value);
+        self::assertSame(PrivacyPolicy::class, $rows[2]->reader);
+    }
+
+    #[Test]
+    public function aCategoryWindowIsNeverShownWithoutItsBaseline(): void
+    {
+        // The global row already reads "unknown"; a bare category number next
+        // to it states nothing an operator could act on.
+        $unreadable = $this->createMock(PrivacyPolicyInterface::class);
+        $unreadable->method('level')->willReturn(PrivacyLevel::METADATA);
+        $unreadable->method('retentionDays')->willThrowException(new RuntimeException('privacy resolver unavailable', 1785200003));
+        $unreadable->method('retentionDaysFor')->willReturn(7);
+
+        $rows = $this->readout($unreadable, [])->rows();
+
+        self::assertFalse($rows[1]->isKnown());
+        self::assertSame(
+            ['privacy.level', 'privacy.retentionDays', 'tools.dataClassEnforcement', 'skills.minTrustLevel'],
+            array_map(static fn(EffectivePolicyRow $row): string => $row->key, $rows),
+        );
+    }
+
+    /**
+     * A readout whose privacy rows come from the real {@see PrivacyPolicy}, so
+     * the per-category fallback is the production one.
+     *
+     * @param array<string, mixed> $extensionConfigurationValue
+     */
+    private function readoutOnConfiguration(array $extensionConfigurationValue): EffectivePolicyReadout
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn($extensionConfigurationValue);
+
+        return new EffectivePolicyReadout(
+            new PrivacyPolicy($extensionConfiguration, new ContentRedactor()),
+            new DataClassEnforcementResolver($extensionConfiguration),
+            new SkillComposerFactory($extensionConfiguration),
+        );
     }
 
     /**

--- a/Tests/Unit/Service/Governance/EffectivePolicyReadoutTest.php
+++ b/Tests/Unit/Service/Governance/EffectivePolicyReadoutTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Governance;
+
+use Netresearch\NrLlm\Domain\Enum\PrivacyLevel;
+use Netresearch\NrLlm\Service\Governance\EffectivePolicyReadout;
+use Netresearch\NrLlm\Service\Governance\EffectivePolicyRow;
+use Netresearch\NrLlm\Service\Privacy\ContentRedactor;
+use Netresearch\NrLlm\Service\Privacy\PrivacyPolicy;
+use Netresearch\NrLlm\Service\Privacy\PrivacyPolicyInterface;
+use Netresearch\NrLlm\Service\Skill\SkillComposerFactory;
+use Netresearch\NrLlm\Service\Tool\DataClassEnforcementResolver;
+use Netresearch\NrLlm\Tests\Fixture\FixedPrivacyPolicy;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+#[CoversClass(EffectivePolicyReadout::class)]
+#[CoversClass(EffectivePolicyRow::class)]
+final class EffectivePolicyReadoutTest extends TestCase
+{
+    #[Test]
+    public function theFourKeysAreReportedInOrderWithTheirRuntimeReader(): void
+    {
+        $rows = $this->readout(
+            new FixedPrivacyPolicy(PrivacyLevel::REDACTED, 90),
+            ['tools' => ['dataClassEnforcement' => 'observe'], 'skills' => ['minTrustLevel' => 'verified']],
+        )->rows();
+
+        self::assertSame(
+            ['privacy.level', 'privacy.retentionDays', 'tools.dataClassEnforcement', 'skills.minTrustLevel'],
+            array_map(static fn(EffectivePolicyRow $row): string => $row->key, $rows),
+        );
+        self::assertSame(
+            ['redacted', '90', 'observe', 'verified'],
+            array_map(static fn(EffectivePolicyRow $row): ?string => $row->value, $rows),
+        );
+        self::assertSame(
+            [
+                FixedPrivacyPolicy::class,
+                FixedPrivacyPolicy::class,
+                DataClassEnforcementResolver::class,
+                SkillComposerFactory::class,
+            ],
+            array_map(static fn(EffectivePolicyRow $row): string => $row->reader, $rows),
+        );
+
+        foreach ($rows as $row) {
+            self::assertTrue($row->isKnown());
+        }
+    }
+
+    #[Test]
+    public function theReaderIsTheRuntimeClassNotAHardcodedName(): void
+    {
+        // The production wiring reads privacy through PrivacyPolicy; the readout
+        // reports whatever class DI handed it, so the column cannot go stale.
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn([]);
+
+        $rows = $this->readout(
+            new PrivacyPolicy($extensionConfiguration, new ContentRedactor()),
+            [],
+        )->rows();
+
+        self::assertSame(PrivacyPolicy::class, $rows[0]->reader);
+    }
+
+    #[Test]
+    public function aResolverThatCannotBeAskedYieldsUnknownAndNeverAValue(): void
+    {
+        $unreadable = $this->createMock(PrivacyPolicyInterface::class);
+        $unreadable->method('level')->willThrowException(new RuntimeException('privacy resolver unavailable', 1785200001));
+        $unreadable->method('retentionDays')->willReturn(30);
+
+        $rows = $this->readout($unreadable, ['tools' => ['dataClassEnforcement' => 'observe']])->rows();
+
+        // The failing row is unknown — not "metadata", not the shipped default.
+        self::assertFalse($rows[0]->isKnown());
+        self::assertNull($rows[0]->value);
+        // ... and only that row. A single unavailable resolver does not blank the page.
+        self::assertTrue($rows[1]->isKnown());
+        self::assertSame('30', $rows[1]->value);
+        self::assertSame('observe', $rows[2]->value);
+    }
+
+    #[Test]
+    public function theFailClosedResolversNeverReportUnknownBecauseTheyCannotThrow(): void
+    {
+        // A broken extension configuration is a resolver ANSWER (fail-closed to
+        // enforce / untrusted), not an unanswerable one — ADR-113 / ADR-061.
+        $throwing = $this->createMock(ExtensionConfiguration::class);
+        $throwing->method('get')->willThrowException(new RuntimeException('config unreadable', 1785200002));
+
+        $rows = (new EffectivePolicyReadout(
+            new FixedPrivacyPolicy(),
+            new DataClassEnforcementResolver($throwing),
+            new SkillComposerFactory($throwing),
+        ))->rows();
+
+        self::assertSame('enforce', $rows[2]->value);
+        self::assertSame('untrusted', $rows[3]->value);
+    }
+
+    /**
+     * @param array<string, mixed> $extensionConfigurationValue
+     */
+    private function readout(
+        PrivacyPolicyInterface $privacyPolicy,
+        array $extensionConfigurationValue,
+    ): EffectivePolicyReadout {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn($extensionConfigurationValue);
+
+        return new EffectivePolicyReadout(
+            $privacyPolicy,
+            new DataClassEnforcementResolver($extensionConfiguration),
+            new SkillComposerFactory($extensionConfiguration),
+        );
+    }
+}

--- a/Tests/Unit/Service/Tool/DataClassEnforcementResolverTest.php
+++ b/Tests/Unit/Service/Tool/DataClassEnforcementResolverTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\DataClassEnforcementResolver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+/**
+ * The full fail-closed matrix of `tools.dataClassEnforcement` (ADR-113),
+ * asserted directly on the resolver extracted from ToolCallPolicy (ADR-140).
+ */
+#[CoversClass(DataClassEnforcementResolver::class)]
+final class DataClassEnforcementResolverTest extends TestCase
+{
+    /**
+     * @return array<string, array{0: mixed, 1: bool}>
+     */
+    public static function configurationProvider(): array
+    {
+        return [
+            // Only a literal `observe` observes.
+            'exact observe'            => [['tools' => ['dataClassEnforcement' => 'observe']], false],
+            'uppercase with trailing space' => [['tools' => ['dataClassEnforcement' => 'OBSERVE ']], false],
+            'leading space'            => [['tools' => ['dataClassEnforcement' => ' observe']], false],
+
+            // Everything else enforces.
+            'explicit enforce'         => [['tools' => ['dataClassEnforcement' => 'enforce']], true],
+            'typo observ'              => [['tools' => ['dataClassEnforcement' => 'observ']], true],
+            'empty string'             => [['tools' => ['dataClassEnforcement' => '']], true],
+            'not a string (bool)'      => [['tools' => ['dataClassEnforcement' => false]], true],
+            'not a string (int)'       => [['tools' => ['dataClassEnforcement' => 0]], true],
+            'not a string (array)'     => [['tools' => ['dataClassEnforcement' => ['observe']]], true],
+            'key missing'              => [['tools' => []], true],
+            'tools not an array'       => [['tools' => 'not-an-array'], true],
+            'tools section missing'    => [['privacy' => ['level' => 'full']], true],
+            'empty configuration'      => [[], true],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('configurationProvider')]
+    public function onlyALiteralObserveObserves(mixed $configuration, bool $expectedEnforcing): void
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn($configuration);
+
+        $resolver = new DataClassEnforcementResolver($extensionConfiguration);
+
+        self::assertSame($expectedEnforcing, $resolver->enforcing());
+        self::assertSame(
+            $expectedEnforcing ? DataClassEnforcementResolver::MODE_ENFORCE : DataClassEnforcementResolver::MODE_OBSERVE,
+            $resolver->mode(),
+        );
+    }
+
+    #[Test]
+    public function anUnreadableExtensionConfigurationEnforces(): void
+    {
+        $throwing = $this->createMock(ExtensionConfiguration::class);
+        $throwing->method('get')->willThrowException(new RuntimeException('config unreadable', 1785100001));
+
+        $resolver = new DataClassEnforcementResolver($throwing);
+
+        self::assertTrue($resolver->enforcing());
+        self::assertSame(DataClassEnforcementResolver::MODE_ENFORCE, $resolver->mode());
+    }
+
+    #[Test]
+    public function noExtensionConfigurationAtAllEnforces(): void
+    {
+        // The pre-extraction ToolCallPolicy carried a nullable dependency and
+        // fell closed when it was absent. Moved verbatim, so this stays true.
+        $resolver = new DataClassEnforcementResolver();
+
+        self::assertTrue($resolver->enforcing());
+        self::assertSame(DataClassEnforcementResolver::MODE_ENFORCE, $resolver->mode());
+    }
+}

--- a/Tests/Unit/Service/Tool/Fixtures/FakeRemoteTool.php
+++ b/Tests/Unit/Service/Tool/Fixtures/FakeRemoteTool.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\RemoteToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+
+/**
+ * A tool whose behaviour lives on a remote server, as an MCP tool does.
+ *
+ * The marker is the whole point: the trust-zone ceiling is enforced for a
+ * {@see RemoteToolInterface} tool even where the install runs the gate in
+ * observe mode (ADR-115). Unlike the real
+ * {@see \Netresearch\NrLlm\Service\Tool\Mcp\McpTool} this double does not
+ * require an admin, so a test can reach the zone branch without carrying a
+ * backend user it is not testing.
+ */
+final readonly class FakeRemoteTool implements ToolInterface, RemoteToolInterface
+{
+    public function __construct(
+        private string $name,
+        private string $group = 'system',
+    ) {}
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function(
+            $this->name,
+            'desc of ' . $this->name,
+            ['type' => 'object', 'properties' => []],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $arguments
+     */
+    public function execute(array $arguments, ToolExecutionContext $context): ToolResult
+    {
+        return ToolResult::text('ok');
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        return false;
+    }
+
+    public function getGroup(): string
+    {
+        return $this->group;
+    }
+}

--- a/Tests/Unit/Service/Tool/ToolCallPolicyTest.php
+++ b/Tests/Unit/Service/Tool/ToolCallPolicyTest.php
@@ -17,6 +17,7 @@ use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Service\Skill\SkillComposer;
 use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
+use Netresearch\NrLlm\Service\Tool\DataClassEnforcementResolver;
 use Netresearch\NrLlm\Service\Tool\ToolCallPolicy;
 use Netresearch\NrLlm\Service\Tool\ToolDataClassResolver;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
@@ -154,14 +155,14 @@ final class ToolCallPolicyTest extends TestCase
         $throwing = $this->createMock(ExtensionConfiguration::class);
         $throwing->method('get')->willThrowException(new RuntimeException('config unreadable', 1785100001));
         self::assertFalse(
-            $this->policyWith($registry, $throwing)->decide('system_tool', $config, $this->admin())->allowed,
+            $this->policyWith($registry, new DataClassEnforcementResolver($throwing))->decide('system_tool', $config, $this->admin())->allowed,
             'an unreadable configuration enforces',
         );
 
         $malformed = $this->createMock(ExtensionConfiguration::class);
         $malformed->method('get')->willReturn(['tools' => 'not-an-array']);
         self::assertFalse(
-            $this->policyWith($registry, $malformed)->decide('system_tool', $config, $this->admin())->allowed,
+            $this->policyWith($registry, new DataClassEnforcementResolver($malformed))->decide('system_tool', $config, $this->admin())->allowed,
             'a malformed configuration enforces',
         );
     }
@@ -220,7 +221,7 @@ final class ToolCallPolicyTest extends TestCase
         $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
         $extensionConfiguration->method('get')->willReturn(['tools' => ['dataClassEnforcement' => $enforcement]]);
 
-        return $this->policyWith($registry, $extensionConfiguration, $enabled);
+        return $this->policyWith($registry, new DataClassEnforcementResolver($extensionConfiguration), $enabled);
     }
 
     /**
@@ -228,7 +229,7 @@ final class ToolCallPolicyTest extends TestCase
      */
     private function policyWith(
         ?ToolRegistry $registry,
-        ExtensionConfiguration $extensionConfiguration,
+        DataClassEnforcementResolver $enforcementResolver,
         ?array $enabled = null,
     ): ToolCallPolicy {
         $registry ??= new ToolRegistry([]);
@@ -239,7 +240,7 @@ final class ToolCallPolicyTest extends TestCase
             new AllowedToolsResolver(new SkillComposer(), $registry),
             new ToolDataClassResolver($registry),
             new TrustZoneResolver(),
-            $extensionConfiguration,
+            $enforcementResolver,
         );
     }
 

--- a/Tests/Unit/Service/Tool/ToolLoopServiceAssemblyOrderTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceAssemblyOrderTest.php
@@ -33,6 +33,7 @@ use Netresearch\NrLlm\Service\Prompt\PromptSnippetComposer;
 use Netresearch\NrLlm\Service\Skill\SkillComposer;
 use Netresearch\NrLlm\Service\Skill\SkillInjectionService;
 use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
+use Netresearch\NrLlm\Service\Tool\DataClassEnforcementResolver;
 use Netresearch\NrLlm\Service\Tool\RunAugmentation;
 use Netresearch\NrLlm\Service\Tool\RunTrace;
 use Netresearch\NrLlm\Service\Tool\ToolCallPolicy;
@@ -405,6 +406,7 @@ final class ToolLoopServiceAssemblyOrderTest extends TestCase
                 new AllowedToolsResolver(new SkillComposer(), $registry),
                 new ToolDataClassResolver($registry),
                 new TrustZoneResolver(),
+                new DataClassEnforcementResolver(),
             ),
             skillInjection: new SkillInjectionService(new SkillComposer(), new NullLogger()),
             snippetComposer: new PromptSnippetComposer(),

--- a/Tests/Unit/Service/Tool/ToolLoopServiceAugmentationTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceAugmentationTest.php
@@ -23,6 +23,7 @@ use Netresearch\NrLlm\Service\Prompt\PromptSnippetComposer;
 use Netresearch\NrLlm\Service\Skill\SkillComposer;
 use Netresearch\NrLlm\Service\Skill\SkillInjectionService;
 use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
+use Netresearch\NrLlm\Service\Tool\DataClassEnforcementResolver;
 use Netresearch\NrLlm\Service\Tool\RunAugmentation;
 use Netresearch\NrLlm\Service\Tool\RunTrace;
 use Netresearch\NrLlm\Service\Tool\ToolCallPolicy;
@@ -167,6 +168,7 @@ final class ToolLoopServiceAugmentationTest extends TestCase
                 new AllowedToolsResolver(new SkillComposer(), $registry),
                 new ToolDataClassResolver($registry),
                 new TrustZoneResolver(),
+                new DataClassEnforcementResolver(),
             ),
             skillInjection: new SkillInjectionService(new SkillComposer(), new NullLogger()),
             snippetComposer: new PromptSnippetComposer(),
@@ -215,6 +217,7 @@ final class ToolLoopServiceAugmentationTest extends TestCase
                 new AllowedToolsResolver(new SkillComposer(), $registry),
                 new ToolDataClassResolver($registry),
                 new TrustZoneResolver(),
+                new DataClassEnforcementResolver(),
             ),
             skillInjection: new SkillInjectionService(new SkillComposer(), new NullLogger()),
             snippetComposer: new PromptSnippetComposer(),

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -36,6 +36,7 @@ use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Skill\SkillComposer;
 use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
+use Netresearch\NrLlm\Service\Tool\DataClassEnforcementResolver;
 use Netresearch\NrLlm\Service\Tool\Exception\ToolApprovalRequiredException;
 use Netresearch\NrLlm\Service\Tool\Exception\ToolInputRequiredException;
 use Netresearch\NrLlm\Service\Tool\RemoteCallBudget;
@@ -1452,6 +1453,7 @@ final class ToolLoopServiceTest extends TestCase
             new AllowedToolsResolver(new SkillComposer(), $registry),
             new ToolDataClassResolver($registry),
             new TrustZoneResolver(),
+            new DataClassEnforcementResolver(),
         );
     }
 


### PR DESCRIPTION
## Description

Governance lives in `ext_conf_template.txt`, several TCA tables, `be_groups` and three dashboard widgets. There was no place where an operator could see the **effective** state.

Four keys with actual decision content — `privacy.level`, `privacy.retentionDays`, `tools.dataClassEnforcement`, `skills.minTrustLevel` — each with its value and the FQCN of the reader, **read through the same resolvers the runtime uses**. That is the point: the view cannot drift from behaviour, and a functional test pins it by moving `tools.dataClassEnforcement` to `observe` and asserting policy and view move together.

`ToolCallPolicy::enforcing()` is extracted verbatim into `DataClassEnforcementResolver` and stays in `Service\Tool`. `SkillComposerFactory::resolveMinTrustLevel()` becomes public `minTrustLevel()`.

### No apply path — that is the decision, not an omission (ADR-140)

- `ExtensionConfiguration::set()` is `@internal` (`ExtensionConfiguration.php:150`), documented "Set full extension config" (`:165`), and writes the **whole array** via `setLocalConfigurationValueByPath()` (`:166`). No per-key write exists.
- `additional.php` overrides "spoil the `->set()` call" (core docblock `:145-146`), so an apply would report success while the next request serves the old value.

The Install Tool stays where instance-wide keys are set.

**Correction to one half of that argument.** The plan claimed an apply would destroy ADR-115's "default vs chosen" distinction. `storedEnforcement()` says it reads pre-template-merge, but it reads `$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']`, and `synchronizeExtConfTemplateWithLocalConfigurationOfAllExtensions()` (`:197-218`) writes the merged template there on any unknown-key read or Install Tool entry. On an install that has entered the Install Tool since the default flipped, the distinction is **already** gone. An apply would guarantee the loss rather than cause it. The decision stands on the other two grounds; the ADR records the weaker claim accurately rather than repeating the stronger one.

### No provenance column

No resolver exposes provenance, and the template sync writes shipped defaults into `settings.php` regardless — the distinction cannot be reconstructed.

### The seven retention overrides are not shown

They all ship as `0` and resolve to the global value by design. Eleven rows, eight of them showing "30", informs nobody. They belong in the administration chapter (#640).

## Module placement

**Overview**, as a third docheader tab. Analytics answers "what did this install spend and do over time" from usage rows; this answers "what does this install allow right now" — a static property, which is what Overview's readiness cards already report. ADR-119 rules out a thirteenth flat module entry.

The plan's cost warning was right: `buildDocHeaderTabMenu()` builds links to real routes, not in-page tabs, so a new action, template, `Modules.php` entries and both XLIFF files were all needed.

## Related Issue

Closes #639

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `composer ci` and all checks pass — unit, PHPStan level 10 (which runs phpat) and cgl re-run independently of the authoring pass: all SUCCESS; the functional classes executed for real. Rector green under an 8.2 resolve, then restored to 8.4 and the suites re-run on that tree.
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation accordingly
- [x] I have added a `CHANGELOG.md` entry under `## [Unreleased]`
- [x] I have added an ADR under `Documentation/Adr/` if this changes the public surface — ADR-140
- [x] My changes generate no new warnings

### Falsification criterion for the extraction — met

The extraction is a pure refactor, so the test was: **no behavioural assertion may change.** `git diff Tests/Unit/Service/Tool/ToolCallPolicyTest.php` contains one import, two construction sites wrapped in `new DataClassEnforcementResolver(...)`, and one parameter type. No assertion, expected value, message or test name. Same for the five other construction sites.

### Three things reviewers should look at

1. **`Tests/Architecture/ModuleSeamTest.php` grew its by-name exception list from six to seven.** `EffectivePolicyReadout` must import `DataClassEnforcementResolver` — that crossing *is* the ticket, since asking the runtime's own resolver is what keeps the view honest. It follows the exact precedent of `OverviewReadinessService` (a core-located read model feeding backend Overview), and the rule's docblock demands a recorded split destination, which is there (`→ nr_llm_backend`). Flagged rather than buried: that docblock also says not to grow the list without a reason.
2. **ADR number is 140, while the issue text says 141.** 140 was reserved for a context-classification ticket that was deliberately dropped (deferred in ADR-139), so it is free. A rename plus one toctree line if you prefer 141.
3. **"Unknown" is not reachable from the current resolvers** — all three fail closed and swallow their own read errors, so on a real install every row is answered. It is implemented as a per-row `catch (Throwable)` and tested with a throwing double, proving one bad row does not blank the others. No nullable constructor argument was added to manufacture the state; that would be the `Null*`-dummy shape ADR-120 rejected. The ADR states the limit.

### No screenshot

The running DDEV instance serves `main`, the reference-only worktree, which does not carry this branch. Taking a screenshot of a backend without the tab would have been worse than none.