### PR TITLE
feat(analytics): provider health and circuit readout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,21 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   runs another configuration stepped in for. `ProviderHealthRepository` is
   unchanged — its scores deliberately count only `fallback_attempts = 0`
   rows, so a rescued run still counts against the primary.
+- A **Provider health and circuits** table in the analytics module, the
+  readout ADR-063 deferred: per provider the health score with the sample
+  count and the rolling window it was taken over, plus the circuit state
+  from the `nrllm_circuit` cache. A provider with no telemetry in the
+  window shows "no data", never a zero — it was idle, not broken. Both
+  gates are stated on the page, because a score that changes nothing is
+  the likeliest misreading of such a panel: `health.reorderFallback` is
+  off by default, and a disabled `circuitBreaker.enabled` means the
+  circuit column is not being evaluated at all. No new backend module
+  (ADR-119) — it is a section of the existing analytics view.
+  `ProviderHealthServiceInterface` gains `windowSeconds()` and
+  `reorderEnabled()` so the window and the switch are read from the
+  advisor instead of restated by its consumers; neither the interface nor
+  the new `Service\Analytics\ProviderHealthReport` is part of the `@api`
+  surface, which is unchanged.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   advisor instead of restated by its consumers; neither the interface nor
   the new `Service\Analytics\ProviderHealthReport` is part of the `@api`
   surface, which is unchanged.
+  The same "no data is not a zero" rule applies to the latency column: a
+  provider present in the window whose every run a fallback rescued has no
+  self-served run to measure, and the cell says so instead of showing
+  `0 ms`. `ProviderHealthScore::$avgLatencyMs` is nullable for that case
+  (the score is unchanged — an unknown latency carries no penalty, and the
+  failure is already in the success rate). Circuits opened for direct calls
+  with a pinned provider are NOT in the table: such a run records no
+  provider and its circuit is keyed on the call identifier
+  (`ad-hoc:chat:openai`); the limitation is stated on `providerKeys()` and
+  in the administration docs instead of being claimed away.
 
 ### Changed
 

--- a/Classes/Controller/Backend/AnalyticsController.php
+++ b/Classes/Controller/Backend/AnalyticsController.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Controller\Backend;
 use DateTimeImmutable;
 use Netresearch\NrLlm\Service\Analytics\AnalyticsPeriod;
 use Netresearch\NrLlm\Service\Analytics\FallbackRescueReport;
+use Netresearch\NrLlm\Service\Analytics\ProviderHealthReport;
 use Netresearch\NrLlm\Service\UsageAnalyticsServiceInterface;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Backend\Attribute\AsController;
@@ -36,6 +37,7 @@ final class AnalyticsController extends ActionController
         private readonly ModuleTemplateFactory $moduleTemplateFactory,
         private readonly UsageAnalyticsServiceInterface $analytics,
         private readonly FallbackRescueReport $fallbackRescues,
+        private readonly ProviderHealthReport $providerHealth,
         private readonly BackendUriBuilder $backendUriBuilder,
         private readonly PageRenderer $pageRenderer,
     ) {}
@@ -84,6 +86,10 @@ final class AnalyticsController extends ActionController
             // Reads tx_nrllm_telemetry, not the usage table: the runs a sibling
             // configuration answered for after the requested one failed.
             'rescues'    => $this->fallbackRescues->rescuesSince($period->from),
+            // Ignores the selected range on purpose: health is a rolling
+            // telemetry window (ADR-063) and circuit state is live cache
+            // state — neither can be re-cut to a 90-day report period.
+            'health'     => $this->providerHealth->readout(),
             // JSON consumed by Analytics.js, embedded in a <script> tag via
             // f:format.raw(). JSON_HEX_* neutralises tag-breaking characters
             // (e.g. a model_id/provider label containing "</script>") so the

--- a/Classes/Provider/CircuitBreaker/CircuitBreakerConfig.php
+++ b/Classes/Provider/CircuitBreaker/CircuitBreakerConfig.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Provider\CircuitBreaker;
 
+use Throwable;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
 /**
  * Resolved circuit breaker tunables (ADR-063).
  *
@@ -19,9 +22,57 @@ namespace Netresearch\NrLlm\Provider\CircuitBreaker;
  */
 final readonly class CircuitBreakerConfig
 {
+    private const DEFAULT_FAILURE_THRESHOLD = 5;
+
+    private const DEFAULT_COOLDOWN_SECONDS = 30;
+
     public function __construct(
         public bool $enabled,
         public int $failureThreshold,
         public int $cooldownSeconds,
     ) {}
+
+    /**
+     * Read the `circuitBreaker.*` extension settings, tolerantly: any read
+     * failure or missing key falls back to the safe defaults (enabled, with the
+     * default threshold and cooldown).
+     *
+     * Lives here rather than in the middleware because a reader OUTSIDE the
+     * pipeline needs the same answer — a stored {@see CircuitState} only
+     * derives a {@see CircuitStatus} against the configured cooldown, so a
+     * second reader with its own defaults could report a circuit as half-open
+     * that the middleware still fails fast on.
+     *
+     * @internal
+     */
+    public static function fromExtensionConfiguration(ExtensionConfiguration $extensionConfiguration): self
+    {
+        try {
+            /** @var array<string, mixed> $config */
+            $config = $extensionConfiguration->get('nr_llm');
+        } catch (Throwable) {
+            $config = [];
+        }
+
+        $circuit = \is_array($config['circuitBreaker'] ?? null) ? $config['circuitBreaker'] : [];
+
+        return new self(
+            enabled: !\array_key_exists('enabled', $circuit) || (bool)$circuit['enabled'],
+            failureThreshold: self::positiveIntOr($circuit['failureThreshold'] ?? null, self::DEFAULT_FAILURE_THRESHOLD),
+            cooldownSeconds: self::positiveIntOr($circuit['cooldownSeconds'] ?? null, self::DEFAULT_COOLDOWN_SECONDS),
+        );
+    }
+
+    private static function positiveIntOr(mixed $value, int $default): int
+    {
+        if (\is_int($value) && $value > 0) {
+            return $value;
+        }
+
+        if (\is_string($value) && ctype_digit($value) && (int)$value > 0) {
+            return (int)$value;
+        }
+
+        return $default;
+    }
 }

--- a/Classes/Provider/Middleware/CircuitBreakerMiddleware.php
+++ b/Classes/Provider/Middleware/CircuitBreakerMiddleware.php
@@ -90,10 +90,6 @@ final readonly class CircuitBreakerMiddleware implements ProviderMiddlewareInter
         return 20;
     }
 
-    private const DEFAULT_FAILURE_THRESHOLD = 5;
-
-    private const DEFAULT_COOLDOWN_SECONDS  = 30;
-
     public function __construct(
         private CircuitBreakerStoreInterface $store,
         private ExtensionConfiguration $extensionConfiguration,
@@ -235,38 +231,12 @@ final readonly class CircuitBreakerMiddleware implements ProviderMiddlewareInter
 
     /**
      * Read the circuit configuration from the `circuitBreaker.*` extension
-     * settings, mirroring TelemetryMiddleware's tolerant reader: any read
-     * failure or missing key falls back to the safe defaults (enabled, with the
-     * default threshold and cooldown).
+     * settings. The tolerant reader itself lives on the config object, because
+     * the backend readout resolves the same cooldown to derive a circuit's
+     * status outside the pipeline.
      */
     private function config(): CircuitBreakerConfig
     {
-        try {
-            /** @var array<string, mixed> $config */
-            $config = $this->extensionConfiguration->get('nr_llm');
-        } catch (Throwable) {
-            $config = [];
-        }
-
-        $circuit = \is_array($config['circuitBreaker'] ?? null) ? $config['circuitBreaker'] : [];
-
-        return new CircuitBreakerConfig(
-            enabled: !\array_key_exists('enabled', $circuit) || (bool)$circuit['enabled'],
-            failureThreshold: $this->positiveIntOr($circuit['failureThreshold'] ?? null, self::DEFAULT_FAILURE_THRESHOLD),
-            cooldownSeconds: $this->positiveIntOr($circuit['cooldownSeconds'] ?? null, self::DEFAULT_COOLDOWN_SECONDS),
-        );
-    }
-
-    private function positiveIntOr(mixed $value, int $default): int
-    {
-        if (\is_int($value) && $value > 0) {
-            return $value;
-        }
-
-        if (\is_string($value) && ctype_digit($value) && (int)$value > 0) {
-            return (int)$value;
-        }
-
-        return $default;
+        return CircuitBreakerConfig::fromExtensionConfiguration($this->extensionConfiguration);
     }
 }

--- a/Classes/Service/Analytics/ProviderHealthReport.php
+++ b/Classes/Service/Analytics/ProviderHealthReport.php
@@ -35,6 +35,10 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
  *    window gets `sampleCount = 0` and NULL score/success/latency, never the
  *    neutral 0.5 the advisor hands its own callers or a 0.0 that would read as
  *    "broken". The absence is structural, not a flag a template may forget.
