### PR TITLE
feat(configuration): compose snippet tags into the effective system prompt

### DIFF
--- a/Build/rector/rector.php
+++ b/Build/rector/rector.php
@@ -18,9 +18,11 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
+use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
 use Ssch\TYPO3Rector\CodeQuality\General\AddErrorCodeToExceptionRector;
+use Ssch\TYPO3Rector\CodeQuality\General\GeneralUtilityMakeInstanceToConstructorPropertyRector;
 use Ssch\TYPO3Rector\Set\Typo3LevelSetList;
 use Ssch\TYPO3Rector\Set\Typo3SetList;
 
@@ -73,6 +75,23 @@ return static function (RectorConfig $rectorConfig) use ($configure): void {
             __DIR__ . '/../../Classes/Provider/Middleware/BudgetMiddleware.php',
             __DIR__ . '/../../Classes/Service/Streaming/StreamingDispatcher.php',
             __DIR__ . '/../../Classes/Specialized/AbstractSpecializedService.php',
+        ],
+        // FormEngine instantiates an itemsProcFunc through
+        // GeneralUtility::callUserFunction() -> makeInstance() with NO
+        // constructor arguments, and makeInstance only consults the container
+        // for services it reports via has() — private ones (everything under
+        // the Netresearch\NrLlm\ namespace block) are not among them. Turning
+        // the makeInstance call into a required constructor property would
+        // therefore fatal in the backend. The established pattern here is the
+        // opposite one: keep the itemsProcFunc constructor-less and make its
+        // collaborator public (see GuardrailRegistry in Services.yaml).
+        GeneralUtilityMakeInstanceToConstructorPropertyRector::class => [
+            __DIR__ . '/../../Classes/Form/Tca/SnippetTagItems.php',
+        ],
+        // Same reason: without a constructor there is nothing to make readonly,
+        // and the rule only fires because of the rewrite skipped above.
+        ReadOnlyClassRector::class => [
+            __DIR__ . '/../../Classes/Form/Tca/SnippetTagItems.php',
         ],
         // Skip Fuzzy tests - Eris\Generator namespace functions conflict with auto-imports
         __DIR__ . '/../../Tests/Fuzzy/',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   an error. Configurations without tags are unaffected. The `@api`
   surface gains `LlmConfiguration::getSnippetTags()`,
   `setSnippetTags()` and `getSnippetTagList()` (additive).
+  A hidden snippet is not composed: the repository keeps ignoring enable
+  fields (the backend module lists hidden records), so the filter sits in
+  `ConfigurationSnippetResolver`, and `PromptSnippet::isHidden()` is
+  mapped for it. In the tool playground a forced snippet the
+  configuration already selects by tag is no longer added a second time.
+  The composed prompt is passed to `ContextWindowManagerInterface::fit()`
+  by `ToolLoopService` and `ConversationService` (new optional
+  `$effectiveSystemPrompt` argument, defaulting to the previous
+  behaviour), so the ADR-107 budget counts the snippet block that goes on
+  the wire.
 
 ## [0.26.0] - 2026-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- A configuration can attach prompt snippets by tag
+  (`tx_nrllm_configuration.snippet_tags`, amendment to ADR-031). The
+  active snippets carrying any selected tag are composed into the
+  configuration's effective system prompt, so they reach chat,
+  completion, streaming and the agent loop through one insertion point
+  in `ConfigurationCallPlanner::callOptions()`. Before this the snippet
+  library reached no production prompt at all — its only consumers were
+  the tool playground's forced snippets and the codec that rehydrates
+  them. The select lists the tags the snippet records actually carry, so
+  the vocabulary stays consumer-owned; a snippet carrying two selected
+  tags is composed once, and an unknown tag yields nothing rather than
+  an error. Configurations without tags are unaffected. The `@api`
+  surface gains `LlmConfiguration::getSnippetTags()`,
+  `setSnippetTags()` and `getSnippetTagList()` (additive).
+
 ## [0.26.0] - 2026-08-06
 
 ### Added

--- a/Classes/Domain/Model/LlmConfiguration.php
+++ b/Classes/Domain/Model/LlmConfiguration.php
@@ -88,6 +88,14 @@ class LlmConfiguration extends AbstractEntity
      */
     protected string $allowedGuardrails = '';
 
+    /**
+     * Comma list of prompt-snippet tags (ADR-031); empty = no snippets.
+     * The active snippets carrying any of these tags are composed into the
+     * effective system prompt. See {@see getSnippetTagList()} and
+     * ConfigurationSnippetResolver.
+     */
+    protected string $snippetTags = '';
+
     protected int $maxRequestsPerDay = 0;
 
     protected int $maxTokensPerDay = 0;
@@ -868,6 +876,40 @@ class LlmConfiguration extends AbstractEntity
             $id = trim($id);
             if ($id !== '') {
                 $list[] = $id;
+            }
+        }
+
+        return $list;
+    }
+
+    public function getSnippetTags(): string
+    {
+        return $this->snippetTags;
+    }
+
+    public function setSnippetTags(string $snippetTags): void
+    {
+        $this->snippetTags = $snippetTags;
+    }
+
+    /**
+     * The selected prompt-snippet tags, normalized the same way
+     * {@see PromptSnippet::getTagList()} normalizes a snippet's own tags:
+     * trimmed, lowercased, empty entries dropped, duplicates removed. Empty
+     * list = no snippets are composed into the system prompt.
+     *
+     * Normalizing here (rather than in the resolver) keeps the tag comparison
+     * case-insensitive on both sides, which is what ADR-031 promises.
+     *
+     * @return list<string>
+     */
+    public function getSnippetTagList(): array
+    {
+        $list = [];
+        foreach (explode(',', $this->snippetTags) as $tag) {
+            $tag = strtolower(trim($tag));
+            if ($tag !== '' && !in_array($tag, $list, true)) {
+                $list[] = $tag;
             }
         }
 

--- a/Classes/Domain/Model/PromptSnippet.php
+++ b/Classes/Domain/Model/PromptSnippet.php
@@ -45,6 +45,15 @@ class PromptSnippet extends AbstractEntity
 
     protected bool $isActive = true;
 
+    /**
+     * The TCA enable column (`enablecolumns.disabled`), mapped so a reader can
+     * see it: {@see \Netresearch\NrLlm\Service\Prompt\ConfigurationSnippetResolver}
+     * drops hidden snippets from a configuration's composed prompt. The
+     * repository keeps ignoring enable fields (the backend module lists hidden
+     * records), so the filter has to happen on the object.
+     */
+    protected bool $hidden = false;
+
     protected int $sorting = 0;
 
     // Getters
@@ -94,6 +103,11 @@ class PromptSnippet extends AbstractEntity
         return $this->getIsActive();
     }
 
