### PR TITLE
feat(telemetry): record the configuration that actually served the call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Telemetry records the configuration that actually SERVED a run, not only
+  the one that was requested: `tx_nrllm_telemetry` gains
+  `served_configuration_identifier`, `served_provider` and `served_model`.
+  Until now a fallback showed only as `fallback_attempts > 0`, so the row
+  credited a configuration that did not answer the call. Both paths write
+  the new columns — the pipeline through a new `TelemetrySignals` signal
+  (`recordServedBy()`, recorded in the API snapshot), the streaming
+  lifecycle from the configuration `openWithFallback()` returns. A run
+  nobody served (exhausted chain) keeps naming the requested configuration
+  on both sides, and so does a run that needed no fallback, so "which
+  configuration answered this call" is one column rather than a fallback
+  chain of two. Rows written before this release carry an empty
+  `served_configuration_identifier` and are not counted as a swap.
+  The analytics module reads them back as a **Fallback rescues** list: the
+  runs another configuration stepped in for. `ProviderHealthRepository` is
+  unchanged — its scores deliberately count only `fallback_attempts = 0`
+  rows, so a rescued run still counts against the primary.
+
 ### Changed
 
 - The candidate walk over a primary configuration's fallback chain is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   chain of two. Rows written before this release carry an empty
   `served_configuration_identifier` and are not counted as a swap.
   The analytics module reads them back as a **Fallback rescues** list: the
-  runs another configuration stepped in for. `ProviderHealthRepository` is
+  runs another configuration stepped in for, capped at the 200 newest. The
+  cap counts rescues, not fallback attempts — the query narrows to the
+  swaps, so an outage writing exhausted-chain rows in bulk cannot crowd the
+  period's rescues out of the list. `ProviderHealthRepository` is
   unchanged — its scores deliberately count only `fallback_attempts = 0`
   rows, so a rescued run still counts against the primary.
 

--- a/Classes/Controller/Backend/AnalyticsController.php
+++ b/Classes/Controller/Backend/AnalyticsController.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Controller\Backend;
 
 use DateTimeImmutable;
 use Netresearch\NrLlm\Service\Analytics\AnalyticsPeriod;
+use Netresearch\NrLlm\Service\Analytics\FallbackRescueReport;
 use Netresearch\NrLlm\Service\UsageAnalyticsServiceInterface;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Backend\Attribute\AsController;
@@ -34,6 +35,7 @@ final class AnalyticsController extends ActionController
     public function __construct(
         private readonly ModuleTemplateFactory $moduleTemplateFactory,
         private readonly UsageAnalyticsServiceInterface $analytics,
+        private readonly FallbackRescueReport $fallbackRescues,
         private readonly BackendUriBuilder $backendUriBuilder,
         private readonly PageRenderer $pageRenderer,
     ) {}
@@ -79,6 +81,9 @@ final class AnalyticsController extends ActionController
             'byModel'    => $byModel,
             'byService'  => $byService,
             'perUser'    => $this->analytics->getPerUserUsage($period->from, $period->to),
+            // Reads tx_nrllm_telemetry, not the usage table: the runs a sibling
+            // configuration answered for after the requested one failed.
+            'rescues'    => $this->fallbackRescues->rescuesSince($period->from),
             // JSON consumed by Analytics.js, embedded in a <script> tag via
             // f:format.raw(). JSON_HEX_* neutralises tag-breaking characters
             // (e.g. a model_id/provider label containing "</script>") so the