+ *    The rule repeats one level down: a provider that WAS called but whose every
+ *    run a fallback rescued has a real score and success rate — its first
+ *    attempt lost — and NO latency, because not one run measured its own. That
+ *    row carries `avgLatencyMs = null` and `latencyMeasured = false`.
  *  - **A switch that is off makes the scores decorative.** Both gates
  *    (`health.reorderFallback`, `circuitBreaker.enabled`) travel with the
  *    numbers so the view can say when they change nothing.
@@ -59,6 +63,7 @@ final readonly class ProviderHealthReport
      *         score: float|null,
      *         successRate: float|null,
      *         avgLatencyMs: float|null,
+     *         latencyMeasured: bool,
      *         circuit: string,
      *         consecutiveFailures: int
      *     }>
@@ -81,6 +86,12 @@ final readonly class ProviderHealthReport
                 'score'               => $score?->score,
                 'successRate'         => $score?->successRate,
                 'avgLatencyMs'        => $score?->avgLatencyMs,
+                // Fluid cannot tell null from 0.0 in a condition (an unquoted
+                // NULL parses as the string "NULL"), so the template gets the
+                // same discriminator it already uses for the score column: a
+                // flag, never the value itself. Read by the latency cell in
+                // Resources/Private/Templates/Backend/Analytics/Index.html.
+                'latencyMeasured'     => $score?->avgLatencyMs !== null,
                 'circuit'             => $state->status($now, $circuit->cooldownSeconds)->value,
                 'consecutiveFailures' => $state->consecutiveFailures,
             ];
@@ -100,11 +111,28 @@ final readonly class ProviderHealthReport
      * The union of two sets, because neither alone is the answer: the
      * configured active providers (so one that has not been called shows up as
      * "no data" instead of vanishing) and the providers the telemetry window
-     * saw (so a specialized or ad-hoc caller's provider is not hidden just
-     * because no provider record carries that adapter type). Health and circuit
-     * state are both keyed by ADAPTER TYPE, not by provider record — two
-     * provider records on the same adapter share one row, the same way they
-     * share one circuit.
+     * saw (so a specialized service's provider — image, speech, translation,
+     * which call through {@see \Netresearch\NrLlm\Provider\Middleware\ProviderCallContext::forService()}
+     * with an explicit provider string — is not hidden just because no provider
+     * record carries that adapter type). Health and circuit state are both keyed
+     * by ADAPTER TYPE, not by provider record — two provider records on the same
+     * adapter share one row, the same way they share one circuit.
+     *
+     * NOT covered: ad-hoc calls with a pinned provider
+     * ({@see \Netresearch\NrLlm\Service\LlmServiceManager::chat()} and siblings
+     * with a `provider` option). Their transient configuration carries no model,
+     * so `telemetryProvider()` is empty: telemetry stores an empty provider —
+     * which {@see \Netresearch\NrLlm\Service\Health\ProviderHealthRepositoryInterface::scoresSince()}
+     * excludes — and {@see \Netresearch\NrLlm\Provider\Middleware\CircuitBreakerMiddleware}
+     * keys their circuit on the identifier instead (`ad-hoc:chat:openai`), one
+     * per operation. Neither set can produce that key, and the store offers no
+     * way to enumerate keys, so an ad-hoc circuit is not in this table — while
+     * an `openai` row, if a provider record exists, reports the SEPARATE circuit
+     * keyed `openai`. Closing this means giving the transient configuration its
+     * pinned provider identity upstream (telemetry and circuit key would follow);
+     * it cannot be papered over here, and guessing `ad-hoc:<operation>:<provider>`
+     * per operation would merge several circuits into one badge that states less
+     * than it seems to.
      *
      * @param array<string, ProviderHealthScore> $scores
      *

--- a/Classes/Service/Analytics/ProviderHealthReport.php
+++ b/Classes/Service/Analytics/ProviderHealthReport.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Analytics;
+
+use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
+use Netresearch\NrLlm\Provider\CircuitBreaker\CircuitBreakerConfig;
+use Netresearch\NrLlm\Provider\CircuitBreaker\CircuitBreakerStoreInterface;
+use Netresearch\NrLlm\Service\Health\ProviderHealthScore;
+use Netresearch\NrLlm\Service\Health\ProviderHealthServiceInterface;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+/**
+ * The resilience state of every provider, as one readable answer (ADR-063).
+ *
+ * ADR-063 built two mechanisms and no way to look at them: health scores over
+ * the telemetry window ({@see ProviderHealthServiceInterface}) and per-provider
+ * circuit state in the `nrllm_circuit` cache
+ * ({@see CircuitBreakerStoreInterface}). This joins them for the analytics
+ * module — the numbers stay where they are computed, only the reading is here.
+ *
+ * Three things it is careful about, because each is a way to misread the page:
+ *
+ *  - **A score without its sample size and window says nothing.** A 0.9 over
+ *    two calls and a 0.9 over two thousand are different facts, so the window
+ *    is asked of the health service rather than restated here, and every row
+ *    carries its sample count.
+ *  - **No telemetry is not a score of zero.** A provider absent from the
+ *    window gets `sampleCount = 0` and NULL score/success/latency, never the
+ *    neutral 0.5 the advisor hands its own callers or a 0.0 that would read as
+ *    "broken". The absence is structural, not a flag a template may forget.
+ *  - **A switch that is off makes the scores decorative.** Both gates
+ *    (`health.reorderFallback`, `circuitBreaker.enabled`) travel with the
+ *    numbers so the view can say when they change nothing.
+ */
+final readonly class ProviderHealthReport
+{
+    public function __construct(
+        private ProviderHealthServiceInterface $health,
+        private CircuitBreakerStoreInterface $circuitStore,
+        private ProviderRepository $providerRepository,
+        private ExtensionConfiguration $extensionConfiguration,
+    ) {}
+
+    /**
+     * @return array{
+     *     windowSeconds: int,
+     *     reorderFallback: bool,
+     *     circuitBreakerEnabled: bool,
+     *     providers: list<array{
+     *         provider: string,
+     *         sampleCount: int,
+     *         score: float|null,
+     *         successRate: float|null,
+     *         avgLatencyMs: float|null,
+     *         circuit: string,
+     *         consecutiveFailures: int
+     *     }>
+     * }
+     */
+    public function readout(): array
+    {
+        $scores  = $this->health->all();
+        $circuit = CircuitBreakerConfig::fromExtensionConfiguration($this->extensionConfiguration);
+        $now     = time();
+
+        $rows = [];
+        foreach ($this->providerKeys($scores) as $provider) {
+            $score = $scores[$provider] ?? null;
+            $state = $this->circuitStore->load($provider);
+
+            $rows[] = [
+                'provider'            => $provider,
+                'sampleCount'         => $score !== null ? $score->sampleCount : 0,
+                'score'               => $score?->score,
+                'successRate'         => $score?->successRate,
+                'avgLatencyMs'        => $score?->avgLatencyMs,
+                'circuit'             => $state->status($now, $circuit->cooldownSeconds)->value,
+                'consecutiveFailures' => $state->consecutiveFailures,
+            ];
+        }
+
+        return [
+            'windowSeconds'         => $this->health->windowSeconds(),
+            'reorderFallback'       => $this->health->reorderEnabled(),
+            'circuitBreakerEnabled' => $circuit->enabled,
+            'providers'             => $rows,
+        ];
+    }
+
+    /**
+     * Every provider worth a row, sorted, without duplicates.
+     *
+     * The union of two sets, because neither alone is the answer: the
+     * configured active providers (so one that has not been called shows up as
+     * "no data" instead of vanishing) and the providers the telemetry window
+     * saw (so a specialized or ad-hoc caller's provider is not hidden just
+     * because no provider record carries that adapter type). Health and circuit
+     * state are both keyed by ADAPTER TYPE, not by provider record — two
+     * provider records on the same adapter share one row, the same way they
+     * share one circuit.
+     *
+     * @param array<string, ProviderHealthScore> $scores
+     *
+     * @return list<string>
+     */
+    private function providerKeys(array $scores): array
+    {
+        $keys = array_keys($scores);
+
+        foreach ($this->providerRepository->findActive() as $provider) {
+            $adapterType = $provider->getAdapterType();
+            if ($adapterType !== '') {
+                $keys[] = $adapterType;
+            }
+        }
+
+        $keys = array_values(array_unique($keys));
+        sort($keys);
+
+        return $keys;
+    }
+}

--- a/Classes/Service/Health/ProviderHealthRepository.php
+++ b/Classes/Service/Health/ProviderHealthRepository.php
@@ -71,7 +71,11 @@ final readonly class ProviderHealthRepository implements ProviderHealthRepositor
 
             $samples    = is_numeric($row['samples'] ?? null) ? (int)$row['samples'] : 0;
             $successes  = is_numeric($row['successes'] ?? null) ? (int)$row['successes'] : 0;
-            $avgLatency = is_numeric($row['avg_latency'] ?? null) ? (float)$row['avg_latency'] : 0.0;
+            // NULL, not 0.0, when AVG had nothing to average: every run of this
+            // provider in the window was fallback-rescued, so none of them
+            // measures its own latency. Collapsing that to 0.0 would report a
+            // provider that never answered on its own as instantaneous.
+            $avgLatency = is_numeric($row['avg_latency'] ?? null) ? (float)$row['avg_latency'] : null;
 
             $scores[$provider] = ProviderHealthScore::fromSamples($provider, $samples, $successes, $avgLatency);
         }