+    public function isHidden(): bool
+    {
+        return $this->hidden;
+    }
+
     public function getSorting(): int
     {
         return $this->sorting;
@@ -134,6 +148,11 @@ class PromptSnippet extends AbstractEntity
     public function setIsActive(bool $isActive): void
     {
         $this->isActive = $isActive;
+    }
+
+    public function setHidden(bool $hidden): void
+    {
+        $this->hidden = $hidden;
     }
 
     public function setSorting(int $sorting): void

--- a/Classes/Form/Tca/SnippetTagItems.php
+++ b/Classes/Form/Tca/SnippetTagItems.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Form\Tca;
+
+use Doctrine\DBAL\Exception;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * TCA itemsProcFunc listing the prompt-snippet tags actually in use for the
+ * `snippet_tags` select on tx_nrllm_configuration (ADR-031).
+ *
+ * The tag vocabulary is free-form and consumer-owned, so the list is derived
+ * from the snippet records rather than from an enum — a new fragment kind needs
+ * no nr_llm release. Tags are read straight from the table (not through the
+ * Extbase repository): an itemsProcFunc runs inside FormEngine, where no
+ * Extbase context is guaranteed.
+ *
+ * Tags are normalized the same way {@see \Netresearch\NrLlm\Domain\Model\PromptSnippet::getTagList()}
+ * normalizes them — trimmed and lowercased — so what an editor picks matches
+ * what the runtime compares. Values already stored on the record but no longer
+ * carried by any snippet are appended so the stored selection stays visible and
+ * editable rather than silently dropped.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
+final class SnippetTagItems
+{
+    /**
+     * @param array{items: array<int, array{label: string, value: string}>, row?: array<string, mixed>} $params
+     */
+    public function addItems(array &$params): void
+    {
+        $tags = [];
+        foreach ($this->tagsInUse() as $tag) {
+            $tags[$tag] = true;
+        }
+
+        ksort($tags);
+
+        // Keep already-stored but currently unused tags selectable.
+        $row    = is_array($params['row'] ?? null) ? $params['row'] : [];
+        $stored = $row['snippet_tags'] ?? '';
+        if (is_array($stored)) {
+            $stored = implode(',', array_map(
+                static fn(mixed $value): string => is_scalar($value) ? (string)$value : '',
+                $stored,
+            ));
+        } elseif (!is_scalar($stored)) {
+            $stored = '';
+        } else {
+            $stored = (string)$stored;
+        }
+
+        foreach (GeneralUtility::trimExplode(',', $stored, true) as $known) {
+            $tags[strtolower($known)] ??= true;
+        }
+
+        foreach (array_keys($tags) as $tag) {
+            $params['items'][] = ['label' => $tag, 'value' => $tag];
+        }
+    }
+
+    /**
+     * Every tag token carried by a non-deleted snippet, normalized.
+     *
+     * A database error yields an empty list rather than a broken edit form:
+     * the field must stay usable (the stored selection is still appended
+     * above) when the snippet table cannot be read.
+     *
+     * @return list<string>
+     */
+    private function tagsInUse(): array
+    {
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('tx_nrllm_promptsnippet');
+        $queryBuilder->getRestrictions()->removeAll()->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+
+        try {
+            $rows = $queryBuilder
+                ->select('tags')
+                ->from('tx_nrllm_promptsnippet')
+                ->executeQuery()
+                ->fetchFirstColumn();
+        } catch (Exception) {
+            return [];
+        }
+
+        $tags = [];
+        foreach ($rows as $row) {
+            if (!is_string($row)) {
+                continue;
+            }
+
+            foreach (explode(',', $row) as $tag) {
+                $tag = strtolower(trim($tag));
+                if ($tag !== '') {
+                    $tags[] = $tag;
+                }
+            }
+        }
+
+        return array_values(array_unique($tags));
+    }
+}

--- a/Classes/Service/ConfigurationCallPlanner.php
+++ b/Classes/Service/ConfigurationCallPlanner.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
+use Netresearch\NrLlm\Service\Prompt\ConfigurationSnippetResolver;
 
 /**
  * Plans a configuration-driven call: which Model, which adapter, which
@@ -35,6 +36,7 @@ final readonly class ConfigurationCallPlanner
     public function __construct(
         private ProviderAdapterRegistryInterface $adapterRegistry,
         private ?ModelSelectionServiceInterface $modelSelectionService = null,
+        private ?ConfigurationSnippetResolver $snippetResolver = null,
     ) {}
 
     /**
@@ -95,6 +97,8 @@ final readonly class ConfigurationCallPlanner
         $options = array_merge($config->toOptionsArray(), $optionOverrides);
         unset($options['provider']);
 
+        $options = $this->withSnippetTags($options, $config);
+
         // An explicit non-positive max_tokens override means "unset" too —
         // passing 0 through would fail provider-side validation.
         if (!isset($options['max_tokens']) || (is_int($options['max_tokens']) && $options['max_tokens'] <= 0)) {
@@ -104,6 +108,45 @@ final readonly class ConfigurationCallPlanner
                 unset($options['max_tokens']);
             }
         }
+
+        return $options;
+    }
+
+    /**
+     * Compose the configuration's tag-selected prompt snippets (ADR-031) into
+     * the merged call options' `system_prompt`.
+     *
+     * This is the single insertion point that reaches chat, completion,
+     * streaming and the agent loop: every configuration-driven entry point on
+     * {@see LlmServiceManager} builds its options here, and the value is read
+     * downstream by {@see MessageShaper::applySystemPrompt()} for the message
+     * paths and by {@see \Netresearch\NrLlm\Provider\AbstractProvider::complete()}
+     * for the single-prompt path.
+     *
+     * The snippets are appended to whatever system prompt is effective AFTER
+     * the per-call overrides are merged, so a caller-supplied system prompt
+     * still wins on the text while the configuration's editorial context is
+     * kept. A configuration without tags returns the options untouched.
+     *
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>
+     */
+    private function withSnippetTags(array $options, LlmConfiguration $config): array
+    {
+        if (!$this->snippetResolver instanceof ConfigurationSnippetResolver) {
+            return $options;
+        }
+
+        $current = $options['system_prompt'] ?? '';
+        $current = is_string($current) ? $current : '';
+
+        $effective = $this->snippetResolver->appendTo($current, $config);
+        if ($effective === $current) {
+            return $options;
+        }
+
+        $options['system_prompt'] = $effective;
 
         return $options;
     }

--- a/Classes/Service/Context/ContextWindowManager.php
+++ b/Classes/Service/Context/ContextWindowManager.php
@@ -56,6 +56,7 @@ final class ContextWindowManager implements ContextWindowManagerInterface
         ?ChatOptions $options,
         ?UsageStatistics $lastUsage,
         array $toolSpecs = [],
+        ?string $effectiveSystemPrompt = null,
     ): ContextFitResult {
         // A null $lastUsage marks the first send of a run's loop. Reset the
         // per-run calibration state here so a single shared manager instance
@@ -84,7 +85,7 @@ final class ContextWindowManager implements ContextWindowManagerInterface
         // The system prompt is prepended by MessageShaper AFTER fit() on the
         // public path (ADR-093), so when the transcript has no leading system
         // message its size must still be counted against the wire.
-        $systemPromptTokens = $this->missingSystemPromptTokens($messages, $configuration);
+        $systemPromptTokens = $this->missingSystemPromptTokens($messages, $configuration, $effectiveSystemPrompt);
         $estimate = function (array $msgs) use ($toolSpecs, $systemPromptTokens): int {
             /** @var list<ChatMessage|array<string, mixed>> $msgs the caller always passes the partitioned transcript */
             return $this->estimator->estimate($msgs, $toolSpecs, $this->calibration) + $systemPromptTokens;
@@ -140,15 +141,24 @@ final class ContextWindowManager implements ContextWindowManagerInterface
     }
 
     /**
+     * The prompt that will be prepended, not the one the entity stores: the
+     * caller composes per-call overrides and the configuration's tag-selected
+     * snippets (ADR-031) into it before the send, so re-deriving it from the
+     * entity here would under-count the wire by exactly that block. Callers
+     * that have nothing to compose pass null and get the entity's prompt.
+     *
      * @param list<ChatMessage|array<string, mixed>> $messages
      */
-    private function missingSystemPromptTokens(array $messages, LlmConfiguration $configuration): int
-    {
+    private function missingSystemPromptTokens(
+        array $messages,
+        LlmConfiguration $configuration,
+        ?string $effectiveSystemPrompt,
+    ): int {
         if (isset($messages[0]) && $this->roleOf($messages[0]) === 'system') {
             return 0;
         }
 
-        $systemPrompt = $configuration->getSystemPrompt();
+        $systemPrompt = $effectiveSystemPrompt ?? $configuration->getSystemPrompt();
         if ($systemPrompt === '') {
             return 0;
         }

--- a/Classes/Service/Context/ContextWindowManagerInterface.php
+++ b/Classes/Service/Context/ContextWindowManagerInterface.php
@@ -34,8 +34,9 @@ interface ContextWindowManagerInterface
      * it (even the floor overflows).
      *
      * @param list<ChatMessage|array<string, mixed>> $messages
-     * @param list<array<string, mixed>>             $toolSpecs the tool schemas on the wire for THIS send; empty for a plain completion
-     * @param UsageStatistics|null                   $lastUsage the previous call's usage, to calibrate the estimator; null before the first call
+     * @param list<array<string, mixed>>             $toolSpecs             the tool schemas on the wire for THIS send; empty for a plain completion
+     * @param UsageStatistics|null                   $lastUsage             the previous call's usage, to calibrate the estimator; null before the first call
+     * @param string|null                            $effectiveSystemPrompt the system prompt the caller will actually put on the wire when the transcript carries none — the configuration's prompt AFTER per-call overrides and composed snippets (ADR-031). Null means "derive it from the configuration", the pre-composition behaviour.
      */
     public function fit(
         array $messages,
@@ -43,5 +44,6 @@ interface ContextWindowManagerInterface
         ?ChatOptions $options,
         ?UsageStatistics $lastUsage,
         array $toolSpecs = [],
+        ?string $effectiveSystemPrompt = null,
     ): ContextFitResult;
 }

--- a/Classes/Service/Feature/ConversationService.php
+++ b/Classes/Service/Feature/ConversationService.php
@@ -23,6 +23,7 @@ use Netresearch\NrLlm\Service\ConfigurationResolver;
 use Netresearch\NrLlm\Service\Context\ContextWindowManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
+use Netresearch\NrLlm\Service\Prompt\ConfigurationSnippetResolver;
 use Netresearch\NrLlm\Service\Session\AiSessionRepositoryInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -58,6 +59,11 @@ final readonly class ConversationService implements ConversationServiceInterface
         // absent it a conversation grows unbounded exactly as before.
         private ?ContextWindowManagerInterface $contextWindow = null,
         private ?LoggerInterface $logger = null,
+        // Only reader: the effective system prompt handed to the context
+        // window below. The manager composes the configuration's tag-selected
+        // snippets (ADR-031) into the prompt it sends, so the estimate has to
+        // know about them or it budgets for a smaller message than it sends.
+        private ?ConfigurationSnippetResolver $snippetResolver = null,
     ) {}
 
     public function startSession(AiActorContext $actor, string $title = '', ?LlmConfiguration $configuration = null): AiSession
@@ -124,7 +130,18 @@ final readonly class ConversationService implements ConversationServiceInterface
             // lastUsage is null: each turn is a fresh assembly, so the
             // manager's calibration starts from its seed rather than carrying a
             // ratio over from an unrelated turn.
-            $fit          = $this->contextWindow->fit($messages, $configuration, $options, null, []);
+            // The effective system prompt only matters when this turn carries
+            // no system message of its own; then the manager prepends the
+            // configuration's prompt WITH its composed snippets, and that is
+            // what has to be counted.
+            $fit = $this->contextWindow->fit(
+                $messages,
+                $configuration,
+                $options,
+                null,
+                [],
+                $this->snippetResolver?->appendTo($configuration->getSystemPrompt(), $configuration),
+            );
             $messages     = $fit->messages;
             $droppedTurns = $fit->droppedTurns;
 

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -33,6 +33,7 @@ use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Service\Option\EmbeddingOptions;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Option\VisionOptions;
+use Netresearch\NrLlm\Service\Prompt\ConfigurationSnippetResolver;
 use Netresearch\NrLlm\Service\Skill\SkillInjectionService;
 use Netresearch\NrLlm\Service\Streaming\StreamingDispatcher;
 use TYPO3\CMS\Core\SingletonInterface;
@@ -59,12 +60,17 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         // nothing to screen, which is honest; a null screener meant "screening
         // was requested and skipped", which was not.
         private InputGuardrailScreener $inputScreener = new InputGuardrailScreener([]),
+        // Composes a configuration's tag-selected prompt snippets (ADR-031)
+        // into the effective system prompt. Optional so the unit-test
+        // constructions that omit it keep the pre-snippet behaviour verbatim;
+        // production wiring is autowired.
+        private ?ConfigurationSnippetResolver $snippetResolver = null,
     ) {
         // Built here from the manager's own dependencies, not injected: the
         // constructor signature is pinned by the shared test factory, and both
         // are implementation details of this facade's dispatch (ADR-059
         // stage 2).
-        $this->planner  = new ConfigurationCallPlanner($this->adapterRegistry, $this->modelSelectionService);
+        $this->planner  = new ConfigurationCallPlanner($this->adapterRegistry, $this->modelSelectionService, $this->snippetResolver);
         $this->metadata = new CallMetadataFactory();
     }
 

--- a/Classes/Service/Prompt/ConfigurationSnippetResolver.php
+++ b/Classes/Service/Prompt/ConfigurationSnippetResolver.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Prompt;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\PromptSnippet;
+use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
+
+/**
+ * Composes the snippets a configuration selects by tag (ADR-031, extended by
+ * ADR-139) onto the effective system prompt.
+ *
+ * This is the only reader that turns a stored `snippet_tags` selection into
+ * prompt text. It appends rather than prepends: the configuration's own system
+ * prompt keeps the lead, and the snippet block is the editorial context added
+ * behind it. Composing into the system prompt — instead of emitting extra
+ * system messages — is what keeps the assembly order pinned by #637 intact:
+ * a second system message ahead of the configuration's prompt would satisfy
+ * {@see \Netresearch\NrLlm\Service\MessageShaper::applySystemPrompt()}'s guard
+ * and silently drop that prompt from the run.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
+final readonly class ConfigurationSnippetResolver
+{
+    public function __construct(
+        private PromptSnippetRepository $promptSnippetRepository,
+        private PromptSnippetComposer $promptSnippetComposer,
+    ) {}
+
+    /**
+     * Append the configuration's tag-selected snippets to the given system
+     * prompt.
+     *
+     * Returns `$systemPrompt` unchanged when the configuration selects no tags,
+     * when no active snippet carries any of them (an unknown tag is empty, not
+     * an error), or when every matching snippet has empty text — so a
+     * configuration without tags behaves byte-identically to before the field
+     * existed.
+     */
+    public function appendTo(string $systemPrompt, LlmConfiguration $configuration): string
+    {
+        $block = $this->compose($configuration);
+        if ($block === '') {
+            return $systemPrompt;
+        }
+
+        return $systemPrompt === '' ? $block : $systemPrompt . "\n\n" . $block;
+    }
+
+    /**
+     * Render the selected snippets as labeled blocks, in tag-selection order
+     * and, within a tag, in the repository's own order (sorting, then name).
+     *
+     * A snippet carrying two selected tags is rendered once:
+     * {@see PromptSnippetRepository::findActiveByTag()} filters in PHP over all
+     * active snippets, so the same record comes back from every matching tag.
+     * The dedup key is the snippet identifier, falling back to the uid for
+     * records that carry none.
+     */
+    private function compose(LlmConfiguration $configuration): string
+    {
+        $blocks = [];
+        $seen   = [];
+
+        foreach ($configuration->getSnippetTagList() as $tag) {
+            foreach ($this->promptSnippetRepository->findActiveByTag($tag) as $snippet) {
+                $key = $this->dedupKey($snippet);
+                if (isset($seen[$key])) {
+                    continue;
+                }
+
+                $seen[$key] = true;
+
+                // One snippet per composer call: the composer keys its sections
+                // by label, so two snippets sharing a name would collide in a
+                // single call and one would be dropped.
+                $block = $this->promptSnippetComposer->composeSections([$snippet->getName() => $snippet]);
+                if ($block !== '') {
+                    $blocks[] = $block;
+                }
+            }
+        }
+
+        return implode("\n\n", $blocks);
+    }
+
+    private function dedupKey(PromptSnippet $snippet): string
+    {
+        $identifier = trim($snippet->getIdentifier());
+        if ($identifier !== '') {
+            return 'id:' . strtolower($identifier);
+        }
+
+        return 'uid:' . ($snippet->getUid() ?? spl_object_id($snippet));
+    }
+}

--- a/Classes/Service/Prompt/ConfigurationSnippetResolver.php
+++ b/Classes/Service/Prompt/ConfigurationSnippetResolver.php
@@ -64,6 +64,14 @@ final readonly class ConfigurationSnippetResolver
      * active snippets, so the same record comes back from every matching tag.
      * The dedup key is the snippet identifier, falling back to the uid for
      * records that carry none.
