### PR TITLE
refactor(fallback): one candidate resolution for the primary's chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- The candidate walk over a primary configuration's fallback chain is
+  implemented once, in the `@internal`
+  `Provider\Fallback\FallbackCandidateResolver` (ADR-137). It owns the
+  ADR-021 rules — shallow, no self-retry, missing and inactive entries
+  skipped — while ordering, the primary attempt and the skip log lines stay
+  with each caller: the health-aware reorder (ADR-063) remains on the
+  pipelined path only, and streaming keeps the configured order.
+  `FallbackMiddleware` and `StreamingDispatcher` now take the resolver in
+  place of `LlmConfigurationRepository`; neither is part of the `@api`
+  surface, which is unchanged. Streaming resolves the chain lazily now: when an
+  early candidate serves, later entries are no longer looked up and a broken
+  entry behind it no longer logs a skip warning.
+
 ## [0.26.0] - 2026-08-06
 
 ### Added

--- a/Classes/Provider/Fallback/FallbackCandidateResolver.php
+++ b/Classes/Provider/Fallback/FallbackCandidateResolver.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\Fallback;
+
+use Closure;
+use Generator;
+use Netresearch\NrLlm\Domain\DTO\FallbackChain;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+
+/**
+ * The one candidate loop over a primary configuration's fallback chain
+ * (ADR-137).
+ *
+ * It owns exactly the rules ADR-021 states, and nothing else:
+ *
+ *  - **Shallow.** Only the primary's own chain is walked; a candidate's chain
+ *    is never followed, so recursion and cycles cannot occur.
+ *  - **No self-retry.** The primary's identifier is removed from its own chain
+ *    ({@see self::chainFor()}); a configuration that lists itself yields no
+ *    candidate.
+ *  - **A missing identifier is skipped**, not an error — an operator can delete
+ *    a configuration another one still names.
+ *  - **An inactive configuration is skipped**, for the same reason.
+ *
+ * What it deliberately does NOT own:
+ *
+ *  - **Ordering.** The health-aware reorder (ADR-063) applies to the
+ *    non-streaming path only; the caller hands in the chain it wants walked.
+ *  - **The primary itself.** The middleware's primary has already been
+ *    attempted by the pipeline when the chain walk starts, while the streaming
+ *    dispatcher opens it as its own first candidate. Whoever needs it prepends
+ *    it.
+ *  - **Logging.** Skips are reported to the caller, which words them for its
+ *    own path.
+ *
+ * Resolution is lazy: {@see self::resolve()} hits the repository for the entry
+ * it is asked for and no further, so a chain entry after the one that served is
+ * never looked up.
+ *
+ * @internal
+ */
+final readonly class FallbackCandidateResolver
+{
+    public function __construct(
+        private LlmConfigurationRepository $repository,
+    ) {}
+
+    /**
+     * The chain to walk for this primary: its own identifier removed, so a
+     * configuration listing itself does not retry against itself.
+     */
+    public function chainFor(LlmConfiguration $primary): FallbackChain
+    {
+        return $primary->getFallbackChainDTO()->without($primary->getIdentifier());
+    }
+
+    /**
+     * Resolve the chain entry by entry, skipping what cannot be dispatched.
+     *
+     * The key of each yielded pair is the CHAIN identifier, not the resolved
+     * configuration's own — the caller reports the entry it was asked to try.
+     *
+     * @param Closure(string, FallbackSkipReason): void $onSkip called for every entry that is not dispatchable
+     *
+     * @return Generator<string, LlmConfiguration>
+     */
+    public function resolve(FallbackChain $chain, Closure $onSkip): Generator
+    {
+        foreach ($chain->configurationIdentifiers as $identifier) {
+            $candidate = $this->repository->findOneByIdentifier($identifier);
+            if (!$candidate instanceof LlmConfiguration) {
+                $onSkip($identifier, FallbackSkipReason::NotFound);
+
+                continue;
+            }
+
+            if (!$candidate->isActive()) {
+                $onSkip($identifier, FallbackSkipReason::Inactive);
+
+                continue;
+            }
+
+            yield $identifier => $candidate;
+        }
+    }
+}

--- a/Classes/Provider/Fallback/FallbackSkipReason.php
+++ b/Classes/Provider/Fallback/FallbackSkipReason.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Provider\Fallback;
+
+/**
+ * Why {@see FallbackCandidateResolver} dropped a chain entry (ADR-137).
+ *
+ * The reason is reported to the caller instead of being logged in the
+ * resolver: the two candidate loops word their skip lines differently — the
+ * middleware distinguishes the two cases, the streaming dispatcher collapses
+ * them — and the merge must not rewrite either log surface.
+ *
+ * @internal
+ */
+enum FallbackSkipReason
+{
+    /**
+     * No configuration row carries this identifier.
+     */
+    case NotFound;
+
+    /**
+     * The configuration exists but is switched off.
+     */
+    case Inactive;
+}

--- a/Classes/Provider/Middleware/FallbackMiddleware.php
+++ b/Classes/Provider/Middleware/FallbackMiddleware.php
@@ -10,8 +10,9 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Provider\Middleware;
 
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
-use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Provider\Exception\FallbackChainExhaustedException;
+use Netresearch\NrLlm\Provider\Fallback\FallbackCandidateResolver;
+use Netresearch\NrLlm\Provider\Fallback\FallbackSkipReason;
 use Netresearch\NrLlm\Service\Health\ProviderHealthServiceInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -32,8 +33,11 @@ use Throwable;
  * streaming, or use ProviderCallContext::operation === Stream as a
  * short-circuit condition if a mixed pipeline is ever needed.
  *
- * Fallback is shallow: a fallback configuration's own chain is ignored to
- * prevent recursion and cycles.
+ * Which configurations the chain actually offers is decided by the shared
+ * {@see FallbackCandidateResolver} (ADR-137) — shallow, no self-retry, missing
+ * and inactive entries skipped — so this middleware and the streaming
+ * dispatcher cannot drift apart on those rules. Ordering is not part of that:
+ * the health-aware reorder below applies to this path only.
  *
  * The registered pipeline order, pinned by tag priority:
  *