--- a/Classes/Service/Health/ProviderHealthScore.php
+++ b/Classes/Service/Health/ProviderHealthScore.php
@@ -13,15 +13,21 @@ namespace Netresearch\NrLlm\Service\Health;
  * A provider's recent health, derived from the telemetry log (ADR-063).
  *
  * `successRate` is the share of successful runs in the sampled window (0.0–1.0);
- * `avgLatencyMs` the mean end-to-end latency of those runs. `score` is a single
- * comparable 0.0–1.0 number combining both — success rate dominates, latency is
- * a mild secondary penalty — so two providers can be ordered by health with one
- * comparison.
+ * `avgLatencyMs` the mean end-to-end latency of the runs the provider served
+ * ITSELF. `score` is a single comparable 0.0–1.0 number combining both — success
+ * rate dominates, latency is a mild secondary penalty — so two providers can be
+ * ordered by health with one comparison.
  *
  * A provider with no telemetry in the window is "unknown": `sampleCount === 0`
  * and a neutral `score` of {@see self::NEUTRAL_SCORE}, so an absence of data
  * never reads as unhealthy (it must not push a provider down the fallback order
  * just because it has not been called yet).
+ *
+ * `avgLatencyMs` is NULL for a second, narrower absence: the provider WAS called
+ * in the window, but a fallback rescued every one of those runs, so not one of
+ * them is a measurement of this provider's own latency. NULL is not 0.0 —
+ * "never answered on its own" must not read as "answered in under a
+ * millisecond".
  */
 final readonly class ProviderHealthScore
 {
@@ -42,7 +48,7 @@ final readonly class ProviderHealthScore
         public string $provider,
         public int $sampleCount,
         public float $successRate,
-        public float $avgLatencyMs,
+        public ?float $avgLatencyMs,
         public float $score,
     ) {}
 
@@ -51,7 +57,7 @@ final readonly class ProviderHealthScore
      */
     public static function unknown(string $provider): self
     {
-        return new self($provider, 0, 0.0, 0.0, self::NEUTRAL_SCORE);
+        return new self($provider, 0, 0.0, null, self::NEUTRAL_SCORE);
     }
 
     /**
@@ -62,8 +68,13 @@ final readonly class ProviderHealthScore
      * Success rate is weighted four times the latency term: a provider that
      * answers slowly is preferable to one that fails. Latency is normalised
      * against {@see self::LATENCY_CEILING_MS} and clamped to [0, 1].
+     *
+     * A NULL `$avgLatencyMs` (no self-served run to measure) carries no penalty,
+     * exactly as before it could be told apart from a measured 0.0: an unknown
+     * is not evidence of slowness, and the failure it comes from is already
+     * priced into `$successCount`, which such a run never increments.
      */