+     *
+     * Hidden records are dropped here rather than in the repository: every
+     * repository in this extension ignores enable fields on purpose (the
+     * backend modules list hidden records, and `is_active` is the runtime
+     * switch), so the query must keep returning them. Editorial and operational
+     * roles are separate, though — an editor who hides a snippet in the list
+     * module must not keep shipping it into every production prompt — so the
+     * one reader that turns snippets into prompt text filters them out.
      */
     private function compose(LlmConfiguration $configuration): string
     {
@@ -72,6 +80,10 @@ final readonly class ConfigurationSnippetResolver
 
         foreach ($configuration->getSnippetTagList() as $tag) {
             foreach ($this->promptSnippetRepository->findActiveByTag($tag) as $snippet) {
+                if ($snippet->isHidden()) {
+                    continue;
+                }
+
                 $key = $this->dedupKey($snippet);
                 if (isset($seen[$key])) {
                     continue;

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -100,9 +100,11 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         // the byte caps can be absent (ADR-120's pattern).
         private ToolResultBounder $bounder = new ToolResultBounder(),
         // Composes the configuration's tag-selected snippets (ADR-031) into the
-        // system prompt this service bakes for an augmented run. Must be the
-        // same value the manager's planner composes, or the addition would be
-        // missing in exactly the place that inspects it — the playground.
+        // system prompt this service bakes for an augmented run, and into the
+        // prompt size the context-window estimate budgets for. Must be the same
+        // value the manager's planner composes, or the addition would be missing
+        // in exactly the place that inspects it — the playground — and the
+        // budget would be short by the snippet block on every production run.
         private ?ConfigurationSnippetResolver $snippetResolver = null,
     ) {}
 
@@ -412,7 +414,14 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
             return $messages;
         }
 
-        $fit = $this->contextWindow->fit($messages, $configuration, $options, $lastUsage, $toolSpecs);
+        $fit = $this->contextWindow->fit(
+            $messages,
+            $configuration,
+            $options,
+            $lastUsage,
+            $toolSpecs,
+            $this->effectiveSystemPrompt($configuration, $options),
+        );
 
         if ($fit->overflowAtFloor) {
             throw ContextTruncatedException::fromFit($fit);
@@ -675,18 +684,28 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         // The same composition the manager's planner applies, so the playground
         // shows the prompt a live run sends rather than one without the
         // configuration's snippets.
-        $override = $options?->getSystemPrompt() ?? '';
-        $system   = $override !== '' ? $override : $configuration->getSystemPrompt();
-        $system   = $this->snippetResolver?->appendTo($system, $configuration) ?? $system;
+        $system = $this->effectiveSystemPrompt($configuration, $options);
         if ($system !== '') {
             $lead[] = ChatMessage::system($system);
         }
 
         foreach ($augmentation->forcedSnippets as $snippet) {
             $text = $this->snippetComposer?->composeSections([$snippet->getName() => $snippet]) ?? '';
-            if ($text !== '') {
-                $lead[] = ChatMessage::system($text);
+            if ($text === '') {
+                continue;
             }
+
+            // A forced snippet the configuration already selects by tag is
+            // composed into $system above, by the same stateless composer and
+            // therefore byte-identically. Emitting it again would put the same
+            // instruction in the prompt twice — the resolver's identifier dedup
+            // never sees the forced list, so the containment check is what
+            // spans both sources.
+            if ($system !== '' && str_contains($system, $text)) {
+                continue;
+            }
+
+            $lead[] = ChatMessage::system($text);
         }
 
         if ($lead !== []) {
@@ -694,6 +713,25 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         }
 
         return [$messages, $augmentation->dryRun];
+    }
+
+    /**
+     * The system prompt this run actually puts on the wire: the per-call
+     * override wins over the configuration's own text, and the configuration's
+     * tag-selected snippets (ADR-031) follow it — the same composition
+     * {@see \Netresearch\NrLlm\Service\ConfigurationCallPlanner::callOptions()}
+     * applies on the manager side.
+     *
+     * Two readers: the playground bake site in {@see self::assemble()} and the
+     * context-window estimate in {@see self::enforceContextWindow()}, which
+     * would otherwise budget for a prompt smaller than the one sent.
+     */
+    private function effectiveSystemPrompt(LlmConfiguration $configuration, ?ToolOptions $options): string
+    {
+        $override = $options?->getSystemPrompt() ?? '';
+        $system   = $override !== '' ? $override : $configuration->getSystemPrompt();
+
+        return $this->snippetResolver?->appendTo($system, $configuration) ?? $system;
     }
 
     private function elapsedMs(int $startNs): float

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -29,6 +29,7 @@ use Netresearch\NrLlm\Service\Context\ContextWindowManagerInterface;
 use Netresearch\NrLlm\Service\Governance\GovernanceEventRepositoryInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Netresearch\NrLlm\Service\Prompt\ConfigurationSnippetResolver;
 use Netresearch\NrLlm\Service\Prompt\PromptSnippetComposer;
 use Netresearch\NrLlm\Service\Schema\JsonSchemaValidator;
 use Netresearch\NrLlm\Service\Skill\SkillInjectionService;
@@ -98,6 +99,11 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         // stateless and has no constructor, so there is no wiring under which
         // the byte caps can be absent (ADR-120's pattern).
         private ToolResultBounder $bounder = new ToolResultBounder(),
+        // Composes the configuration's tag-selected snippets (ADR-031) into the
+        // system prompt this service bakes for an augmented run. Must be the
+        // same value the manager's planner composes, or the addition would be
+        // missing in exactly the place that inspects it — the playground.
+        private ?ConfigurationSnippetResolver $snippetResolver = null,
     ) {}
 
     /**
@@ -666,8 +672,12 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         // the snippet system messages below would satisfy the manager's "a
         // system message already exists" guard and suppress the configuration
         // system prompt for the run.
+        // The same composition the manager's planner applies, so the playground
+        // shows the prompt a live run sends rather than one without the
+        // configuration's snippets.
         $override = $options?->getSystemPrompt() ?? '';
         $system   = $override !== '' ? $override : $configuration->getSystemPrompt();
+        $system   = $this->snippetResolver?->appendTo($system, $configuration) ?? $system;
         if ($system !== '') {
             $lead[] = ChatMessage::system($system);
         }

--- a/Configuration/TCA/tx_nrllm_configuration.php
+++ b/Configuration/TCA/tx_nrllm_configuration.php
@@ -8,6 +8,7 @@
 declare(strict_types=1);
 
 use Netresearch\NrLlm\Form\Tca\GuardrailItems;
+use Netresearch\NrLlm\Form\Tca\SnippetTagItems;
 use Netresearch\NrLlm\Form\Tca\ToolGroupItems;
 
 return [
@@ -39,6 +40,7 @@ return [
                 --div--;LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tab.parameters,
                     --palette--;;parameters,
                     system_prompt,
+                    snippet_tags,
                     skills,
                     options,
                 --div--;LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tab.limits,
@@ -415,6 +417,16 @@ return [
                 'type' => 'select',
                 'renderType' => 'selectCheckBox',
                 'itemsProcFunc' => GuardrailItems::class . '->addItems',
+                'default' => '',
+            ],
+        ],
+        'snippet_tags' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_configuration.snippet_tags',
+            'description' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_configuration.snippet_tags.description',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectCheckBox',
+                'itemsProcFunc' => SnippetTagItems::class . '->addItems',
                 'default' => '',
             ],
         ],

--- a/Documentation/Administration/Configurations.rst
+++ b/Documentation/Administration/Configurations.rst
@@ -44,6 +44,13 @@ Adding a configuration manually
       The system message that sets the AI's behavior
       and context.
 
+   :guilabel:`Prompt snippet tags`
+      Optional. Active :ref:`prompt snippets
+      <administration-snippets-configuration>`
+      carrying any ticked tag are appended to the
+      system prompt of every request made with this
+      configuration.
+
 4. Optionally adjust temperature (0.0-2.0), top_p,
    frequency/presence penalty, max tokens, and
    use-case type (``chat``, ``completion``,

--- a/Documentation/Administration/PromptSnippets.rst
+++ b/Documentation/Administration/PromptSnippets.rst
@@ -80,6 +80,54 @@ text-to-speech voice:
 
     {"voice": "nova"}
 
+.. _administration-snippets-configuration:
+
+Attaching snippets to a configuration
+=====================================
+
+A configuration can select snippets by tag. Every
+request made with that configuration then carries
+them — chat, single-prompt completion, streaming and
+agent runs alike — without any extension code.
+
+1. Navigate to :guilabel:`Admin Tools > LLM >
+   Configurations` and edit a configuration.
+2. Open the :guilabel:`Parameters` tab.
+3. Tick the wanted tags under :guilabel:`Prompt
+   snippet tags`. The list offers the tags the
+   snippet records actually carry.
+4. Click :guilabel:`Save`.
+
+The active snippets carrying any ticked tag are
+appended to the configuration's
+:guilabel:`System Prompt`, each as a ``NAME:`` block
+separated by a blank line, in the order the tags are
+listed. A snippet carrying two ticked tags is added
+once. A tag no snippet carries adds nothing — there
+is no error, matching the free-tag model above.
+
+..  code-block:: text
+    :caption: Effective system prompt of a configuration with the tags ``persona`` and ``tone_of_voice``
+
+    You are a helpful assistant.
+
+    Nova persona:
+    You are Nova, a friendly expert.
+
+    Formal tone:
+    Use a formal, professional tone of voice.
+
+Two limits are worth knowing:
+
+- Only **active** snippets are composed; hiding a
+  snippet removes it from every configuration that
+  selects its tag.
+- A caller that supplies its own system message
+  replaces the configuration's system prompt for
+  that call, and with it the snippet block. This is
+  the documented per-call precedence and predates
+  this field.
+
 .. _administration-snippets-developer:
 
 Using snippets from an extension

--- a/Documentation/Administration/PromptSnippets.rst
+++ b/Documentation/Administration/PromptSnippets.rst
@@ -156,5 +156,13 @@ snippet as a ``LABEL:`` block followed by the
 snippet text, joined by blank lines. Null entries
 and empty snippets are skipped.
 
+:php:`findActiveByTag()` filters on ``is_active``
+only — like every repository here it ignores the
+enable fields, so **hidden** records are part of
+its result. Configurations drop them when they
+compose their prompt; an extension that queries
+directly has to skip :php:`isHidden()` snippets
+itself if it wants the same behaviour.
+
 See :ref:`ADR-031 <adr-031>` for the design
 rationale.

--- a/Documentation/Adr/Adr031PromptSnippetLibrary.rst
+++ b/Documentation/Adr/Adr031PromptSnippetLibrary.rst
@@ -113,7 +113,7 @@ leaves the list alone: the configuration's own system prompt would be
 dropped from the run, silently and with no error. The characterisation
 tests added with :ref:`ADR-139 <adr-139>` pin that behaviour.
 
-Three details follow from the code:
+These details follow from the code:
 
 - **Dedup is by snippet identifier.**
   :php:`PromptSnippetRepository::findActiveByTag()` loads all active
@@ -123,7 +123,27 @@ Three details follow from the code:
   referential integrity by design, so a typo degrades to "no snippets".
 - **The tool playground reads the same composed value.** Its bake site
   in :php:`ToolLoopService::assemble()` goes through the same resolver,
-  so a previewed transcript is the transcript a live run sends.
+  so a previewed transcript is the transcript a live run sends. A forced
+  snippet the configuration already selects by tag is composed once, not
+  twice: the resolver's identifier dedup never sees the forced list, so
+  the bake site skips a forced block its composed prompt already
+  contains.
+- **Hiding a snippet takes it out of every configuration.** The
+  repository ignores enable fields on purpose — the backend module lists
+  hidden records — so :php:`ConfigurationSnippetResolver` is where a
+  hidden record is dropped. ``is_active`` remains the operational
+  switch; ``hidden`` is the editorial one, and both now keep a snippet
+  out of a production prompt. This is the one place in the extension
+  where ``hidden`` decides a runtime outcome, because it is the one
+  place where an editor's list-module action would otherwise keep
+  shipping text to a provider.
+- **The composed block counts against the context window.** The prompt
+  is prepended after :php:`ContextWindowManagerInterface::fit()` has
+  run, so both callers (:php:`ToolLoopService` and
+  :php:`ConversationService`) hand the composed prompt to ``fit()``
+  instead of letting it re-read
+  :php:`LlmConfiguration::getSystemPrompt()` — otherwise the budget of
+  :ref:`ADR-107 <adr-107>` is short by exactly the snippet block.
 
 What this does not change: a caller-supplied system *message* still
 suppresses the configuration's system prompt — and with it the snippet

--- a/Documentation/Adr/Adr031PromptSnippetLibrary.rst
+++ b/Documentation/Adr/Adr031PromptSnippetLibrary.rst
@@ -75,6 +75,61 @@ Introduce a separate, lightweight :php:`PromptSnippet` entity
    list following the established Providers/Models/Tasks pattern;
    create/edit links into FormEngine, no custom forms.
 
+.. _adr-031-amendment-configuration:
+
+Amendment (2026-08-09): a configuration selects snippets by tag
+===============================================================
+
+Until this amendment the library had no reader in a production
+prompt. The only consumers were :php:`RunAugmentation::$forcedSnippets`
+and the codec that rehydrates it, and :php:`RunAugmentation` is
+constructed nowhere but the tool playground — so outside the playground
+the whole snippet system was inert, and the "consuming extension"
+of point 2 above was the only way a snippet ever reached a model.
+
+:ref:`ADR-139 <adr-139>` names a tagged snippet as the supported way to
+attach editorial context to a request. That needs a selection an
+operator can make. ``tx_nrllm_configuration.snippet_tags`` is it: a CSV
+of tags whose :php:`itemsProcFunc` lists the tags the snippet records
+actually carry, so the vocabulary stays consumer-owned and a new
+fragment kind still needs no nr_llm release.
+
+**The selection is composed into the effective system prompt, not into
+extra system messages.** :php:`ConfigurationSnippetResolver` appends the
+labeled blocks to the ``system_prompt`` that
+:php:`ConfigurationCallPlanner::callOptions()` has merged, behind the
+configuration's own prompt. One insertion point reaches chat,
+completion, streaming and the agent loop, because every
+configuration-driven entry point on :php:`LlmServiceManager` builds its
+options there.
+
+The alternative — rendering each snippet as its own leading system
+message, the shape the playground uses — was rejected. It only works in
+the playground because the loop bakes the configuration's system prompt
+ahead of the snippet messages first. Anywhere else a snippet system
+message would be the first system message in the list, which is exactly
+the condition under which :php:`MessageShaper::applySystemPrompt()`
+leaves the list alone: the configuration's own system prompt would be
+dropped from the run, silently and with no error. The characterisation
+tests added with :ref:`ADR-139 <adr-139>` pin that behaviour.
+
+Three details follow from the code:
+
+- **Dedup is by snippet identifier.**
+  :php:`PromptSnippetRepository::findActiveByTag()` loads all active
+  snippets and filters in PHP, so a snippet carrying two selected tags
+  comes back from both lookups and would otherwise be composed twice.
+- **An unknown tag is empty, not an error** — the free-tag model has no
+  referential integrity by design, so a typo degrades to "no snippets".
+- **The tool playground reads the same composed value.** Its bake site
+  in :php:`ToolLoopService::assemble()` goes through the same resolver,
+  so a previewed transcript is the transcript a live run sends.
+
+What this does not change: a caller-supplied system *message* still
+suppresses the configuration's system prompt — and with it the snippet
+block — because per-call precedence is decided before this composition
+is read. That is the pre-existing rule, not a new one.
+
 .. _adr-031-consequences:
 
 Consequences
@@ -93,3 +148,7 @@ Consequences
 - Two prompt-related entities now coexist. The split is intentional
   (template = complete prompt, snippet = fragment) and documented here,
   in the administration guide, and in both entities' PHPDoc.
+- Since the 2026-08-09 amendment an operator can attach snippets to a
+  configuration without writing any code, and every request made with
+  that configuration carries them — including requests from consuming
+  extensions that know nothing about snippets.

--- a/Resources/Private/Language/de.locallang_tca.xlf
+++ b/Resources/Private/Language/de.locallang_tca.xlf
@@ -302,6 +302,15 @@
                 <target>Welche optionalen Schutzmechanismen für Läufe mit dieser Konfiguration gelten. Leer = alle aktiv. Sicherheitskritische Schutzmechanismen (Schwärzung von Geheimnissen) laufen immer und werden hier nicht aufgeführt.</target>
             </trans-unit>
 
+            <trans-unit id="tx_nrllm_configuration.snippet_tags">
+                <source>Prompt snippet tags</source>
+                <target>Tags für Prompt-Bausteine</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_configuration.snippet_tags.description">
+                <source>Active prompt snippets carrying any of the selected tags are appended to this configuration's system prompt. Empty = no snippets. Tags are matched as whole tokens and case-insensitively, so "style" does not match "lifestyle".</source>
+                <target>Aktive Prompt-Bausteine mit einem der gewählten Tags werden an den System-Prompt dieser Konfiguration angehängt. Leer = keine Bausteine. Tags werden als ganze Token und ohne Beachtung der Groß-/Kleinschreibung verglichen, „style“ trifft also nicht „lifestyle“.</target>
+            </trans-unit>
+
             <trans-unit id="tx_nrllm_configuration.skills">
                 <source>Attached Skills</source>
                 <target>Zugewiesene Skills</target>

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -235,6 +235,13 @@
                 <source>Which optional guardrails apply to runs with this configuration. Empty = all apply. Security-critical guardrails (secret redaction) always run and are not listed here.</source>
             </trans-unit>
 
+            <trans-unit id="tx_nrllm_configuration.snippet_tags">
+                <source>Prompt snippet tags</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_configuration.snippet_tags.description">
+                <source>Active prompt snippets carrying any of the selected tags are appended to this configuration's system prompt. Empty = no snippets. Tags are matched as whole tokens and case-insensitively, so "style" does not match "lifestyle".</source>
+            </trans-unit>
+
             <trans-unit id="tx_nrllm_configuration.skills">
                 <source>Attached Skills</source>
             </trans-unit>

--- a/Tests/Functional/Fixtures/PromptSnippets.csv
+++ b/Tests/Functional/Fixtures/PromptSnippets.csv
@@ -9,3 +9,4 @@
 ,7,0,"tone-inactive","Inactive tone","An inactive snippet","tone_of_voice","This snippet is inactive.","",0,60,1703347200,1703347200,0,0
 ,8,0,"tone-deleted","Deleted tone","A deleted snippet","tone_of_voice","This snippet is deleted.","",1,70,1703347200,1703347200,1,0
 ,9,0,"persona-nova","Nova persona","A persona carrying voice metadata","persona","You are Nova, a friendly expert.","{""voice"":""nova""}",1,80,1703347200,1703347200,0,0
+,10,0,"persona-hidden","Hidden persona","An active but hidden persona","persona","You are the hidden persona.","",1,90,1703347200,1703347200,0,1

--- a/Tests/Functional/Form/Tca/SnippetTagItemsTest.php
+++ b/Tests/Functional/Form/Tca/SnippetTagItemsTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Form\Tca;
+
+use Netresearch\NrLlm\Form\Tca\SnippetTagItems;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The `snippet_tags` select lists the tags actually carried by snippet records
+ * (#638) — the vocabulary is consumer-owned (ADR-031), so it cannot come from
+ * an enum.
+ *
+ * Constructed the way FormEngine constructs it: no arguments. The class must
+ * stay constructor-less, because `GeneralUtility::callUserFunction()` resolves
+ * an itemsProcFunc through `makeInstance()` without arguments and the class is
+ * a private DI service.
+ */
+#[CoversClass(SnippetTagItems::class)]
+final class SnippetTagItemsTest extends AbstractFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importFixture('PromptSnippets.csv');
+    }
+
+    #[Test]
+    public function everyTagCarriedByASnippetIsOfferedOnceAndNormalized(): void
+    {
+        self::assertSame(
+            ['audience', 'image', 'layout', 'lifestyle', 'persona', 'style', 'tone_of_voice'],
+            $this->values(['items' => []]),
+        );
+    }
+
+    /**
+     * A stored tag no longer carried by any snippet stays selectable, so an
+     * editor sees (and can remove) it instead of losing it on the next save.
+     */
+    #[Test]
+    public function aStoredButUnusedTagStaysSelectable(): void
+    {
+        $values = $this->values(['items' => [], 'row' => ['snippet_tags' => 'Retired_Tag']]);
+
+        self::assertContains('retired_tag', $values);
+    }
+
+    /**
+     * A stored tag that IS in use must not be offered twice.
+     */
+    #[Test]
+    public function aStoredTagInUseIsNotDuplicated(): void
+    {
+        $values = $this->values(['items' => [], 'row' => ['snippet_tags' => 'persona']]);
+
+        self::assertCount(1, array_filter($values, static fn(string $v): bool => $v === 'persona'));
+    }
+
+    /**
+     * @param array{items: array<int, array{label: string, value: string}>, row?: array<string, mixed>} $params
+     *
+     * @return list<string>
+     */
+    private function values(array $params): array
+    {
+        (new SnippetTagItems())->addItems($params);
+
+        return array_values(array_map(
+            static fn(array $item): string => $item['value'],
+            $params['items'],
+        ));
+    }
+}