--- a/Classes/Provider/Middleware/FallbackMiddleware.php
+++ b/Classes/Provider/Middleware/FallbackMiddleware.php
@@ -163,6 +163,12 @@ final readonly class FallbackMiddleware implements ProviderMiddlewareInterface
 
             try {
                 $result = $next($context->withConfiguration($fallback));
+                // This sibling ANSWERED. Recorded only here, after $next
+                // returned, so the telemetry row never names a configuration
+                // that was merely dispatched (ADR-058 / issue #633): an
+                // exhausted chain leaves the signal untouched and the row keeps
+                // naming the requested primary.
+                $context->telemetrySignals->recordServedBy($fallback);
                 $this->logger->info(
                     'LLM fallback configuration succeeded',
                     [

--- a/Classes/Provider/Middleware/TelemetryMiddleware.php
+++ b/Classes/Provider/Middleware/TelemetryMiddleware.php
@@ -47,13 +47,16 @@ use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
  * provider produced a response; the guardrail then blocked it) — not a provider
  * failure. A genuine provider/budget exception still records success=false.
  *
- * What it records: the OPERATION and requested primary CONFIGURATION
- * (identifier, plus its provider/model). When FallbackMiddleware swaps to a
- * sibling configuration the swap is captured as `fallback_attempts > 0`; the
- * provider/model/cost of the configuration that actually SERVED live in the
- * usage table (UsageMiddleware sees the served config). Ad-hoc direct calls
- * carry no attached model, so provider/model are empty and the provider is
- * encoded in the `ad-hoc:<operation>:<provider>` identifier.
+ * What it records: the OPERATION, the requested primary CONFIGURATION
+ * (identifier, plus its provider/model) AND the one that actually served the
+ * run (`served_*`). The two are equal unless FallbackMiddleware swapped to a
+ * sibling that then answered — which it signals through the scratchpad on the
+ * context, the only channel that survives the pipeline unwind (see
+ * {@see TelemetrySignals}). `fallback_attempts` still counts the hops; it
+ * cannot say which configuration answered, and a chain that was exhausted
+ * without anyone answering has hops but no swap. Ad-hoc direct calls carry no
+ * attached model, so provider/model are empty and the provider is encoded in
+ * the `ad-hoc:<operation>:<provider>` identifier.
  *
  * Privacy: no prompt, no response, no exception message — only the exception
  * FQCN (`error_class`), because messages can carry payload fragments. The
@@ -147,6 +150,8 @@ final readonly class TelemetryMiddleware implements ProviderMiddlewareInterface
         int $latencyMs,
     ): void {
         try {
+            $signals = $context->telemetrySignals;
+
             $this->repository->record(new TelemetryRecord(
                 correlationId: $context->correlationId,
                 operation: $context->operation->value,
@@ -157,8 +162,16 @@ final readonly class TelemetryMiddleware implements ProviderMiddlewareInterface
                 success: $success,
                 errorClass: $errorClass,
                 latencyMs: $latencyMs,
-                cacheHit: $context->telemetrySignals->cacheHit,
-                fallbackAttempts: $context->telemetrySignals->fallbackAttempts,
+                cacheHit: $signals->cacheHit,
+                fallbackAttempts: $signals->fallbackAttempts,
+                // No swap recorded ⇒ the requested configuration is the one that
+                // served (or nothing did, on a failed run). Writing the requested
+                // triple rather than leaving the columns empty keeps every row
+                // self-describing: "which configuration answered this call" is one
+                // column, never a COALESCE over two.
+                servedConfigurationIdentifier: $signals->servedConfigurationIdentifier ?? $context->telemetryConfigurationIdentifier(),
+                servedProvider: $signals->servedProvider ?? $context->telemetryProvider(),
+                servedModel: $signals->servedModel ?? $context->telemetryModel(),
             ));
         } catch (Throwable $e) {
             // Observability must not break the call it observes. safeRecord()

--- a/Classes/Provider/Middleware/TelemetrySignals.php
+++ b/Classes/Provider/Middleware/TelemetrySignals.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\Middleware;
 
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+
 /**
  * Mutable scratchpad an inner middleware uses to signal an outer one within a
  * single pipeline run.
@@ -28,8 +30,8 @@ namespace Netresearch\NrLlm\Provider\Middleware;
  * weaken the "context carries no payload" rule of ADR-026.
  *
  * A fresh, un-annotated instance reads as "nothing happened" (no cache hit,
- * zero fallback attempts), which is the correct default for any pipeline run
- * that never touches those layers.
+ * zero fallback attempts, no configuration swap), which is the correct default
+ * for any pipeline run that never touches those layers.
  *
  * @api
  */
@@ -40,12 +42,42 @@ final class TelemetrySignals
     public int $fallbackAttempts = 0;
 
     /**
+     * Identifier of the configuration that ANSWERED, when that is not the one
+     * the caller requested. null while nothing has swapped — which the
+     * TelemetryMiddleware reads as "the requested configuration served it".
+     */
+    public ?string $servedConfigurationIdentifier = null;
+
+    /** Provider of the configuration that answered; null with the identifier. */
+    public ?string $servedProvider = null;
+
+    /** Model of the configuration that answered; null with the identifier. */
+    public ?string $servedModel = null;
+
+    /**
      * CacheMiddleware calls this when it serves a stored response instead of
      * invoking the terminal.
      */
     public function recordCacheHit(): void
     {
         $this->cacheHit = true;
+    }
+
+    /**
+     * FallbackMiddleware calls this with the sibling configuration whose call
+     * RETURNED — never with one that was merely attempted.
+     *
+     * The distinction is the whole point of the signal: `fallbackAttempts`
+     * already says how many siblings were dispatched, and the last of those is
+     * usually the one that failed. Only a configuration that produced a
+     * response is recorded as having served the run, so an exhausted chain
+     * leaves this null and the row keeps naming the requested configuration.
+     */
+    public function recordServedBy(LlmConfiguration $configuration): void
+    {
+        $this->servedConfigurationIdentifier = $configuration->getIdentifier();
+        $this->servedProvider                = $configuration->getProviderType();
+        $this->servedModel                   = $configuration->getModelId();
     }
 
     /**

--- a/Classes/Service/Analytics/FallbackRescueReport.php
+++ b/Classes/Service/Analytics/FallbackRescueReport.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Analytics;
+
+use DateTimeImmutable;
+use Netresearch\NrLlm\Service\Telemetry\FallbackHop;
+use Netresearch\NrLlm\Service\Telemetry\TelemetryRepositoryInterface;
+
+/**
+ * The runs a sibling configuration answered for — the reader of the
+ * `served_*` telemetry columns.
+ *
+ * The repository narrows to runs that dispatched a fallback at all
+ * (`fallback_attempts > 0`, time-bounded, newest first). That is a cheap
+ * index-friendly filter, not the answer: a hop can also be a chain that was
+ * exhausted with nobody serving, and a row written before the `served_*`
+ * columns existed carries '' for them. Deciding which hops are RESCUES is
+ * therefore done here, on the one field that can tell:
+ *
+ *  - the served identifier must be present ('' means "row predates the
+ *    columns" — it must not be read as a swap to a nameless configuration);
+ *  - it must differ from the requested one (equal means the requested
+ *    configuration answered, or nothing did — `fallback_attempts` alone would
+ *    have counted both of those as rescues, which is the defect this list
+ *    exists to make visible).
+ *
+ * The outcome is kept on the row rather than filtered out: on the streaming
+ * path a sibling can open the stream and the stream still break while draining,
+ * which is a swap that happened and is worth seeing.
+ */
+final readonly class FallbackRescueReport
+{
+    /**
+     * How many recent hops are examined for the rescues among them. A fallback
+     * is by nature rare, so a window this size covers a normal period; a period
+     * with more hops than this shows the newest ones, and the primary they
+     * requested is the thing to fix first anyway.
+     */
+    private const HOP_SCAN_LIMIT = 200;
+
+    public function __construct(
+        private TelemetryRepositoryInterface $telemetry,
+    ) {}
+
+    /**
+     * The rescues from $from until now, newest first.
+     *
+     * There is no upper bound: every {@see AnalyticsPeriod} preset ends at the
+     * current day, so an explicit `to` would be a parameter that always says
+     * "now" — and one whose midnight anchoring (the usage table's day buckets)
+     * would silently cut today's per-second telemetry rows.
+     *
+     * @return list<array{
+     *     when: int,
+     *     operation: string,
+     *     requestedConfiguration: string,
+     *     requestedProvider: string,
+     *     requestedModel: string,
+     *     servedConfiguration: string,
+     *     servedProvider: string,
+     *     servedModel: string,
+     *     fallbackAttempts: int,
+     *     latencyMs: int,
+     *     success: bool
+     * }>
+     */
+    public function rescuesSince(DateTimeImmutable $from): array
+    {
+        $rescues = [];
+        foreach ($this->telemetry->recentFallbackHops($from->getTimestamp(), self::HOP_SCAN_LIMIT) as $hop) {
+            if (!$this->isRescue($hop)) {
+                continue;
+            }
+
+            $rescues[] = [
+                'when'                   => $hop->crdate,
+                'operation'              => $hop->operation,
+                'requestedConfiguration' => $hop->configurationIdentifier,
+                'requestedProvider'      => $hop->provider,
+                'requestedModel'         => $hop->model,
+                'servedConfiguration'    => $hop->servedConfigurationIdentifier,
+                'servedProvider'         => $hop->servedProvider,
+                'servedModel'            => $hop->servedModel,
+                'fallbackAttempts'       => $hop->fallbackAttempts,
+                'latencyMs'              => $hop->latencyMs,
+                'success'                => $hop->success,
+            ];
+        }
+
+        return $rescues;
+    }
+
+    private function isRescue(FallbackHop $hop): bool
+    {
+        return $hop->servedConfigurationIdentifier !== ''
+            && $hop->servedConfigurationIdentifier !== $hop->configurationIdentifier;
+    }
+}

--- a/Classes/Service/Analytics/FallbackRescueReport.php
+++ b/Classes/Service/Analytics/FallbackRescueReport.php
@@ -17,12 +17,12 @@ use Netresearch\NrLlm\Service\Telemetry\TelemetryRepositoryInterface;
  * The runs a sibling configuration answered for — the reader of the
  * `served_*` telemetry columns.
  *
- * The repository narrows to runs that dispatched a fallback at all
- * (`fallback_attempts > 0`, time-bounded, newest first). That is a cheap
- * index-friendly filter, not the answer: a hop can also be a chain that was
+ * The repository narrows to runs a sibling served (time-bounded, newest
+ * first) — `fallback_attempts > 0` alone would also match a chain that was
  * exhausted with nobody serving, and a row written before the `served_*`
- * columns existed carries '' for them. Deciding which hops are RESCUES is
- * therefore done here, on the one field that can tell:
+ * columns existed carries '' for them. That narrowing has to happen in the
+ * query because the scan limit below is applied there. What a RESCUE IS is
+ * nevertheless stated here, on the one field that can tell:
  *
  *  - the served identifier must be present ('' means "row predates the
  *    columns" — it must not be read as a swap to a nameless configuration);
@@ -38,10 +38,12 @@ use Netresearch\NrLlm\Service\Telemetry\TelemetryRepositoryInterface;
 final readonly class FallbackRescueReport
 {
     /**
-     * How many recent hops are examined for the rescues among them. A fallback
-     * is by nature rare, so a window this size covers a normal period; a period
-     * with more hops than this shows the newest ones, and the primary they
-     * requested is the thing to fix first anyway.
+     * How many rescues are read back at most. A rescue is by nature rare, so a
+     * window this size covers a normal period; a period with more shows the
+     * newest ones, and the primary they requested is the thing to fix first
+     * anyway. The limit counts rescues, not fallback attempts — an exhausted
+     * chain repeating through an outage must not push a rescue out of the list
+     * and turn the module's empty state into a false "none in this period".
      */
     private const HOP_SCAN_LIMIT = 200;
 

--- a/Classes/Service/Streaming/StreamingDispatcher.php
+++ b/Classes/Service/Streaming/StreamingDispatcher.php
@@ -430,6 +430,7 @@ final readonly class StreamingDispatcher
             $this->recordTelemetry(
                 $context,
                 $requested,
+                $served,
                 $success,
                 $errorClass,
                 $this->elapsedMs($startNs),
@@ -587,6 +588,7 @@ final readonly class StreamingDispatcher
     private function recordTelemetry(
         ProviderCallContext $context,
         LlmConfiguration $requested,
+        LlmConfiguration $served,
         bool $success,
         string $errorClass,
         int $latencyMs,
@@ -597,10 +599,11 @@ final readonly class StreamingDispatcher
         }
 
         // Attribution mirrors the non-streaming TelemetryMiddleware: the row
-        // names the REQUESTED primary configuration; a fallback swap shows as
-        // fallback_attempts > 0, while the provider/model that actually served
-        // live in the usage table. cacheHit is always false — streaming never
-        // caches.
+        // names the REQUESTED primary configuration AND the one that served the
+        // stream. This path needs no scratchpad signal — openWithFallback()
+        // returns the serving configuration, and $served falls back to the
+        // requested one when nothing ever primed. cacheHit is always false —
+        // streaming never caches.
         $this->telemetryRepository->record(new TelemetryRecord(
             correlationId: $context->correlationId,
             operation: $context->operation->value,
@@ -613,6 +616,9 @@ final readonly class StreamingDispatcher
             latencyMs: $latencyMs,
             cacheHit: false,
             fallbackAttempts: $context->telemetrySignals->fallbackAttempts,
+            servedConfigurationIdentifier: $served->getIdentifier(),
+            servedProvider: $served->getProviderType(),
+            servedModel: $served->getModelId(),
             timeToFirstTokenMs: $timeToFirstTokenMs,
         ));
     }

--- a/Classes/Service/Telemetry/FallbackHop.php
+++ b/Classes/Service/Telemetry/FallbackHop.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Telemetry;
+
+/**
+ * One telemetry row that dispatched at least one fallback configuration, read
+ * back for the analytics module.
+ *
+ * Metadata only, exactly like the row it comes from: which configuration was
+ * requested, which one answered, whether the run ended well and how long it
+ * took. No prompt, no response, no exception message.
+ *
+ * Whether a hop was a RESCUE — a sibling actually answering for the requested
+ * configuration — is not decided here; see
+ * {@see \Netresearch\NrLlm\Service\Analytics\FallbackRescueReport}.
+ */
+final readonly class FallbackHop
+{
+    public function __construct(
+        public string $correlationId,
+        public string $operation,
+        public string $configurationIdentifier,
+        public string $provider,
+        public string $model,
+        public string $servedConfigurationIdentifier,
+        public string $servedProvider,
+        public string $servedModel,
+        public bool $success,
+        public int $fallbackAttempts,
+        public int $latencyMs,
+        public int $crdate,
+    ) {}
+}

--- a/Classes/Service/Telemetry/TelemetryRecord.php
+++ b/Classes/Service/Telemetry/TelemetryRecord.php
@@ -20,13 +20,20 @@ namespace Netresearch\NrLlm\Service\Telemetry;
 final readonly class TelemetryRecord
 {
     /**
-     * @param ?int $timeToFirstTokenMs wall-clock milliseconds from the start of
-     *                                 the run to the first streamed chunk. Only
-     *                                 the streaming lifecycle (ADR-062) supplies
-     *                                 it; every non-streaming pipeline run leaves
-     *                                 it null (there is no partial-response
-     *                                 milestone to measure), which is stored as
-     *                                 SQL NULL — distinct from a genuine 0 ms.
+     * @param string $configurationIdentifier       the configuration the caller REQUESTED
+     * @param string $servedConfigurationIdentifier the configuration that ANSWERED. Equal to the
+     *                                              requested one unless a fallback swap served the
+     *                                              run; a run nothing served keeps the requested
+     *                                              values. The three served* fields always move
+     *                                              together — a row never mixes one configuration's
+     *                                              identifier with another's provider.
+     * @param ?int   $timeToFirstTokenMs            wall-clock milliseconds from the start of
+     *                                              the run to the first streamed chunk. Only
+     *                                              the streaming lifecycle (ADR-062) supplies
+     *                                              it; every non-streaming pipeline run leaves
+     *                                              it null (there is no partial-response
+     *                                              milestone to measure), which is stored as
+     *                                              SQL NULL — distinct from a genuine 0 ms.
      */
     public function __construct(
         public string $correlationId,
@@ -40,6 +47,9 @@ final readonly class TelemetryRecord
         public int $latencyMs,
         public bool $cacheHit,
         public int $fallbackAttempts,
+        public string $servedConfigurationIdentifier,
+        public string $servedProvider,
+        public string $servedModel,
         public ?int $timeToFirstTokenMs = null,
     ) {}
 }

--- a/Classes/Service/Telemetry/TelemetryRepository.php
+++ b/Classes/Service/Telemetry/TelemetryRepository.php
@@ -125,6 +125,22 @@ final readonly class TelemetryRepository implements TelemetryRepositoryInterface
             ->where(
                 $queryBuilder->expr()->gte('crdate', $queryBuilder->createNamedParameter($since, Connection::PARAM_INT)),
                 $queryBuilder->expr()->gt('fallback_attempts', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+                // The swap itself, not just the attempt: '' is a row written
+                // before these columns existed, and an identifier equal to the
+                // requested one means the chain was exhausted with nobody
+                // serving. Both are hops, neither is a rescue. They belong in
+                // the query rather than only in the reader because $limit is
+                // applied here: a two-hour outage writes thousands of
+                // exhausted-chain rows, and filtering afterwards would let them
+                // fill the window and report a period's real rescues as none.
+                $queryBuilder->expr()->neq(
+                    'served_configuration_identifier',
+                    $queryBuilder->createNamedParameter('', Connection::PARAM_STR),
+                ),
+                $queryBuilder->expr()->neq(
+                    'served_configuration_identifier',
+                    $queryBuilder->quoteIdentifier('configuration_identifier'),
+                ),
             )
             ->orderBy('crdate', 'DESC')
             ->addOrderBy('uid', 'DESC')

--- a/Classes/Service/Telemetry/TelemetryRepository.php
+++ b/Classes/Service/Telemetry/TelemetryRepository.php
@@ -43,6 +43,9 @@ final readonly class TelemetryRepository implements TelemetryRepositoryInterface
             'latency_ms'               => $record->latencyMs,
             'cache_hit'                => $record->cacheHit ? 1 : 0,
             'fallback_attempts'        => $record->fallbackAttempts,
+            'served_configuration_identifier' => $record->servedConfigurationIdentifier,
+            'served_provider'          => $record->servedProvider,
+            'served_model'             => $record->servedModel,
             'time_to_first_token_ms'   => $record->timeToFirstTokenMs,
             'crdate'                   => time(),
         ]);
@@ -96,5 +99,77 @@ final readonly class TelemetryRepository implements TelemetryRepositoryInterface
             ->fetchOne();
 
         return is_numeric($avg) ? (int)round((float)$avg) : 0;
+    }
+
+    public function recentFallbackHops(int $since, int $limit): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+
+        $rows = $queryBuilder
+            ->select(
+                'correlation_id',
+                'operation',
+                'configuration_identifier',
+                'provider',
+                'model',
+                'served_configuration_identifier',
+                'served_provider',
+                'served_model',
+                'success',
+                'fallback_attempts',
+                'latency_ms',
+                'crdate',
+            )
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->gte('crdate', $queryBuilder->createNamedParameter($since, Connection::PARAM_INT)),
+                $queryBuilder->expr()->gt('fallback_attempts', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+            )
+            ->orderBy('crdate', 'DESC')
+            ->addOrderBy('uid', 'DESC')
+            ->setMaxResults(max(1, $limit))
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $hops = [];
+        foreach ($rows as $row) {
+            $hops[] = new FallbackHop(
+                correlationId: $this->str($row, 'correlation_id'),
+                operation: $this->str($row, 'operation'),
+                configurationIdentifier: $this->str($row, 'configuration_identifier'),
+                provider: $this->str($row, 'provider'),
+                model: $this->str($row, 'model'),
+                servedConfigurationIdentifier: $this->str($row, 'served_configuration_identifier'),
+                servedProvider: $this->str($row, 'served_provider'),
+                servedModel: $this->str($row, 'served_model'),
+                success: $this->int($row, 'success') === 1,
+                fallbackAttempts: $this->int($row, 'fallback_attempts'),
+                latencyMs: $this->int($row, 'latency_ms'),
+                crdate: $this->int($row, 'crdate'),
+            );
+        }
+
+        return $hops;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function str(array $row, string $column): string
+    {
+        $value = $row[$column] ?? null;
+
+        return is_scalar($value) ? (string)$value : '';
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function int(array $row, string $column): int
+    {
+        $value = $row[$column] ?? null;
+
+        return is_numeric($value) ? (int)$value : 0;
     }
 }

--- a/Classes/Service/Telemetry/TelemetryRepositoryInterface.php
+++ b/Classes/Service/Telemetry/TelemetryRepositoryInterface.php
@@ -46,12 +46,17 @@ interface TelemetryRepositoryInterface
     public function averageLatencyMs(int $since): int;
 
     /**
-     * The most recent runs that dispatched at least one fallback configuration
-     * (`fallback_attempts > 0`), newest first, capped at $limit.
+     * The most recent runs another configuration answered for, newest first,
+     * capped at $limit.
      *
-     * This is the cheap narrowing only: a run that hopped may still have ended
-     * with nobody serving it. Deciding which of these is a rescue is the
-     * report's job, not the query's.
+     * "Another configuration" is the narrowing: `fallback_attempts > 0` alone
+     * also matches a chain that was exhausted with nobody serving, and a row
+     * written before the `served_*` columns existed. Both name no serving
+     * sibling and must not reach $limit — an outage produces them in bulk and
+     * would otherwise crowd a period's real rescues out of the window.
+     * Classifying the rows that do arrive stays with the reader
+     * ({@see \Netresearch\NrLlm\Service\Analytics\FallbackRescueReport}), which
+     * is where the rule is stated in domain terms.
      *
      * @return list<FallbackHop>
      */

--- a/Classes/Service/Telemetry/TelemetryRepositoryInterface.php
+++ b/Classes/Service/Telemetry/TelemetryRepositoryInterface.php
@@ -12,9 +12,11 @@ namespace Netresearch\NrLlm\Service\Telemetry;
 /**
  * Persistence boundary for provider pipeline telemetry rows (ADR-058).
  *
- * Append one row, purge old rows, or read a small set of dashboard aggregates.
- * Telemetry stays append-only — there is no update path; the read methods only
- * ever aggregate, never expose a single row's payload.
+ * Append one row, purge old rows, or read back what the dashboards need.
+ * Telemetry stays append-only — there is no update path. A read either
+ * aggregates or, for {@see self::recentFallbackHops()}, hands out whole rows;
+ * either way it can only expose what the table holds, which is metadata (no
+ * prompt, no response, no exception message).
  */
 interface TelemetryRepositoryInterface
 {
@@ -42,4 +44,16 @@ interface TelemetryRepositoryInterface
      * Zero matching rows ⇒ 0.
      */
     public function averageLatencyMs(int $since): int;
+
+    /**
+     * The most recent runs that dispatched at least one fallback configuration
+     * (`fallback_attempts > 0`), newest first, capped at $limit.
+     *
+     * This is the cheap narrowing only: a run that hopped may still have ended
+     * with nobody serving it. Deciding which of these is a rescue is the
+     * report's job, not the query's.
+     *
+     * @return list<FallbackHop>
+     */
+    public function recentFallbackHops(int $since, int $limit): array;
 }

--- a/Documentation/Administration/Analytics.rst
+++ b/Documentation/Administration/Analytics.rst
@@ -116,6 +116,34 @@ have consumed.
 Requests made without an authenticated backend user (CLI, scheduler,
 ``be_user = 0``) are grouped under a **system** row.
 
+..  _administration-analytics-rescues:
+
+Fallback rescues
+================
+
+A table lists the runs a **different** configuration answered after the
+requested one failed — each line is one request the configuration you
+configured did not serve. It shows what was requested and what answered,
+each with its provider and model, how many configurations were tried, and
+how long the whole run took.
+
+Unlike the rest of this module the list is read from the telemetry log
+(``tx_nrllm_telemetry``), not from the usage table, so it also covers
+runs that produced no billable usage.
+
+Two things it deliberately does not show:
+
+*   **Runs nobody served.** A chain that was tried and exhausted names no
+    serving configuration — it is a failure, not a rescue, and appears in
+    the provider health scores instead.
+*   **Runs recorded before this feature existed.** Rows written by an
+    older version carry no serving configuration and are left out rather
+    than guessed at.
+
+A configuration appearing here repeatedly is the signal to look at: its
+calls are being answered by a sibling, which may use a different provider,
+model and price than the one you selected.
+
 ..  _administration-analytics-cost-note:
 
 A note on cost

--- a/Documentation/Administration/Analytics.rst
+++ b/Documentation/Administration/Analytics.rst
@@ -140,6 +140,10 @@ Two things it deliberately does not show:
     older version carry no serving configuration and are left out rather
     than guessed at.
 
+At most the 200 newest rescues of the period are listed. The limit counts
+rescues, not failed attempts, so a long outage — which writes one row per
+request — cannot push the rescues out of the list.
+
 A configuration appearing here repeatedly is the signal to look at: its
 calls are being answered by a sibling, which may use a different provider,
 model and price than the one you selected.

--- a/Documentation/Adr/Adr058TelemetryMiddleware.rst
+++ b/Documentation/Adr/Adr058TelemetryMiddleware.rst
@@ -114,6 +114,17 @@ Consequences
   the usage table (:php:`UsageMiddleware` sees the served config). Ad-hoc
   direct calls carry no attached model, so provider/model are empty and the
   provider is encoded in the ``ad-hoc:<operation>:<provider>`` identifier.
+
+  .. note::
+
+     **Overtaken.** The row no longer names only the requested configuration.
+     ``served_configuration_identifier``, ``served_provider`` and
+     ``served_model`` name the one that answered, carried out of the pipeline
+     through the same :php:`TelemetrySignals` scratchpad as the cache hit
+     (``recordServedBy()``, called only after the sibling's call *returned*).
+     ``fallback_attempts`` still counts the hops; it never said which
+     configuration answered, and an exhausted chain has hops but no swap.
+     The requested columns above are unchanged.
 * **Fail-soft.** A telemetry write error is logged and swallowed; it never
   breaks the call it observes.
 * **Streaming produces no telemetry row.** Streaming deliberately stays out of

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -628,6 +628,46 @@
                 <source>Tokens (30d)</source>
                 <target>Tokens (30 T.)</target>
             </trans-unit>
+            <trans-unit id="analytics.rescues.title">
+                <source>Fallback rescues</source>
+                <target>Eingesprungene Konfigurationen</target>
+            </trans-unit>
+            <trans-unit id="analytics.rescues.description">
+                <source>Runs a different configuration answered after the requested one failed. Each line is a request the requested configuration did not serve.</source>
+                <target>Aufrufe, die eine andere Konfiguration beantwortet hat, nachdem die angefragte ausgefallen ist. Jede Zeile ist eine Anfrage, die die angefragte Konfiguration nicht bedient hat.</target>
+            </trans-unit>
+            <trans-unit id="analytics.rescues.table.when">
+                <source>When</source>
+                <target>Zeitpunkt</target>
+            </trans-unit>
+            <trans-unit id="analytics.rescues.table.operation">
+                <source>Operation</source>
+                <target>Operation</target>
+            </trans-unit>
+            <trans-unit id="analytics.rescues.table.requested">
+                <source>Requested</source>
+                <target>Angefragt</target>
+            </trans-unit>
+            <trans-unit id="analytics.rescues.table.served">
+                <source>Served by</source>
+                <target>Bedient von</target>
+            </trans-unit>
+            <trans-unit id="analytics.rescues.table.attempts">
+                <source>Hops</source>
+                <target>Wechsel</target>
+            </trans-unit>
+            <trans-unit id="analytics.rescues.table.latency">
+                <source>Latency</source>
+                <target>Laufzeit</target>
+            </trans-unit>
+            <trans-unit id="analytics.rescues.outcome.failed">
+                <source>ended with an error</source>
+                <target>endete mit einem Fehler</target>
+            </trans-unit>
+            <trans-unit id="analytics.rescues.empty">
+                <source>No configuration had to step in for another one in this period.</source>
+                <target>In diesem Zeitraum musste keine Konfiguration für eine andere einspringen.</target>
+            </trans-unit>
 
             <!-- Skills backend module -->
             <trans-unit id="skill.list.title">

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -477,6 +477,36 @@
             <trans-unit id="analytics.col.tokens">
                 <source>Tokens (30d)</source>
             </trans-unit>
+            <trans-unit id="analytics.rescues.title">
+                <source>Fallback rescues</source>
+            </trans-unit>
+            <trans-unit id="analytics.rescues.description">
+                <source>Runs a different configuration answered after the requested one failed. Each line is a request the requested configuration did not serve.</source>
+            </trans-unit>
+            <trans-unit id="analytics.rescues.table.when">
+                <source>When</source>
+            </trans-unit>
+            <trans-unit id="analytics.rescues.table.operation">
+                <source>Operation</source>
+            </trans-unit>
+            <trans-unit id="analytics.rescues.table.requested">
+                <source>Requested</source>
+            </trans-unit>
+            <trans-unit id="analytics.rescues.table.served">
+                <source>Served by</source>
+            </trans-unit>
+            <trans-unit id="analytics.rescues.table.attempts">
+                <source>Hops</source>
+            </trans-unit>
+            <trans-unit id="analytics.rescues.table.latency">
+                <source>Latency</source>
+            </trans-unit>
+            <trans-unit id="analytics.rescues.outcome.failed">
+                <source>ended with an error</source>
+            </trans-unit>
+            <trans-unit id="analytics.rescues.empty">
+                <source>No configuration had to step in for another one in this period.</source>
+            </trans-unit>
 
             <!-- Skills backend module -->
             <trans-unit id="skill.list.title">

--- a/Resources/Private/Templates/Backend/Analytics/Index.html
+++ b/Resources/Private/Templates/Backend/Analytics/Index.html
@@ -117,6 +117,50 @@
                 </f:be.infobox>
             </f:else>
         </f:if>
+
+        <f:comment>Fallback rescues — from the telemetry log, not the usage table</f:comment>
+        <h3><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.rescues.title" /></h3>
+        <p class="text-body-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.rescues.description" /></p>
+        <f:if condition="{rescues}">
+            <f:then>
+                <div class="table-fit">
+                    <table class="table table-striped">
+                        <thead>
+                            <tr>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.rescues.table.when" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.rescues.table.operation" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.rescues.table.requested" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.rescues.table.served" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.rescues.table.attempts" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.rescues.table.latency" /></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <f:for each="{rescues}" as="r">
+                                <tr>
+                                    <td><f:format.date format="Y-m-d H:i">@{r.when}</f:format.date></td>
+                                    <td>{r.operation}</td>
+                                    <td>
+                                        {r.requestedConfiguration}
+                                        <f:if condition="{r.requestedProvider}"><br /><span class="text-body-secondary">{r.requestedProvider} / {r.requestedModel}</span></f:if>
+                                    </td>
+                                    <td>
+                                        {r.servedConfiguration}
+                                        <f:if condition="{r.servedProvider}"><br /><span class="text-body-secondary">{r.servedProvider} / {r.servedModel}</span></f:if>
+                                        <f:if condition="{r.success}"><f:else><br /><span class="badge text-bg-warning"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.rescues.outcome.failed" /></span></f:else></f:if>
+                                    </td>
+                                    <td>{r.fallbackAttempts}</td>
+                                    <td>{r.latencyMs} ms</td>
+                                </tr>
+                            </f:for>
+                        </tbody>
+                    </table>
+                </div>
+            </f:then>
+            <f:else>
+                <p class="text-body-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.rescues.empty" /></p>
+            </f:else>
+        </f:if>
     </div>
 </f:section>
 

--- a/Tests/Functional/Controller/Backend/AnalyticsControllerTest.php
+++ b/Tests/Functional/Controller/Backend/AnalyticsControllerTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;
 
 use Netresearch\NrLlm\Controller\Backend\AnalyticsController;
+use Netresearch\NrLlm\Service\Analytics\FallbackRescueReport;
 use Netresearch\NrLlm\Service\UsageAnalyticsServiceInterface;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -20,6 +21,7 @@ use TYPO3\CMS\Backend\Routing\Route;
 use TYPO3\CMS\Backend\Routing\UriBuilder as BackendUriBuilder;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
@@ -61,6 +63,25 @@ final class AnalyticsControllerTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function indexActionRendersTheFallbackRescueListFromRealTelemetryRows(): void
+    {
+        // Two rows a `fallback_attempts > 0` query cannot tell apart: one a
+        // sibling answered, one where the chain was exhausted. Rendering with
+        // real rows (not the empty state) is what exercises the table markup.
+        $this->insertTelemetryRow('rescued-corr', 'primary-config', 'sibling-config');
+        $this->insertTelemetryRow('exhausted-corr', 'primary-config', 'primary-config');
+
+        $body = (string)$this->dispatchIndex([])->getBody();
+
+        self::assertStringContainsString('sibling-config', $body, 'The rescue must be listed.');
+        self::assertSame(
+            1,
+            substr_count($body, 'primary-config'),
+            'Only the rescued run appears — the exhausted one names no other configuration.',
+        );
+    }
+
+    #[Test]
     public function indexActionNormalizesUnknownRangeParameter(): void
     {
         $response = $this->dispatchIndex(['range' => 'bogus-range']);
@@ -80,6 +101,7 @@ final class AnalyticsControllerTest extends AbstractFunctionalTestCase
         $controller = new AnalyticsController(
             $this->getService(ModuleTemplateFactory::class),
             $this->getService(UsageAnalyticsServiceInterface::class),
+            $this->getService(FallbackRescueReport::class),
             $this->getService(BackendUriBuilder::class),
             $this->getService(PageRenderer::class),
         );
@@ -107,6 +129,30 @@ final class AnalyticsControllerTest extends AbstractFunctionalTestCase
         $GLOBALS['TYPO3_REQUEST'] = $serverRequest;
 
         return new ExtbaseRequest($serverRequest);
+    }
+
+    private function insertTelemetryRow(string $correlationId, string $requested, string $served): void
+    {
+        $this->getService(ConnectionPool::class)
+            ->getConnectionForTable('tx_nrllm_telemetry')
+            ->insert('tx_nrllm_telemetry', [
+                'pid'                             => 0,
+                'correlation_id'                  => $correlationId,
+                'operation'                       => 'chat',
+                'provider'                        => 'openai',
+                'model'                           => 'gpt-5',
+                'configuration_identifier'        => $requested,
+                'served_configuration_identifier' => $served,
+                'served_provider'                 => 'ollama',
+                'served_model'                    => 'llama3.3:70b',
+                'be_user'                         => 1,
+                'success'                         => 1,
+                'error_class'                     => '',
+                'latency_ms'                      => 42,
+                'cache_hit'                       => 0,
+                'fallback_attempts'               => 1,
+                'crdate'                          => time(),
+            ]);
     }
 
     private function setPrivateProperty(object $object, string $property, mixed $value): void

--- a/Tests/Functional/Fixtures/ServedConfigurations.csv
+++ b/Tests/Functional/Fixtures/ServedConfigurations.csv
@@ -1,0 +1,13 @@
+"tx_nrllm_provider"
+,"uid","pid","identifier","name","adapter_type","endpoint_url","api_key","api_timeout","max_retries","is_active","sorting","deleted","hidden"
+,901,0,"served-openai","Served OpenAI","openai","https://api.openai.com/v1","",30,3,1,1,0,0
+,902,0,"served-ollama","Served Ollama","ollama","http://ollama:11434","",30,3,1,2,0,0
+"tx_nrllm_model"
+,"uid","pid","identifier","name","provider_uid","model_id","context_length","max_output_tokens","capabilities","default_timeout","cost_input","cost_output","is_active","is_default","sorting","deleted","hidden"
+,901,0,"served-gpt","Served GPT",901,"gpt-5",256000,16384,"chat",120,0,0,1,0,1,0,0
+,902,0,"served-llama","Served Llama",902,"llama3.3:70b",131072,4096,"chat",120,0,0,1,0,2,0,0
+"tx_nrllm_configuration"
+,"uid","pid","identifier","name","model_uid","fallback_chain","is_active","deleted","hidden","sorting"
+,901,0,"served-primary","Served Primary",901,"{""configurationIdentifiers"":[""served-alt""]}",1,0,0,1
+,902,0,"served-alt","Served Alternative",902,"",1,0,0,2
+,903,0,"served-lonely","Served Without Chain",901,"",1,0,0,3

--- a/Tests/Functional/Provider/Middleware/ServedConfigurationTelemetryTest.php
+++ b/Tests/Functional/Provider/Middleware/ServedConfigurationTelemetryTest.php
@@ -1,0 +1,276 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Provider\Middleware;
+
+use DateTimeImmutable;
+use Generator;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
+use Netresearch\NrLlm\Provider\Fallback\FallbackCandidateResolver;
+use Netresearch\NrLlm\Provider\Middleware\FallbackMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\TelemetryMiddleware;
+use Netresearch\NrLlm\Service\Analytics\FallbackRescueReport;
+use Netresearch\NrLlm\Service\Health\ProviderHealthServiceInterface;
+use Netresearch\NrLlm\Service\Streaming\StreamingDispatcher;
+use Netresearch\NrLlm\Service\Telemetry\TelemetryRepository;
+use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
+use Netresearch\NrLlm\Tests\Fixture\AllowingBudgetService;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
+use Throwable;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * A telemetry row names the configuration that ANSWERED, not only the one that
+ * was asked (issue #633).
+ *
+ * The load-bearing case is the first test: a retryable primary failure routes
+ * the call to a sibling, and the single row that run produces must attribute it
+ * to that sibling — provider and model included — while still recording what
+ * was requested. Before the `served_*` columns the row credited the primary,
+ * which never served it.
+ *
+ * The other tests pin the boundaries of that: no swap means both sides name the
+ * same configuration, an exhausted chain is NOT a swap (nobody served), and the
+ * streaming lifecycle writes the same two triples as the pipeline.
+ */
+#[CoversClass(TelemetryMiddleware::class)]
+#[CoversClass(FallbackMiddleware::class)]
+#[CoversClass(StreamingDispatcher::class)]
+#[CoversClass(TelemetryRepository::class)]
+final class ServedConfigurationTelemetryTest extends AbstractFunctionalTestCase
+{
+    private const TABLE = 'tx_nrllm_telemetry';
+
+    private ConnectionPool $connectionPool;
+
+    private LlmConfigurationRepository $configurations;
+
+    private FallbackCandidateResolver $resolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importFixture('ServedConfigurations.csv');
+
+        $this->connectionPool = $this->getService(ConnectionPool::class);
+        $this->configurations = $this->getService(LlmConfigurationRepository::class);
+        $this->resolver       = new FallbackCandidateResolver($this->configurations);
+    }
+
+    #[Test]
+    public function aRetryablePrimaryFailureAttributesTheRunToTheSiblingThatAnswered(): void
+    {
+        self::assertSame('served-alt', $this->runWithFailingPrimary());
+
+        $rows = $this->rows();
+        self::assertCount(1, $rows, 'One pipeline run writes exactly one telemetry row.');
+
+        $row = $rows[0];
+        self::assertSame(1, (int)$row['success']);
+        self::assertSame(1, (int)$row['fallback_attempts']);
+
+        // What was asked for.
+        self::assertSame('served-primary', $row['configuration_identifier']);
+        self::assertSame('openai', $row['provider']);
+        self::assertSame('gpt-5', $row['model']);
+
+        // What answered — all three differ from what was asked for.
+        self::assertSame('served-alt', $row['served_configuration_identifier']);
+        self::assertSame('ollama', $row['served_provider']);
+        self::assertSame('llama3.3:70b', $row['served_model']);
+    }
+
+    #[Test]
+    public function aRunWithoutAFallbackNamesTheRequestedConfigurationOnBothSides(): void
+    {
+        $this->pipeline()->run(
+            ProviderCallContext::forConfiguration(ProviderOperation::Chat, $this->configuration('served-lonely')),
+            static fn(): string => 'answer',
+        );
+
+        $row = $this->rows()[0];
+        self::assertSame(0, (int)$row['fallback_attempts']);
+        self::assertSame('served-lonely', $row['configuration_identifier']);
+        self::assertSame('served-lonely', $row['served_configuration_identifier']);
+        self::assertSame($row['provider'], $row['served_provider']);
+        self::assertSame($row['model'], $row['served_model']);
+    }
+
+    #[Test]
+    public function anExhaustedChainIsNotASwapAndKeepsNamingTheRequestedConfiguration(): void
+    {
+        $caught = null;
+
+        try {
+            $this->pipeline()->run(
+                ProviderCallContext::forConfiguration(ProviderOperation::Chat, $this->configuration('served-primary')),
+                static function (): string {
+                    throw new ProviderConnectionException('everything down', 1770000102);
+                },
+            );
+        } catch (Throwable $e) {
+            // The exception type is FallbackMiddleware's business; this test is
+            // about the row it leaves behind.
+            $caught = $e;
+        }
+
+        self::assertInstanceOf(Throwable::class, $caught, 'The exhausted chain must surface an exception.');
+
+        $row = $this->rows()[0];
+        self::assertSame(0, (int)$row['success']);
+        self::assertSame(1, (int)$row['fallback_attempts'], 'The sibling was dispatched...');
+        self::assertSame(
+            'served-primary',
+            $row['served_configuration_identifier'],
+            '...but it did not serve, so it must not be named as the serving configuration.',
+        );
+    }
+
+    #[Test]
+    public function theStreamingPathWritesTheSameTwoTriplesAsThePipeline(): void
+    {
+        $dispatcher = new StreamingDispatcher(
+            new AllowingBudgetService(),
+            $this->getService(UsageTrackerServiceInterface::class),
+            new TelemetryRepository($this->connectionPool),
+            $this->resolver,
+            new NullLogger(),
+            $this->getService(Context::class),
+            $this->getService(ExtensionConfiguration::class),
+        );
+
+        $chunks = iterator_to_array($dispatcher->stream(
+            new ProviderCallContext(ProviderOperation::Stream, 'served-stream-corr'),
+            $this->configuration('served-primary'),
+            static function (LlmConfiguration $configuration): Generator {
+                if ($configuration->getIdentifier() === 'served-primary') {
+                    yield from [];
+
+                    throw new ProviderConnectionException('primary down', 1770000103);
+                }
+
+                yield $configuration->getIdentifier();
+            },
+        ));
+
+        self::assertSame(['served-alt'], $chunks);
+
+        $row = $this->rows()[0];
+        self::assertSame(1, (int)$row['fallback_attempts']);
+        self::assertSame('served-primary', $row['configuration_identifier']);
+        self::assertSame('openai', $row['provider']);
+        self::assertSame('gpt-5', $row['model']);
+        self::assertSame('served-alt', $row['served_configuration_identifier']);
+        self::assertSame('ollama', $row['served_provider']);
+        self::assertSame('llama3.3:70b', $row['served_model']);
+    }
+
+    #[Test]
+    public function theAnalyticsListShowsTheRescueAndNotTheRunThatNeededNone(): void
+    {
+        // One rescued run and one that served itself.
+        $this->runWithFailingPrimary();
+        $this->pipeline()->run(
+            ProviderCallContext::forConfiguration(ProviderOperation::Chat, $this->configuration('served-lonely')),
+            static fn(): string => 'answer',
+        );
+
+        $rescues = (new FallbackRescueReport(new TelemetryRepository($this->connectionPool)))
+            ->rescuesSince(new DateTimeImmutable('-1 day'));
+
+        self::assertCount(1, $rescues);
+        self::assertSame('served-primary', $rescues[0]['requestedConfiguration']);
+        self::assertSame('served-alt', $rescues[0]['servedConfiguration']);
+        self::assertSame('ollama', $rescues[0]['servedProvider']);
+    }
+
+    /**
+     * One pipeline run whose primary fails retryably and whose sibling answers.
+     *
+     * @return string the identifier of the configuration whose call returned
+     */
+    private function runWithFailingPrimary(): string
+    {
+        $result = $this->pipeline()->run(
+            ProviderCallContext::forConfiguration(ProviderOperation::Chat, $this->configuration('served-primary')),
+            static function (ProviderCallContext $context): string {
+                $configuration = $context->configuration;
+                self::assertInstanceOf(LlmConfiguration::class, $configuration);
+
+                if ($configuration->getIdentifier() === 'served-primary') {
+                    throw new ProviderConnectionException('primary down', 1770000101);
+                }
+
+                return $configuration->getIdentifier();
+            },
+        );
+
+        self::assertIsString($result);
+
+        return $result;
+    }
+
+    private function pipeline(): MiddlewarePipeline
+    {
+        $health = self::createStub(ProviderHealthServiceInterface::class);
+        $health->method('reorder')->willReturnArgument(0);
+
+        return new MiddlewarePipeline([
+            new TelemetryMiddleware(
+                new TelemetryRepository($this->connectionPool),
+                $this->getService(Context::class),
+                $this->getService(ExtensionConfiguration::class),
+                new NullLogger(),
+            ),
+            new FallbackMiddleware($this->resolver, new NullLogger(), $health),
+        ]);
+    }
+
+    private function configuration(string $identifier): LlmConfiguration
+    {
+        $configuration = $this->configurations->findOneByIdentifier($identifier);
+        self::assertInstanceOf(
+            LlmConfiguration::class,
+            $configuration,
+            sprintf('Fixture row %s missing — the test would prove nothing.', $identifier),
+        );
+
+        return $configuration;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function rows(): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+
+        /** @var list<array<string, mixed>> $rows */
+        $rows = $queryBuilder
+            ->select('*')
+            ->from(self::TABLE)
+            ->orderBy('uid', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return $rows;
+    }
+}

--- a/Tests/Functional/Service/Telemetry/TelemetryRepositoryTest.php
+++ b/Tests/Functional/Service/Telemetry/TelemetryRepositoryTest.php
@@ -54,6 +54,9 @@ final class TelemetryRepositoryTest extends AbstractFunctionalTestCase
             latencyMs: 1234,
             cacheHit: true,
             fallbackAttempts: 2,
+            servedConfigurationIdentifier: 'sibling',
+            servedProvider: 'ollama',
+            servedModel: 'llama3.3:70b',
         ));
 
         $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
@@ -70,6 +73,9 @@ final class TelemetryRepositoryTest extends AbstractFunctionalTestCase
         self::assertSame(1234, (int)$row['latency_ms']);
         self::assertSame(1, (int)$row['cache_hit']);
         self::assertSame(2, (int)$row['fallback_attempts']);
+        self::assertSame('sibling', $row['served_configuration_identifier']);
+        self::assertSame('ollama', $row['served_provider']);
+        self::assertSame('llama3.3:70b', $row['served_model']);
         self::assertGreaterThan(0, (int)$row['crdate']);
     }
 
@@ -88,6 +94,9 @@ final class TelemetryRepositoryTest extends AbstractFunctionalTestCase
             latencyMs: 5,
             cacheHit: false,
             fallbackAttempts: 0,
+            servedConfigurationIdentifier: 'primary',
+            servedProvider: '',
+            servedModel: '',
         ));
 
         $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