-    public static function fromSamples(string $provider, int $sampleCount, int $successCount, float $avgLatencyMs): self
+    public static function fromSamples(string $provider, int $sampleCount, int $successCount, ?float $avgLatencyMs): self
     {
         if ($sampleCount <= 0) {
             return self::unknown($provider);
@@ -71,7 +82,7 @@ final readonly class ProviderHealthScore
 
         $successRate = $successCount / $sampleCount;
 
-        $latencyPenalty = min(1.0, max(0.0, $avgLatencyMs) / self::LATENCY_CEILING_MS);
+        $latencyPenalty = min(1.0, max(0.0, $avgLatencyMs ?? 0.0) / self::LATENCY_CEILING_MS);
         $score          = (0.8 * $successRate) + (0.2 * (1.0 - $latencyPenalty));
 
         return new self(

--- a/Classes/Service/Health/ProviderHealthService.php
+++ b/Classes/Service/Health/ProviderHealthService.php
@@ -66,6 +66,11 @@ final class ProviderHealthService implements ProviderHealthServiceInterface
         return $scores;
     }
 
+    public function windowSeconds(): int
+    {
+        return self::WINDOW_SECONDS;
+    }
+
     public function reorder(FallbackChain $chain): FallbackChain
     {
         if ($chain->count() < 2 || !$this->reorderEnabled()) {
@@ -113,7 +118,7 @@ final class ProviderHealthService implements ProviderHealthServiceInterface
         return $provider !== '' ? $provider : null;
     }
 
-    private function reorderEnabled(): bool
+    public function reorderEnabled(): bool
     {
         try {
             /** @var array<string, mixed> $config */

--- a/Classes/Service/Health/ProviderHealthServiceInterface.php
+++ b/Classes/Service/Health/ProviderHealthServiceInterface.php
@@ -37,6 +37,29 @@ interface ProviderHealthServiceInterface
     public function all(): array;
 
     /**
+     * Length of the rolling window the scores reflect, in seconds.
+     *
+     * A score is only readable next to the window it was taken over — "80 %
+     * over the last quarter hour" and "80 % over the last day" are different
+     * statements. A readout must therefore be able to name the window rather
+     * than restate it from a constant of its own, which would silently drift
+     * from the one the scores were actually computed with.
+     */
+    public function windowSeconds(): int;
+
+    /**
+     * Whether the operator opted into the health-aware fallback reorder
+     * (`health.reorderFallback`, default off).
+     *
+     * Exposed because a score that influences nothing is the likeliest
+     * misreading of a health readout: a consumer that shows scores must be
+     * able to say whether they currently change any decision. The default-off
+     * semantics live here, with {@see self::reorder()}, so a second reader
+     * cannot disagree about what an unset setting means.
+     */
+    public function reorderEnabled(): bool;
+
+    /**
      * Return the fallback chain reordered by descending provider health, as a
      * HINT — a stable sort, so configurations whose providers are equally
      * healthy (or unknown) keep their configured order. This is the tie-break

--- a/Documentation/Administration/Analytics.rst
+++ b/Documentation/Administration/Analytics.rst
@@ -144,6 +144,63 @@ A configuration appearing here repeatedly is the signal to look at: its
 calls are being answered by a sibling, which may use a different provider,
 model and price than the one you selected.
 
+..  _administration-analytics-health:
+
+Provider health and circuits
+============================
+
+A table lists every provider that is either configured and active or was
+called recently, with its **health score**, the **number of samples** the
+score is based on, the **window** those samples were taken over, and the
+state of its **circuit breaker**.
+
+Health and circuit state are both keyed by **adapter type**, not by
+provider record — two provider records on the same adapter share one score
+and one circuit, because it is the provider that is unhealthy, not the
+record.
+
+..  list-table::
+    :header-rows: 1
+    :widths: 25 75
+
+    * - Column
+      - Meaning
+    * - Score
+      - A single 0.00–1.00 number combining success rate and mean
+        latency, success rate weighted four times as heavily (see
+        :ref:`adr-063`). Higher is healthier.
+    * - Samples in window
+      - How many runs the score was computed from. Read it before the
+        score: 0.90 over two calls and 0.90 over two thousand are
+        different statements.
+    * - Success rate
+      - Share of runs the provider served **itself**. A run a fallback
+        rescued counts as a failure of the requested provider.
+    * - Avg latency
+      - Mean end-to-end time of the self-served runs.
+    * - Circuit
+      - ``closed`` (normal), ``open`` (failing fast for the cooldown) or
+        ``half-open`` (cooldown elapsed, one probe due), plus the current
+        consecutive-failure streak.
+
+Unlike the rest of this module the table ignores the date range selected
+above. Scores come from a rolling telemetry window (15 minutes by
+default, named on the page) and circuit state is live cache state — neither
+can be re-cut to a 90-day report period.
+
+..  important::
+    **A score only changes something when you switched it on.**
+    :guilabel:`Health-Aware Fallback Reorder` (``health.reorderFallback``
+    in the extension configuration) is **off by default**. While it is
+    off, the scores are diagnostic only: the fallback chain keeps the
+    order you configured. The page states which of the two positions the
+    switch is in, above the table. The circuit breaker
+    (``circuitBreaker.enabled``) is on by default, and the page says so
+    when it is not.
+
+A provider with no telemetry in the window shows **no data** — not a score
+of zero. It was not called; that is not the same as failing.
+
 ..  _administration-analytics-cost-note:
 
 A note on cost

--- a/Documentation/Administration/Analytics.rst
+++ b/Documentation/Administration/Analytics.rst
@@ -149,15 +149,27 @@ model and price than the one you selected.
 Provider health and circuits
 ============================
 
-A table lists every provider that is either configured and active or was
-called recently, with its **health score**, the **number of samples** the
-score is based on, the **window** those samples were taken over, and the
-state of its **circuit breaker**.
+A table lists every provider that is either configured and active or named
+by a run in the telemetry window, with its **health score**, the **number
+of samples** the score is based on, the **window** those samples were taken
+over, and the state of its **circuit breaker**.
 
 Health and circuit state are both keyed by **adapter type**, not by
 provider record — two provider records on the same adapter share one score
 and one circuit, because it is the provider that is unhealthy, not the
 record.
+
+..  note::
+    **Direct calls with a pinned provider are not in this table.**
+    :php:`chat()`, :php:`complete()`, :php:`embed()` and their siblings
+    called with a ``provider`` option skip the default configuration
+    entirely and run against a transient one carrying no model. Such a run
+    records no provider in the telemetry log, and its circuit is kept
+    under the call's own identifier (``ad-hoc:chat:openai``, one per
+    operation) rather than under ``openai``. An ``openai`` row here
+    therefore reports the circuit of the configuration-backed calls only;
+    a circuit opened for direct pinned calls is not shown anywhere on this
+    page. Route traffic through a configuration if you need it covered.
 
 ..  list-table::
     :header-rows: 1
@@ -177,7 +189,11 @@ record.
       - Share of runs the provider served **itself**. A run a fallback
         rescued counts as a failure of the requested provider.
     * - Avg latency
-      - Mean end-to-end time of the self-served runs.
+      - Mean end-to-end time of the self-served runs. A provider whose runs
+        in the window were **all** rescued by a fallback has no self-served
+        run to measure: the cell says the latency was not measured instead
+        of showing ``0 ms``. Its score and success rate are real — the
+        first attempt did lose.
     * - Circuit
       - ``closed`` (normal), ``open`` (failing fast for the cooldown) or
         ``half-open`` (cooldown elapsed, one probe due), plus the current

--- a/Documentation/Adr/Adr063ProviderResilience.rst
+++ b/Documentation/Adr/Adr063ProviderResilience.rst
@@ -223,6 +223,20 @@ Deferred / follow-ups
 
 * A backend readout of circuit state and health scores (a diagnostics panel).
   The services expose the data; only a view is missing.
+
+  ..  note::
+
+      **Overtaken.** The view exists: the analytics module renders a
+      **Provider health and circuits** table
+      (:php:`Service\Analytics\ProviderHealthReport`, joining
+      :php:`ProviderHealthServiceInterface` with
+      :php:`CircuitBreakerStoreInterface`). It names each score's sample count
+      and the rolling window, shows a provider with no telemetry as "no data"
+      rather than a zero, and states whether ``health.reorderFallback`` and
+      ``circuitBreaker.enabled`` are on — a score that decides nothing is the
+      likeliest misreading of such a panel. No new module was added
+      (:ref:`adr-119`); it is a section of the existing analytics view.
+
 * Per-operation idempotency TTL override via call metadata (the middleware uses
   a single window today).
 * Concurrent-double-submit dedup. The current get-then-run-then-set has no atomic

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -668,6 +668,78 @@
                 <source>No configuration had to step in for another one in this period.</source>
                 <target>In diesem Zeitraum musste keine Konfiguration für eine andere einspringen.</target>
             </trans-unit>
+            <trans-unit id="analytics.health.title">
+                <source>Provider health and circuits</source>
+                <target>Provider-Zustand und Circuit Breaker</target>
+            </trans-unit>
+            <trans-unit id="analytics.health.description">
+                <source>Live resilience state, not the date range selected above: scores are recomputed over a rolling window of the last %s seconds of telemetry, circuit state is read from the cache as it stands now.</source>
+                <target>Der aktuelle Zustand, nicht der oben gewählte Zeitraum: Die Bewertungen entstehen aus einem gleitenden Fenster der letzten %s Sekunden Telemetrie, der Zustand der Circuit Breaker kommt so aus dem Cache, wie er gerade ist.</target>
+            </trans-unit>
+            <trans-unit id="analytics.health.reorder.on">
+                <source>Health-aware fallback reorder is ON: these scores reprioritise the fallback chain, healthiest provider first, with the configured order as the tie-break.</source>
+                <target>Die zustandsabhängige Umsortierung der Fallback-Kette ist EIN: Diese Bewertungen sortieren die Kette um, der gesündeste Provider zuerst; bei Gleichstand bleibt die konfigurierte Reihenfolge.</target>
+            </trans-unit>
+            <trans-unit id="analytics.health.reorder.off">
+                <source>Health-aware fallback reorder is OFF (the default). These scores are informational only — they change nothing about which provider is called. Turn on "Health-Aware Fallback Reorder" in the extension configuration to let them reprioritise the fallback chain.</source>
+                <target>Die zustandsabhängige Umsortierung der Fallback-Kette ist AUS (Voreinstellung). Diese Bewertungen sind reine Information – sie ändern nichts daran, welcher Provider aufgerufen wird. Schalte „Health-Aware Fallback Reorder“ in der Extension-Konfiguration ein, damit sie die Fallback-Kette umsortieren.</target>
+            </trans-unit>
+            <trans-unit id="analytics.health.circuit.disabled">
+                <source>The circuit breaker is switched off in the extension configuration. No circuit is evaluated, so no provider is failed fast; any state below is left over from when it was on.</source>
+                <target>Der Circuit Breaker ist in der Extension-Konfiguration abgeschaltet. Es wird kein Circuit ausgewertet, kein Provider bricht deshalb früh ab; ein Zustand unten stammt noch aus der Zeit, als er eingeschaltet war.</target>
+            </trans-unit>
+            <trans-unit id="analytics.health.table.provider">
+                <source>Provider (adapter type)</source>
+                <target>Provider (Adapter-Typ)</target>
+            </trans-unit>
+            <trans-unit id="analytics.health.table.score">
+                <source>Score</source>
+                <target>Bewertung</target>
+            </trans-unit>
+            <trans-unit id="analytics.health.table.samples">
+                <source>Samples in window</source>
+                <target>Stichproben im Fenster</target>
+            </trans-unit>
+            <trans-unit id="analytics.health.table.successRate">
+                <source>Success rate</source>
+                <target>Erfolgsquote</target>
+            </trans-unit>
+            <trans-unit id="analytics.health.table.latency">
+                <source>Avg latency</source>
+                <target>Mittlere Laufzeit</target>
+            </trans-unit>
+            <trans-unit id="analytics.health.table.circuit">
+                <source>Circuit</source>
+                <target>Circuit</target>
+            </trans-unit>
+            <trans-unit id="analytics.health.noData">
+                <source>No data in the window — this provider was not called, which is not the same as a score of zero.</source>
+                <target>Keine Daten im Fenster – dieser Provider wurde nicht aufgerufen. Das ist etwas anderes als eine Bewertung von null.</target>
+            </trans-unit>
+            <trans-unit id="analytics.health.circuit.closed">
+                <source>closed</source>
+                <target>geschlossen</target>
+            </trans-unit>
+            <trans-unit id="analytics.health.circuit.open">
+                <source>open</source>
+                <target>offen</target>
+            </trans-unit>
+            <trans-unit id="analytics.health.circuit.halfOpen">
+                <source>half-open</source>
+                <target>halb offen</target>
+            </trans-unit>
+            <trans-unit id="analytics.health.circuit.failures">
+                <source>%s consecutive failures</source>
+                <target>%s Fehler in Folge</target>
+            </trans-unit>
+            <trans-unit id="analytics.health.circuit.offShort">
+                <source>not evaluated</source>
+                <target>nicht ausgewertet</target>
+            </trans-unit>
+            <trans-unit id="analytics.health.empty">
+                <source>No active provider is configured and no provider was called recently.</source>
+                <target>Es ist kein aktiver Provider konfiguriert, und zuletzt wurde keiner aufgerufen.</target>
+            </trans-unit>
 
             <!-- Skills backend module -->
             <trans-unit id="skill.list.title">

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -716,6 +716,10 @@
                 <source>No data in the window — this provider was not called, which is not the same as a score of zero.</source>
                 <target>Keine Daten im Fenster – dieser Provider wurde nicht aufgerufen. Das ist etwas anderes als eine Bewertung von null.</target>
             </trans-unit>
+            <trans-unit id="analytics.health.noLatency">
+                <source>not measured — every run in the window was rescued by a fallback, so this provider never answered on its own</source>
+                <target>nicht gemessen – jeder Lauf im Fenster wurde von einem Fallback aufgefangen, dieser Provider hat also nie selbst geantwortet</target>
+            </trans-unit>
             <trans-unit id="analytics.health.circuit.closed">
                 <source>closed</source>
                 <target>geschlossen</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -543,6 +543,9 @@
             <trans-unit id="analytics.health.noData">
                 <source>No data in the window — this provider was not called, which is not the same as a score of zero.</source>
             </trans-unit>
+            <trans-unit id="analytics.health.noLatency">
+                <source>not measured — every run in the window was rescued by a fallback, so this provider never answered on its own</source>
+            </trans-unit>
             <trans-unit id="analytics.health.circuit.closed">
                 <source>closed</source>
             </trans-unit>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -507,6 +507,60 @@
             <trans-unit id="analytics.rescues.empty">
                 <source>No configuration had to step in for another one in this period.</source>
             </trans-unit>
+            <trans-unit id="analytics.health.title">
+                <source>Provider health and circuits</source>
+            </trans-unit>
+            <trans-unit id="analytics.health.description">
+                <source>Live resilience state, not the date range selected above: scores are recomputed over a rolling window of the last %s seconds of telemetry, circuit state is read from the cache as it stands now.</source>
+            </trans-unit>
+            <trans-unit id="analytics.health.reorder.on">
+                <source>Health-aware fallback reorder is ON: these scores reprioritise the fallback chain, healthiest provider first, with the configured order as the tie-break.</source>
+            </trans-unit>
+            <trans-unit id="analytics.health.reorder.off">
+                <source>Health-aware fallback reorder is OFF (the default). These scores are informational only — they change nothing about which provider is called. Turn on "Health-Aware Fallback Reorder" in the extension configuration to let them reprioritise the fallback chain.</source>
+            </trans-unit>
+            <trans-unit id="analytics.health.circuit.disabled">
+                <source>The circuit breaker is switched off in the extension configuration. No circuit is evaluated, so no provider is failed fast; any state below is left over from when it was on.</source>
+            </trans-unit>
+            <trans-unit id="analytics.health.table.provider">
+                <source>Provider (adapter type)</source>
+            </trans-unit>
+            <trans-unit id="analytics.health.table.score">
+                <source>Score</source>
+            </trans-unit>
+            <trans-unit id="analytics.health.table.samples">
+                <source>Samples in window</source>
+            </trans-unit>
+            <trans-unit id="analytics.health.table.successRate">
+                <source>Success rate</source>
+            </trans-unit>
+            <trans-unit id="analytics.health.table.latency">
+                <source>Avg latency</source>
+            </trans-unit>
+            <trans-unit id="analytics.health.table.circuit">
+                <source>Circuit</source>
+            </trans-unit>
+            <trans-unit id="analytics.health.noData">
+                <source>No data in the window — this provider was not called, which is not the same as a score of zero.</source>
+            </trans-unit>
+            <trans-unit id="analytics.health.circuit.closed">
+                <source>closed</source>
+            </trans-unit>
+            <trans-unit id="analytics.health.circuit.open">
+                <source>open</source>
+            </trans-unit>
+            <trans-unit id="analytics.health.circuit.halfOpen">
+                <source>half-open</source>
+            </trans-unit>
+            <trans-unit id="analytics.health.circuit.failures">
+                <source>%s consecutive failures</source>
+            </trans-unit>
+            <trans-unit id="analytics.health.circuit.offShort">
+                <source>not evaluated</source>
+            </trans-unit>
+            <trans-unit id="analytics.health.empty">
+                <source>No active provider is configured and no provider was called recently.</source>
+            </trans-unit>
 
             <!-- Skills backend module -->
             <trans-unit id="skill.list.title">

--- a/Resources/Private/Templates/Backend/Analytics/Index.html
+++ b/Resources/Private/Templates/Backend/Analytics/Index.html
@@ -214,7 +214,17 @@
                                             <td>{p.score -> f:format.number(decimals: 2)}</td>
                                             <td>{p.sampleCount -> f:format.number(decimals: 0)}</td>
                                             <td>{p.successRate -> f:format.number(decimals: 2)}</td>
-                                            <td>{p.avgLatencyMs -> f:format.number(decimals: 0)} ms</td>
+                                            <f:comment>latencyMeasured, not the value: a measured 0 ms is a statement, and a provider whose every run a fallback rescued has nothing to state</f:comment>
+                                            <f:if condition="{p.latencyMeasured}">
+                                                <f:then>
+                                                    <td>{p.avgLatencyMs -> f:format.number(decimals: 0)} ms</td>
+                                                </f:then>
+                                                <f:else>
+                                                    <td class="text-body-secondary">
+                                                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.health.noLatency" />
+                                                    </td>
+                                                </f:else>
+                                            </f:if>
                                         </f:then>
                                         <f:else>
                                             <td colspan="4" class="text-body-secondary">

--- a/Resources/Private/Templates/Backend/Analytics/Index.html
+++ b/Resources/Private/Templates/Backend/Analytics/Index.html
@@ -161,6 +161,92 @@
                 <p class="text-body-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.rescues.empty" /></p>
             </f:else>
         </f:if>
+
+        <f:comment>Provider health and circuit state — live resilience state (ADR-063), not the selected report range</f:comment>
+        <h3><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.health.title" /></h3>
+        <p class="text-body-secondary">
+            <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.health.description"
+                         arguments="{0: health.windowSeconds}" />
+        </p>
+
+        <f:comment>A score that changes no decision is the likeliest misreading of this table — so the switch says so first</f:comment>
+        <f:if condition="{health.reorderFallback}">
+            <f:then>
+                <f:be.infobox state="0">
+                    <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.health.reorder.on" /></p>
+                </f:be.infobox>
+            </f:then>
+            <f:else>
+                <f:be.infobox state="1">
+                    <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.health.reorder.off" /></p>
+                </f:be.infobox>
+            </f:else>
+        </f:if>
+        <f:if condition="{health.circuitBreakerEnabled}">
+            <f:else>
+                <f:be.infobox state="1">
+                    <p class="mb-0"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.health.circuit.disabled" /></p>
+                </f:be.infobox>
+            </f:else>
+        </f:if>
+
+        <f:if condition="{health.providers}">
+            <f:then>
+                <div class="table-fit">
+                    <table class="table table-striped">
+                        <thead>
+                            <tr>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.health.table.provider" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.health.table.score" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.health.table.samples" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.health.table.successRate" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.health.table.latency" /></th>
+                                <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.health.table.circuit" /></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <f:for each="{health.providers}" as="p">
+                                <tr>
+                                    <td>{p.provider}</td>
+                                    <f:comment>sampleCount, not the score itself: a genuine score of 0.00 is a statement, and "{p.score}" would render it as no data</f:comment>
+                                    <f:if condition="{p.sampleCount} > 0">
+                                        <f:then>
+                                            <td>{p.score -> f:format.number(decimals: 2)}</td>
+                                            <td>{p.sampleCount -> f:format.number(decimals: 0)}</td>
+                                            <td>{p.successRate -> f:format.number(decimals: 2)}</td>
+                                            <td>{p.avgLatencyMs -> f:format.number(decimals: 0)} ms</td>
+                                        </f:then>
+                                        <f:else>
+                                            <td colspan="4" class="text-body-secondary">
+                                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.health.noData" />
+                                            </td>
+                                        </f:else>
+                                    </f:if>
+                                    <td>
+                                        <f:if condition="{health.circuitBreakerEnabled}">
+                                            <f:then>
+                                                <f:switch expression="{p.circuit}">
+                                                    <f:case value="open"><span class="badge text-bg-danger"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.health.circuit.open" /></span></f:case>
+                                                    <f:case value="half_open"><span class="badge text-bg-warning"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.health.circuit.halfOpen" /></span></f:case>
+                                                    <f:defaultCase><span class="badge text-bg-success"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.health.circuit.closed" /></span></f:defaultCase>
+                                                </f:switch>
+                                                <f:if condition="{p.consecutiveFailures} > 0">
+                                                    <span class="text-body-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.health.circuit.failures" arguments="{0: p.consecutiveFailures}" /></span>
+                                                </f:if>
+                                            </f:then>
+                                            <f:else><span class="text-body-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.health.circuit.offShort" /></span></f:else>
+                                        </f:if>
+                                    </td>
+                                </tr>
+                            </f:for>
+                        </tbody>
+                    </table>
+                </div>
+            </f:then>
+            <f:else>
+                <p class="text-body-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.health.empty" /></p>
+            </f:else>
+        </f:if>
     </div>
 </f:section>
 

--- a/Tests/Functional/Controller/Backend/AnalyticsControllerTest.php
+++ b/Tests/Functional/Controller/Backend/AnalyticsControllerTest.php
@@ -118,6 +118,23 @@ final class AnalyticsControllerTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function indexActionShowsNoLatencyForAProviderThatNeverServedARunItself(): void
+    {
+        // Two runs in the window, both rescued by a fallback: openai has a real
+        // score and success rate but nothing that measures its own latency.
+        // "0 ms" here reads as sub-millisecond fast — the same zero-for-no-data
+        // confusion the score column avoids.
+        $this->insertRescuedHealthRow('openai', 153);
+        $this->insertRescuedHealthRow('openai', 247);
+
+        $body = (string)$this->dispatchIndex([])->getBody();
+
+        self::assertStringContainsString('<td>0.20</td>', $body, 'The score is a real statement and stays.');
+        self::assertStringNotContainsString('<td>0 ms</td>', $body, 'An unmeasured latency must never render as a duration.');
+        self::assertStringContainsString('never answered on its own', $body);
+    }
+
+    #[Test]
     public function indexActionSaysTheFallbackReorderSwitchIsOff(): void
     {
         // Default: health.reorderFallback is off, so the scores decide nothing.
@@ -235,6 +252,31 @@ final class AnalyticsControllerTest extends AbstractFunctionalTestCase
                 'latency_ms'               => $latencyMs,
                 'cache_hit'                => 0,
                 'fallback_attempts'        => 0,
+                'crdate'                   => time(),
+            ]);
+    }
+
+    /**
+     * A run the requested provider lost and a fallback rescued: a sample and a
+     * primary failure, but no measurement of the requested provider's latency.
+     */
+    private function insertRescuedHealthRow(string $provider, int $latencyMs): void
+    {
+        $this->getService(ConnectionPool::class)
+            ->getConnectionForTable('tx_nrllm_telemetry')
+            ->insert('tx_nrllm_telemetry', [
+                'pid'                      => 0,
+                'correlation_id'           => 'health-' . uniqid('', true),
+                'operation'                => 'chat',
+                'provider'                 => $provider,
+                'model'                    => '',
+                'configuration_identifier' => 'primary',
+                'be_user'                  => 0,
+                'success'                  => 1,
+                'error_class'              => '',
+                'latency_ms'               => $latencyMs,
+                'cache_hit'                => 0,
+                'fallback_attempts'        => 1,
                 'crdate'                   => time(),
             ]);
     }

--- a/Tests/Functional/Controller/Backend/AnalyticsControllerTest.php
+++ b/Tests/Functional/Controller/Backend/AnalyticsControllerTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;
 
 use Netresearch\NrLlm\Controller\Backend\AnalyticsController;
 use Netresearch\NrLlm\Service\Analytics\FallbackRescueReport;
+use Netresearch\NrLlm\Service\Analytics\ProviderHealthReport;
 use Netresearch\NrLlm\Service\UsageAnalyticsServiceInterface;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -82,6 +83,63 @@ final class AnalyticsControllerTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function indexActionRendersProviderHealthScoresWithTheirSampleCountAndWindow(): void
+    {
+        // Two active providers (ollama, openai); only openai is exercised.
+        $this->importFixture('Providers.csv');
+        $this->insertHealthRow('openai', true, 100);
+        $this->insertHealthRow('openai', true, 300);
+        $this->insertHealthRow('openai', false, 200);
+
+        $body = (string)$this->dispatchIndex([])->getBody();
+
+        // The window the scores were taken over is named, not left implicit.
+        self::assertStringContainsString('last 900 seconds', $body);
+        // 0.8 * (2/3) + 0.2 * (1 - 200/5000) = 0.7253
+        self::assertStringContainsString('<td>0.73</td>', $body, 'The score must be rendered.');
+        self::assertStringContainsString('<td>3</td>', $body, 'The sample count must be next to the score.');
+        self::assertStringContainsString('<td>0.67</td>', $body, 'The success rate must be rendered.');
+        self::assertStringContainsString('<td>200 ms</td>', $body, 'The mean latency must be rendered.');
+    }
+
+    #[Test]
+    public function indexActionShowsNoDataForAProviderWithoutTelemetryInsteadOfAZero(): void
+    {
+        // ollama is configured and active but was never called; openai has one
+        // sample. A 0 for ollama would read as "broken" — it was simply idle.
+        $this->importFixture('Providers.csv');
+        $this->insertHealthRow('openai', true, 100);
+
+        $body = (string)$this->dispatchIndex([])->getBody();
+
+        self::assertStringContainsString('No data in the window', $body);
+        self::assertStringNotContainsString('<td>0.00</td>', $body, 'An unused provider must never be scored 0.');
+        self::assertStringNotContainsString('<td>0</td>', $body, 'An unused provider must show no sample count either.');
+    }
+
+    #[Test]
+    public function indexActionSaysTheFallbackReorderSwitchIsOff(): void
+    {
+        // Default: health.reorderFallback is off, so the scores decide nothing.
+        $body = (string)$this->dispatchIndex([])->getBody();
+
+        self::assertStringContainsString('Health-aware fallback reorder is OFF', $body);
+    }
+
+    #[Test]
+    public function indexActionSaysTheFallbackReorderSwitchIsOn(): void
+    {
+        // The instance-level switch ExtensionConfiguration reads. Each
+        // functional test re-bootstraps TYPO3_CONF_VARS, so this does not leak.
+        $this->storeNrLlmConfig(['health' => ['reorderFallback' => '1']]);
+
+        $body = (string)$this->dispatchIndex([])->getBody();
+
+        self::assertStringContainsString('Health-aware fallback reorder is ON', $body);
+        self::assertStringNotContainsString('Health-aware fallback reorder is OFF', $body);
+    }
+
+    #[Test]
     public function indexActionNormalizesUnknownRangeParameter(): void
     {
         $response = $this->dispatchIndex(['range' => 'bogus-range']);
@@ -102,6 +160,7 @@ final class AnalyticsControllerTest extends AbstractFunctionalTestCase
             $this->getService(ModuleTemplateFactory::class),
             $this->getService(UsageAnalyticsServiceInterface::class),
             $this->getService(FallbackRescueReport::class),
+            $this->getService(ProviderHealthReport::class),
             $this->getService(BackendUriBuilder::class),
             $this->getService(PageRenderer::class),
         );
@@ -153,6 +212,54 @@ final class AnalyticsControllerTest extends AbstractFunctionalTestCase
                 'fallback_attempts'               => 1,
                 'crdate'                          => time(),
             ]);
+    }
+
+    /**
+     * A self-served run (no fallback hop), which is what the health scores
+     * count — see ProviderHealthRepository.
+     */
+    private function insertHealthRow(string $provider, bool $success, int $latencyMs): void
+    {
+        $this->getService(ConnectionPool::class)
+            ->getConnectionForTable('tx_nrllm_telemetry')
+            ->insert('tx_nrllm_telemetry', [
+                'pid'                      => 0,
+                'correlation_id'           => 'health-' . uniqid('', true),
+                'operation'                => 'chat',
+                'provider'                 => $provider,
+                'model'                    => '',
+                'configuration_identifier' => 'primary',
+                'be_user'                  => 0,
+                'success'                  => $success ? 1 : 0,
+                'error_class'              => '',
+                'latency_ms'               => $latencyMs,
+                'cache_hit'                => 0,
+                'fallback_attempts'        => 0,
+                'crdate'                   => time(),
+            ]);
+    }
+
+    /**
+     * Write the raw stored nr_llm extension configuration, narrowing the untyped
+     * $GLOBALS shape step by step so the writes stay PHPStan-clean.
+     *
+     * @param array<string, mixed> $nrLlm
+     */
+    private function storeNrLlmConfig(array $nrLlm): void
+    {
+        $confVars = $GLOBALS['TYPO3_CONF_VARS'] ?? [];
+        if (!is_array($confVars)) {
+            $confVars = [];
+        }
+
+        $extensions = $confVars['EXTENSIONS'] ?? [];
+        if (!is_array($extensions)) {
+            $extensions = [];
+        }
+
+        $extensions['nr_llm']       = $nrLlm;
+        $confVars['EXTENSIONS']     = $extensions;
+        $GLOBALS['TYPO3_CONF_VARS'] = $confVars;
     }
 
     private function setPrivateProperty(object $object, string $property, mixed $value): void

--- a/Tests/Functional/Service/Analytics/ProviderHealthReportTest.php
+++ b/Tests/Functional/Service/Analytics/ProviderHealthReportTest.php
@@ -1,0 +1,228 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Analytics;
+
+use Netresearch\NrLlm\Provider\CircuitBreaker\CircuitBreakerConfig;
+use Netresearch\NrLlm\Provider\CircuitBreaker\CircuitBreakerStoreInterface;
+use Netresearch\NrLlm\Provider\CircuitBreaker\CircuitState;
+use Netresearch\NrLlm\Service\Analytics\ProviderHealthReport;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * The readout ADR-063 deferred, against real telemetry rows and the real
+ * `nrllm_circuit` cache.
+ */
+#[CoversClass(ProviderHealthReport::class)]
+#[CoversClass(CircuitBreakerConfig::class)]
+final class ProviderHealthReportTest extends AbstractFunctionalTestCase
+{
+    private const TABLE = 'tx_nrllm_telemetry';
+
+    #[Test]
+    public function scoreCarriesItsSampleCountAndTheWindowItWasTakenOver(): void
+    {
+        $this->insertRow('openai', true, 100);
+        $this->insertRow('openai', true, 300);
+        $this->insertRow('openai', false, 200);
+
+        $readout = $this->report()->readout();
+
+        self::assertSame(900, $readout['windowSeconds']);
+        $row = $this->rowFor($readout, 'openai');
+        self::assertSame(3, $row['sampleCount']);
+        self::assertEqualsWithDelta(2 / 3, $row['successRate'], 0.0001);
+        self::assertEqualsWithDelta(200.0, $row['avgLatencyMs'], 0.0001);
+        self::assertNotNull($row['score']);
+        self::assertEqualsWithDelta(0.7253, $row['score'], 0.0001);
+    }
+
+    #[Test]
+    public function aProviderWithoutTelemetryHasNoScoreRatherThanAZero(): void
+    {
+        // ollama is configured and active; nothing called it.
+        $this->importFixture('Providers.csv');
+        $this->insertRow('openai', true, 100);
+
+        $row = $this->rowFor($this->report()->readout(), 'ollama');
+
+        self::assertSame(0, $row['sampleCount']);
+        self::assertNull($row['score'], 'No samples means no score — not the neutral 0.5, not 0.0.');
+        self::assertNull($row['successRate']);
+        self::assertNull($row['avgLatencyMs']);
+    }
+
+    #[Test]
+    public function aConfiguredProviderThatWasNeverCalledStillGetsARow(): void
+    {
+        $this->importFixture('Providers.csv');
+
+        $providers = array_column($this->report()->readout()['providers'], 'provider');
+
+        self::assertContains('ollama', $providers);
+        self::assertContains('openai', $providers);
+    }
+
+    #[Test]
+    public function reorderSwitchIsReportedInBothPositions(): void
+    {
+        $this->storeNrLlmConfig(['health' => ['reorderFallback' => '0']]);
+        self::assertFalse($this->report()->readout()['reorderFallback']);
+
+        $this->storeNrLlmConfig(['health' => ['reorderFallback' => '1']]);
+        self::assertTrue($this->report()->readout()['reorderFallback']);
+    }
+
+    #[Test]
+    public function circuitStateIsReadBackPerProvider(): void
+    {
+        $this->insertRow('openai', false, 100);
+        $this->store()->save('openai', new CircuitState(5, time()), 300);
+        $this->store()->save('groq', CircuitState::closed(), 300);
+
+        $readout = $this->report()->readout();
+
+        self::assertSame('open', $this->rowFor($readout, 'openai')['circuit']);
+        self::assertSame(5, $this->rowFor($readout, 'openai')['consecutiveFailures']);
+        // groq has neither telemetry nor a provider record, so it is not a row
+        // at all — an all-closed circuit is not a reason to list a provider.
+        self::assertSame([], array_filter(
+            $readout['providers'],
+            static fn(array $row): bool => $row['provider'] === 'groq',
+        ));
+    }
+
+    #[Test]
+    public function anElapsedCooldownReadsAsHalfOpen(): void
+    {
+        $this->insertRow('openai', false, 100);
+        $this->store()->save('openai', new CircuitState(5, time() - 100), 300);
+
+        // Default cooldown is 30s, so 100s ago is past it: a probe is due.
+        self::assertSame('half_open', $this->rowFor($this->report()->readout(), 'openai')['circuit']);
+    }
+
+    #[Test]
+    public function theConfiguredCooldownDecidesTheStatusNotADefaultOfItsOwn(): void
+    {
+        // The same state as above, but the operator widened the cooldown. A
+        // reader with its own default would call this half-open while the
+        // middleware still fails fast on it.
+        $this->storeNrLlmConfig(['circuitBreaker' => ['cooldownSeconds' => '600']]);
+        $this->insertRow('openai', false, 100);
+        $this->store()->save('openai', new CircuitState(5, time() - 100), 900);
+
+        self::assertSame('open', $this->rowFor($this->report()->readout(), 'openai')['circuit']);
+    }
+
+    #[Test]
+    public function aDisabledCircuitBreakerIsReported(): void
+    {
+        $this->storeNrLlmConfig(['circuitBreaker' => ['enabled' => '0']]);
+
+        self::assertFalse($this->report()->readout()['circuitBreakerEnabled']);
+    }
+
+    /**
+     * Write the raw stored nr_llm extension configuration, narrowing the untyped
+     * $GLOBALS shape step by step so the writes stay PHPStan-clean.
+     *
+     * @param array<string, mixed> $nrLlm
+     */
+    private function storeNrLlmConfig(array $nrLlm): void
+    {
+        $confVars = $GLOBALS['TYPO3_CONF_VARS'] ?? [];
+        if (!is_array($confVars)) {
+            $confVars = [];
+        }
+
+        $extensions = $confVars['EXTENSIONS'] ?? [];
+        if (!is_array($extensions)) {
+            $extensions = [];
+        }
+
+        $extensions['nr_llm']       = $nrLlm;
+        $confVars['EXTENSIONS']     = $extensions;
+        $GLOBALS['TYPO3_CONF_VARS'] = $confVars;
+    }
+
+    private function report(): ProviderHealthReport
+    {
+        return $this->getService(ProviderHealthReport::class);
+    }
+
+    private function store(): CircuitBreakerStoreInterface
+    {
+        $store = $this->get(CircuitBreakerStoreInterface::class);
+        self::assertInstanceOf(CircuitBreakerStoreInterface::class, $store);
+
+        return $store;
+    }
+
+    /**
+     * @param array{
+     *     windowSeconds: int,
+     *     reorderFallback: bool,
+     *     circuitBreakerEnabled: bool,
+     *     providers: list<array{
+     *         provider: string,
+     *         sampleCount: int,
+     *         score: float|null,
+     *         successRate: float|null,
+     *         avgLatencyMs: float|null,
+     *         circuit: string,
+     *         consecutiveFailures: int
+     *     }>
+     * } $readout
+     *
+     * @return array{
+     *     provider: string,
+     *     sampleCount: int,
+     *     score: float|null,
+     *     successRate: float|null,
+     *     avgLatencyMs: float|null,
+     *     circuit: string,
+     *     consecutiveFailures: int
+     * }
+     */
+    private function rowFor(array $readout, string $provider): array
+    {
+        foreach ($readout['providers'] as $row) {
+            if ($row['provider'] === $provider) {
+                return $row;
+            }
+        }
+
+        self::fail(sprintf('No readout row for provider "%s".', $provider));
+    }
+
+    private function insertRow(string $provider, bool $success, int $latencyMs): void
+    {
+        $this->getService(ConnectionPool::class)
+            ->getConnectionForTable(self::TABLE)
+            ->insert(self::TABLE, [
+                'pid'                      => 0,
+                'correlation_id'           => 'corr-' . uniqid('', true),
+                'operation'                => 'chat',
+                'provider'                 => $provider,
+                'model'                    => '',
+                'configuration_identifier' => 'primary',
+                'be_user'                  => 0,
+                'success'                  => $success ? 1 : 0,
+                'error_class'              => '',
+                'latency_ms'               => $latencyMs,
+                'cache_hit'                => 0,
+                'fallback_attempts'        => 0,
+                'crdate'                   => time(),
+            ]);
+    }
+}

--- a/Tests/Functional/Service/Analytics/ProviderHealthReportTest.php
+++ b/Tests/Functional/Service/Analytics/ProviderHealthReportTest.php
@@ -42,8 +42,28 @@ final class ProviderHealthReportTest extends AbstractFunctionalTestCase
         self::assertSame(3, $row['sampleCount']);
         self::assertEqualsWithDelta(2 / 3, $row['successRate'], 0.0001);
         self::assertEqualsWithDelta(200.0, $row['avgLatencyMs'], 0.0001);
+        self::assertTrue($row['latencyMeasured']);
         self::assertNotNull($row['score']);
         self::assertEqualsWithDelta(0.7253, $row['score'], 0.0001);
+    }
+
+    #[Test]
+    public function aProviderRescuedOnEveryRunReportsNoLatencyRatherThanZero(): void
+    {
+        // Present in the window, never self-served: the score (0.20) and the
+        // success rate (0.00) are real statements about the primary's first
+        // attempt, the latency is not a measurement at all.
+        $this->insertRow('openai', true, 150, 1);
+        $this->insertRow('openai', true, 250, 2);
+
+        $row = $this->rowFor($this->report()->readout(), 'openai');
+
+        self::assertSame(2, $row['sampleCount']);
+        self::assertSame(0.0, $row['successRate']);
+        self::assertNull($row['avgLatencyMs'], 'Never answered on its own is not "answered in 0 ms".');
+        self::assertFalse($row['latencyMeasured'], 'The template branches on this, since Fluid cannot test for null.');
+        self::assertNotNull($row['score']);
+        self::assertEqualsWithDelta(0.2, $row['score'], 0.0001);
     }
 
     #[Test]
@@ -59,6 +79,7 @@ final class ProviderHealthReportTest extends AbstractFunctionalTestCase
         self::assertNull($row['score'], 'No samples means no score — not the neutral 0.5, not 0.0.');
         self::assertNull($row['successRate']);
         self::assertNull($row['avgLatencyMs']);
+        self::assertFalse($row['latencyMeasured']);
     }
 
     #[Test]