--- a/Tests/Functional/Service/ConfigurationSnippetTagsTest.php
+++ b/Tests/Functional/Service/ConfigurationSnippetTagsTest.php
@@ -1,0 +1,273 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\Provider;
+use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
+use Netresearch\NrLlm\Service\CacheManagerInterface;
+use Netresearch\NrLlm\Service\ConfigurationCallPlanner;
+use Netresearch\NrLlm\Service\ConfigurationResolver;
+use Netresearch\NrLlm\Service\EmbedCacheKeyBuilder;
+use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
+use Netresearch\NrLlm\Service\KeyedProviderRegistry;
+use Netresearch\NrLlm\Service\LlmServiceManager;
+use Netresearch\NrLlm\Service\MessageShaper;
+use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Netresearch\NrLlm\Service\Prompt\ConfigurationSnippetResolver;
+use Netresearch\NrLlm\Service\Prompt\PromptSnippetComposer;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use Netresearch\NrLlm\Tests\Functional\Service\Fixtures\RecordingPromptAdapter;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+/**
+ * A configuration's `snippet_tags` selection reaches the effective system
+ * prompt on every configuration-driven path (#638).
+ *
+ * This is the end-to-end proof that the snippet library (ADR-031) is no longer
+ * inert outside the tool playground: the real {@see PromptSnippetRepository}
+ * runs against the real snippet table, and the composed prompt is asserted at
+ * the provider boundary — where a live call would read it.
+ *
+ * The snippets come from `PromptSnippets.csv`; `style-minimalist` is tagged
+ * " Style , image" there, which also exercises the normalisation on the
+ * snippet side, and `layout-lifestyle` carries `lifestyle`, which the tag
+ * `style` must never reach.
+ */
+#[CoversClass(LlmServiceManager::class)]
+#[CoversClass(ConfigurationCallPlanner::class)]
+#[CoversClass(ConfigurationSnippetResolver::class)]
+final class ConfigurationSnippetTagsTest extends AbstractFunctionalTestCase
+{
+    private const SYSTEM_PROMPT = 'You are the configured assistant.';
+
+    private const MINIMALIST_BLOCK = "Minimalist style:\nUse a minimalist visual style.";
+
+    private RecordingPromptAdapter $adapter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importFixture('PromptSnippets.csv');
+
+        $this->adapter = new RecordingPromptAdapter();
+    }
+
+    #[Test]
+    public function aSelectedTagReachesTheSystemMessageOnTheChatPath(): void
+    {
+        $this->manager()->chatWithConfiguration(
+            [['role' => 'user', 'content' => 'Describe the product.']],
+            $this->configuration('style'),
+        );
+
+        self::assertSame(
+            self::SYSTEM_PROMPT . "\n\n" . self::MINIMALIST_BLOCK,
+            $this->adapter->recordedSystemMessage(),
+        );
+    }
+
+    /**
+     * The single-prompt completion path hands the provider a bare string, so
+     * the effective system prompt travels in the options; the provider base
+     * class turns it into the leading system message
+     * ({@see \Netresearch\NrLlm\Provider\AbstractProvider::complete()}).
+     */
+    #[Test]
+    public function aSelectedTagReachesTheOptionsOnTheCompletionPath(): void
+    {
+        $this->manager()->completeWithConfiguration('Describe the product.', $this->configuration('style'));
+
+        self::assertSame('Describe the product.', $this->adapter->recordedPrompt);
+        self::assertSame(
+            self::SYSTEM_PROMPT . "\n\n" . self::MINIMALIST_BLOCK,
+            $this->adapter->recordedSystemPromptOption(),
+        );
+    }
+
+    #[Test]
+    public function aSelectedTagReachesTheSystemMessageOnTheStreamingPath(): void
+    {
+        iterator_to_array($this->manager()->streamChatWithConfiguration(
+            [['role' => 'user', 'content' => 'Describe the product.']],
+            $this->configuration('style'),
+        ));
+
+        self::assertSame(
+            self::SYSTEM_PROMPT . "\n\n" . self::MINIMALIST_BLOCK,
+            $this->adapter->recordedSystemMessage(),
+        );
+    }
+
+    /**
+     * The agent loop's only provider call is
+     * `chatWithToolsForConfiguration()`, so covering that entry point covers
+     * the loop.
+     */
+    #[Test]
+    public function aSelectedTagReachesTheSystemMessageOnTheAgentLoopPath(): void
+    {
+        $this->manager()->chatWithToolsForConfiguration(
+            [['role' => 'user', 'content' => 'Describe the product.']],
+            [ToolSpec::function('noop', 'Does nothing', ['type' => 'object', 'properties' => []])],
+            $this->configuration('style'),
+            ToolOptions::auto(),
+        );
+
+        self::assertSame(
+            self::SYSTEM_PROMPT . "\n\n" . self::MINIMALIST_BLOCK,
+            $this->adapter->recordedSystemMessage(),
+        );
+    }
+
+    /**
+     * An unknown tag is empty, not an error: the call goes through and the
+     * system prompt is exactly the configuration's own.
+     */
+    #[Test]
+    public function anUnknownTagYieldsTheUnchangedSystemPromptAndNoError(): void
+    {
+        $this->manager()->chatWithConfiguration(
+            [['role' => 'user', 'content' => 'Describe the product.']],
+            $this->configuration('no_such_tag'),
+        );
+
+        self::assertSame(self::SYSTEM_PROMPT, $this->adapter->recordedSystemMessage());
+    }
+
+    /**
+     * The token boundary of ADR-031, end to end: the tag `style` selects
+     * `style-minimalist` and never the snippet tagged `lifestyle`.
+     */
+    #[Test]
+    public function theTagStyleDoesNotReachTheSnippetTaggedLifestyle(): void
+    {
+        $this->manager()->chatWithConfiguration(
+            [['role' => 'user', 'content' => 'Describe the product.']],
+            $this->configuration('style'),
+        );
+
+        $systemMessage = $this->adapter->recordedSystemMessage();
+        self::assertIsString($systemMessage);
+        self::assertStringContainsString('Use a minimalist visual style.', $systemMessage);
+        self::assertStringNotContainsString('lifestyle magazine spread', $systemMessage);
+    }
+
+    /**
+     * `style-minimalist` carries both `style` and `image`; selecting both must
+     * compose it once.
+     */
+    #[Test]
+    public function aSnippetCarryingTwoSelectedTagsIsComposedOnce(): void
+    {
+        $this->manager()->chatWithConfiguration(
+            [['role' => 'user', 'content' => 'Describe the product.']],
+            $this->configuration('style,image'),
+        );
+
+        $systemMessage = $this->adapter->recordedSystemMessage();
+        self::assertIsString($systemMessage);
+        self::assertSame(1, substr_count($systemMessage, 'Use a minimalist visual style.'));
+    }
+
+    /**
+     * Inactive and deleted snippets stay out — the resolver goes through
+     * `findActiveByTag()`, which the fixture's `tone-inactive` and
+     * `tone-deleted` rows exercise.
+     */
+    #[Test]
+    public function inactiveAndDeletedSnippetsAreNotComposed(): void
+    {
+        $this->manager()->chatWithConfiguration(
+            [['role' => 'user', 'content' => 'Describe the product.']],
+            $this->configuration('tone_of_voice'),
+        );
+
+        $systemMessage = $this->adapter->recordedSystemMessage();
+        self::assertIsString($systemMessage);
+        self::assertStringContainsString('Use a formal, professional tone of voice.', $systemMessage);
+        self::assertStringContainsString('Write in a relaxed, casual tone.', $systemMessage);
+        self::assertStringNotContainsString('This snippet is inactive.', $systemMessage);
+        self::assertStringNotContainsString('This snippet is deleted.', $systemMessage);
+    }
+
+    /**
+     * The regression guard: a configuration that selects no tags sends the
+     * system prompt it always sent.
+     */
+    #[Test]
+    public function aConfigurationWithoutTagsSendsTheUnchangedSystemPrompt(): void
+    {
+        $this->manager()->chatWithConfiguration(
+            [['role' => 'user', 'content' => 'Describe the product.']],
+            $this->configuration(''),
+        );
+
+        self::assertSame(self::SYSTEM_PROMPT, $this->adapter->recordedSystemMessage());
+    }
+
+    /**
+     * A manager wired exactly as production wires it — the real snippet
+     * repository from the container, the real composer — with only the adapter
+     * registry replaced so no HTTP happens.
+     */
+    private function manager(): LlmServiceManager
+    {
+        $repository = $this->get(PromptSnippetRepository::class);
+        self::assertInstanceOf(PromptSnippetRepository::class, $repository);
+
+        $adapterRegistry = $this->createMock(ProviderAdapterRegistryInterface::class);
+        $adapterRegistry->method('createAdapterFromModel')->willReturn($this->adapter);
+
+        $extensionConfiguration = self::createStub(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn(['providers' => []]);
+
+        return new LlmServiceManager(
+            $adapterRegistry,
+            new MiddlewarePipeline([]),
+            new KeyedProviderRegistry($extensionConfiguration, new NullLogger()),
+            new ConfigurationResolver(),
+            new MessageShaper(),
+            new EmbedCacheKeyBuilder(self::createStub(CacheManagerInterface::class)),
+            null,
+            null,
+            null,
+            new InputGuardrailScreener([]),
+            new ConfigurationSnippetResolver($repository, new PromptSnippetComposer()),
+        );
+    }
+
+    private function configuration(string $snippetTags): LlmConfiguration
+    {
+        $provider = new Provider();
+        $provider->setIdentifier('recording-prompt-fake');
+        $provider->setAdapterType('openai');
+
+        $model = new Model();
+        $model->setModelId('recording-model');
+        $model->setProvider($provider);
+
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('snippet-tags');
+        $configuration->setLlmModel($model);
+        $configuration->setSystemPrompt(self::SYSTEM_PROMPT);
+        $configuration->setSnippetTags($snippetTags);
+
+        return $configuration;
+    }
+}