@@ -134,6 +143,9 @@ final class TelemetryRepositoryTest extends AbstractFunctionalTestCase
             latencyMs: 1,
             cacheHit: false,
             fallbackAttempts: 0,
+            servedConfigurationIdentifier: 'primary',
+            servedProvider: '',
+            servedModel: '',
         ));
 
         // Purge everything older than 5 days: removes the old row, keeps the fresh one.
@@ -160,6 +172,9 @@ final class TelemetryRepositoryTest extends AbstractFunctionalTestCase
             latencyMs: 1,
             cacheHit: false,
             fallbackAttempts: 0,
+            servedConfigurationIdentifier: 'primary',
+            servedProvider: '',
+            servedModel: '',
         ));
 
         // Cutoff far in the past: the only row is newer, so nothing is deleted.

--- a/Tests/Functional/Service/Telemetry/TelemetryRepositoryTest.php
+++ b/Tests/Functional/Service/Telemetry/TelemetryRepositoryTest.php
@@ -224,6 +224,67 @@ final class TelemetryRepositoryTest extends AbstractFunctionalTestCase
         self::assertSame(0, $this->repository->averageLatencyMs(time() - 60));
     }
 
+    #[Test]
+    public function recentFallbackHopsSkipsRunsNoSiblingServed(): void
+    {
+        $now = time();
+        // A chain that was tried and exhausted: hops happened, the row still
+        // names the requested configuration as the serving one.
+        $this->insertHop('exhausted', 'primary', 'primary', $now);
+        // Written before the served_* columns existed: unknown, not a swap.
+        $this->insertHop('legacy', 'primary', '', $now);
+        // The one real rescue.
+        $this->insertHop('rescued', 'primary', 'sibling', $now);
+
+        $hops = $this->repository->recentFallbackHops($now - 3600, 200);
+
+        self::assertCount(1, $hops);
+        self::assertSame('corr-rescued', $hops[0]->correlationId);
+        self::assertSame('sibling', $hops[0]->servedConfigurationIdentifier);
+    }
+
+    #[Test]
+    public function recentFallbackHopsCapsRescuesRatherThanFallbackAttempts(): void
+    {
+        $now = time();
+        // An outage: three newer rows that hopped and ended with nobody
+        // serving. They exceed the limit on their own.
+        $this->insertHop('outage-1', 'primary', 'primary', $now);
+        $this->insertHop('outage-2', 'primary', 'primary', $now - 1);
+        $this->insertHop('outage-3', 'primary', 'primary', $now - 2);
+        // An older, genuine rescue behind them.
+        $this->insertHop('rescued', 'primary', 'sibling', $now - 10);
+
+        $hops = $this->repository->recentFallbackHops($now - 3600, 2);
+
+        // Capping fallback attempts instead of rescues would return the two
+        // newest outage rows here and report the period as rescue-free.
+        self::assertCount(1, $hops);
+        self::assertSame('corr-rescued', $hops[0]->correlationId);
+    }
+
+    private function insertHop(string $correlationId, string $requested, string $served, int $crdate): void
+    {
+        $this->connectionPool->getConnectionForTable(self::TABLE)->insert(self::TABLE, [
+            'pid'                             => 0,
+            'correlation_id'                  => 'corr-' . $correlationId,
+            'operation'                       => 'chat',
+            'provider'                        => 'openai',
+            'model'                           => 'gpt-5',
+            'configuration_identifier'        => $requested,
+            'served_configuration_identifier' => $served,
+            'served_provider'                 => $served === '' ? '' : 'ollama',
+            'served_model'                    => $served === '' ? '' : 'llama3.3:70b',
+            'be_user'                         => 0,
+            'success'                         => 1,
+            'error_class'                     => '',
+            'latency_ms'                      => 100,
+            'cache_hit'                       => 0,
+            'fallback_attempts'               => 2,
+            'crdate'                          => $crdate,
+        ]);
+    }
+
     private function insertRow(string $correlationId, bool $success, int $latencyMs, int $crdate): void
     {
         $this->connectionPool->getConnectionForTable(self::TABLE)->insert(self::TABLE, [

--- a/Tests/Unit/Api/api-surface.txt
+++ b/Tests/Unit/Api/api-surface.txt
@@ -943,8 +943,12 @@ Netresearch\NrLlm\Provider\Middleware\ProviderOperation (enum)
 Netresearch\NrLlm\Provider\Middleware\TelemetrySignals (class)
   method recordCacheHit(): void
   method recordFallbackAttempt(): void
+  method recordServedBy(Netresearch\NrLlm\Domain\Model\LlmConfiguration $configuration): void
   property cacheHit: bool
   property fallbackAttempts: int
+  property servedConfigurationIdentifier: ?string
+  property servedModel: ?string
+  property servedProvider: ?string
 
 Netresearch\NrLlm\Provider\Middleware\Usage\ProviderUsageRecord (class)
   property readonly beUserUid: ?int

--- a/Tests/Unit/Fixture/InMemoryTelemetryRepository.php
+++ b/Tests/Unit/Fixture/InMemoryTelemetryRepository.php
@@ -67,9 +67,11 @@ final class InMemoryTelemetryRepository implements TelemetryRepositoryInterface
     }
 
     /**
-     * Rows recentFallbackHops() hands back, newest first — the narrowing the
-     * SQL does (`fallback_attempts > 0`, time-bounded) is the caller's given,
-     * so a test states the hops it wants the reader to classify.
+     * Rows recentFallbackHops() hands back, newest first. Deliberately
+     * unnarrowed: the SQL implementation filters to served swaps so its
+     * $limit counts rescues, but a test states the hops it wants the reader
+     * to classify — including the ones the query would have dropped, so the
+     * reader's own rule stays under test rather than the stub's.
      *
      * @var list<FallbackHop>
      */

--- a/Tests/Unit/Fixture/InMemoryTelemetryRepository.php
+++ b/Tests/Unit/Fixture/InMemoryTelemetryRepository.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Fixture;
 
+use Netresearch\NrLlm\Service\Telemetry\FallbackHop;
 use Netresearch\NrLlm\Service\Telemetry\TelemetryRecord;
 use Netresearch\NrLlm\Service\Telemetry\TelemetryRepositoryInterface;
 use Throwable;
@@ -63,5 +64,27 @@ final class InMemoryTelemetryRepository implements TelemetryRepositoryInterface
     public function averageLatencyMs(int $since): int
     {
         return $this->averageLatencyMsReturns;
+    }
+
+    /**
+     * Rows recentFallbackHops() hands back, newest first — the narrowing the
+     * SQL does (`fallback_attempts > 0`, time-bounded) is the caller's given,
+     * so a test states the hops it wants the reader to classify.
+     *
+     * @var list<FallbackHop>
+     */
+    public array $fallbackHops = [];
+
+    /** The ($since, $limit) pair the last recentFallbackHops() was asked for. */
+    public ?int $hopsSince = null;
+
+    public ?int $hopsLimit = null;
+
+    public function recentFallbackHops(int $since, int $limit): array
+    {
+        $this->hopsSince = $since;
+        $this->hopsLimit = $limit;
+
+        return \array_slice($this->fallbackHops, 0, max(1, $limit));
     }
 }

--- a/Tests/Unit/Provider/Middleware/TelemetryMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/TelemetryMiddlewareTest.php
@@ -179,6 +179,44 @@ final class TelemetryMiddlewareTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function namesTheRequestedConfigurationAsTheServingOneWhenNothingSwapped(): void
+    {
+        $repository = $this->recordingRepository();
+
+        $this->pipeline($repository)->run(
+            (new ProviderCallContext(ProviderOperation::Chat, 'corr'))
+                ->withConfiguration($this->configuration('primary')),
+            static fn(): string => 'x',
+        );
+
+        $record = $repository->records[0];
+        self::assertSame('primary', $record->servedConfigurationIdentifier);
+        self::assertSame($record->configurationIdentifier, $record->servedConfigurationIdentifier);
+        self::assertSame($record->provider, $record->servedProvider);
+        self::assertSame($record->model, $record->servedModel);
+    }
+
+    #[Test]
+    public function readsTheServingConfigurationSignalSetByTheFallbackLayer(): void
+    {
+        $repository = $this->recordingRepository();
+
+        $context = (new ProviderCallContext(ProviderOperation::Chat, 'corr'))
+            ->withConfiguration($this->configuration('primary'));
+        $context->telemetrySignals->recordFallbackAttempt();
+        $context->telemetrySignals->recordServedBy($this->configuration('sibling'));
+
+        $this->pipeline($repository)->run(
+            $context,
+            static fn(): string => 'x',
+        );
+
+        $record = $repository->records[0];
+        self::assertSame('primary', $record->configurationIdentifier, 'The row still names what was requested.');
+        self::assertSame('sibling', $record->servedConfigurationIdentifier);
+    }
+
+    #[Test]
     public function isNoOpWhenDisabled(): void
     {
         $repository = $this->recordingRepository();

--- a/Tests/Unit/Service/Analytics/FallbackRescueReportTest.php
+++ b/Tests/Unit/Service/Analytics/FallbackRescueReportTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Analytics;
+
+use DateTimeImmutable;
+use Netresearch\NrLlm\Service\Analytics\FallbackRescueReport;
+use Netresearch\NrLlm\Service\Telemetry\FallbackHop;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Tests\Unit\Fixture\InMemoryTelemetryRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The analytics list shows exactly the runs another configuration answered.
+ *
+ * The repository hands over every recent run that dispatched a fallback; three
+ * kinds of row look alike there and only the served identifier tells them
+ * apart. This pins that all three are classified correctly — the whole reason
+ * the `served_*` columns exist, since `fallback_attempts > 0` is true for all
+ * of them.
+ */
+#[CoversClass(FallbackRescueReport::class)]
+final class FallbackRescueReportTest extends AbstractUnitTestCase
+{
+    #[Test]
+    public function listsOnlyTheHopsAnotherConfigurationActuallyServed(): void
+    {
+        $repository               = new InMemoryTelemetryRepository();
+        $repository->fallbackHops = [
+            // A rescue: the sibling answered.
+            $this->hop('rescued', 'primary', 'sibling'),
+            // Chain exhausted: hops happened, nobody served, the row still
+            // names the requested configuration on both sides.
+            $this->hop('exhausted', 'primary', 'primary', success: false),
+            // Written before the served_* columns existed: unknown, not a swap.
+            $this->hop('legacy', 'primary', ''),
+        ];
+
+        $rescues = (new FallbackRescueReport($repository))->rescuesSince(new DateTimeImmutable('-30 days'));
+
+        self::assertCount(1, $rescues);
+        self::assertSame('rescued', $rescues[0]['operation']);
+        self::assertSame('primary', $rescues[0]['requestedConfiguration']);
+        self::assertSame('sibling', $rescues[0]['servedConfiguration']);
+    }
+
+    #[Test]
+    public function carriesBothConfigurationsProviderAndModelIntoTheRow(): void
+    {
+        $repository               = new InMemoryTelemetryRepository();
+        $repository->fallbackHops = [
+            new FallbackHop(
+                correlationId: 'corr-1',
+                operation: 'chat',
+                configurationIdentifier: 'primary',
+                provider: 'openai',
+                model: 'gpt-5',
+                servedConfigurationIdentifier: 'sibling',
+                servedProvider: 'ollama',
+                servedModel: 'llama3.3:70b',
+                success: true,
+                fallbackAttempts: 2,
+                latencyMs: 1234,
+                crdate: 1_770_000_000,
+            ),
+        ];
+
+        $rescues = (new FallbackRescueReport($repository))->rescuesSince(new DateTimeImmutable('-30 days'));
+
+        self::assertSame([
+            'when'                   => 1_770_000_000,
+            'operation'              => 'chat',
+            'requestedConfiguration' => 'primary',
+            'requestedProvider'      => 'openai',
+            'requestedModel'         => 'gpt-5',
+            'servedConfiguration'    => 'sibling',
+            'servedProvider'         => 'ollama',
+            'servedModel'            => 'llama3.3:70b',
+            'fallbackAttempts'       => 2,
+            'latencyMs'              => 1234,
+            'success'                => true,
+        ], $rescues[0]);
+    }
+
+    #[Test]
+    public function keepsASwapWhoseRunLaterFailed(): void
+    {
+        // The streaming path can open a sibling's stream and still break while
+        // draining it. The sibling stepped in, so the swap is worth showing —
+        // marked as the failure it ended in.
+        $repository               = new InMemoryTelemetryRepository();
+        $repository->fallbackHops = [$this->hop('stream', 'primary', 'sibling', success: false)];
+
+        $rescues = (new FallbackRescueReport($repository))->rescuesSince(new DateTimeImmutable('-30 days'));
+
+        self::assertCount(1, $rescues);
+        self::assertFalse($rescues[0]['success']);
+    }
+
+    #[Test]
+    public function asksTheRepositoryOnlyForRunsInsideTheSelectedPeriod(): void
+    {
+        $repository = new InMemoryTelemetryRepository();
+        $from       = new DateTimeImmutable('2026-07-01 00:00:00');
+
+        (new FallbackRescueReport($repository))->rescuesSince($from);
+
+        self::assertSame($from->getTimestamp(), $repository->hopsSince);
+        self::assertNotNull($repository->hopsLimit);
+        self::assertGreaterThan(0, $repository->hopsLimit);
+    }
+
+    private function hop(string $operation, string $requested, string $served, bool $success = true): FallbackHop
+    {
+        return new FallbackHop(
+            correlationId: 'corr-' . $operation,
+            operation: $operation,
+            configurationIdentifier: $requested,
+            provider: 'openai',
+            model: 'gpt-5',
+            servedConfigurationIdentifier: $served,
+            servedProvider: $served === '' ? '' : 'ollama',
+            servedModel: $served === '' ? '' : 'llama3.3:70b',
+            success: $success,
+            fallbackAttempts: 1,
+            latencyMs: 100,
+            crdate: 1_770_000_000,
+        );
+    }
+}

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -550,6 +550,16 @@ CREATE TABLE tx_nrllm_telemetry (
     model varchar(128) DEFAULT '' NOT NULL,
     configuration_identifier varchar(150) DEFAULT '' NOT NULL,
 
+    -- What ANSWERED: the configuration that actually served the run. Equal to
+    -- the requested triple above whenever no fallback swap happened, so a row
+    -- always names its serving configuration without a COALESCE. A failed run
+    -- that nothing served keeps the requested values here — "served" is only
+    -- ever a configuration that produced a response. Rows written before these
+    -- columns existed carry '' and are therefore not mistakable for a rescue.
+    served_configuration_identifier varchar(150) DEFAULT '' NOT NULL,
+    served_provider varchar(64) DEFAULT '' NOT NULL,
+    served_model varchar(128) DEFAULT '' NOT NULL,
+
     -- Attribution (backend user; 0 for CLI / scheduler / unauthenticated)
     be_user int(11) unsigned DEFAULT '0' NOT NULL,
 


### PR DESCRIPTION
> **Stacked on #655**, which is stacked on #641. Base is `refactor/one-candidate-resolution`; GitHub retargets as the chain merges.

## Description

`tx_nrllm_telemetry` stored only the **requested** primary configuration. `fallback_attempts` says how many hops happened, never which one answered — so after a fallback the row attributed the call to a configuration that did not serve it.

Three new columns, written from the `telemetrySignals` scratchpad that `ProviderCallContext` already carries across the swap.

`recordServedBy()` is called **only after `$next` returns**. A configuration that was merely attempted must never land in the log as the serving one, and calling it before the call would do exactly that.

The streaming path needs no scratchpad — `openWithFallback()` already returns the value, and `$served` is initialised to the requested configuration before the `try`, so the `finally` sees it on every exit.

### Reader in the same change

A **Fallback rescues** list in the analytics module. A column nobody reads does not ship here (ADR-120).

The split is deliberate: SQL narrows by time and `fallback_attempts > 0`; the semantic decision — served identifier present **and** different — is made in PHP, where it can be unit-tested without asserting a stub. Two real exclusions fall out of it: an exhausted chain (served == requested) and pre-migration rows (`''`).

### Semantics without a fallback: equal, not empty

`served_*` carry the requested values. "Which configuration answered this call" is then **one** column rather than a `COALESCE` over two, and `''` stays unambiguously reserved for rows written before the migration — otherwise every old row would read as a rescue by a nameless configuration. A run nobody served (exhausted chain) also keeps the requested identifier.

## Two things beyond the issue

1. **ADR-058 was left saying something false.** It states that the telemetry row names only the requested configuration and that the serving one lives in the usage table. After this change that is wrong, so the passage carries an `Overtaken` note — the same form this branch's ancestor introduced for ADR-021 in #641. No new ADR, per the issue. Leaving a false statement standing would have been worse than three lines of documentation.
2. **`FallbackRescueReport` takes no `$to`.** Every `AnalyticsPeriod` preset ends on the current day and `to` is midnight, so an upper bound would silently cut off today's hits — telemetry is second-accurate while the usage table is day-bucketed. The parameter would have been an argument that always says "now".

## As instructed and confirmed

`ProviderHealthRepository` (lines 39-55) counts only `fallback_attempts = 0` in both aggregates, with a comment saying why — a rescued call must not flatter the health score. Verified and **untouched**, confirmed by `git status`; its regression test runs green.

## Related Issue

Closes #633

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

`TelemetryRecord`'s three new parameters are **required**, without defaults: a forgotten field should be loud, not silently write `''`.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `composer ci` and all checks pass — unit, PHPStan (level 10), cgl and fuzzy re-run independently of the authoring pass: all SUCCESS; the functional classes executed for real (12 tests, 152 assertions in my scoped re-run). Rector green under an 8.2 resolve, then restored to 8.4.
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation accordingly — `Administration/Analytics.rst` plus the ADR-058 note
- [x] I have added a `CHANGELOG.md` entry under `## [Unreleased]`
- [ ] I have added an ADR under `Documentation/Adr/` — not needed; CHANGELOG + snapshot, with ADR-058 corrected
- [x] My changes generate no new warnings

### Snapshot and retention

`Tests/Unit/Api/api-surface.txt` changes: `TelemetrySignals` gains `recordServedBy()` and three properties. `ProviderCallContext` is **unchanged** — `withConfiguration()` already carried the scratchpad, so its public surface does not grow.

Retention is unaffected: `RetentionCoverageTest` checks tables, not columns; no new table; purge deletes whole rows. It runs green.

### Tests

`ServedConfigurationTelemetryTest` (5): a forced retryable primary failure writes exactly one row whose `served_*` differ from the requested identifier; no fallback → equal; exhausted chain → no swap; streaming writes the same values; the reader reads it back. Plus `FallbackRescueReportTest` (4) and an analytics render test with **real rows** rather than the empty state, so the Fluid markup is actually exercised.