@@ -99,6 +120,30 @@ final class ProviderHealthReportTest extends AbstractFunctionalTestCase
             $readout['providers'],
             static fn(array $row): bool => $row['provider'] === 'groq',
         ));
+    }
+
+    #[Test]
+    public function anAdHocCircuitIsNotAProviderRowAndDoesNotColourTheProvidersOwn(): void
+    {
+        // A direct call with a pinned provider records no provider in telemetry
+        // and keys its circuit on the transient identifier, one per operation.
+        // Neither the telemetry window nor the provider records can produce that
+        // key, and the store cannot be enumerated — so the open ad-hoc circuit
+        // is absent here while the openai row reports its OWN (closed) circuit.
+        // Documented as a limitation on providerKeys() and in Analytics.rst;
+        // closing it means giving the transient configuration a provider
+        // identity upstream, which this readout cannot do.
+        $this->importFixture('Providers.csv');
+        $this->store()->save('ad-hoc:chat:openai', new CircuitState(9, time()), 300);
+
+        $readout = $this->report()->readout();
+
+        self::assertSame([], array_filter(
+            $readout['providers'],
+            static fn(array $row): bool => $row['provider'] === 'ad-hoc:chat:openai',
+        ));
+        self::assertSame('closed', $this->rowFor($readout, 'openai')['circuit']);
+        self::assertSame(0, $this->rowFor($readout, 'openai')['consecutiveFailures']);
     }
 
     #[Test]