--- a/Tests/Functional/Service/ConfigurationSnippetTagsTest.php
+++ b/Tests/Functional/Service/ConfigurationSnippetTagsTest.php
@@ -207,6 +207,28 @@ final class ConfigurationSnippetTagsTest extends AbstractFunctionalTestCase
     }
 
     /**
+     * A hidden snippet stays out, against the real table: the repository
+     * ignores enable fields (its `initializeObject()` is what the backend
+     * module needs), so `findActiveByTag()` returns the `persona-hidden` row
+     * and the resolver has to drop it. This also proves the `hidden` column is
+     * mapped onto the entity at all — without the mapping the filter would
+     * silently read a default-false property.
+     */
+    #[Test]
+    public function aHiddenSnippetIsNotComposed(): void
+    {
+        $this->manager()->chatWithConfiguration(
+            [['role' => 'user', 'content' => 'Describe the product.']],
+            $this->configuration('persona'),
+        );
+
+        $systemMessage = $this->adapter->recordedSystemMessage();
+        self::assertIsString($systemMessage);
+        self::assertStringContainsString('You are Nova, a friendly expert.', $systemMessage);
+        self::assertStringNotContainsString('You are the hidden persona.', $systemMessage);
+    }
+
+    /**
      * The regression guard: a configuration that selects no tags sends the
      * system prompt it always sent.
      */

--- a/Tests/Functional/Service/Fixtures/RecordingPromptAdapter.php
+++ b/Tests/Functional/Service/Fixtures/RecordingPromptAdapter.php
@@ -1,0 +1,175 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Fixtures;
+
+use Generator;
+use Netresearch\NrLlm\Domain\Enum\ModelCapability;
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
+use Netresearch\NrLlm\Provider\Contract\StreamingCapableInterface;
+use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
+
+/**
+ * In-memory provider adapter double that records what reaches the wire on
+ * every text path: chat, single-prompt completion, streaming and tool calls.
+ *
+ * Used by {@see \Netresearch\NrLlm\Tests\Functional\Service\ConfigurationSnippetTagsTest}
+ * to assert that a configuration's tag-selected prompt snippets arrive in the
+ * effective system prompt on all four paths.
+ */
+final class RecordingPromptAdapter implements ProviderInterface, StreamingCapableInterface, ToolCapableInterface
+{
+    /** @var list<ChatMessage|array<string, mixed>> */
+    public array $recordedMessages = [];
+
+    /** @var array<string, mixed> */
+    public array $recordedOptions = [];
+
+    public ?string $recordedPrompt = null;
+
+    public function chatCompletion(array $messages, array $options = []): CompletionResponse
+    {
+        $this->recordedMessages = array_values($messages);
+        $this->recordedOptions  = $options;
+
+        return $this->response($options);
+    }
+
+    public function complete(string $prompt, array $options = []): CompletionResponse
+    {
+        $this->recordedPrompt  = $prompt;
+        $this->recordedOptions = $options;
+
+        return $this->response($options);
+    }
+
+    public function streamChatCompletion(array $messages, array $options = []): Generator
+    {
+        $this->recordedMessages = array_values($messages);
+        $this->recordedOptions  = $options;
+
+        yield 'chunk';
+    }
+
+    public function supportsStreaming(): bool
+    {
+        return true;
+    }
+
+    public function chatCompletionWithTools(array $messages, array $tools, array $options = []): CompletionResponse
+    {
+        $this->recordedMessages = array_values($messages);
+        $this->recordedOptions  = $options;
+
+        return $this->response($options);
+    }
+
+    public function supportsTools(): bool
+    {
+        return true;
+    }
+
+    /**
+     * The system message the manager (or the provider base class) put at the
+     * head of the recorded list, or null when the list carries none.
+     */
+    public function recordedSystemMessage(): ?string
+    {
+        foreach ($this->recordedMessages as $message) {
+            if ($message instanceof ChatMessage) {
+                if ($message->isSystem()) {
+                    return $message->content;
+                }
+
+                continue;
+            }
+
+            if (($message['role'] ?? null) === 'system' && is_string($message['content'] ?? null)) {
+                return $message['content'];
+            }
+        }
+
+        return null;
+    }
+
+    public function recordedSystemPromptOption(): ?string
+    {
+        $systemPrompt = $this->recordedOptions['system_prompt'] ?? null;
+
+        return is_string($systemPrompt) ? $systemPrompt : null;
+    }
+
+    // ------------------------------------------------------------------
+    // ProviderInterface methods not exercised by the test
+    // ------------------------------------------------------------------
+
+    public function getName(): string
+    {
+        return 'Recording Prompt Fake';
+    }
+
+    public function getIdentifier(): string
+    {
+        return 'recording-prompt-fake';
+    }
+
+    public function configure(array $config): void
+    {
+        // intentional no-op: the double is handed out by a mocked
+        // createAdapterFromModel(), so configure() is never invoked.
+    }
+
+    public function isAvailable(): bool
+    {
+        return true;
+    }
+
+    public function supportsFeature(string|ModelCapability $feature): bool
+    {
+        return true;
+    }
+
+    public function embeddings(string|array $input, array $options = []): EmbeddingResponse
+    {
+        return new EmbeddingResponse([], 'recording-default-model', new UsageStatistics(0, 0, 0));
+    }
+
+    public function getAvailableModels(): array
+    {
+        return [];
+    }
+
+    public function getDefaultModel(): string
+    {
+        return 'recording-default-model';
+    }
+
+    public function testConnection(): array
+    {
+        return ['success' => true, 'message' => 'ok'];
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function response(array $options): CompletionResponse
+    {
+        return new CompletionResponse(
+            content: 'done',
+            model: is_string($options['model'] ?? null) ? $options['model'] : 'recording-default-model',
+            usage: new UsageStatistics(7, 3, 10),
+            finishReason: 'stop',
+            provider: 'recording-prompt-fake',
+        );
+    }
+}

--- a/Tests/Unit/Api/api-surface.txt
+++ b/Tests/Unit/Api/api-surface.txt
@@ -410,6 +410,8 @@ Netresearch\NrLlm\Domain\Model\LlmConfiguration (class)
   method getProvider(): ?Netresearch\NrLlm\Domain\Model\Provider
   method getProviderType(): string
   method getSkills(): TYPO3\CMS\Extbase\Persistence\ObjectStorage
+  method getSnippetTagList(): array
+  method getSnippetTags(): string
   method getSystemPrompt(): string
   method getTemperature(): float
   method getTimeout(): int
@@ -448,6 +450,7 @@ Netresearch\NrLlm\Domain\Model\LlmConfiguration (class)
   method setPresencePenalty(float $presencePenalty): void
   method setPresetChecksum(string $presetChecksum): void
   method setSkills(TYPO3\CMS\Extbase\Persistence\ObjectStorage $skills): void
+  method setSnippetTags(string $snippetTags): void
   method setSystemPrompt(string $systemPrompt): void
   method setTemperature(float $temperature): void
   method setTimeout(int $timeout): void

--- a/Tests/Unit/Domain/Model/LlmConfigurationTest.php
+++ b/Tests/Unit/Domain/Model/LlmConfigurationTest.php
@@ -781,4 +781,64 @@ final class LlmConfigurationTest extends AbstractUnitTestCase
         $this->subject->setTemperature($input);
         self::assertSame($expected, $this->subject->getTemperature());
     }
+
+    #[Test]
+    public function snippetTagsDefaultToNone(): void
+    {
+        self::assertSame('', $this->subject->getSnippetTags());
+        self::assertSame([], $this->subject->getSnippetTagList());
+    }
+
+    #[Test]
+    public function snippetTagsGetterAndSetter(): void
+    {
+        $this->subject->setSnippetTags('persona,tone_of_voice');
+
+        self::assertSame('persona,tone_of_voice', $this->subject->getSnippetTags());
+    }
+
+    /**
+     * @return array<string, array{string, list<string>}>
+     */
+    public static function snippetTagNormalizationProvider(): array
+    {
+        return [
+            'empty stays empty' => ['', []],
+            'whitespace only stays empty' => ['   ', []],
+            'single tag' => ['persona', ['persona']],
+            'trims surrounding whitespace' => [' persona , layout ', ['persona', 'layout']],
+            'lowercases' => ['Persona,TONE_OF_VOICE', ['persona', 'tone_of_voice']],
+            'drops empty entries' => ['persona,,layout,', ['persona', 'layout']],
+            'drops duplicates after normalization' => ['persona,Persona, persona ', ['persona']],
+            'preserves selection order' => ['layout,audience,persona', ['layout', 'audience', 'persona']],
+        ];
+    }
+
+    /**
+     * @param list<string> $expected
+     */
+    #[Test]
+    #[DataProvider('snippetTagNormalizationProvider')]
+    public function getSnippetTagListNormalizesCsvTags(string $tags, array $expected): void
+    {
+        $this->subject->setSnippetTags($tags);
+
+        self::assertSame($expected, $this->subject->getSnippetTagList());
+    }
+
+    /**
+     * The snippet tags are NOT part of the options array — they are resolved
+     * against the snippet library by ConfigurationSnippetResolver, not carried
+     * to a provider. A configuration that only sets tags must still produce the
+     * same options as one that sets none.
+     */
+    #[Test]
+    public function toOptionsArrayCarriesNoSnippetTagKey(): void
+    {
+        $before = $this->subject->toOptionsArray();
+
+        $this->subject->setSnippetTags('persona');
+
+        self::assertSame($before, $this->subject->toOptionsArray());
+    }
 }

--- a/Tests/Unit/Domain/Model/PromptSnippetTest.php
+++ b/Tests/Unit/Domain/Model/PromptSnippetTest.php
@@ -143,6 +143,25 @@ final class PromptSnippetTest extends AbstractUnitTestCase
         self::assertSame($expected, $this->subject->getTagList());
     }
 
+    /**
+     * The token-boundary rule of ADR-031, at the level where it is decided:
+     * the tag list holds whole tokens, so the exact-match lookup in
+     * {@see \Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository::findActiveByTag()}
+     * — and with it a configuration selecting the tag `style` — can never reach
+     * a snippet tagged `lifestyle`.
+     */
+    #[Test]
+    public function getTagListKeepsTagsWholeSoStyleIsNotATokenOfLifestyle(): void
+    {
+        $this->subject->setTags('lifestyle,layout');
+
+        $tags = $this->subject->getTagList();
+
+        self::assertSame(['lifestyle', 'layout'], $tags);
+        self::assertNotContains('style', $tags);
+        self::assertNotContains('life', $tags);
+    }
+
     // ========================================
     // getMetadataArray()
     // ========================================