@@ -65,7 +69,7 @@ final readonly class FallbackMiddleware implements ProviderMiddlewareInterface
     }
 
     public function __construct(
-        private LlmConfigurationRepository $repository,
+        private FallbackCandidateResolver $candidates,
         private LoggerInterface $logger,
         private ProviderHealthServiceInterface $health,
     ) {}
@@ -118,7 +122,7 @@ final readonly class FallbackMiddleware implements ProviderMiddlewareInterface
         // empty after filtering. No fallback was actually attempted — rethrow
         // the primary's error verbatim instead of wrapping one attempt as
         // "every configuration failed".
-        $chain = $configuration->getFallbackChainDTO()->without($configuration->getIdentifier());
+        $chain = $this->candidates->chainFor($configuration);
         if ($chain->isEmpty()) {
             $this->logger->warning(
                 'LLM primary configuration failed; fallback chain contained only the primary, nothing left to try',
@@ -137,36 +141,24 @@ final readonly class FallbackMiddleware implements ProviderMiddlewareInterface
         // chain untouched unless the operator opted into health-aware reorder.
         $chain = $this->health->reorder($chain);
 
-        foreach ($chain->configurationIdentifiers as $identifier) {
-            $fallback = $this->repository->findOneByIdentifier($identifier);
-            if (!$fallback instanceof LlmConfiguration) {
-                $this->logger->warning(
-                    'LLM fallback configuration not found, skipping',
-                    [
-                        'configuration' => $identifier,
-                        'operation'     => $context->operation->value,
-                        'correlationId' => $context->correlationId,
-                    ],
-                );
-                continue;
-            }
+        $onSkip = function (string $identifier, FallbackSkipReason $reason) use ($context): void {
+            $this->logger->warning(
+                $reason === FallbackSkipReason::NotFound
+                    ? 'LLM fallback configuration not found, skipping'
+                    : 'LLM fallback configuration is inactive, skipping',
+                [
+                    'configuration' => $identifier,
+                    'operation'     => $context->operation->value,
+                    'correlationId' => $context->correlationId,
+                ],
+            );
+        };
 
-            if (!$fallback->isActive()) {
-                $this->logger->warning(
-                    'LLM fallback configuration is inactive, skipping',
-                    [
-                        'configuration' => $identifier,
-                        'operation'     => $context->operation->value,
-                        'correlationId' => $context->correlationId,
-                    ],
-                );
-                continue;
-            }
-
+        foreach ($this->candidates->resolve($chain, $onSkip) as $identifier => $fallback) {
             // Count this as a fallback attempt for the outer TelemetryMiddleware
-            // (ADR-058): a real dispatch to a sibling configuration, after the
-            // not-found / inactive skips above. The primary attempt is not
-            // counted.
+            // (ADR-058): a real dispatch to a sibling configuration — the
+            // resolver has already dropped the not-found / inactive entries.
+            // The primary attempt is not counted.
             $context->telemetrySignals->recordFallbackAttempt();
 
             try {

--- a/Classes/Service/Streaming/StreamingDispatcher.php
+++ b/Classes/Service/Streaming/StreamingDispatcher.php
@@ -15,9 +15,9 @@ use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
-use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
+use Netresearch\NrLlm\Provider\Fallback\FallbackCandidateResolver;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\FailureClassifier;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
@@ -123,7 +123,7 @@ final readonly class StreamingDispatcher
         private BudgetServiceInterface $budgetService,
         private UsageTrackerServiceInterface $usageTracker,
         private TelemetryRepositoryInterface $telemetryRepository,
-        private LlmConfigurationRepository $repository,
+        private FallbackCandidateResolver $candidateResolver,
         private LoggerInterface $logger,
         private Context $context,
         private ExtensionConfiguration $extensionConfiguration,
@@ -280,17 +280,19 @@ final readonly class StreamingDispatcher
         LlmConfiguration $primary,
         callable $open,
     ): array {
-        $candidates    = $this->candidates($context, $primary);
         $lastRetryable = null;
+        $isPrimary     = true;
 
-        foreach ($candidates as $index => $configuration) {
-            if ($index > 0) {
+        foreach ($this->candidates($context, $primary) as $configuration) {
+            if (!$isPrimary) {
                 // Count every dispatched sibling BEFORE priming (the primary is
                 // not counted), so a fallback that then fails retryably or
                 // exhausts the chain is still counted — mirroring
                 // FallbackMiddleware, which records before each $next($fallback).
                 $context->telemetrySignals->recordFallbackAttempt();
             }
+
+            $isPrimary = false;
 
             $stream = $open($configuration);
 
@@ -327,33 +329,39 @@ final readonly class StreamingDispatcher
     }
 
     /**
-     * Primary first, then each active, resolvable fallback configuration. The
-     * primary's own identifier is filtered out of the chain (no self-retry) and
-     * missing / inactive fallbacks are skipped with a log line, exactly as
-     * {@see \Netresearch\NrLlm\Provider\Middleware\FallbackMiddleware} does.
+     * Primary first, then each active, resolvable fallback configuration.
      *
-     * @return non-empty-list<LlmConfiguration>
+     * Which entries the chain offers is decided by the shared
+     * {@see FallbackCandidateResolver} (ADR-137) — the primary's own identifier
+     * is filtered out (no self-retry), missing and inactive entries are
+     * skipped. Two things stay on this side deliberately: the primary is a
+     * candidate here (the pipeline has already tried it on the non-streaming
+     * path, this dispatcher still has to open it), and the order is the
+     * configured one — the health-aware reorder (ADR-063) is not applied to a
+     * stream.
+     *
+     * Yielded lazily, so a chain entry behind the one that primes successfully
+     * is never looked up.
+     *
+     * @return Generator<int, LlmConfiguration>
      */
-    private function candidates(ProviderCallContext $context, LlmConfiguration $primary): array
+    private function candidates(ProviderCallContext $context, LlmConfiguration $primary): Generator
     {
-        $candidates = [$primary];
+        yield $primary;
 
-        $chain = $primary->getFallbackChainDTO()->without($primary->getIdentifier());
-        foreach ($chain->configurationIdentifiers as $identifier) {
-            $fallback = $this->repository->findOneByIdentifier($identifier);
-            if (!$fallback instanceof LlmConfiguration || !$fallback->isActive()) {
+        $candidates = $this->candidateResolver->resolve(
+            $this->candidateResolver->chainFor($primary),
+            function (string $identifier) use ($context): void {
                 $this->logger->warning(
                     'LLM streaming fallback configuration missing or inactive, skipping',
                     $this->logContext($context, ['configuration' => $identifier]),
                 );
+            },
+        );
 
-                continue;
-            }
-
-            $candidates[] = $fallback;
+        foreach ($candidates as $candidate) {
+            yield $candidate;
         }
-
-        return $candidates;
     }
 
     private function isRetryable(Throwable $e): bool

--- a/Documentation/Adr/Adr137OneCandidateResolution.rst
+++ b/Documentation/Adr/Adr137OneCandidateResolution.rst
@@ -1,0 +1,84 @@
+.. _adr-137:
+
+===============================================================
+ADR-137: One candidate resolution for the primary's chain
+===============================================================
+
+:Status: Accepted
+:Date: 2026-08-09
+
+Context
+=======
+
+The walk over a primary configuration's fallback chain existed twice:
+:php:`Provider\Middleware\FallbackMiddleware` for pipelined calls and
+:php:`Service\Streaming\StreamingDispatcher` for streamed ones. Both applied
+the same four rules from ADR-021 — shallow, no self-retry, missing entry
+skipped, inactive entry skipped — from two separate pieces of code, so a fix
+to one was not a fix to the other.
+
+The duplication is not free. :php:`Service\Tool\TrustZoneResolver` walks the
+same chain to derive the data-class ceiling for tools (ADR-094). That ceiling
+is only sound while the set a call may actually reach stays inside the set the
+ceiling considered. Two independent loops are two chances for that to stop
+being true.
+
+Not every difference between the two was duplication, though. The
+health-aware reorder (ADR-063) applies to the pipelined path only, and the
+streaming path opens the primary itself while the middleware receives it
+already attempted.
+
+Decision
+========
+
+The candidate loop moves into one class,
+:php:`Provider\Fallback\FallbackCandidateResolver`, marked ``@internal``. It
+owns the four ADR-021 rules and nothing else:
+
+1. **It resolves, it does not order.** The caller hands in the chain it wants
+   walked. The health reorder stays in :php:`FallbackMiddleware`, where its
+   single caller is; streaming keeps the configured order. No
+   ``RoutingPolicyInterface`` is introduced —
+   :php:`ProviderHealthServiceInterface::reorder()` has exactly one caller
+   repo-wide, and an interface with one implementation and one reader is a
+   declaration nobody reads.
+2. **It does not own the primary.** :php:`chainFor()` removes the primary's
+   own identifier from its chain; whether the primary is itself a candidate is
+   the caller's business. The middleware's primary has already run in the
+   pipeline; the dispatcher prepends it because it still has to open it.
+3. **It does not log.** A skipped entry is reported to the caller through a
+   callback carrying the identifier and a :php:`FallbackSkipReason`. The
+   middleware words the two reasons separately, the dispatcher collapses them
+   into one line; merging the rules must not rewrite either log surface.
+4. **It resolves lazily.** Each entry is looked up when the caller asks for
+   it, so an entry behind the one that served is never queried.
+
+:php:`TrustZoneResolver` is **not** touched. Its optional repository argument
+is the fail-closed path: without a repository every chain entry resolves to
+:php:`null` and the zone falls to ``EXTERNAL_GLOBAL``, the most restrictive
+ceiling. Making it mandatory would trade that safety for symmetry and break
+six test construction sites.
+
+The invariant that ties the two together — the set either path attempts is
+always a subset of the raw chain :php:`TrustZoneResolver::zoneFor()` walks —
+is pinned as a test
+(:file:`Tests/Unit/Provider/Fallback/CandidateResolutionTest.php`), not as a
+shared class. A shared class would have to own both the ceiling and the
+routing, coupling a security decision to a retry policy.
+
+Consequences
+============
+
+- Both call sites take the resolver instead of
+  :php:`LlmConfigurationRepository`; neither queries configurations itself
+  anymore.
+- The two deliberate differences are now asserted per path, including a
+  reflection assertion that the dispatcher has no health-service dependency —
+  wiring one in is a routing change and fails that test.
+- Streaming no longer resolves the whole chain up front. When an early
+  candidate serves, later entries are no longer looked up and a broken entry
+  behind it no longer produces a skip warning. The pipelined path already
+  behaved this way; the eager resolution was an artefact of building an array,
+  not a decision.
+- ADR-021's rules now have exactly one implementation. A change to them is a
+  change to one class, and both paths inherit it.

--- a/Documentation/Adr/Adr137OneCandidateResolution.rst
+++ b/Documentation/Adr/Adr137OneCandidateResolution.rst
@@ -79,6 +79,9 @@ Consequences
   candidate serves, later entries are no longer looked up and a broken entry
   behind it no longer produces a skip warning. The pipelined path already
   behaved this way; the eager resolution was an artefact of building an array,
-  not a decision.
+  not a decision. The trade-off is that a typo'd chain entry is now reported
+  only once the primary fails, so it is pinned as a dispatcher-level test
+  (:php:`theStreamingPathLooksUpNoChainEntryWhileThePrimaryServes`) — going
+  back to an eagerly built array fails it.
 - ADR-021's rules now have exactly one implementation. A change to them is a
   change to one class, and both paths inherit it.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -429,3 +429,4 @@ Tools
    Adr129StructuredConsumers
    Adr130BackendUserGrants
    Adr131EditorModule
+   Adr137OneCandidateResolution

--- a/Tests/Fixture/SkipRecordingLogger.php
+++ b/Tests/Fixture/SkipRecordingLogger.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Fixture;
+
+use Psr\Log\AbstractLogger;
+use Stringable;
+
+/**
+ * A PSR-3 logger that answers one question: which configuration identifiers
+ * were logged under a given wording?
+ *
+ * Used where the log line IS the asserted behaviour — the fallback candidate
+ * loop reports a skipped chain entry only that way.
+ */
+final class SkipRecordingLogger extends AbstractLogger
+{
+    /** @var list<array{message: string, configuration: mixed}> */
+    private array $records = [];
+
+    /**
+     * @param array<array-key, mixed> $context
+     */
+    public function log($level, string|Stringable $message, array $context = []): void
+    {
+        $this->records[] = [
+            'message'       => (string)$message,
+            'configuration' => $context['configuration'] ?? null,
+        ];
+    }
+
+    /**
+     * The `configuration` context value of every record whose message contains
+     * $messageNeedle, in order.
+     *
+     * @return list<mixed>
+     */
+    public function skipped(string $messageNeedle): array
+    {
+        $skipped = [];
+        foreach ($this->records as $record) {
+            if (str_contains($record['message'], $messageNeedle)) {
+                $skipped[] = $record['configuration'];
+            }
+        }
+
+        return $skipped;
+    }
+}

--- a/Tests/Functional/Fixtures/FallbackChains.csv
+++ b/Tests/Functional/Fixtures/FallbackChains.csv
@@ -1,0 +1,5 @@
+"tx_nrllm_configuration"
+,"uid","pid","identifier","name","fallback_chain","is_active","deleted","hidden","sorting"
+,101,0,"chain-primary","Chain Primary","{""configurationIdentifiers"":[""chain-primary"",""chain-gone"",""chain-inactive"",""chain-alt""]}",1,0,0,1
+,102,0,"chain-inactive","Chain Inactive Sibling","",0,0,0,2
+,103,0,"chain-alt","Chain Alternative","",1,0,0,3

--- a/Tests/Functional/Provider/Fallback/CandidateResolutionTest.php
+++ b/Tests/Functional/Provider/Fallback/CandidateResolutionTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Provider\Fallback;
+
+use Generator;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
+use Netresearch\NrLlm\Provider\Fallback\FallbackCandidateResolver;
+use Netresearch\NrLlm\Provider\Middleware\FallbackMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Service\Health\ProviderHealthServiceInterface;
+use Netresearch\NrLlm\Service\Streaming\StreamingDispatcher;
+use Netresearch\NrLlm\Service\Telemetry\TelemetryRepository;
+use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
+use Netresearch\NrLlm\Tests\Fixture\AllowingBudgetService;
+use Netresearch\NrLlm\Tests\Fixture\SkipRecordingLogger;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Missing and inactive chain entries against the real repository, on BOTH
+ * paths (ADR-137).
+ *
+ * The unit tests drive the candidate loop with a stubbed repository; this
+ * proves the two skips still happen when the lookup is a real Extbase query
+ * against real rows — `chain-gone` has no row at all, `chain-inactive` has one
+ * with `is_active = 0` (which `findOneByIdentifier()` deliberately still
+ * returns, because it ignores enable fields, so the skip has to be the
+ * candidate loop's own decision).
+ *
+ * The distinct skip wording of each path is asserted too: the merge shares the
+ * rules, not the log surface.
+ */
+#[CoversClass(FallbackCandidateResolver::class)]
+final class CandidateResolutionTest extends AbstractFunctionalTestCase
+{
+    private FallbackCandidateResolver $resolver;
+
+    private LlmConfiguration $primary;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importFixture('FallbackChains.csv');
+
+        $repository = $this->getService(LlmConfigurationRepository::class);
+        $primary    = $repository->findOneByIdentifier('chain-primary');
+        self::assertInstanceOf(LlmConfiguration::class, $primary, 'Fixture row missing — the test would prove nothing.');
+
+        $this->primary  = $primary;
+        $this->resolver = new FallbackCandidateResolver($repository);
+    }
+
+    #[Test]
+    public function theNonStreamingPathSkipsTheMissingAndTheInactiveEntryAndServesFromTheNextOne(): void
+    {
+        $logger = new SkipRecordingLogger();
+
+        $health = self::createStub(ProviderHealthServiceInterface::class);
+        $health->method('reorder')->willReturnArgument(0);
+
+        $middleware = new FallbackMiddleware($this->resolver, $logger, $health);
+
+        $served = $middleware->handle(
+            ProviderCallContext::forConfiguration(ProviderOperation::Chat, $this->primary),
+            static function (ProviderCallContext $context): string {
+                $configuration = $context->configuration;
+                assert($configuration instanceof LlmConfiguration);
+                if ($configuration->getIdentifier() === 'chain-primary') {
+                    throw new ProviderConnectionException('primary down', 1770000003);
+                }
+
+                return $configuration->getIdentifier();
+            },
+        );
+
+        self::assertSame('chain-alt', $served, 'The first dispatchable sibling must serve.');
+
+        // This path names the two reasons separately, and still does.
+        self::assertSame(['chain-gone'], $logger->skipped('fallback configuration not found'));
+        self::assertSame(['chain-inactive'], $logger->skipped('fallback configuration is inactive'));
+    }
+
+    #[Test]
+    public function theStreamingPathSkipsTheMissingAndTheInactiveEntryAndServesFromTheNextOne(): void
+    {
+        $logger = new SkipRecordingLogger();
+
+        $dispatcher = new StreamingDispatcher(
+            new AllowingBudgetService(),
+            $this->getService(UsageTrackerServiceInterface::class),
+            new TelemetryRepository($this->getService(ConnectionPool::class)),
+            $this->resolver,
+            $logger,
+            $this->getService(Context::class),
+            $this->getService(ExtensionConfiguration::class),
+        );
+
+        $open = static function (LlmConfiguration $configuration): Generator {
+            if ($configuration->getIdentifier() === 'chain-primary') {
+                yield from [];
+
+                throw new ProviderConnectionException('primary down', 1770000004);
+            }
+
+            yield $configuration->getIdentifier();
+        };
+
+        $chunks = iterator_to_array($dispatcher->stream(
+            new ProviderCallContext(ProviderOperation::Stream, 'func-adr137'),
+            $this->primary,
+            $open,
+        ));
+
+        self::assertSame(['chain-alt'], $chunks, 'The first dispatchable sibling must serve.');
+
+        // This path collapses both reasons into one line, and still does.
+        self::assertSame(
+            ['chain-gone', 'chain-inactive'],
+            $logger->skipped('streaming fallback configuration missing or inactive'),
+        );
+    }
+
+}

--- a/Tests/Functional/Service/Streaming/StreamingDispatcherTest.php
+++ b/Tests/Functional/Service/Streaming/StreamingDispatcherTest.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Tests\Functional\Service\Streaming;
 use Generator;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Provider\Fallback\FallbackCandidateResolver;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
@@ -54,7 +55,7 @@ final class StreamingDispatcherTest extends AbstractFunctionalTestCase
             $this->getService(BudgetServiceInterface::class),
             $this->getService(UsageTrackerServiceInterface::class),
             new TelemetryRepository($this->connectionPool),
-            $this->getService(LlmConfigurationRepository::class),
+            new FallbackCandidateResolver($this->getService(LlmConfigurationRepository::class)),
             new NullLogger(),
             $this->getService(Context::class),
             $this->getService(ExtensionConfiguration::class),

--- a/Tests/Unit/Provider/Fallback/CandidateResolutionTest.php
+++ b/Tests/Unit/Provider/Fallback/CandidateResolutionTest.php
@@ -120,6 +120,41 @@ final class CandidateResolutionTest extends AbstractUnitTestCase
         self::assertSame(['a'], $looked, 'Resolution must not query the whole chain up front.');
     }
 
+    #[Test]
+    public function theStreamingPathLooksUpNoChainEntryWhileThePrimaryServes(): void
+    {
+        // The operator effect of lazy resolution, at the dispatcher rather than
+        // at the resolver: a typo'd chain entry behind a healthy primary costs
+        // no repository query and produces no skip warning during normal
+        // operation. The warning is deferred to the moment the primary actually
+        // fails — which is when the entry would have been needed.
+        $primary = $this->configuration('p', new FallbackChain(['chain-gone']));
+
+        $looked     = [];
+        $logger     = new RecordingLogger();
+        $dispatcher = $this->streamingDispatcher(['chain-gone' => null], $looked, $logger);
+
+        $chunks = iterator_to_array($dispatcher->stream(
+            new ProviderCallContext(ProviderOperation::Stream, 'corr-adr137'),
+            $primary,
+            static function (): Generator {
+                yield 'served-by-primary';
+            },
+        ));
+
+        self::assertSame(['served-by-primary'], $chunks);
+        self::assertSame(
+            [],
+            $looked,
+            'A chain entry behind a primary that primes must not be resolved: eagerly building the '
+            . 'candidate list would query it on every streamed call.',
+        );
+        self::assertNull(
+            $logger->firstMatching('warning', 'missing or inactive'),
+            'A chain entry that was never resolved cannot be reported as skipped.',
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Difference 1: the health reorder belongs to the non-streaming path only
     // -----------------------------------------------------------------------
@@ -302,28 +337,8 @@ final class CandidateResolutionTest extends AbstractUnitTestCase
      */
     private function attemptedByStreaming(LlmConfiguration $primary, array $rows): array
     {
-        $looked = [];
-
-        $budget = self::createStub(BudgetServiceInterface::class);
-        $budget->method('check')->willReturn(BudgetCheckResult::allowed());
-
-        $aspect = self::createStub(AspectInterface::class);
-        $aspect->method('get')->willReturn(0);
-        $typo3Context = self::createStub(Context::class);
-        $typo3Context->method('getAspect')->willReturn($aspect);
-
-        $extensionConfiguration = self::createStub(ExtensionConfiguration::class);
-        $extensionConfiguration->method('get')->willReturn(['telemetry' => ['enabled' => '0']]);
-
-        $dispatcher = new StreamingDispatcher(
-            $budget,
-            new RecordingUsageTracker(),
-            new InMemoryTelemetryRepository(),
-            new FallbackCandidateResolver($this->repository($rows, $looked)),
-            new RecordingLogger(),
-            $typo3Context,
-            $extensionConfiguration,
-        );
+        $looked     = [];
+        $dispatcher = $this->streamingDispatcher($rows, $looked, new RecordingLogger());
 
         /** @var list<string> $attempted */
         $attempted = [];
@@ -346,6 +361,37 @@ final class CandidateResolutionTest extends AbstractUnitTestCase
         }
 
         return $attempted;
+    }
+
+    /**
+     * A streaming dispatcher wired to a recording repository and the given
+     * logger, with telemetry off and the budget allowing.
+     *
+     * @param array<string, LlmConfiguration|null> $rows   the repository's content
+     * @param list<string>                         $looked records every identifier the repository was asked for
+     */
+    private function streamingDispatcher(array $rows, array &$looked, RecordingLogger $logger): StreamingDispatcher
+    {
+        $budget = self::createStub(BudgetServiceInterface::class);
+        $budget->method('check')->willReturn(BudgetCheckResult::allowed());
+
+        $aspect = self::createStub(AspectInterface::class);
+        $aspect->method('get')->willReturn(0);
+        $typo3Context = self::createStub(Context::class);
+        $typo3Context->method('getAspect')->willReturn($aspect);
+
+        $extensionConfiguration = self::createStub(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn(['telemetry' => ['enabled' => '0']]);
+
+        return new StreamingDispatcher(
+            $budget,
+            new RecordingUsageTracker(),
+            new InMemoryTelemetryRepository(),
+            new FallbackCandidateResolver($this->repository($rows, $looked)),
+            $logger,
+            $typo3Context,
+            $extensionConfiguration,
+        );
     }
 
     /**

--- a/Tests/Unit/Provider/Fallback/CandidateResolutionTest.php
+++ b/Tests/Unit/Provider/Fallback/CandidateResolutionTest.php
@@ -1,0 +1,386 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Provider\Fallback;
+
+use Generator;
+use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
+use Netresearch\NrLlm\Domain\DTO\FallbackChain;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
+use Netresearch\NrLlm\Provider\Fallback\FallbackCandidateResolver;
+use Netresearch\NrLlm\Provider\Fallback\FallbackSkipReason;
+use Netresearch\NrLlm\Provider\Middleware\FallbackMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Service\BudgetServiceInterface;
+use Netresearch\NrLlm\Service\Health\ProviderHealthServiceInterface;
+use Netresearch\NrLlm\Service\Streaming\StreamingDispatcher;
+use Netresearch\NrLlm\Service\Tool\TrustZoneResolver;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Tests\Unit\Fixture\InMemoryTelemetryRepository;
+use Netresearch\NrLlm\Tests\Unit\Fixture\RecordingLogger;
+use Netresearch\NrLlm\Tests\Unit\Fixture\RecordingUsageTracker;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+use ReflectionNamedType;
+use Throwable;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Context\AspectInterface;
+use TYPO3\CMS\Core\Context\Context;
+
+/**
+ * The single candidate loop over a primary's fallback chain (ADR-137), and the
+ * two things that stay different between the paths that use it.
+ *
+ * The shared rules (shallow, no self-retry, missing and inactive entries
+ * skipped) are asserted once on the resolver. The two deliberate differences —
+ * the health-aware reorder on the non-streaming path only, and the primary
+ * being a candidate on the streaming path only — are asserted SEPARATELY per
+ * path, so a later attempt to "harmonise" them fails here instead of silently
+ * changing routing.
+ *
+ * The last test pins the invariant the tool trust ceiling depends on: whatever
+ * either path ends up attempting is a subset of the raw chain
+ * {@see TrustZoneResolver} walks for its data-class ceiling (ADR-094). If a
+ * path could reach a configuration that walk never saw, a run could be offered
+ * tools above the trust zone it actually reaches.
+ */
+#[CoversClass(FallbackCandidateResolver::class)]
+final class CandidateResolutionTest extends AbstractUnitTestCase
+{
+    // -----------------------------------------------------------------------
+    // The shared rules
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function dropsThePrimaryFromItsOwnChain(): void
+    {
+        $primary  = $this->configuration('p', new FallbackChain(['a', 'p', 'b']));
+        $looked   = [];
+        $resolver = new FallbackCandidateResolver($this->repository([], $looked));
+
+        self::assertSame(['a', 'b'], $resolver->chainFor($primary)->configurationIdentifiers);
+    }
+
+    #[Test]
+    public function yieldsOnlyDispatchableEntriesAndReportsEachSkipWithItsReason(): void
+    {
+        $looked   = [];
+        $resolver = new FallbackCandidateResolver($this->repository([
+            'gone' => null,
+            'off'  => $this->configuration('off', active: false),
+            'a'    => $this->configuration('a'),
+        ], $looked));
+
+        /** @var list<array{0: string, 1: FallbackSkipReason}> $skips */
+        $skips = [];
+        /** @var list<array{0: string, 1: string}> $yielded */
+        $yielded = [];
+
+        foreach ($resolver->resolve(
+            new FallbackChain(['gone', 'off', 'a']),
+            static function (string $identifier, FallbackSkipReason $reason) use (&$skips): void {
+                $skips[] = [$identifier, $reason];
+            },
+        ) as $identifier => $candidate) {
+            $yielded[] = [$identifier, $candidate->getIdentifier()];
+        }
+
+        self::assertSame([['a', 'a']], $yielded, 'The key is the chain entry, the value the resolved configuration.');
+        self::assertSame(
+            [['gone', FallbackSkipReason::NotFound], ['off', FallbackSkipReason::Inactive]],
+            $skips,
+        );
+    }
+
+    #[Test]
+    public function resolvesLazilySoAnEntryBehindTheServingOneIsNeverLookedUp(): void
+    {
+        $looked   = [];
+        $resolver = new FallbackCandidateResolver($this->repository([
+            'a' => $this->configuration('a'),
+            'b' => $this->configuration('b'),
+        ], $looked));
+
+        foreach ($resolver->resolve(new FallbackChain(['a', 'b']), static function (): void {}) as $candidate) {
+            self::assertSame('a', $candidate->getIdentifier());
+
+            break;
+        }
+
+        self::assertSame(['a'], $looked, 'Resolution must not query the whole chain up front.');
+    }
+
+    // -----------------------------------------------------------------------
+    // Difference 1: the health reorder belongs to the non-streaming path only
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function theNonStreamingPathWalksTheChainInTheOrderTheHealthServiceReturns(): void
+    {
+        $primary = $this->configuration('p', new FallbackChain(['a', 'b']));
+        $rows    = ['a' => $this->configuration('a'), 'b' => $this->configuration('b')];
+
+        self::assertSame(
+            ['b', 'a'],
+            $this->attemptedByMiddleware($primary, $rows, reverseOrder: true),
+            'ADR-063: the health service may reorder the fallback candidates.',
+        );
+    }
+
+    #[Test]
+    public function theStreamingPathWalksTheChainInItsConfiguredOrder(): void
+    {
+        $primary = $this->configuration('p', new FallbackChain(['a', 'b']));
+        $rows    = ['a' => $this->configuration('a'), 'b' => $this->configuration('b')];
+
+        self::assertSame(
+            ['p', 'a', 'b'],
+            $this->attemptedByStreaming($primary, $rows),
+            'A stream keeps the configured order: no reorder is applied on this path.',
+        );
+    }
+
+    #[Test]
+    public function theStreamingDispatcherHasNoHealthServiceDependency(): void
+    {
+        $constructor = (new ReflectionClass(StreamingDispatcher::class))->getConstructor();
+        self::assertNotNull($constructor);
+
+        $types = [];
+        foreach ($constructor->getParameters() as $parameter) {
+            $type = $parameter->getType();
+            if ($type instanceof ReflectionNamedType) {
+                $types[] = $type->getName();
+            }
+        }
+
+        self::assertNotContains(
+            ProviderHealthServiceInterface::class,
+            $types,
+            'Streaming deliberately keeps no health reorder (ADR-137). Wiring one in is a routing change, not a refactor.',
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Difference 2: who owns the primary attempt
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function theStreamingCandidateSetOpensWithThePrimaryWhileTheMiddlewareChainWalkDoesNot(): void
+    {
+        // Nothing but the primary is dispatchable: the chain lists only itself.
+        $primary = $this->configuration('p', new FallbackChain(['p']));
+
+        // Streaming opens the primary itself, so it is attempted here.
+        self::assertSame(['p'], $this->attemptedByStreaming($primary, []));
+
+        // The middleware's own walk attempts nothing: the pipeline already ran
+        // the primary before handing over, and the chain filtered down to empty.
+        self::assertSame([], $this->attemptedByMiddleware($primary, []));
+    }
+
+    // -----------------------------------------------------------------------
+    // The invariant
+    // -----------------------------------------------------------------------
+
+    #[Test]
+    public function everyAttemptedConfigurationIsPartOfTheChainTheTrustZoneResolverWalks(): void
+    {
+        // One chain with every edge case at once: a self-reference, a deleted
+        // entry, a switched-off entry and two live ones.
+        $primary = $this->configuration('p', new FallbackChain(['p', 'gone', 'off', 'a', 'b']));
+        $rows    = [
+            'p'    => $primary,
+            'gone' => null,
+            'off'  => $this->configuration('off', active: false),
+            'a'    => $this->configuration('a'),
+            'b'    => $this->configuration('b'),
+        ];
+
+        // What the data-class ceiling actually inspects (TrustZoneResolver).
+        $walked = [];
+        (new TrustZoneResolver($this->repository($rows, $walked)))->zoneFor($primary);
+        self::assertSame(['p', 'gone', 'off', 'a', 'b'], $walked);
+
+        // Both paths, with the reorder switched on for the one that has it.
+        $streamed  = $this->attemptedByStreaming($primary, $rows);
+        $pipelined = $this->attemptedByMiddleware($primary, $rows, reverseOrder: true);
+
+        // Spelled out so the invariant is checked against a real walk, not an
+        // empty one: streaming opens the primary and both live siblings in the
+        // configured order; the middleware walks the reordered chain and drops
+        // the switched-off and the deleted entry.
+        self::assertSame(['p', 'a', 'b'], $streamed);
+        self::assertSame(['b', 'a'], $pipelined);
+
+        foreach (['streaming' => $streamed, 'non-streaming' => $pipelined] as $path => $attempted) {
+            // The primary is covered by the resolver's own provider zone, not
+            // by the chain walk.
+            $fallbacks = array_values(array_filter($attempted, static fn(string $id): bool => $id !== 'p'));
+
+            self::assertSame(
+                [],
+                array_values(array_diff($fallbacks, $walked)),
+                sprintf('The %s path attempted a configuration the trust-zone walk never saw.', $path),
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Test helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Identifiers the non-streaming path really dispatched, in order. Every
+     * attempt fails retryably, so the whole walk is observed. The pipeline's
+     * own primary attempt is not part of the chain walk and is filtered out.
+     *
+     * @param array<string, LlmConfiguration|null> $rows the repository's content
+     *
+     * @return list<string>
+     */
+    private function attemptedByMiddleware(
+        LlmConfiguration $primary,
+        array $rows,
+        bool $reverseOrder = false,
+    ): array {
+        $looked = [];
+
+        $health = self::createStub(ProviderHealthServiceInterface::class);
+        $health->method('reorder')->willReturnCallback(
+            static fn(FallbackChain $chain): FallbackChain => $reverseOrder
+                ? new FallbackChain(array_reverse($chain->configurationIdentifiers))
+                : $chain,
+        );
+
+        $middleware = new FallbackMiddleware(
+            new FallbackCandidateResolver($this->repository($rows, $looked)),
+            new RecordingLogger(),
+            $health,
+        );
+
+        /** @var list<string> $attempted */
+        $attempted = [];
+
+        try {
+            $middleware->handle(
+                ProviderCallContext::forConfiguration(ProviderOperation::Chat, $primary),
+                static function (ProviderCallContext $ctx) use (&$attempted, $primary): never {
+                    $configuration = $ctx->configuration;
+                    assert($configuration instanceof LlmConfiguration);
+                    if ($configuration->getIdentifier() !== $primary->getIdentifier()) {
+                        $attempted[] = $configuration->getIdentifier();
+                    }
+
+                    throw new ProviderConnectionException('down', 1770000001);
+                },
+            );
+        } catch (Throwable) {
+            // Exhaustion is the expected outcome; the walk is what is asserted.
+        }
+
+        return $attempted;
+    }
+
+    /**
+     * Identifiers the streaming path really primed, in order — the primary
+     * included, because the dispatcher opens it itself.
+     *
+     * @param array<string, LlmConfiguration|null> $rows the repository's content
+     *
+     * @return list<string>
+     */
+    private function attemptedByStreaming(LlmConfiguration $primary, array $rows): array
+    {
+        $looked = [];
+
+        $budget = self::createStub(BudgetServiceInterface::class);
+        $budget->method('check')->willReturn(BudgetCheckResult::allowed());
+
+        $aspect = self::createStub(AspectInterface::class);
+        $aspect->method('get')->willReturn(0);
+        $typo3Context = self::createStub(Context::class);
+        $typo3Context->method('getAspect')->willReturn($aspect);
+
+        $extensionConfiguration = self::createStub(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn(['telemetry' => ['enabled' => '0']]);
+
+        $dispatcher = new StreamingDispatcher(
+            $budget,
+            new RecordingUsageTracker(),
+            new InMemoryTelemetryRepository(),
+            new FallbackCandidateResolver($this->repository($rows, $looked)),
+            new RecordingLogger(),
+            $typo3Context,
+            $extensionConfiguration,
+        );
+
+        /** @var list<string> $attempted */
+        $attempted = [];
+        $open      = static function (LlmConfiguration $configuration) use (&$attempted): Generator {
+            $attempted[] = $configuration->getIdentifier();
+
+            yield from [];
+
+            throw new ProviderConnectionException('down', 1770000002);
+        };
+
+        try {
+            iterator_to_array($dispatcher->stream(
+                new ProviderCallContext(ProviderOperation::Stream, 'corr-adr137'),
+                $primary,
+                $open,
+            ));
+        } catch (Throwable) {
+            // Exhaustion is the expected outcome; the walk is what is asserted.
+        }
+
+        return $attempted;
+    }
+
+    /**
+     * A repository that answers from $rows and records every identifier it was
+     * asked for, in order.
+     *
+     * @param array<string, LlmConfiguration|null> $rows
+     * @param list<string>                         $looked
+     */
+    private function repository(array $rows, array &$looked): LlmConfigurationRepository
+    {
+        $repository = self::createStub(LlmConfigurationRepository::class);
+        $repository->method('findOneByIdentifier')->willReturnCallback(
+            static function (string $identifier) use ($rows, &$looked): ?LlmConfiguration {
+                $looked[] = $identifier;
+
+                return $rows[$identifier] ?? null;
+            },
+        );
+
+        return $repository;
+    }
+
+    private function configuration(
+        string $identifier,
+        ?FallbackChain $chain = null,
+        bool $active = true,
+    ): LlmConfiguration {
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier($identifier);
+        $configuration->setIsActive($active);
+        if ($chain instanceof FallbackChain) {
+            $configuration->setFallbackChainDTO($chain);
+        }
+
+        return $configuration;
+    }
+}

--- a/Tests/Unit/Provider/Middleware/FallbackMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/FallbackMiddlewareTest.php
@@ -18,6 +18,7 @@ use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException;
+use Netresearch\NrLlm\Provider\Fallback\FallbackCandidateResolver;
 use Netresearch\NrLlm\Provider\Middleware\FallbackMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
@@ -571,7 +572,11 @@ final class FallbackMiddlewareTest extends AbstractUnitTestCase
         $health = self::createStub(ProviderHealthServiceInterface::class);
         $health->method('reorder')->willReturnArgument(0);
 
-        return new FallbackMiddleware($this->repositoryStub, new NullLogger(), $health);
+        return new FallbackMiddleware(
+            new FallbackCandidateResolver($this->repositoryStub),
+            new NullLogger(),
+            $health,
+        );
     }
 
     private function makePipeline(): MiddlewarePipeline

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -34,6 +34,7 @@ use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
 use Netresearch\NrLlm\Provider\Contract\VisionCapableInterface;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException;
+use Netresearch\NrLlm\Provider\Fallback\FallbackCandidateResolver;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\CacheMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
@@ -2361,7 +2362,7 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
             $budget,
             $usage,
             $telemetry,
-            self::createStub(LlmConfigurationRepository::class),
+            new FallbackCandidateResolver(self::createStub(LlmConfigurationRepository::class)),
             new NullLogger(),
             $context,
             $extensionConfiguration,

--- a/Tests/Unit/Service/Streaming/StreamingDispatcherTest.php
+++ b/Tests/Unit/Service/Streaming/StreamingDispatcherTest.php
@@ -20,6 +20,7 @@ use Netresearch\NrLlm\Domain\ValueObject\GuardrailResult;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
+use Netresearch\NrLlm\Provider\Fallback\FallbackCandidateResolver;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
@@ -1012,7 +1013,7 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
             $budget ?? $this->budget(BudgetCheckResult::allowed()),
             $this->usage,
             $this->telemetry,
-            $repository ?? self::createStub(LlmConfigurationRepository::class),
+            new FallbackCandidateResolver($repository ?? self::createStub(LlmConfigurationRepository::class)),
             $this->logger,
             $this->contextWithAmbientUser(0),
             $extensionConfiguration ?? $this->extensionConfiguration(true),


### PR DESCRIPTION
> **Stacked on #641.** Base is `docs/adr021-streaming-scope-overtaken` (ADR text only). GitHub retargets when #641 merges.

## Description

The candidate loop over a primary's fallback chain was implemented twice, with the same ADR-021 rules and separate bugs: `FallbackMiddleware` and `StreamingDispatcher::candidates()`. It moves into one `@internal` class.

The resolver owns only the rules — shallow, no self-retry, missing and inactive entries skipped — and **reports** each skip to the caller through a callback rather than logging itself. Both operator-facing log surfaces are kept verbatim; rewriting one of them would not have been a refactor.

### The differences were classified, not flattened

| Difference | Verdict | What happened |
|---|---|---|
| Health reorder on the middleware only | intentional (ADR-063) | left exactly where it was — a stream cannot re-route after the first chunk |
| Primary is candidate 0 in streaming, absent from the middleware's walk | intentional, structural | the pipeline already ran the primary through `$next`; the dispatcher must open it itself. The resolver owns neither. |
| "Chain contains only the primary → rethrow verbatim" only in the middleware | intentional | on the streaming path the primary is candidate 0, so its error surfaces as `$lastRetryable` without a special case |
| Exhaustion outcome (`FallbackChainExhaustedException` vs rethrow) | intentional, **out of scope** | that is failure aggregation, not candidate resolution. Not merged, not changed. |
| Two skip messages vs one collapsed message | **accidental** in origin | kept anyway — an operator-facing log surface is not a refactor's business. Now pinned by a functional test, which is why the resolver reports a reason instead of logging. |
| Eager (array) vs lazy (in-loop) | **accidental** | unified to lazy |

### One observable change, stated rather than smuggled

Lazy resolution means that when an early streaming candidate serves, entries behind it are no longer looked up — and a broken entry behind it no longer logs a skip warning. The middleware already behaved this way. Recorded in ADR-137 and in CHANGELOG.

### Two "do not touch" premises — checked, not assumed

- `ProviderHealthServiceInterface::reorder()` has exactly one caller repo-wide (`FallbackMiddleware.php:142`). One implementation needs no interface, so **no `RoutingPolicyInterface`** was introduced.
- `TrustZoneResolver` is untouched. `new TrustZoneResolver()` appears at exactly the six no-argument test sites the issue names, and its optional repository **is** the fail-closed path: with a null repository every chain entry resolves to `null` and `zoneFor()` collapses to `EXTERNAL_GLOBAL`, the most restrictive ceiling.

### The subset invariant

The attempted candidate set is always a subset of the raw chain `TrustZoneResolver` walks for the data-class ceiling — otherwise a call could run against a configuration whose trust zone was never considered for the ceiling. Pinned as a **test**, not as a shared class.

## Related Issue

Closes #632

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

With the one exception named above, which is why it is named.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `composer ci` and all checks pass — unit, PHPStan (level 10), cgl and fuzzy re-run independently of the authoring pass: all SUCCESS; the functional classes executed for real (4 tests, 42 assertions). The architecture suite was run too, because the new `Provider\Fallback` namespace touches the phpat deny sets. Rector green under an 8.2 resolve, then restored to 8.4.
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation accordingly
- [x] I have added a `CHANGELOG.md` entry under `## [Unreleased]`
- [x] I have added an ADR under `Documentation/Adr/` if this changes the public surface — ADR-137
- [x] My changes generate no new warnings

### No existing assertion changed

| | before | after |
|---|---|---|
| unit `FallbackMiddlewareTest` | 18 / 41 | 18 / 41 |
| unit `StreamingDispatcherTest` | 33 / 144 | 33 / 144 |
| functional `StreamingDispatcherTest` | 1 / 18 | 1 / 18 |

Four test files were touched for **construction only** — swapping `LlmConfigurationRepository` for the resolver changes both constructors. The alternative, `new`-ing the resolver inside each class, would have hidden a dependency from the container; the wiring churn is the better trade.

New: unit `CandidateResolutionTest` 8 / 16, functional `CandidateResolutionTest` 2 / 13 (real Extbase repository, missing identifier and inactive configuration, on both paths).