@@ -179,6 +224,7 @@ final class ProviderHealthReportTest extends AbstractFunctionalTestCase
      *         score: float|null,
      *         successRate: float|null,
      *         avgLatencyMs: float|null,
+     *         latencyMeasured: bool,
      *         circuit: string,
      *         consecutiveFailures: int
      *     }>
@@ -190,6 +236,7 @@ final class ProviderHealthReportTest extends AbstractFunctionalTestCase
      *     score: float|null,
      *     successRate: float|null,
      *     avgLatencyMs: float|null,
+     *     latencyMeasured: bool,
      *     circuit: string,
      *     consecutiveFailures: int
      * }
@@ -205,7 +252,7 @@ final class ProviderHealthReportTest extends AbstractFunctionalTestCase
         self::fail(sprintf('No readout row for provider "%s".', $provider));
     }
 
-    private function insertRow(string $provider, bool $success, int $latencyMs): void
+    private function insertRow(string $provider, bool $success, int $latencyMs, int $fallbackAttempts = 0): void
     {
         $this->getService(ConnectionPool::class)
             ->getConnectionForTable(self::TABLE)
@@ -221,7 +268,7 @@ final class ProviderHealthReportTest extends AbstractFunctionalTestCase
                 'error_class'              => '',
                 'latency_ms'               => $latencyMs,
                 'cache_hit'                => 0,
-                'fallback_attempts'        => 0,
+                'fallback_attempts'        => $fallbackAttempts,
                 'crdate'                   => time(),
             ]);
     }