--- a/Tests/Unit/Service/ConfigurationCallPlannerSnippetTagsTest.php
+++ b/Tests/Unit/Service/ConfigurationCallPlannerSnippetTagsTest.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\PromptSnippet;
+use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
+use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
+use Netresearch\NrLlm\Service\ConfigurationCallPlanner;
+use Netresearch\NrLlm\Service\Prompt\ConfigurationSnippetResolver;
+use Netresearch\NrLlm\Service\Prompt\PromptSnippetComposer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The one insertion point that puts a configuration's tag-selected snippets
+ * into the effective system prompt (#638).
+ *
+ * Every configuration-driven entry point on LlmServiceManager — chat,
+ * completion, streaming, the agent loop's tool call — builds its options here,
+ * so composing in `callOptions()` is what reaches all of them at once.
+ */
+#[CoversClass(ConfigurationCallPlanner::class)]
+final class ConfigurationCallPlannerSnippetTagsTest extends TestCase
+{
+    private const SYSTEM_PROMPT = 'You are the configured assistant.';
+
+    /**
+     * The regression guard: without tags the merged options are the same array
+     * they were before the field existed, key for key and byte for byte.
+     */
+    #[Test]
+    public function aConfigurationWithoutTagsProducesByteIdenticalOptions(): void
+    {
+        $configuration = $this->configuration('');
+        $model         = new Model();
+
+        $withoutResolver = $this->planner(null)->callOptions($configuration, $model, []);
+        $withResolver    = $this->planner($this->resolver())->callOptions($configuration, $model, []);
+
+        self::assertSame($withoutResolver, $withResolver);
+        self::assertSame(self::SYSTEM_PROMPT, $withResolver['system_prompt'] ?? null);
+    }
+
+    /**
+     * A configuration with neither a system prompt nor tags must not gain a
+     * `system_prompt` key — an empty string there would make
+     * MessageShaper::applySystemPrompt() skip anyway, but the key itself would
+     * still travel to every adapter.
+     */
+    #[Test]
+    public function aConfigurationWithoutPromptAndWithoutTagsGainsNoSystemPromptKey(): void
+    {
+        $configuration = $this->configuration('');
+        $configuration->setSystemPrompt('');
+
+        $options = $this->planner($this->resolver())->callOptions($configuration, new Model(), []);
+
+        self::assertArrayNotHasKey('system_prompt', $options);
+    }
+
+    #[Test]
+    public function aSelectedTagIsAppendedToTheConfigurationSystemPrompt(): void
+    {
+        $options = $this->planner($this->resolver())->callOptions($this->configuration('persona'), new Model(), []);
+
+        self::assertSame(
+            self::SYSTEM_PROMPT . "\n\n" . "Nova:\nYou are Nova.",
+            $options['system_prompt'] ?? null,
+        );
+    }
+
+    /**
+     * Composition happens AFTER the per-call overrides are merged: a caller
+     * that overrides the system prompt still gets the configuration's editorial
+     * context, because the tags are a property of the configuration, not of the
+     * call.
+     */
+    #[Test]
+    public function snippetsAreAppendedToAPerCallSystemPromptOverrideToo(): void
+    {
+        $options = $this->planner($this->resolver())->callOptions(
+            $this->configuration('persona'),
+            new Model(),
+            ['system_prompt' => 'Per-call prompt.'],
+        );
+
+        self::assertSame("Per-call prompt.\n\nNova:\nYou are Nova.", $options['system_prompt'] ?? null);
+    }
+
+    /**
+     * With tags but no system prompt anywhere, the snippet block becomes the
+     * system prompt — this is the case that makes the snippet library reach a
+     * production prompt at all.
+     */
+    #[Test]
+    public function withoutASystemPromptTheSnippetBlockBecomesTheSystemPrompt(): void
+    {
+        $configuration = $this->configuration('persona');
+        $configuration->setSystemPrompt('');
+
+        $options = $this->planner($this->resolver())->callOptions($configuration, new Model(), []);
+
+        self::assertSame("Nova:\nYou are Nova.", $options['system_prompt'] ?? null);
+    }
+
+    /**
+     * An unknown tag is empty, not an error, and leaves the options untouched.
+     */
+    #[Test]
+    public function anUnknownTagLeavesTheOptionsUntouched(): void
+    {
+        $configuration = $this->configuration('typo_tag');
+
+        self::assertSame(
+            $this->planner(null)->callOptions($configuration, new Model(), []),
+            $this->planner($this->resolver())->callOptions($configuration, new Model(), []),
+        );
+    }
+
+    private function planner(?ConfigurationSnippetResolver $resolver): ConfigurationCallPlanner
+    {
+        return new ConfigurationCallPlanner(
+            self::createStub(ProviderAdapterRegistryInterface::class),
+            null,
+            $resolver,
+        );
+    }
+
+    private function resolver(): ConfigurationSnippetResolver
+    {
+        $snippet = new PromptSnippet();
+        $snippet->setIdentifier('persona-nova');
+        $snippet->setName('Nova');
+        $snippet->setSnippet('You are Nova.');
+
+        $repository = self::createStub(PromptSnippetRepository::class);
+        $repository->method('findActiveByTag')->willReturnCallback(
+            static fn(string $tag): array => $tag === 'persona' ? [$snippet] : [],
+        );
+
+        return new ConfigurationSnippetResolver($repository, new PromptSnippetComposer());
+    }
+
+    private function configuration(string $snippetTags): LlmConfiguration
+    {
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('snippet-tags');
+        $configuration->setSystemPrompt(self::SYSTEM_PROMPT);
+        $configuration->setSnippetTags($snippetTags);
+
+        return $configuration;
+    }
+}

--- a/Tests/Unit/Service/Context/ContextWindowManagerTest.php
+++ b/Tests/Unit/Service/Context/ContextWindowManagerTest.php
@@ -134,6 +134,58 @@ final class ContextWindowManagerTest extends TestCase
         self::assertGreaterThan($first->estimatedTokens, $second->estimatedTokens);
     }
 
+    /**
+     * A transcript without a leading system message is counted together with
+     * the prompt that will be prepended to it. The caller passes the prompt it
+     * will actually send — the configuration's own text plus its composed
+     * snippets (ADR-031) — and that whole size has to land in the estimate,
+     * not just the entity's field.
+     */
+    #[Test]
+    public function theEffectiveSystemPromptIsCountedInsteadOfTheConfigurationField(): void
+    {
+        $messages = [ChatMessage::user('go')];
+        $config   = $this->config(128000);
+        $config->setSystemPrompt('short prompt');
+
+        $withEntityPrompt    = (new ContextWindowManager())->fit($messages, $config, null, null);
+        $withComposedPrompt  = (new ContextWindowManager())->fit(
+            $messages,
+            $config,
+            null,
+            null,
+            [],
+            'short prompt' . "\n\n" . str_repeat('snippet text ', 400),
+        );
+
+        self::assertGreaterThan($withEntityPrompt->estimatedTokens, $withComposedPrompt->estimatedTokens);
+    }
+
+    /**
+     * The composed prompt only counts when the transcript does not already
+     * carry a system message — then it is already in the estimate and adding
+     * it again would over-prune.
+     */
+    #[Test]
+    public function anEffectiveSystemPromptIsIgnoredWhenTheTranscriptLeadsWithASystemMessage(): void
+    {
+        $messages = [ChatMessage::system('sys'), ChatMessage::user('go')];
+        $config   = $this->config(128000);
+        $config->setSystemPrompt('short prompt');
+
+        $without = (new ContextWindowManager())->fit($messages, $config, null, null);
+        $with    = (new ContextWindowManager())->fit(
+            $messages,
+            $config,
+            null,
+            null,
+            [],
+            str_repeat('snippet text ', 400),
+        );
+
+        self::assertSame($without->estimatedTokens, $with->estimatedTokens);
+    }
+
     #[Test]
     public function nonPositiveBudgetDefersTheWholeTranscriptToTheProvider(): void
     {

--- a/Tests/Unit/Service/Feature/ConversationServiceTest.php
+++ b/Tests/Unit/Service/Feature/ConversationServiceTest.php
@@ -12,8 +12,10 @@ namespace Netresearch\NrLlm\Tests\Unit\Service\Feature;
 use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\PromptSnippet;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
 use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
 use Netresearch\NrLlm\Domain\ValueObject\AiSessionMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
@@ -25,6 +27,8 @@ use Netresearch\NrLlm\Service\Context\ContextWindowManagerInterface;
 use Netresearch\NrLlm\Service\Feature\ConversationService;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
+use Netresearch\NrLlm\Service\Prompt\ConfigurationSnippetResolver;
+use Netresearch\NrLlm\Service\Prompt\PromptSnippetComposer;
 use Netresearch\NrLlm\Tests\Unit\Service\Session\Fixtures\RecordingAiSessionRepository;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -475,6 +479,71 @@ final class ConversationServiceTest extends TestCase
         $session = $service->startSession($actor, '', $configuration);
 
         self::assertSame('answered anyway', $service->send($actor, $session->uuid, 'a very long turn')->content);
+    }
+
+    /**
+     * The turn's system prompt is composed by the manager (configuration
+     * prompt + its tag-selected snippets, ADR-031) and prepended after the fit,
+     * so the fit is told what it will be. Without that the budget is short by
+     * the whole snippet block on every turn of a snippet-using configuration.
+     */
+    #[Test]
+    public function theContextWindowIsToldTheComposedSystemPrompt(): void
+    {
+        $repository    = new RecordingAiSessionRepository();
+        $configuration = $this->configuration('editorial');
+        $configuration->setSystemPrompt('You are the configured assistant.');
+        $configuration->setSnippetTags('persona');
+
+        $seen = null;
+
+        $contextWindow = self::createStub(ContextWindowManagerInterface::class);
+        $contextWindow->method('fit')->willReturnCallback(
+            static function (
+                array $messages,
+                LlmConfiguration $configuration,
+                ?ChatOptions $options,
+                ?UsageStatistics $lastUsage,
+                array $toolSpecs,
+                ?string $effectiveSystemPrompt,
+            ) use (&$seen): ContextFitResult {
+                $seen = $effectiveSystemPrompt;
+
+                return new ContextFitResult([ChatMessage::user('fitted')], false, 0, 1, 10, 1000, false, 1.15);
+            },
+        );
+
+        $llmManager = $this->createMock(LlmServiceManagerInterface::class);
+        $llmManager->method('chatForConfiguration')->willReturn($this->response('answered'));
+
+        $service = new ConversationService(
+            $llmManager,
+            $repository,
+            $this->resolverReturning($configuration),
+            $contextWindow,
+            null,
+            $this->snippetResolver(),
+        );
+        $actor   = $this->owner();
+        $session = $service->startSession($actor, '', $configuration);
+        $service->send($actor, $session->uuid, 'hi');
+
+        self::assertSame("You are the configured assistant.\n\nNova:\nYou are Nova.", $seen);
+    }
+
+    private function snippetResolver(): ConfigurationSnippetResolver
+    {
+        $snippet = new PromptSnippet();
+        $snippet->setIdentifier('persona-nova');
+        $snippet->setName('Nova');
+        $snippet->setSnippet('You are Nova.');
+
+        $snippets = self::createStub(PromptSnippetRepository::class);
+        $snippets->method('findActiveByTag')->willReturnCallback(
+            static fn(string $tag): array => $tag === 'persona' ? [$snippet] : [],
+        );
+
+        return new ConfigurationSnippetResolver($snippets, new PromptSnippetComposer());
     }
 
     /**

--- a/Tests/Unit/Service/Prompt/ConfigurationSnippetResolverTest.php
+++ b/Tests/Unit/Service/Prompt/ConfigurationSnippetResolverTest.php
@@ -1,0 +1,248 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Prompt;
+
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\PromptSnippet;
+use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
+use Netresearch\NrLlm\Service\Prompt\ConfigurationSnippetResolver;
+use Netresearch\NrLlm\Service\Prompt\PromptSnippetComposer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The composition rule for a configuration's tag-selected snippets (#638).
+ *
+ * The repository is stubbed here with an in-memory tag index; the exact-token
+ * matching it performs has its own coverage in PromptSnippetRepositoryTest
+ * (functional) and PromptSnippetTest (unit).
+ */
+#[CoversClass(ConfigurationSnippetResolver::class)]
+final class ConfigurationSnippetResolverTest extends TestCase
+{
+    private const SYSTEM_PROMPT = 'You are the configured assistant.';
+
+    /**
+     * A configuration without tags must be byte-identical to the state before
+     * the field existed — no separator, no trailing newline, nothing.
+     */
+    #[Test]
+    public function aConfigurationWithoutTagsLeavesTheSystemPromptByteIdentical(): void
+    {
+        $resolver = $this->resolver(['persona' => [$this->snippet('persona-nova', 'Nova', 'You are Nova.')]]);
+
+        self::assertSame(
+            self::SYSTEM_PROMPT,
+            $resolver->appendTo(self::SYSTEM_PROMPT, $this->configuration('')),
+        );
+    }
+
+    /**
+     * An empty system prompt with no tags stays empty — the caller must not
+     * end up adding a system message that did not exist before.
+     */
+    #[Test]
+    public function anEmptySystemPromptWithoutTagsStaysEmpty(): void
+    {
+        $resolver = $this->resolver([]);
+
+        self::assertSame('', $resolver->appendTo('', $this->configuration('')));
+    }
+
+    #[Test]
+    public function aSelectedTagAppendsItsSnippetAsALabelledBlock(): void
+    {
+        $resolver = $this->resolver(['persona' => [$this->snippet('persona-nova', 'Nova', 'You are Nova.')]]);
+
+        self::assertSame(
+            self::SYSTEM_PROMPT . "\n\n" . "Nova:\nYou are Nova.",
+            $resolver->appendTo(self::SYSTEM_PROMPT, $this->configuration('persona')),
+        );
+    }
+
+    /**
+     * Without a system prompt the snippet block IS the system prompt — no
+     * leading blank line.
+     */
+    #[Test]
+    public function withoutASystemPromptTheSnippetBlockBecomesTheWholePrompt(): void
+    {
+        $resolver = $this->resolver(['persona' => [$this->snippet('persona-nova', 'Nova', 'You are Nova.')]]);
+
+        self::assertSame(
+            "Nova:\nYou are Nova.",
+            $resolver->appendTo('', $this->configuration('persona')),
+        );
+    }
+
+    /**
+     * An unknown tag yields nothing and throws nothing — ADR-031's free-tag
+     * model has no referential integrity by design, so a typo must degrade to
+     * "no snippets", never to an error.
+     */
+    #[Test]
+    public function anUnknownTagYieldsAnUnchangedPromptRatherThanAnError(): void
+    {
+        $resolver = $this->resolver(['persona' => [$this->snippet('persona-nova', 'Nova', 'You are Nova.')]]);
+
+        self::assertSame(
+            self::SYSTEM_PROMPT,
+            $resolver->appendTo(self::SYSTEM_PROMPT, $this->configuration('typo_tag')),
+        );
+    }
+
+    /**
+     * The dedup case: findActiveByTag() loads all active snippets and filters
+     * in PHP, so one snippet carrying two selected tags is returned by both
+     * lookups. It must reach the prompt once.
+     */
+    #[Test]
+    public function aSnippetCarryingTwoSelectedTagsIsComposedOnce(): void
+    {
+        $shared   = $this->snippet('style-minimalist', 'Minimalist', 'Use a minimalist visual style.');
+        $resolver = $this->resolver([
+            'style' => [$shared],
+            'image' => [$shared],
+        ]);
+
+        $composed = $resolver->appendTo('', $this->configuration('style,image'));
+
+        self::assertSame("Minimalist:\nUse a minimalist visual style.", $composed);
+        self::assertSame(1, substr_count($composed, 'Minimalist:'));
+    }
+
+    /**
+     * Dedup is by identifier, not by object: two rehydrations of the same
+     * record (as an Extbase query can hand out across two calls) are one
+     * snippet.
+     */
+    #[Test]
+    public function twoInstancesOfTheSameRecordAreDedupedByIdentifier(): void
+    {
+        $resolver = $this->resolver([
+            'style' => [$this->snippet('style-minimalist', 'Minimalist', 'Use a minimalist visual style.')],
+            'image' => [$this->snippet('style-minimalist', 'Minimalist', 'Use a minimalist visual style.')],
+        ]);
+
+        $composed = $resolver->appendTo('', $this->configuration('style,image'));
+
+        self::assertSame(1, substr_count($composed, 'Minimalist:'));
+    }
+
+    /**
+     * Distinct snippets sharing a display name both survive — the composer
+     * keys its sections by label, so they are composed one at a time.
+     */
+    #[Test]
+    public function twoDistinctSnippetsSharingANameAreBothComposed(): void
+    {
+        $resolver = $this->resolver([
+            'persona' => [
+                $this->snippet('persona-a', 'Persona', 'First fragment.'),
+                $this->snippet('persona-b', 'Persona', 'Second fragment.'),
+            ],
+        ]);
+
+        self::assertSame(
+            "Persona:\nFirst fragment.\n\nPersona:\nSecond fragment.",
+            $resolver->appendTo('', $this->configuration('persona')),
+        );
+    }
+
+    /**
+     * Selection order decides block order; the repository's own order decides
+     * within a tag.
+     */
+    #[Test]
+    public function blocksFollowTheTagSelectionOrder(): void
+    {
+        $resolver = $this->resolver([
+            'persona' => [$this->snippet('persona-nova', 'Nova', 'You are Nova.')],
+            'layout'  => [$this->snippet('layout-list', 'List layout', 'Answer as a list.')],
+        ]);
+
+        self::assertSame(
+            "List layout:\nAnswer as a list.\n\nNova:\nYou are Nova.",
+            $resolver->appendTo('', $this->configuration('layout,persona')),
+        );
+    }
+
+    /**
+     * A snippet whose text is empty contributes no block and therefore no
+     * separator either — the composer skips it and the prompt stays as it was.
+     */
+    #[Test]
+    public function aSnippetWithEmptyTextAddsNothing(): void
+    {
+        $resolver = $this->resolver(['persona' => [$this->snippet('persona-blank', 'Blank', '   ')]]);
+
+        self::assertSame(
+            self::SYSTEM_PROMPT,
+            $resolver->appendTo(self::SYSTEM_PROMPT, $this->configuration('persona')),
+        );
+    }
+
+    /**
+     * The configuration normalizes its own tags, so a capitalised or padded
+     * selection reaches the repository lowercased and trimmed.
+     */
+    #[Test]
+    public function theSelectedTagsReachTheRepositoryNormalized(): void
+    {
+        $asked = [];
+
+        $repository = $this->createMock(PromptSnippetRepository::class);
+        $repository->method('findActiveByTag')->willReturnCallback(
+            static function (string $tag) use (&$asked): array {
+                $asked[] = $tag;
+
+                return [];
+            },
+        );
+
+        $resolver = new ConfigurationSnippetResolver($repository, new PromptSnippetComposer());
+        $resolver->appendTo('', $this->configuration(' Persona , LAYOUT '));
+
+        self::assertSame(['persona', 'layout'], $asked);
+    }
+
+    /**
+     * @param array<string, list<PromptSnippet>> $byTag
+     */
+    private function resolver(array $byTag): ConfigurationSnippetResolver
+    {
+        $repository = self::createStub(PromptSnippetRepository::class);
+        $repository->method('findActiveByTag')->willReturnCallback(
+            static fn(string $tag): array => $byTag[$tag] ?? [],
+        );
+
+        return new ConfigurationSnippetResolver($repository, new PromptSnippetComposer());
+    }
+
+    private function configuration(string $snippetTags): LlmConfiguration
+    {
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('snippet-tags');
+        $configuration->setSnippetTags($snippetTags);
+
+        return $configuration;
+    }
+
+    private function snippet(string $identifier, string $name, string $text): PromptSnippet
+    {
+        $snippet = new PromptSnippet();
+        $snippet->setIdentifier($identifier);
+        $snippet->setName($name);
+        $snippet->setSnippet($text);
+
+        return $snippet;
+    }
+}