--- a/Tests/Functional/Service/Health/ProviderHealthRepositoryTest.php
+++ b/Tests/Functional/Service/Health/ProviderHealthRepositoryTest.php
@@ -102,6 +102,24 @@ final class ProviderHealthRepositoryTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function latencyIsNullWhenEveryRunWasRescuedRatherThanZero(): void
+    {
+        $now = time();
+        // Both runs were rescued by a fallback, so AVG has no self-served row
+        // to average and returns SQL NULL. Reported as 0.0 that would claim a
+        // provider which never answered on its own is sub-millisecond fast.
+        $this->insertRow('openai', true, 150, $now, 1);
+        $this->insertRow('openai', true, 250, $now, 2);
+
+        $scores = $this->repository->scoresSince($now - 900);
+
+        self::assertArrayHasKey('openai', $scores);
+        self::assertSame(2, $scores['openai']->sampleCount, 'The rescued runs are still samples');
+        self::assertSame(0.0, $scores['openai']->successRate, 'A rescued run is a failure of the primary');
+        self::assertNull($scores['openai']->avgLatencyMs, 'No self-served run exists to measure');
+    }
+
+    #[Test]
     public function separatesProvidersIntoDistinctScores(): void
     {
         $now = time();

--- a/Tests/Unit/Service/Health/ProviderHealthScoreTest.php
+++ b/Tests/Unit/Service/Health/ProviderHealthScoreTest.php
@@ -25,6 +25,23 @@ final class ProviderHealthScoreTest extends AbstractUnitTestCase
         self::assertSame('openai', $score->provider);
         self::assertSame(0, $score->sampleCount);
         self::assertSame(ProviderHealthScore::NEUTRAL_SCORE, $score->score);
+        self::assertNull($score->avgLatencyMs, 'Nothing was measured — 0.0 would claim a measurement.');
+    }
+
+    #[Test]
+    public function anUnmeasurableLatencyIsNullNotZero(): void
+    {
+        // Called four times, rescued by a fallback every time: the failures are
+        // real (successRate 0.0), the latency is not a measurement of this
+        // provider at all. 0.0 here would read as "answered instantly".
+        $score = ProviderHealthScore::fromSamples('openai', 4, 0, null);
+
+        self::assertSame(4, $score->sampleCount);
+        self::assertSame(0.0, $score->successRate);
+        self::assertNull($score->avgLatencyMs);
+        // Unchanged from the value a 0.0 produced: an unknown latency must not
+        // invent a penalty, and the failure is already priced into the 0.8 term.
+        self::assertEqualsWithDelta(0.2, $score->score, 0.0001);
     }
 
     #[Test]

--- a/Tests/Unit/Service/Health/ProviderHealthServiceTest.php
+++ b/Tests/Unit/Service/Health/ProviderHealthServiceTest.php
@@ -130,6 +130,21 @@ final class ProviderHealthServiceTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function reorderEnabledReportsTheSettingInBothPositions(): void
+    {
+        // A readout must be able to say whether the scores decide anything;
+        // the default-off semantics stay in one place.
+        self::assertFalse($this->service($this->repositoryReturning([]), [], enabled: false)->reorderEnabled());
+        self::assertTrue($this->service($this->repositoryReturning([]), [], enabled: true)->reorderEnabled());
+    }
+
+    #[Test]
+    public function windowSecondsNamesTheWindowTheScoresAreTakenOver(): void
+    {
+        self::assertSame(900, $this->service($this->repositoryReturning([]), [], enabled: false)->windowSeconds());
+    }
+
+    #[Test]
     public function allServesFromCacheWithoutQueryingTelemetry(): void
     {
         $cached = ['openai' => ProviderHealthScore::fromSamples('openai', 3, 3, 10.0)];


### PR DESCRIPTION
> **Stacked on #660** → #655 → #641. Base is `feat/telemetry-served-configuration`; GitHub retargets as the chain merges.

## Description

ADR-063 deferred exactly this: *"A backend readout of circuit state **and** health scores … The services expose the data; only a view is missing."* `ProviderHealthServiceInterface` had one consumer (`FallbackMiddleware`) and no controller.

No new module (ADR-119) — the readout goes into the analytics module, beside #660's fallback-rescue list.

### The switch state is the point, not decoration

`health.reorderFallback` ships **off**. A score that influences nothing is the most likely misreading of this entire view, so the view states the switch. `circuitBreaker.enabled` is shown for the same reason: a "closed" circuit on a disabled breaker is the same class of false statement, and it cost one boolean from a config that was already being read.

### One reader for the cooldown, not two

Circuit **state** was already queryable through `CircuitBreakerStoreInterface::load()`. What was missing is the **cooldown**, which only `CircuitBreakerMiddleware::config()` read — privately, with private defaults.

A second reader with its own defaults could report a circuit as *half-open* while the middleware still fails fast on it. So the reader moved **verbatim** onto `CircuitBreakerConfig::fromExtensionConfiguration()` (`@internal`) — same defaults (5, 30), same `positiveIntOr` parsing — and the middleware delegates to it. No new reader class; that deviates from what the issue anticipated, and it is the reason.

### "No data" is structural

`score` / `successRate` / `avgLatencyMs` are `null` when `sampleCount === 0` — never the neutral 0.5, never 0.0. The Fluid condition branches on `sampleCount > 0`, **not** on the score: a real score of 0.00 is a statement about a provider and would otherwise have rendered as "no data".

Provider rows are keyed by **adapter type**, not by record — two records on one adapter share a row exactly as they share a circuit.

### A limit stated three times on purpose

The section ignores the page's date range. Scores come from a 15-minute rolling window and circuit state is live cache; neither can be cut to "last 90 days". Said in the controller comment, in the view and in the docs, because a reader who assumes otherwise draws a wrong conclusion from a familiar-looking page.

## Related Issue

Closes #634

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `composer ci` and all checks pass — unit, PHPStan (level 10) and cgl re-run independently of the authoring pass: all SUCCESS; the functional classes executed for real (29 tests, 213 assertions in my scoped re-run). Rector green under an 8.2 resolve, then restored to 8.4 and the suites re-run on that tree.
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation accordingly — appended to #660's section in `Administration/Analytics.rst`, with an `important::` on the default-off switch
- [x] I have added a `CHANGELOG.md` entry under `## [Unreleased]`
- [ ] I have added an ADR under `Documentation/Adr/` — not needed, but **ADR-063 is corrected**: it still said the view was missing. `Overtaken` note in the same form this chain uses for ADR-021 and ADR-058.
- [x] My changes generate no new warnings

`Tests/Unit/Api/api-surface.txt` is unchanged: none of the new classes carries `@api`, so the snapshot does not cover them — including the readonly constructor's promoted properties. `ApiSurfaceSnapshotTest` runs green in the unit suite.

### Two interface methods added, deliberately

`WINDOW_SECONDS` was a private const and `reorderEnabled()` a private method. Recomputing either in the view would create drift risk in exactly the two numbers the view exists to report, so both are on `ProviderHealthServiceInterface` and come from the advisor.

### No screenshot

The running DDEV project serves `main`, which does not carry this branch. The new section has no `figure::`, so nothing dangles.