--- a/Tests/Unit/Service/Prompt/ConfigurationSnippetResolverTest.php
+++ b/Tests/Unit/Service/Prompt/ConfigurationSnippetResolverTest.php
@@ -191,6 +191,45 @@ final class ConfigurationSnippetResolverTest extends TestCase
     }
 
     /**
+     * A hidden snippet is not composed. The repository cannot make that call —
+     * it ignores enable fields by convention, so `findActiveByTag()` hands out
+     * hidden records and the resolver is the place that drops them.
+     */
+    #[Test]
+    public function aHiddenSnippetIsNotComposed(): void
+    {
+        $hidden = $this->snippet('persona-hidden', 'Hidden', 'You are the hidden persona.');
+        $hidden->setHidden(true);
+
+        $resolver = $this->resolver(['persona' => [$hidden]]);
+
+        self::assertSame(
+            self::SYSTEM_PROMPT,
+            $resolver->appendTo(self::SYSTEM_PROMPT, $this->configuration('persona')),
+        );
+    }
+
+    /**
+     * Hiding one snippet of a tag leaves the others alone — and leaves no
+     * separator behind either.
+     */
+    #[Test]
+    public function aHiddenSnippetDoesNotSuppressItsVisibleSiblings(): void
+    {
+        $hidden = $this->snippet('persona-hidden', 'Hidden', 'You are the hidden persona.');
+        $hidden->setHidden(true);
+
+        $resolver = $this->resolver([
+            'persona' => [$hidden, $this->snippet('persona-nova', 'Nova', 'You are Nova.')],
+        ]);
+
+        self::assertSame(
+            "Nova:\nYou are Nova.",
+            $resolver->appendTo('', $this->configuration('persona')),
+        );
+    }
+
+    /**
      * The configuration normalizes its own tags, so a capitalised or padded
      * selection reaches the repository lowercased and trimmed.
      */

--- a/Tests/Unit/Service/Tool/ToolLoopServiceSnippetTagsTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceSnippetTagsTest.php
@@ -18,7 +18,10 @@ use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\ContextFitResult;
+use Netresearch\NrLlm\Service\Context\ContextWindowManagerInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Service\Option\ToolOptions;
 use Netresearch\NrLlm\Service\Prompt\ConfigurationSnippetResolver;
 use Netresearch\NrLlm\Service\Prompt\PromptSnippetComposer;
@@ -114,12 +117,85 @@ final class ToolLoopServiceSnippetTagsTest extends TestCase
     }
 
     /**
+     * A forced snippet the configuration already selects by tag reaches the
+     * prompt once. The resolver dedups by identifier within the tag selection,
+     * but the playground's forced list is a second source it never sees.
+     */
+    #[Test]
+    public function aForcedSnippetTheConfigurationAlreadySelectsIsNotRepeated(): void
+    {
+        $sent = $this->runAndCaptureMessages(
+            $this->configuration('persona'),
+            new RunAugmentation(forcedSnippets: [$this->novaSnippet()]),
+        );
+
+        $prompt = implode("\n", array_map($this->contentOf(...), $sent));
+        self::assertSame(1, substr_count($prompt, 'You are Nova.'));
+    }
+
+    /**
+     * A forced snippet the configuration does NOT select still gets its own
+     * system message — the containment check must not swallow it.
+     */
+    #[Test]
+    public function aForcedSnippetOutsideTheTagSelectionIsStillAdded(): void
+    {
+        $extra = new PromptSnippet();
+        $extra->setIdentifier('layout-list');
+        $extra->setName('List layout');
+        $extra->setSnippet('Answer as a list.');
+
+        $sent = $this->runAndCaptureMessages(
+            $this->configuration('persona'),
+            new RunAugmentation(forcedSnippets: [$extra]),
+        );
+
+        $prompt = implode("\n", array_map($this->contentOf(...), $sent));
+        self::assertStringContainsString("List layout:\nAnswer as a list.", $prompt);
+        self::assertSame(1, substr_count($prompt, 'You are Nova.'));
+    }
+
+    /**
+     * The context-window estimate must budget for the prompt that goes on the
+     * wire. The manager's planner composes the snippets in after this service
+     * hands the transcript over, so the loop passes the composed prompt to
+     * fit() rather than letting it re-read the configuration entity — which
+     * would under-count the wire by the whole snippet block (ADR-107).
+     */
+    #[Test]
+    public function theContextWindowIsToldTheComposedSystemPrompt(): void
+    {
+        $seen = null;
+
+        $contextWindow = self::createStub(ContextWindowManagerInterface::class);
+        $contextWindow->method('fit')->willReturnCallback(
+            static function (
+                array $messages,
+                LlmConfiguration $configuration,
+                ?ChatOptions $options,
+                ?UsageStatistics $lastUsage,
+                array $toolSpecs,
+                ?string $effectiveSystemPrompt,
+            ) use (&$seen): ContextFitResult {
+                $seen = $effectiveSystemPrompt;
+
+                return new ContextFitResult([ChatMessage::user('fitted')], false, 0, 1, 10, 1000, false, 1.15);
+            },
+        );
+
+        $this->runAndCaptureMessages($this->configuration('persona'), null, null, $contextWindow);
+
+        self::assertSame(self::CONFIG_SYSTEM_PROMPT . "\n\n" . self::SNIPPET_BLOCK, $seen);
+    }
+
+    /**
      * @return list<ChatMessage|array<string, mixed>>
      */
     private function runAndCaptureMessages(
         LlmConfiguration $configuration,
         ?RunAugmentation $augmentation,
         ?ToolOptions $options = null,
+        ?ContextWindowManagerInterface $contextWindow = null,
     ): array {
         $sent = [];
 
@@ -132,7 +208,7 @@ final class ToolLoopServiceSnippetTagsTest extends TestCase
             },
         );
 
-        $this->service($manager)->runLoop(
+        $this->service($manager, $contextWindow)->runLoop(
             [ChatMessage::user('translate this')],
             $configuration,
             ToolExecutionContext::none(),
@@ -149,8 +225,10 @@ final class ToolLoopServiceSnippetTagsTest extends TestCase
         return $sent;
     }
 
-    private function service(LlmServiceManagerInterface $manager): ToolLoopService
-    {
+    private function service(
+        LlmServiceManagerInterface $manager,
+        ?ContextWindowManagerInterface $contextWindow = null,
+    ): ToolLoopService {
         $registry = new ToolRegistry([new FakeTool('noop')]);
 
         return new ToolLoopService(
@@ -164,16 +242,24 @@ final class ToolLoopServiceSnippetTagsTest extends TestCase
                 new TrustZoneResolver(),
             ),
             snippetComposer: new PromptSnippetComposer(),
+            contextWindow: $contextWindow,
             snippetResolver: $this->resolver(),
         );
     }
 
-    private function resolver(): ConfigurationSnippetResolver
+    private function novaSnippet(): PromptSnippet
     {
         $snippet = new PromptSnippet();
         $snippet->setIdentifier('persona-nova');
         $snippet->setName('Nova');
         $snippet->setSnippet('You are Nova.');
+
+        return $snippet;
+    }
+
+    private function resolver(): ConfigurationSnippetResolver
+    {
+        $snippet = $this->novaSnippet();
 
         $repository = self::createStub(PromptSnippetRepository::class);
         $repository->method('findActiveByTag')->willReturnCallback(

--- a/Tests/Unit/Service/Tool/ToolLoopServiceSnippetTagsTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceSnippetTagsTest.php
@@ -1,0 +1,230 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
+
+use Netresearch\NrLlm\Domain\Enum\TrustZone;
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\PromptSnippet;
+use Netresearch\NrLlm\Domain\Model\Provider;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Netresearch\NrLlm\Service\Prompt\ConfigurationSnippetResolver;
+use Netresearch\NrLlm\Service\Prompt\PromptSnippetComposer;
+use Netresearch\NrLlm\Service\Skill\SkillComposer;
+use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
+use Netresearch\NrLlm\Service\Tool\RunAugmentation;
+use Netresearch\NrLlm\Service\Tool\ToolCallPolicy;
+use Netresearch\NrLlm\Service\Tool\ToolDataClassResolver;
+use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
+use Netresearch\NrLlm\Service\Tool\ToolLoopService;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Service\Tool\TrustZoneResolver;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeToolAvailability;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The playground bake site is the second reader of the composed system prompt
+ * (#638).
+ *
+ * The loop bakes the effective system prompt itself for an augmented run
+ * instead of leaving it to the manager's shaper (see
+ * {@see ToolLoopServiceAssemblyOrderTest} for why the lead position is
+ * load-bearing). If that site took the raw configuration prompt while the
+ * manager's planner composed the snippets in, the playground would preview a
+ * transcript a live run never sends.
+ */
+#[CoversClass(ToolLoopService::class)]
+final class ToolLoopServiceSnippetTagsTest extends TestCase
+{
+    private const CONFIG_SYSTEM_PROMPT = 'You are the configured assistant.';
+
+    private const SNIPPET_BLOCK = "Nova:\nYou are Nova.";
+
+    #[Test]
+    public function thePlaygroundBakesTheSameSystemPromptTheConfigurationComposes(): void
+    {
+        $sent = $this->runAndCaptureMessages($this->configuration('persona'), new RunAugmentation());
+
+        self::assertSame('system', $this->roleOf($sent[0]));
+        self::assertSame(
+            self::CONFIG_SYSTEM_PROMPT . "\n\n" . self::SNIPPET_BLOCK,
+            $this->contentOf($sent[0]),
+        );
+    }
+
+    /**
+     * A per-run override still wins on the text and keeps the lead position;
+     * the configuration's snippets follow it, matching what the planner does
+     * for a per-call override on the live paths.
+     */
+    #[Test]
+    public function aPerRunSystemPromptOverrideStillCarriesTheConfigurationSnippets(): void
+    {
+        $sent = $this->runAndCaptureMessages(
+            $this->configuration('persona'),
+            new RunAugmentation(),
+            new ToolOptions(systemPrompt: 'Per-run prompt.'),
+        );
+
+        self::assertSame("Per-run prompt.\n\n" . self::SNIPPET_BLOCK, $this->contentOf($sent[0]));
+    }
+
+    /**
+     * The regression guard for the pinned assembly order: a configuration
+     * without tags bakes exactly what it baked before the field existed.
+     */
+    #[Test]
+    public function aConfigurationWithoutTagsBakesTheUnchangedSystemPrompt(): void
+    {
+        $sent = $this->runAndCaptureMessages($this->configuration(''), new RunAugmentation());
+
+        self::assertSame(self::CONFIG_SYSTEM_PROMPT, $this->contentOf($sent[0]));
+    }
+
+    /**
+     * Without a RunAugmentation the loop returns at its early exit, so the
+     * production tool path adds no system message here at all — the composed
+     * prompt reaches it through the manager's planner instead. This is the
+     * invariant #637 pinned and this feature must not move.
+     */
+    #[Test]
+    public function theProductionPathStillBakesNoSystemMessage(): void
+    {
+        $sent = $this->runAndCaptureMessages($this->configuration('persona'), null);
+
+        self::assertSame('user', $this->roleOf($sent[0]));
+        foreach ($sent as $message) {
+            self::assertStringNotContainsString('Nova:', $this->contentOf($message));
+        }
+    }
+
+    /**
+     * @return list<ChatMessage|array<string, mixed>>
+     */
+    private function runAndCaptureMessages(
+        LlmConfiguration $configuration,
+        ?RunAugmentation $augmentation,
+        ?ToolOptions $options = null,
+    ): array {
+        $sent = [];
+
+        $manager = self::createStub(LlmServiceManagerInterface::class);
+        $manager->method('chatWithToolsForConfiguration')->willReturnCallback(
+            static function (array $received) use (&$sent): CompletionResponse {
+                $sent = $received;
+
+                return new CompletionResponse('done', 'test-model', UsageStatistics::fromTokens(1, 1));
+            },
+        );
+
+        $this->service($manager)->runLoop(
+            [ChatMessage::user('translate this')],
+            $configuration,
+            ToolExecutionContext::none(),
+            null,
+            $options,
+            null,
+            null,
+            $augmentation,
+        );
+
+        self::assertNotSame([], $sent, 'The loop did not reach the provider call.');
+
+        /** @var list<ChatMessage|array<string, mixed>> $sent */
+        return $sent;
+    }
+
+    private function service(LlmServiceManagerInterface $manager): ToolLoopService
+    {
+        $registry = new ToolRegistry([new FakeTool('noop')]);
+
+        return new ToolLoopService(
+            $manager,
+            $registry,
+            new ToolCallPolicy(
+                $registry,
+                new FakeToolAvailability($registry->names()),
+                new AllowedToolsResolver(new SkillComposer(), $registry),
+                new ToolDataClassResolver($registry),
+                new TrustZoneResolver(),
+            ),
+            snippetComposer: new PromptSnippetComposer(),
+            snippetResolver: $this->resolver(),
+        );
+    }
+
+    private function resolver(): ConfigurationSnippetResolver
+    {
+        $snippet = new PromptSnippet();
+        $snippet->setIdentifier('persona-nova');
+        $snippet->setName('Nova');
+        $snippet->setSnippet('You are Nova.');
+
+        $repository = self::createStub(PromptSnippetRepository::class);
+        $repository->method('findActiveByTag')->willReturnCallback(
+            static fn(string $tag): array => $tag === 'persona' ? [$snippet] : [],
+        );
+
+        return new ConfigurationSnippetResolver($repository, new PromptSnippetComposer());
+    }
+
+    /**
+     * A LOCAL-trust-zone configuration so the composite gate offers the fake
+     * tool at all (see ToolLoopServiceAugmentationTest).
+     */
+    private function configuration(string $snippetTags): LlmConfiguration
+    {
+        $provider = new Provider();
+        $provider->setTrustZoneEnum(TrustZone::LOCAL);
+
+        $model = new Model();
+        $model->setProvider($provider);
+
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('snippet-tags');
+        $configuration->setLlmModel($model);
+        $configuration->setSystemPrompt(self::CONFIG_SYSTEM_PROMPT);
+        $configuration->setSnippetTags($snippetTags);
+
+        return $configuration;
+    }
+
+    /**
+     * @param ChatMessage|array<string, mixed> $message
+     */
+    private function roleOf(ChatMessage|array $message): string
+    {
+        if ($message instanceof ChatMessage) {
+            return $message->role;
+        }
+
+        return is_string($message['role'] ?? null) ? $message['role'] : '';
+    }
+
+    /**
+     * @param ChatMessage|array<string, mixed> $message
+     */
+    private function contentOf(ChatMessage|array $message): string
+    {
+        if ($message instanceof ChatMessage) {
+            return $message->content;
+        }
+
+        return is_string($message['content'] ?? null) ? $message['content'] : '';
+    }
+}

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -155,6 +155,9 @@ CREATE TABLE tx_nrllm_configuration (
     allowed_tool_groups varchar(255) DEFAULT '' NOT NULL,
     allowed_guardrails varchar(255) DEFAULT '' NOT NULL,
 
+    -- Comma list of prompt-snippet tags composed into the system prompt (ADR-031)
+    snippet_tags varchar(255) DEFAULT '' NOT NULL,
+
     -- Attached skills (MM relation to tx_nrllm_skill)
     skills int(11) DEFAULT '0' NOT NULL,
 


### PR DESCRIPTION
> **Stacked on #647, with #646 merged in.** Base is `docs/adr139-context-seam`; GitHub retargets as the chain merges.

## Description

**The only genuinely new editorial capability in this programme.**

Snippets reached no production prompt. `PromptSnippetRepository::findActiveByTag()` had **no caller in `Classes/` at all**, and `new RunAugmentation(...)` exists only in `ToolPlaygroundController.php:196` and `AgentRunRequestCodec.php:157`. Outside the playground the entire snippet system was inert.

A configuration now selects snippets by tag, and they are composed into the **effective system prompt**.

### Why the system prompt and not extra system messages

The alternative means making the augmentation branch in `ToolLoopService::assemble()` unconditional. That changes system-prompt precedence, and the `MessageShaper` guard then silently swallows the configuration's system prompt — precisely the invariant #646 pins with a counterfactual test.

### One correction to the planned insertion point

The plan put the chain at `LlmConfiguration::toOptionsArray()`. **Not possible:** PHPat rule 2 forbids `Domain\Model` depending on `Domain\Repository`, and the model has no DI. The insertion sits one link later, in `ConfigurationCallPlanner::callOptions()` — which the issue also names, and which is the single point reached by all five configuration-driven entry points in `LlmServiceManager` (tools/agent loop, embed, chat, completion, streaming). Second reader is `ToolLoopService`'s bake site, so the addition is not missing in the playground.

The three links, at current line numbers: `LlmConfiguration.php:776` → `ConfigurationCallPlanner.php:95`/`:100` → `MessageShaper.php:85`/`:101`.

### The traps, handled

- **Dedup by snippet identifier.** `findActiveByTag()` loads all active snippets and filters in PHP, so a snippet carrying two selected tags would otherwise appear twice. One composer call per snippet, so equal names cannot collide on the label key either.
- **Tag matching is exact on token boundaries**, case-insensitive: `style` does not match `lifestyle`. Asserted at unit level where the logic actually lives (`PromptSnippet::getTagList()`) — a resolver test with a stubbed repository would only have asserted the stub — plus an end-to-end functional proof.
- **Unknown tag yields empty, not an error.**

### Two Rector skips, with their reason

`GeneralUtilityMakeInstanceToConstructorPropertyRector` wants to inject `ConnectionPool` into the new `itemsProcFunc`. Applying it would **fatal in the backend**: FormEngine resolves an `itemsProcFunc` through `callUserFunction()` → `makeInstance()` with no arguments, and `makeInstance` only consults the container for ids it `has()` — private services (the whole `Netresearch\NrLlm\` block) are not among them. The repo's own precedent confirms it: `Services.yaml:347-350` makes `GuardrailRegistry` public *specifically* so `GuardrailItems`' `makeInstance` works. Two file-scoped skips with that reasoning in a comment.

## Related Issue

Closes #638 · new finding filed separately: #658

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `composer ci` and all checks pass — unit, PHPStan (level 10), cgl, fuzzy and architecture re-run independently of the authoring pass: all SUCCESS; the functional classes executed for real (27 tests, 63 assertions in my scoped re-run; 62/384 across the author's full touched set). Rector green under an 8.2 resolve, then restored to 8.4.
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation accordingly — ADR-031 amendment (no new ADR; ADR-139 says ADR-031 is extended, not superseded), plus both administration pages
- [x] I have added a `CHANGELOG.md` entry under `## [Unreleased]`
- [x] I have added an ADR under `Documentation/Adr/` if this changes the public surface — amendment to ADR-031
- [x] My changes generate no new warnings

### No characterisation assertion was touched

All 15 assertions across the three `*AssemblyOrderTest` classes from #646 stayed green unmodified. That is the design holding, not luck: on the production tool path `assemble()` returns at its early exit, and the resolver is not injected in those tests, so both the pinned lead position and the "no system message without augmentation" invariant are untouched.

### Behaviour a reviewer should confirm

The snippet block is appended **after** per-call overrides are merged, so a caller-supplied `system_prompt` **option** keeps its text and still carries the configuration's editorial context. A caller-supplied system **message** still suppresses everything downstream through the `MessageShaper` guard — pre-existing precedence, pinned by #646, documented in the ADR amendment and the admin page.

### Second finding, not fixed here

`ToolGroupItems` calls `makeInstance(ToolRegistry::class)` and works only because `ToolRegistry` is public — but `Services.yaml:342` says it is public "so functional tests can fetch registered tools", not for the itemsProcFunc. The dependency is real and undocumented; if that `public: true` is ever removed as test-only, the tool-group dropdown silently empties. Named here rather than claimed as filed.