### PR TITLE
feat(agent): a write preview produced at suspend time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **A write preview, produced when the run suspends** (ADR-136). New opt-in
+  `ToolPreviewInterface`: a tool that implements it describes, in plain lines,
+  what the pending call would do. The lines are produced by `ToolLoopService` at
+  the moment it suspends for approval — so the caller is the loop, the display
+  is the approval card, and the reading identity is the RUN's actor context, not
+  the reviewing administrator's request (which is what ADR-122 deferred the
+  preview over). They are persisted as a new optional field on
+  `SuspendedRunState` (`callPreviews`), inside the blob that ADR-114 already
+  encrypts at rest, and are rendered in the approvals inbox and in BOTH
+  playground approval responses (the JSON payload and the streamed
+  `awaiting_approval` event) as `preview.lines` / `preview.failed`. A run
+  suspended before this field existed still resumes: a missing or malformed
+  value degrades to "no preview", never to an error. A preview that throws is
+  caught, logged and rendered as a marked line stating that there is none — an
+  approver must never mistake a broken preview for nothing to warn about. The
+  exception text is withheld (only its class is shown), as everywhere else in
+  the loop. `update_page_metadata` implements it with a field-by-field
+  before/after: its arguments are the new values, and the card now also shows
+  what they replace. The preview is a snapshot of the pause, NOT a precondition
+  — a page edited by a human in between does not block the approval, because the
+  tool writes absolute values; the ADR argues that case out in full.
 - **`update_page_metadata` — the first writing tool** (ADR-135). It sets a fixed
   allow-list of descriptive fields (`title`, `subtitle`, `nav_title`,
   `abstract`, `description`, `keywords`, plus the EXT:seo titles/descriptions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   before/after: its arguments are the new values, and the card now also shows
   what they replace. The preview is a snapshot of the pause, NOT a precondition
   — a page edited by a human in between does not block the approval, because the
-  tool writes absolute values; the ADR argues that case out in full.
+  tool writes absolute values; the ADR argues that case out in full. Reading a
+  preview is authorised per record against the VIEWER, not only per tool:
+  `agent_approve` (ADR-130) is a tool-level grant, so the card asks the tool
+  whether the backend user it is being rendered for may see that record, and
+  says the preview is withheld where the answer is no. It fails closed when the
+  question cannot be asked — no viewer, or no registered tool under that name.
 - **`update_page_metadata` — the first writing tool** (ADR-135). It sets a fixed
   allow-list of descriptive fields (`title`, `subtitle`, `nav_title`,
   `abstract`, `description`, `keywords`, plus the EXT:seo titles/descriptions

--- a/Classes/Controller/Backend/AgentRunController.php
+++ b/Classes/Controller/Backend/AgentRunController.php
@@ -33,6 +33,7 @@ use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Backend\Attribute\AsController;
 use TYPO3\CMS\Backend\Template\ModuleTemplate;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
@@ -219,8 +220,15 @@ final class AgentRunController extends ActionController
         $terminalRuns = $this->persister->findRecentTerminalRuns(beUser: $restrictTo);
         $dataLoadError = $waitingRuns === null || $terminalRuns === null;
 
+        // The preview a card carries is authorised a second time, per record,
+        // against THIS request's user (ADR-136): the approval grant above is
+        // tool-level and says nothing about individual pages. The ambient user
+        // is the right source here — it IS the viewer, not the run's actor,
+        // which is what ADR-083 forbids reading around.
+        $viewer = $GLOBALS['BE_USER'] ?? null;
+
         $this->moduleTemplate->assignMultiple([
-            'waiting'        => $this->viewFactory->buildWaiting($waitingRuns ?? []),
+            'waiting'        => $this->viewFactory->buildWaiting($waitingRuns ?? [], $viewer instanceof BackendUserAuthentication ? $viewer : null),
             'terminal'       => $this->viewFactory->buildTerminal($terminalRuns ?? []),
             'dataLoadError'  => $dataLoadError,
             'errorRunUuid'   => $errorRunUuid,

--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -20,7 +20,6 @@ use Netresearch\NrLlm\Domain\Repository\SkillRepository;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
-use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Service\Agent\AgentRunRequest;
@@ -444,14 +443,40 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
     }
 
     /**
-     * @return list<array{name: string, arguments: array<string, mixed>}>
+     * The pending calls, each with the preview the loop captured when the run
+     * suspended (ADR-136). Used by BOTH approval surfaces — the batch payload
+     * and the streamed event — so a client cannot get the calls on one and the
+     * preview only on the other.
+     *
+     * `preview.failed` marks lines that state WHY there is no preview rather
+     * than what the call would do; a client that ignores the flag still shows a
+     * line and never a blank.
+     *
+     * @return list<array{name: string, arguments: array<string, mixed>, preview: array{lines: list<string>, failed: bool}}>
      */
     private function pendingTools(AgentRunResult $result): array
     {
-        return array_map(
-            static fn(ToolCall $call): array => ['name' => $call->name, 'arguments' => $call->arguments],
-            $result->suspendedState?->toolCalls() ?? [],
-        );
+        $state    = $result->suspendedState;
+        $previews = [];
+        foreach ($state instanceof SuspendedRunState ? $state->callPreviews : [] as $preview) {
+            $previews[$preview['index']] = $preview;
+        }
+
+        $tools = [];
+        foreach ($state?->toolCalls() ?? [] as $index => $call) {
+            $preview = $previews[$index] ?? null;
+            $match   = $preview !== null && $preview['tool'] === $call->name;
+            $tools[] = [
+                'name'      => $call->name,
+                'arguments' => $call->arguments,
+                'preview'   => [
+                    'lines'  => $match ? $preview['lines'] : [],
+                    'failed' => $match && $preview['failed'],
+                ],
+            ];
+        }
+
+        return $tools;
     }
 
     /**

--- a/Classes/Domain/ValueObject/SuspendedRunState.php
+++ b/Classes/Domain/ValueObject/SuspendedRunState.php
@@ -22,6 +22,12 @@ namespace Netresearch\NrLlm\Domain\ValueObject;
  * carries the target tool name and its declared input schema; on an approval
  * pause both stay at their null/empty defaults.
  *
+ * On an approval pause it may additionally carry a per-call preview of what the
+ * pending calls would do (ADR-136), produced at suspend time in the run's actor
+ * context. It is optional in every sense: a tool that declares no preview
+ * contributes none, and a state persisted before the field existed rehydrates
+ * without it.
+ *
  * Messages and calls are held in their already-serialised
  * ({@see ChatMessage::toArray()} / {@see ToolCall::toArray()}) form so the state
  * is a plain JSON-encodable structure; {@see self::toolCalls()} rebuilds the
@@ -32,12 +38,13 @@ namespace Netresearch\NrLlm\Domain\ValueObject;
 final readonly class SuspendedRunState
 {
     /**
-     * @param list<array<string, mixed>> $messages         serialised ChatMessage transcript (ends with the assistant tool-call turn)
-     * @param list<array<string, mixed>> $pendingCalls     serialised ToolCall list of the suspended turn
-     * @param list<string>|null          $allowedToolNames the run's original tool allow-list, so resume re-applies the SAME per-run constraint (null = the globally-enabled set)
-     * @param array<string, mixed>       $options          the run's serialised ToolOptions, so resume continues with the same temperature/max-tokens/think/etc.
-     * @param string|null                $inputToolName    on an input pause (ADR-105) the tool whose typed input the user must supply; null on an approval pause
-     * @param array<string, mixed>       $inputSchema      on an input pause the tool's declared input schema (a JSON-Schema subset); `[]` on an approval pause
+     * @param list<array<string, mixed>>                                               $messages         serialised ChatMessage transcript (ends with the assistant tool-call turn)
+     * @param list<array<string, mixed>>                                               $pendingCalls     serialised ToolCall list of the suspended turn
+     * @param list<string>|null                                                        $allowedToolNames the run's original tool allow-list, so resume re-applies the SAME per-run constraint (null = the globally-enabled set)
+     * @param array<string, mixed>                                                     $options          the run's serialised ToolOptions, so resume continues with the same temperature/max-tokens/think/etc.
+     * @param string|null                                                              $inputToolName    on an input pause (ADR-105) the tool whose typed input the user must supply; null on an approval pause
+     * @param array<string, mixed>                                                     $inputSchema      on an input pause the tool's declared input schema (a JSON-Schema subset); `[]` on an approval pause
+     * @param list<array{index: int, tool: string, lines: list<string>, failed: bool}> $callPreviews     what the pending calls WOULD do, captured at suspend in the run's actor context (ADR-136); `index` points into `$pendingCalls`. Only calls whose tool implements ToolPreviewInterface appear, so `[]` is the normal case
      */
     public function __construct(
         public array $messages,
@@ -49,10 +56,11 @@ final readonly class SuspendedRunState
         public array $options = [],
         public ?string $inputToolName = null,
         public array $inputSchema = [],
+        public array $callPreviews = [],
     ) {}
 
     /**
-     * @return array{messages: list<array<string, mixed>>, pendingCalls: list<array<string, mixed>>, iterations: int, promptTokens: int, completionTokens: int, allowedToolNames: list<string>|null, options: array<string, mixed>, inputToolName: string|null, inputSchema: array<string, mixed>}
+     * @return array{messages: list<array<string, mixed>>, pendingCalls: list<array<string, mixed>>, iterations: int, promptTokens: int, completionTokens: int, allowedToolNames: list<string>|null, options: array<string, mixed>, inputToolName: string|null, inputSchema: array<string, mixed>, callPreviews: list<array{index: int, tool: string, lines: list<string>, failed: bool}>}
      */
     public function toArray(): array
     {
@@ -66,6 +74,7 @@ final readonly class SuspendedRunState
             'options'          => $this->options,
             'inputToolName'    => $this->inputToolName,
             'inputSchema'      => $this->inputSchema,
+            'callPreviews'     => $this->callPreviews,
         ];
     }
 
@@ -101,7 +110,61 @@ final readonly class SuspendedRunState
             $options,
             $inputToolName,
             $inputSchema,
+            // Back-compat (ADR-136): every row suspended before the preview
+            // existed lacks this key, and a running installation has such rows
+            // in its database. A missing or malformed value degrades to "no
+            // preview" — the card then shows the arguments alone, exactly as it
+            // did before — and NEVER stops the run from resuming.
+            self::previewsFrom($data['callPreviews'] ?? null),
         );
+    }
+
+    /**
+     * The persisted previews, entry by entry, dropping anything that does not
+     * carry the full shape. Written by {@see \Netresearch\NrLlm\Service\Tool\ToolLoopService},
+     * but read back out of a blob that may predate the field or have been
+     * hand-edited, so nothing here is trusted.
+     *
+     * @return list<array{index: int, tool: string, lines: list<string>, failed: bool}>
+     */
+    private static function previewsFrom(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $previews = [];
+        foreach ($value as $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+
+            if (!is_numeric($entry['index'] ?? null)) {
+                continue;
+            }
+
+            if (!is_string($entry['tool'] ?? null)) {
+                continue;
+            }
+
+            if (!is_array($entry['lines'] ?? null)) {
+                continue;
+            }
+
+            $lines = array_values(array_filter($entry['lines'], is_string(...)));
+            if ($lines === []) {
+                continue;
+            }
+
+            $previews[] = [
+                'index'  => (int)$entry['index'],
+                'tool'   => $entry['tool'],
+                'lines'  => $lines,
+                'failed' => (bool)($entry['failed'] ?? false),
+            ];
+        }
+
+        return $previews;
     }
 
     /**

--- a/Classes/Domain/ValueObject/SuspendedRunState.php
+++ b/Classes/Domain/ValueObject/SuspendedRunState.php
@@ -100,9 +100,11 @@ final readonly class SuspendedRunState
         /** @var array<string, mixed> $inputSchema */
         $inputSchema = is_array($inputSchema) ? $inputSchema : [];
 
+        $rawPendingCalls = $data['pendingCalls'] ?? null;
+
         return new self(
             self::listOfArrays($data['messages'] ?? null),
-            self::listOfArrays($data['pendingCalls'] ?? null),
+            self::listOfArrays($rawPendingCalls),
             is_numeric($data['iterations'] ?? null) ? (int)$data['iterations'] : 0,
             is_numeric($data['promptTokens'] ?? null) ? (int)$data['promptTokens'] : 0,
             is_numeric($data['completionTokens'] ?? null) ? (int)$data['completionTokens'] : 0,
@@ -115,8 +117,44 @@ final readonly class SuspendedRunState
             // in its database. A missing or malformed value degrades to "no
             // preview" — the card then shows the arguments alone, exactly as it
             // did before — and NEVER stops the run from resuming.
-            self::previewsFrom($data['callPreviews'] ?? null),
+            self::previewsFrom($data['callPreviews'] ?? null, self::survivingIndexMap($rawPendingCalls)),
         );
+    }
+
+    /**
+     * Maps each position in the RAW pending-call list onto its position in the
+     * filtered list {@see self::listOfArrays()} produces.
+     *
+     * A preview records the index the loop wrote, and the loop counts EVERY
+     * entry of the turn. Rehydration drops entries that are not arrays and
+     * renumbers what is left, so an unusable entry shifts every call behind it
+     * by one. Without this map a preview would then be shown next to the
+     * arguments of the following call — precisely the mismatch the index was
+     * introduced to prevent (ADR-136), and the tool-name guard does not catch it
+     * when both calls name the same tool. A preview whose call did not survive
+     * has no key here and is dropped.
+     *
+     * @return array<int, int>
+     */
+    private static function survivingIndexMap(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $map      = [];
+        $original = 0;
+        $kept     = 0;
+        foreach ($value as $item) {
+            if (is_array($item)) {
+                $map[$original] = $kept;
+                ++$kept;
+            }
+
+            ++$original;
+        }
+
+        return $map;
     }
 
     /**
@@ -125,9 +163,15 @@ final readonly class SuspendedRunState
      * but read back out of a blob that may predate the field or have been
      * hand-edited, so nothing here is trusted.
      *
+     * The stored index counts the RAW pending calls; `$indexMap` translates it
+     * onto the filtered list this state exposes, and a preview whose call did
+     * not survive that filtering is dropped rather than re-pointed.
+     *
+     * @param array<int, int> $indexMap raw pending-call position => position after filtering
+     *
      * @return list<array{index: int, tool: string, lines: list<string>, failed: bool}>
      */
-    private static function previewsFrom(mixed $value): array
+    private static function previewsFrom(mixed $value, array $indexMap): array
     {
         if (!is_array($value)) {
             return [];
@@ -156,8 +200,13 @@ final readonly class SuspendedRunState
                 continue;
             }
 
+            $index = $indexMap[(int)$entry['index']] ?? null;
+            if ($index === null) {
+                continue;
+            }
+
             $previews[] = [
-                'index'  => (int)$entry['index'],
+                'index'  => $index,
                 'tool'   => $entry['tool'],
                 'lines'  => $lines,
                 'failed' => (bool)($entry['failed'] ?? false),

--- a/Classes/Service/Agent/Inbox/PendingCallView.php
+++ b/Classes/Service/Agent/Inbox/PendingCallView.php
@@ -18,12 +18,23 @@ namespace Netresearch\NrLlm\Service\Agent\Inbox;
  * verdict would imply a granularity the runtime does not offer. `$argumentsJson`
  * is pre-encoded here (never in the template) and is auto-escaped by Fluid — it
  * is untrusted, model-chosen text.
+ *
+ * `$previewLines` is what the tool said this call WOULD do, captured when the
+ * run suspended (ADR-136) — empty for a tool that declares no preview.
+ * `$previewFailed` marks the lines as the REASON no preview exists rather than
+ * the preview itself, so the card can say the decision is being made blind
+ * instead of quietly showing nothing.
  */
 final readonly class PendingCallView
 {
+    /**
+     * @param list<string> $previewLines
+     */
     public function __construct(
         public string $name,
         public string $argumentsJson,
         public bool $toolStillRegistered,
+        public array $previewLines = [],
+        public bool $previewFailed = false,
     ) {}
 }

--- a/Classes/Service/Agent/Inbox/WaitingRunViewFactory.php
+++ b/Classes/Service/Agent/Inbox/WaitingRunViewFactory.php
@@ -115,8 +115,16 @@ final readonly class WaitingRunViewFactory
 
     private function buildApproval(AgentRun $run, SuspendedRunState $state): WaitingRunView
     {
+        // Keyed by the position the loop recorded, not by the position in this
+        // (filtered) list: a corrupt call is skipped below, and matching by
+        // order after a skip would attach a preview to the wrong call.
+        $previews = [];
+        foreach ($state->callPreviews as $preview) {
+            $previews[$preview['index']] = $preview;
+        }
+
         $calls = [];
-        foreach ($state->pendingCalls as $raw) {
+        foreach ($state->pendingCalls as $index => $raw) {
             // tryFromArray skips a corrupt entry rather than throwing (unlike
             // SuspendedRunState::toolCalls()), so one bad call never blanks the
             // whole card.
@@ -125,10 +133,17 @@ final readonly class WaitingRunViewFactory
                 continue;
             }
 
+            $preview = $previews[$index] ?? null;
             $calls[] = new PendingCallView(
                 name: $call->name,
                 argumentsJson: $this->encodeArguments($call->arguments),
                 toolStillRegistered: $this->registry->get($call->name) instanceof ToolInterface,
+                // A preview stored under a different tool name than the call at
+                // that position is a state nobody should be able to produce;
+                // dropping it is cheaper than rendering a claim about the wrong
+                // call.
+                previewLines: $preview !== null && $preview['tool'] === $call->name ? $preview['lines'] : [],
+                previewFailed: $preview !== null && $preview['tool'] === $call->name && $preview['failed'],
             );
         }
 

--- a/Classes/Service/Agent/Inbox/WaitingRunViewFactory.php
+++ b/Classes/Service/Agent/Inbox/WaitingRunViewFactory.php
@@ -15,7 +15,9 @@ use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
 use Netresearch\NrLlm\Service\Agent\PendingTurnDigest;
 use Netresearch\NrLlm\Service\Tool\SchemaPropertyClassifier;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolPreviewInterface;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 
 /**
  * Turns persisted {@see AgentRun}s into the logic-free view models the approvals
@@ -25,9 +27,23 @@ use Netresearch\NrLlm\Service\Tool\ToolRegistry;
  * digest a card carries is NOT computed here: it comes from
  * {@see PendingTurnDigest}, the single definition the resume path verifies
  * against (ADR-132).
+ *
+ * One thing here IS a security boundary and not presentation: a captured
+ * preview is released to the viewer only if the tool says that viewer may read
+ * the record it describes (ADR-136). The grant that opens this inbox is
+ * tool-level, so without that question the card would hand every grant holder
+ * the current contents of records they hold no rights on.
  */
 final readonly class WaitingRunViewFactory
 {
+    /**
+     * A preview is withheld rather than shown when the viewer holds no
+     * permission on the record it describes. It replaces the preview lines, so
+     * the card states the gap instead of quietly rendering an empty section —
+     * the same reason a FAILED preview is a line and not a blank (ADR-136).
+     */
+    private const PREVIEW_WITHHELD = 'The preview is not shown: you hold no permission on the record it describes.';
+
     public function __construct(
         private ToolRegistry $registry,
         private SchemaPropertyClassifier $classifier,
@@ -37,13 +53,14 @@ final readonly class WaitingRunViewFactory
     ) {}
 
     /**
-     * @param list<AgentRun> $runs
+     * @param list<AgentRun>                 $runs
+     * @param BackendUserAuthentication|null $viewer the backend user this card is being rendered for — NOT the run's acting user. Null means "cannot be established", and every preview is then withheld (ADR-136)
      *
      * @return list<WaitingRunView>
      */
-    public function buildWaiting(array $runs): array
+    public function buildWaiting(array $runs, ?BackendUserAuthentication $viewer = null): array
     {
-        return array_map($this->buildWaitingOne(...), $runs);
+        return array_map(fn(AgentRun $run): WaitingRunView => $this->buildWaitingOne($run, $viewer), $runs);
     }
 
     /**
@@ -84,7 +101,7 @@ final readonly class WaitingRunViewFactory
         return $state->inputSchema;
     }
 
-    private function buildWaitingOne(AgentRun $run): WaitingRunView
+    private function buildWaitingOne(AgentRun $run, ?BackendUserAuthentication $viewer): WaitingRunView
     {
         $state = $this->decodeState($run);
         if (!$state instanceof SuspendedRunState) {
@@ -92,11 +109,11 @@ final readonly class WaitingRunViewFactory
         }
 
         return $state->inputToolName === null
-            ? $this->buildApproval($run, $state)
+            ? $this->buildApproval($run, $state, $viewer)
             : $this->buildInput($run, $state);
     }
 
-    private function buildApproval(AgentRun $run, SuspendedRunState $state): WaitingRunView
+    private function buildApproval(AgentRun $run, SuspendedRunState $state, ?BackendUserAuthentication $viewer): WaitingRunView
     {
         // Keyed by the position the loop recorded, not by the position in this
         // (filtered) list: a corrupt call is skipped below, and matching by
@@ -116,17 +133,33 @@ final readonly class WaitingRunViewFactory
                 continue;
             }
 
+            $tool    = $this->registry->get($call->name);
             $preview = $previews[$index] ?? null;
+
+            $previewLines  = [];
+            $previewFailed = false;
+            // A preview stored under a different tool name than the call at that
+            // position is a state nobody should be able to produce; dropping it
+            // is cheaper than rendering a claim about the wrong call.
+            if ($preview !== null && $preview['tool'] === $call->name) {
+                if ($this->viewerMayRead($tool, $call->arguments, $viewer)) {
+                    $previewLines  = $preview['lines'];
+                    $previewFailed = $preview['failed'];
+                } else {
+                    // Flagged like a failed preview: both mean the approver is
+                    // deciding without seeing what the write replaces, and the
+                    // line itself says which of the two it is.
+                    $previewLines  = [self::PREVIEW_WITHHELD];
+                    $previewFailed = true;
+                }
+            }
+
             $calls[] = new PendingCallView(
                 name: $call->name,
                 argumentsJson: $this->encodeArguments($call->arguments),
-                toolStillRegistered: $this->registry->get($call->name) instanceof ToolInterface,
-                // A preview stored under a different tool name than the call at
-                // that position is a state nobody should be able to produce;
-                // dropping it is cheaper than rendering a claim about the wrong
-                // call.
-                previewLines: $preview !== null && $preview['tool'] === $call->name ? $preview['lines'] : [],
-                previewFailed: $preview !== null && $preview['tool'] === $call->name && $preview['failed'],
+                toolStillRegistered: $tool instanceof ToolInterface,
+                previewLines: $previewLines,
+                previewFailed: $previewFailed,
             );
         }
 
@@ -142,6 +175,33 @@ final readonly class WaitingRunViewFactory
             turnDigest: $this->digest->forState($state),
             pendingCalls: $calls,
         );
+    }
+
+    /**
+     * The read-side authorisation of a preview (ADR-136). Production authorises
+     * the RUN OWNER; this authorises the person the card is rendered for, who
+     * holds a tool-level grant (ADR-130/133) that says nothing about individual
+     * records.
+     *
+     * Fail-closed on every branch it cannot resolve: no viewer, a tool that is
+     * gone, or a tool that offers no preview contract to ask. The last case is
+     * not hypothetical — the persisted preview outlives the registration that
+     * produced it, so the tool under this name may no longer be the one that
+     * wrote those lines.
+     *
+     * @param array<string, mixed> $arguments
+     */
+    private function viewerMayRead(?ToolInterface $tool, array $arguments, ?BackendUserAuthentication $viewer): bool
+    {
+        if (!$viewer instanceof BackendUserAuthentication) {
+            return false;
+        }
+
+        if (!$tool instanceof ToolPreviewInterface) {
+            return false;
+        }
+
+        return $tool->mayViewerReadPreview($arguments, $viewer);
     }
 
     private function buildInput(AgentRun $run, SuspendedRunState $state): WaitingRunView

--- a/Classes/Service/Tool/Builtin/UpdatePageMetadataTool.php
+++ b/Classes/Service/Tool/Builtin/UpdatePageMetadataTool.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Service\Tool\ToolEffectInterface;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolPreviewInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\Connection;
@@ -66,8 +67,12 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * suspended for human approval (ADR-134); the tool carries no separate approval
  * marker. It is NOT covered by the ADR-112 write fence — that arms only on the
  * queued path, and no shipped entry point reaches it (ADR-135).
+ *
+ * The pause carries a field-by-field before/after ({@see self::previewCall()},
+ * ADR-136): the arguments alone are the NEW values, and an approver deciding
+ * whether a change is right needs to see what it replaces.
  */
-final readonly class UpdatePageMetadataTool implements ToolInterface, ToolEffectInterface
+final readonly class UpdatePageMetadataTool implements ToolInterface, ToolEffectInterface, ToolPreviewInterface
 {
     use SafeCastTrait;
 
@@ -123,6 +128,14 @@ final readonly class UpdatePageMetadataTool implements ToolInterface, ToolEffect
     private const MAX_ERRORS = 5;
 
     private const MAX_ERROR_LENGTH = 200;
+
+    /**
+     * How much of a value the approval preview shows. A `text` column holds up
+     * to {@see self::MAX_VALUE_LENGTH} characters, and a card that pastes two of
+     * them per field is unreadable — the approver needs to see WHICH text is
+     * being replaced, not the whole of both.
+     */
+    private const PREVIEW_EXCERPT_LENGTH = 120;
 
     public function __construct(
         private ConnectionPool $connectionPool,
@@ -234,6 +247,71 @@ final readonly class UpdatePageMetadataTool implements ToolInterface, ToolEffect
             $uid,
             implode(', ', array_keys($values)),
         ));
+    }
+
+    /**
+     * The field-by-field before/after this call would produce (ADR-136).
+     *
+     * Called by the loop when the run suspends for approval — before anything
+     * ran, in the RUN's actor context — so the "before" is the row as it stood
+     * at the pause. It is a snapshot and not a reservation: the ADR decides
+     * explicitly that a human editing the page in between is not fenced off, and
+     * that this tool writes absolute values, so a stale "before" changes what the
+     * approver read, never what the write does.
+     *
+     * Authorised exactly like {@see self::execute()} and against the same
+     * EXPLICIT acting user: a page the run's user may not edit yields the same
+     * neutral string here, so a preview can never disclose a page the run itself
+     * could not have touched.
+     *
+     * NOT checked here, deliberately: the live-workspace and backend-environment
+     * refusals. Both describe the PROCESS that performs the write, and that is
+     * the approver's request, not this one — asserting them now would show the
+     * approver a verdict from the wrong process.
+     *
+     * The row is read through the same {@see self::fetchPage()} the write path
+     * uses. It cannot be shared with the execution's read: the two happen in
+     * different requests, minutes or days apart, which is precisely why the
+     * "before" is a snapshot.
+     *
+     * @param array<string, mixed> $arguments
+     *
+     * @return list<string>
+     */
+    public function previewCall(array $arguments, ToolExecutionContext $context): array
+    {
+        $user = $context->actingBackendUser();
+        if (!$user instanceof BackendUserAuthentication) {
+            return [self::NOT_PERMITTED];
+        }
+
+        $uid = self::toInt($arguments['uid'] ?? 0);
+        if ($uid < 1) {
+            return ['Refused: "uid" must be the positive uid of exactly one page.'];
+        }
+
+        $values = $this->collectValues($arguments);
+        if (is_string($values)) {
+            return [$values];
+        }
+
+        $page = $this->fetchPage($uid);
+        if ($page === null
+            || !$user->doesUserHaveAccess($page, Permission::PAGE_EDIT)
+            || !$user->checkLanguageAccess(self::toInt($page['sys_language_uid'] ?? 0))
+        ) {
+            return [self::NOT_PERMITTED];
+        }
+
+        $lines = [sprintf('Page [%d] "%s" — %d field(s):', $uid, $this->excerpt(self::toStr($page['title'] ?? '')), count($values))];
+        foreach ($values as $field => $new) {
+            $old = self::toStr($page[$field] ?? '');
+            $lines[] = $old === $new
+                ? sprintf('%s: unchanged (%s)', $field, $this->quoted($new))
+                : sprintf('%s: %s → %s', $field, $this->quoted($old), $this->quoted($new));
+        }
+
+        return $lines;
     }
 
     public function isEnabledByDefault(): bool
@@ -447,6 +525,29 @@ final readonly class UpdatePageMetadataTool implements ToolInterface, ToolEffect
         }
 
         return $notApplied;
+    }
+
+    /**
+     * A preview value as it appears on the card: quoted, or the explicit
+     * `(empty)` marker — an empty pair of quotes reads like a rendering bug, and
+     * "this field is currently empty" is information the approver needs.
+     */
+    private function quoted(string $value): string
+    {
+        return $value === '' ? '(empty)' : '"' . $this->excerpt($value) . '"';
+    }
+
+    /**
+     * One line's worth of a value: whitespace collapsed (a `text` column carries
+     * newlines, and a preview line must stay one line) and truncated.
+     */
+    private function excerpt(string $value): string
+    {
+        $flat = trim(preg_replace('/\s+/u', ' ', $value) ?? $value);
+
+        return mb_strlen($flat) > self::PREVIEW_EXCERPT_LENGTH
+            ? mb_substr($flat, 0, self::PREVIEW_EXCERPT_LENGTH) . '…'
+            : $flat;
     }
 
     /**

--- a/Classes/Service/Tool/Builtin/UpdatePageMetadataTool.php
+++ b/Classes/Service/Tool/Builtin/UpdatePageMetadataTool.php
@@ -314,6 +314,36 @@ final readonly class UpdatePageMetadataTool implements ToolInterface, ToolEffect
         return $lines;
     }
 
+    /**
+     * The READ side of the preview (ADR-136): the same record check as
+     * {@see self::previewCall()}, applied to the person looking at the approval
+     * card instead of to the run's acting user.
+     *
+     * `PAGE_EDIT` and not `PAGE_SHOW` on purpose. The card exists to release a
+     * write to this page, and the strict reading of the disclosure — an approver
+     * whose remit is operations, not editing — is the one that decides here: you
+     * see what the write replaces only where you could have written it yourself.
+     *
+     * A refusal is never a probe: nothing distinguishes "no such page" from "not
+     * permitted", exactly as in `previewCall()`, and the card says the same thing
+     * either way.
+     *
+     * @param array<string, mixed> $arguments
+     */
+    public function mayViewerReadPreview(array $arguments, BackendUserAuthentication $viewer): bool
+    {
+        $uid = self::toInt($arguments['uid'] ?? 0);
+        if ($uid < 1) {
+            return false;
+        }
+
+        $page = $this->fetchPage($uid);
+
+        return $page !== null
+            && $viewer->doesUserHaveAccess($page, Permission::PAGE_EDIT)
+            && $viewer->checkLanguageAccess(self::toInt($page['sys_language_uid'] ?? 0));
+    }
+
     public function isEnabledByDefault(): bool
     {
         // A writing tool is never on by default: an admin enables it in the

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -62,6 +62,15 @@ use Throwable;
  */
 final readonly class ToolLoopService implements ToolLoopServiceInterface
 {
+    /**
+     * Bounds for a persisted tool preview (ADR-136). A preview goes into the
+     * encrypted suspended state and onto a card a human has to read, so it is
+     * capped like every other model-triggered payload in this loop.
+     */
+    private const PREVIEW_MAX_LINES = 20;
+
+    private const PREVIEW_MAX_LINE_LENGTH = 500;
+
     public function __construct(
         private LlmServiceManagerInterface $mgr,
         private ToolRegistry $registry,
@@ -268,6 +277,10 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                             // defaults (ADR-084).
                             $allowedToolNames,
                             $options?->toArray() ?? [],
+                            // What the turn WOULD do, captured here and not at
+                            // approval time: this is the run's actor context, the
+                            // only identity allowed to read the targets (ADR-136).
+                            callPreviews: $this->previewsForTurn($resp->toolCalls ?? [], $allowedNames, $context),
                         ));
                     }
                 }
@@ -734,6 +747,91 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         }
 
         return $tool instanceof ToolEffectInterface && $tool->getEffect()->isWrite();
+    }
+
+    /**
+     * What the pending turn WOULD do, one entry per offered call whose tool
+     * implements {@see ToolPreviewInterface} (ADR-136).
+     *
+     * Produced HERE, at the suspend, and not when the card is rendered: this is
+     * the run's actor context, the identity the tool is allowed to read the
+     * target with (ADR-083). The reviewing administrator's request is not.
+     *
+     * Only OFFERED calls are previewed, mirroring the approval scan above: a
+     * registered-but-not-offered tool the model named will be refused at
+     * execution, so running its preview would describe a call that cannot
+     * happen — and would read data the run was never allowed to reach.
+     *
+     * A preview that throws or returns nothing becomes a marked failure line
+     * rather than an exception: the pause exists so a human can decide, and a
+     * card that silently loses its preview would let them decide blind without
+     * knowing it. The exception TEXT is deliberately not shown — as in
+     * {@see self::invoke()}, an exception body may carry DBAL credentials — but
+     * the class name is, and the full exception goes to the log.
+     *
+     * @param list<ToolCall> $calls
+     * @param list<string>   $allowedNames
+     *
+     * @return list<array{index: int, tool: string, lines: list<string>, failed: bool}>
+     */
+    private function previewsForTurn(array $calls, array $allowedNames, ToolExecutionContext $context): array
+    {
+        $previews = [];
+        foreach ($calls as $index => $call) {
+            $tool = $this->registry->get($call->name);
+            if (!in_array($call->name, $allowedNames, true)) {
+                continue;
+            }
+
+            if (!$tool instanceof ToolPreviewInterface) {
+                continue;
+            }
+
+            $failed = false;
+            try {
+                $lines = array_values(array_filter($tool->previewCall($call->arguments, $context), is_string(...)));
+            } catch (Throwable $e) {
+                $this->logger?->warning('Tool preview failed; the approval card will say so.', ['tool' => $call->name, 'exception' => $e]);
+                $lines  = [sprintf('The preview for this call failed (%s), so it shows nothing about what the call would do.', $e::class)];
+                $failed = true;
+            }
+
+            if ($lines === []) {
+                $lines  = ['The tool produced no preview for this call.'];
+                $failed = true;
+            }
+
+            $previews[] = [
+                'index'  => $index,
+                'tool'   => $call->name,
+                // Bounded before it is persisted: the state is encrypted, stored
+                // and re-read on every resume, and a preview is model-triggered
+                // output like any other.
+                'lines'  => $this->boundedPreviewLines($lines),
+                'failed' => $failed,
+            ];
+        }
+
+        return $previews;
+    }
+
+    /**
+     * @param list<string> $lines
+     *
+     * @return list<string>
+     */
+    private function boundedPreviewLines(array $lines): array
+    {
+        $bounded = [];
+        foreach (array_slice($lines, 0, self::PREVIEW_MAX_LINES) as $line) {
+            $bounded[] = mb_substr(trim(preg_replace('/\s+/u', ' ', $line) ?? $line), 0, self::PREVIEW_MAX_LINE_LENGTH);
+        }
+
+        if (count($lines) > self::PREVIEW_MAX_LINES) {
+            $bounded[] = sprintf('… and %d more line(s), not shown.', count($lines) - self::PREVIEW_MAX_LINES);
+        }
+
+        return $bounded;
     }
 
     /**

--- a/Classes/Service/Tool/ToolPreviewInterface.php
+++ b/Classes/Service/Tool/ToolPreviewInterface.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool;
 
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+
 /**
  * Opt-in: a tool that can describe, in human-readable lines, what the call it
  * was handed WOULD do (ADR-136).
@@ -37,6 +39,9 @@ namespace Netresearch\NrLlm\Service\Tool;
  * - Read only what the ACTING user of the run may read, and authorise against
  *   the explicit user from the {@see ToolExecutionContext} — never the ambient
  *   `$GLOBALS['BE_USER']` (ADR-083).
+ * - Answer {@see self::mayViewerReadPreview()} for the person LOOKING at the
+ *   card. Producing a preview and showing it are two authorisations, because
+ *   the run owner and the approver are not the same person.
  * - Never write. A preview that mutates would defeat the pause it decorates.
  *
  * Throwing is survivable: the loop catches it and renders a line saying the
@@ -53,4 +58,24 @@ interface ToolPreviewInterface
      * @return list<string>
      */
     public function previewCall(array $arguments, ToolExecutionContext $context): array;
+
+    /**
+     * May THIS backend user — the one rendering the approval card, not the run's
+     * acting user — be shown the preview of this call?
+     *
+     * The production check in {@see self::previewCall()} authorises the RUN
+     * OWNER. The approver is a different person with a different, tool-level
+     * authority (ADR-130/133), so without a second check the card would show
+     * them the current state of a record they hold no permission on. The tool
+     * answers because only it knows which record its arguments name.
+     *
+     * Read-only, and cheap: it runs once per pending call every time the inbox
+     * is rendered. Return false when in doubt — the card then says the preview
+     * is withheld, which is a worse card but never a disclosure. It is the
+     * FACTORY's job to fail closed when the tool cannot be asked at all
+     * ({@see \Netresearch\NrLlm\Service\Agent\Inbox\WaitingRunViewFactory}).
+     *
+     * @param array<string, mixed> $arguments the model-chosen arguments of the pending call
+     */
+    public function mayViewerReadPreview(array $arguments, BackendUserAuthentication $viewer): bool;
 }

--- a/Classes/Service/Tool/ToolPreviewInterface.php
+++ b/Classes/Service/Tool/ToolPreviewInterface.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+/**
+ * Opt-in: a tool that can describe, in human-readable lines, what the call it
+ * was handed WOULD do (ADR-136).
+ *
+ * The lines are produced by {@see ToolLoopService} at the moment the run
+ * suspends for approval, in the RUN's actor context, and are persisted with the
+ * suspended state so the approval card and both playground surfaces can show
+ * them. That timing is the whole design: it gives the preview a caller (the
+ * loop), a display (the approval card) and the only identity that may read the
+ * target — the run's, never the reviewing administrator's (ADR-083).
+ *
+ * A marker-style optional interface like {@see ToolEffectInterface} and
+ * {@see RequiresApprovalInterface}: the forty-odd read-only builtins are
+ * untouched, and a tool that does not implement it simply has no preview line
+ * on the card.
+ *
+ * Contract for implementors:
+ *
+ * - The lines describe INTENT. They are a snapshot of the moment the run paused,
+ *   not a reservation: nothing prevents a human from editing the same record
+ *   before the approval lands (ADR-136).
+ * - A refusal is a legitimate preview. A call the tool would reject should say
+ *   so — that is exactly what the approver needs to know.
+ * - Return at most a handful of short lines. The loop truncates and caps what it
+ *   persists, because the state is encrypted and re-read on every resume.
+ * - Read only what the ACTING user of the run may read, and authorise against
+ *   the explicit user from the {@see ToolExecutionContext} — never the ambient
+ *   `$GLOBALS['BE_USER']` (ADR-083).
+ * - Never write. A preview that mutates would defeat the pause it decorates.
+ *
+ * Throwing is survivable: the loop catches it and renders a line saying the
+ * preview failed, so the approver knows they are deciding blind rather than
+ * seeing an empty card.
+ */
+interface ToolPreviewInterface
+{
+    /**
+     * Human-readable lines describing what this call would do.
+     *
+     * @param array<string, mixed> $arguments the model-chosen arguments of the pending call
+     *
+     * @return list<string>
+     */
+    public function previewCall(array $arguments, ToolExecutionContext $context): array;
+}

--- a/Documentation/Adr/Adr135UpdatePageMetadataTool.rst
+++ b/Documentation/Adr/Adr135UpdatePageMetadataTool.rst
@@ -221,10 +221,15 @@ the tool, once by the DataHandler.
 the approval coupling had no exerciser; they have one now, and the functional
 tests drive them against a real DataHandler.
 
-◐ ADR-122's deferred pieces stay deferred. This tool needed no idempotency
-scope (its effect is idempotent by construction) and no preview (the approval
-card already shows the arguments, which for this tool ARE the new values). Their
-absence is now an observation rather than a prediction.
+◐ ADR-122's idempotency scope stays deferred: this tool needs none, its effect
+being idempotent by construction. Its absence is now an observation rather than
+a prediction.
+
+◐ The preview did not stay deferred. This ADR argued the approval card already
+shows the arguments, which for this tool ARE the new values — true, and half the
+comparison. :ref:`ADR-136 <adr-136>` supersedes that sentence: the tool
+implements :php:`ToolPreviewInterface` and the card shows the values the write
+would REPLACE.
 
 ✕ A downstream consumer that calls ``enqueue()`` gets the fence; every shipped
 entry point does not. The gap is named above rather than closed — closing it

--- a/Documentation/Adr/Adr136WritePreviewAtSuspend.rst
+++ b/Documentation/Adr/Adr136WritePreviewAtSuspend.rst
@@ -1,0 +1,196 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-136:
+
+============================================================================
+ADR-136: The write preview is produced when the run suspends
+============================================================================
+
+:Status: Accepted
+:Date: 2026-08-09
+:Authors: Netresearch DTT GmbH
+
+.. _adr-136-context:
+
+Context
+=======
+
+:ref:`ADR-122 <adr-122>` deferred the preview on two grounds, and both are
+about placement rather than value:
+
+   "The preview has no caller and no display. The one surface that could show it
+   is the approval card […] It would also have to run inside the reviewing
+   administrator's request rather than the run's actor context, which
+   :ref:`adr-083 <adr-083>` forbids reading around."
+
+Producing the preview **at suspend time** answers both in one move. The caller is
+:php:`ToolLoopService`, at the point it throws
+:php:`ToolApprovalRequiredException`. The display is the approval card, which by
+then is guaranteed to exist — the pause is what creates it. And the context is
+the run's own actor context, because the loop is still executing the run: no
+administrator's request is involved, nothing is read around ADR-083.
+
+The second half of the reason is what :ref:`ADR-135 <adr-135>` got half right.
+It observed that ``update_page_metadata``'s arguments ARE the new values, so the
+card already shows them. What the card does not show is what those values
+REPLACE. "Set the description to X" and "replace this hand-written description
+with X" are different decisions, and only the second one is a decision.
+
+.. _adr-136-decision:
+
+Decision
+========
+
+An opt-in :php:`ToolPreviewInterface` — one method, no base class, no
+:php:`ActionInterface`, exactly the shape :php:`ToolEffectInterface` and
+:php:`RequiresApprovalInterface` already have. A tool that implements it returns
+human-readable lines describing what the pending call would do; the forty-odd
+read-only builtins are untouched and render no preview line at all.
+
+The lines are produced inside the approval scan, for every OFFERED call of the
+suspending turn, and travel with the state:
+
+- **Persisted** as an additional optional field on :php:`SuspendedRunState`. It
+  is inside the same blob as the transcript, so it is encrypted at rest by the
+  same codec (:ref:`ADR-114 <adr-114>`) with no new plumbing.
+- **Degrading, not failing.** :php:`fromArray()` treats a missing or malformed
+  ``callPreviews`` as "no preview". A running installation has suspended runs in
+  its database; every one of them must still resume, and it does — the card
+  falls back to the arguments alone, exactly as before this ADR.
+- **Rendered** in :php:`WaitingRunViewFactory::buildApproval()`, in the Fluid
+  partial, and in BOTH playground responses (the JSON payload and the streamed
+  ``awaiting_approval`` event) through the single ``pendingTools()`` helper the
+  two share.
+- **Bounded** before it is persisted: twenty lines, 500 characters each,
+  whitespace collapsed. A preview is model-triggered output like a tool result,
+  and it goes into an encrypted column that is re-read on every resume.
+
+A failed preview is a line, never a blank and never a fatal
+------------------------------------------------------------
+
+A tool whose preview throws must not kill the run — the loop catches
+:php:`Throwable`, logs it, and stores a line saying the preview failed, marked
+with a ``failed`` flag the card renders as *"No preview — you are deciding
+without one"*. An empty return is treated the same way.
+
+The alternative — swallow the failure and show nothing — is the dangerous one:
+an approver cannot tell a tool that has no preview from a tool whose preview
+broke, and would take a missing warning for the absence of anything to warn
+about.
+
+The exception TEXT is deliberately not shown, only its class. This follows
+:php:`ToolLoopService::invoke()`, which withholds exception bodies for the same
+reason: a DBAL failure carries ``Access denied for user X@host``, and the
+preview is persisted and rendered rather than discarded. The full exception goes
+to the log, where the operator can already read credentials they own.
+
+.. _adr-136-staleness:
+
+What if the target changed between preview and execution
+=========================================================
+
+**The preview is a snapshot of the pause, not a precondition for the write. A
+target that changed in between does not block the approval.** The card says so,
+in as many words: *"Captured when the run paused — the target may have changed
+since."*
+
+The reasoning, in the order it decided the question:
+
+**A writing tool here sets absolute values.** ``update_page_metadata`` writes
+``description = "…"``, not "append" or "increment". A concurrent human edit
+therefore changes what the approver READ, never what the approval DOES. The
+write that executes is the write that was shown; only its "before" column has
+aged.
+
+**A resource fence has no repair path.** Refusing the approval on a changed row
+leaves the run suspended with no way forward: the model cannot re-issue the call
+(it is not running), and the approver cannot edit the pending arguments. Every
+unrelated edit to a busy page — by an editor who never heard of the run — would
+dead-end an approval that a human had already decided was correct.
+
+**The turn digest is not this.** :ref:`ADR-132 <adr-132>` binds a decision to the
+tool CALL that was reviewed, so a stale tab cannot authorise a turn nobody
+looked at. That is a guarantee about the agent's proposal, and it is exact
+because the loop owns both sides of it. The target resource is owned by TYPO3
+and edited by people; binding to it would be a different guarantee with a
+different failure mode, and extending the digest to cover it would silently
+convert ADR-132's precise check into a lossy one.
+
+**TYPO3 has no such fence either.** Two editors on the same page in the backend
+overwrite each other, last write wins. A tool that a human explicitly approved
+is not the place to invent an optimistic-locking regime the rest of the system
+does not have.
+
+**Revisit when a writing tool writes a RELATIVE change.** An append, an
+increment, a "remove the third paragraph" — for those, the "before" is not
+decoration, it is an operand, and a snapshot stops being sufficient. That tool
+needs a precondition token; this one does not, and building the token first
+would be ADR-122's mistake repeated.
+
+.. _adr-136-disclosure:
+
+Who may read a preview
+======================
+
+The preview is produced under the RUN OWNER's authority and read by the
+APPROVER, and those are not always the same person. It is therefore authorised
+twice over:
+
+1. **At production.** The tool checks the EXPLICIT acting user of the run
+   (ADR-083) — for ``update_page_metadata``, ``doesUserHaveAccess()`` plus
+   ``checkLanguageAccess()``, the same checks and the SAME neutral refusal
+   string ``execute()`` uses. A preview can never show a page the run itself
+   could not have written, and cannot be used to probe the page tree for
+   existence.
+2. **At reading.** The approvals inbox is reachable with the ``agent_approve``
+   grant (:ref:`ADR-130 <adr-130>`), and :ref:`ADR-133 <adr-133>` additionally
+   requires the approver to pass the same tool gate the execution would.
+
+**The honest gap:** those gates are tool-level, not record-level. An approver
+who may run ``update_page_metadata`` but holds no permission on THIS page now
+sees that page's title and current metadata. That is a real disclosure, and it
+is accepted for one reason: the same approver is being asked to RELEASE a write
+to that page. Authority over the change is strictly larger than sight of what
+the change replaces, and withholding the "before" would not remove the authority
+— it would only make it blind. Two bounds keep it that shape: only the fields
+the call would write are shown (never the whole row), and each value is
+truncated to a 120-character excerpt.
+
+The same limit stated the other way: a tool's preview must read only what the
+run's acting user may read. That is a contract on implementors, written into
+:php:`ToolPreviewInterface`, not something the loop can enforce for them.
+
+.. _adr-136-consequences:
+
+Consequences
+============
+
+●● An approver sees what a write would replace, in the same card that asks them
+to release it. For the one shipped writer this is the difference between reading
+a model's proposal and reading a diff.
+
+● The interface is opt-in and its absence is silent by design — a writing tool
+that skips it costs its approver the comparison and nothing else. That is the
+same trade as :php:`ToolEffectInterface`, whose silence costs more.
+
+◐ :php:`SuspendedRunState` grew a tenth constructor parameter. It is optional,
+last, and `@api`: the snapshot test records the new public property, and no
+existing caller changes.
+
+✕ A preview runs a tool's read path at suspend time, on the loop's clock. It is
+one bounded read per previewing call in the turn, but it is work the loop did
+not do before, and a slow preview delays the pause the operator is waiting for.
+
+✕ An approver may read metadata of a page they hold no permission on, bounded as
+described above.
+
+.. _adr-136-revisit:
+
+Revisit when
+============
+
+A writing tool needs a preview of a RELATIVE change, or a second surface starts
+rendering previews outside the approval card. The first breaks the snapshot
+argument above; the second would be the moment to ask whether the lines should
+be structured data rather than text, which they deliberately are not today —
+one string list has one rendering, and three surfaces render it identically.

--- a/Documentation/Adr/Adr136WritePreviewAtSuspend.rst
+++ b/Documentation/Adr/Adr136WritePreviewAtSuspend.rst
@@ -41,11 +41,12 @@ with X" are different decisions, and only the second one is a decision.
 Decision
 ========
 
-An opt-in :php:`ToolPreviewInterface` — one method, no base class, no
-:php:`ActionInterface`, exactly the shape :php:`ToolEffectInterface` and
+An opt-in :php:`ToolPreviewInterface` — no base class, no
+:php:`ActionInterface`, the same marker shape :php:`ToolEffectInterface` and
 :php:`RequiresApprovalInterface` already have. A tool that implements it returns
-human-readable lines describing what the pending call would do; the forty-odd
-read-only builtins are untouched and render no preview line at all.
+human-readable lines describing what the pending call would do, and answers
+whether a given viewer may be shown them; the forty-odd read-only builtins are
+untouched and render no preview line at all.
 
 The lines are produced inside the approval scan, for every OFFERED call of the
 suspending turn, and travel with the state:
@@ -57,6 +58,13 @@ suspending turn, and travel with the state:
   ``callPreviews`` as "no preview". A running installation has suspended runs in
   its database; every one of them must still resume, and it does — the card
   falls back to the arguments alone, exactly as before this ADR.
+- **Index-bound to its call, across rehydration.** A preview records the
+  position of the call it describes. Rehydration drops pending-call entries that
+  are not usable at all, which renumbers the rest, so the stored positions are
+  translated onto the surviving list and a preview whose call did not survive is
+  dropped. Without that translation a corrupt blob would move a preview one call
+  along — silently, plausibly, and past the tool-name guard whenever the turn
+  calls the same tool twice.
 - **Rendered** in :php:`WaitingRunViewFactory::buildApproval()`, in the Fluid
   partial, and in BOTH playground responses (the JSON payload and the streamed
   ``awaiting_approval`` event) through the single ``pendingTools()`` helper the
@@ -134,7 +142,7 @@ Who may read a preview
 
 The preview is produced under the RUN OWNER's authority and read by the
 APPROVER, and those are not always the same person. It is therefore authorised
-twice over:
+twice over, once on each side:
 
 1. **At production.** The tool checks the EXPLICIT acting user of the run
    (ADR-083) — for ``update_page_metadata``, ``doesUserHaveAccess()`` plus
@@ -142,23 +150,47 @@ twice over:
    string ``execute()`` uses. A preview can never show a page the run itself
    could not have written, and cannot be used to probe the page tree for
    existence.
-2. **At reading.** The approvals inbox is reachable with the ``agent_approve``
-   grant (:ref:`ADR-130 <adr-130>`), and :ref:`ADR-133 <adr-133>` additionally
-   requires the approver to pass the same tool gate the execution would.
+2. **At reading.** The inbox is reachable with the ``agent_approve`` grant
+   (:ref:`ADR-130 <adr-130>`), which is tool-level and decides nothing about
+   individual records. So the card asks the tool a SECOND question —
+   :php:`ToolPreviewInterface::mayViewerReadPreview()` — about the backend user
+   the page is being rendered for. ``update_page_metadata`` answers it with the
+   same record check it used at production, applied to the viewer. Where the
+   answer is no, the card says the preview is withheld instead of showing the
+   lines.
 
-**The honest gap:** those gates are tool-level, not record-level. An approver
-who may run ``update_page_metadata`` but holds no permission on THIS page now
-sees that page's title and current metadata. That is a real disclosure, and it
-is accepted for one reason: the same approver is being asked to RELEASE a write
-to that page. Authority over the change is strictly larger than sight of what
-the change replaces, and withholding the "before" would not remove the authority
-— it would only make it blind. Two bounds keep it that shape: only the fields
-the call would write are shown (never the whole row), and each value is
-truncated to a 120-character excerpt.
+:ref:`ADR-133 <adr-133>`'s gate is NOT part of this. It sits in
+:php:`ResumeCoordinator::approve()`, on the DECISION, and never runs while the
+list is rendered. Reading the card and pressing "Approve" are gated separately,
+and only the second one passes through ADR-133.
+
+**What the read gate does and does not buy.** It removes the disclosure this
+feature would otherwise create: an approver whose remit is operations rather
+than editing no longer reads the current metadata of pages they hold no rights
+on. It costs one bounded row read per pending call per render, and it can leave
+an approver with a partly blind card — they may still release a write whose
+"before" they were not shown, because the authority to approve is tool-level and
+this gate does not change that. That asymmetry is deliberate: withholding sight
+is cheap and reversible, withholding the decision is :ref:`ADR-133 <adr-133>`'s
+subject and a different change (issue #662, option 3).
+
+Fail closed on every branch the card cannot resolve: no viewer, a tool that is
+no longer registered, or a tool under that name that offers no preview contract.
+The persisted preview outlives the registration that produced it, so "the tool
+cannot be asked" is a normal state, not a corrupt one.
+
+Two bounds remain on what a permitted viewer sees: only the fields the call
+would write (never the whole row), each truncated to a 120-character excerpt.
 
 The same limit stated the other way: a tool's preview must read only what the
-run's acting user may read. That is a contract on implementors, written into
+run's acting user may read, and must answer honestly about what its viewer may
+be shown. Both are contracts on implementors, written into
 :php:`ToolPreviewInterface`, not something the loop can enforce for them.
+
+The playground's two preview surfaces are not gated this way. Every one of its
+actions is admin-gated (``denyNonAdmin()``), and an admin passes every
+record check by definition, so a second question would have exactly one answer.
+The moment a non-admin reaches that module, it needs the gate the inbox has.
 
 .. _adr-136-consequences:
 
@@ -177,12 +209,23 @@ same trade as :php:`ToolEffectInterface`, whose silence costs more.
 last, and `@api`: the snapshot test records the new public property, and no
 existing caller changes.
 
+◐ :php:`ToolPreviewInterface` carries two methods, not one: producing a preview
+and releasing it to a viewer are different authorisations, and only the tool
+knows which record its arguments name. The interface is not `@api`, so this
+costs nothing outside the extension.
+
 ✕ A preview runs a tool's read path at suspend time, on the loop's clock. It is
 one bounded read per previewing call in the turn, but it is work the loop did
 not do before, and a slow preview delays the pause the operator is waiting for.
 
-✕ An approver may read metadata of a page they hold no permission on, bounded as
-described above.
+✕ Rendering the inbox now costs one further record read per previewing pending
+call, for the read gate. The list is a handful of runs; a queue of thousands
+would need the answer cached per viewer.
+
+✕ An approver may still RELEASE a write to a page they hold no rights on — the
+approval authority stays tool-level (:ref:`ADR-133 <adr-133>`). They now do it
+without seeing the "before". Withholding sight without withholding the decision
+is the deliberate half-measure; issue #662 option 3 is the other half.
 
 .. _adr-136-revisit:
 

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -433,3 +433,4 @@ Tools
    Adr133ApproverToolGate
    Adr134WriteEffectImpliesApproval
    Adr135UpdatePageMetadataTool
+   Adr136WritePreviewAtSuspend

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -2738,6 +2738,18 @@
                 <source>Pending tool call</source>
                 <target>Ausstehender Tool-Aufruf</target>
             </trans-unit>
+            <trans-unit id="runs.preview">
+                <source>What this call would do</source>
+                <target>Was dieser Aufruf tun würde</target>
+            </trans-unit>
+            <trans-unit id="runs.previewUnavailable">
+                <source>No preview — you are deciding without one</source>
+                <target>Keine Vorschau — Sie entscheiden ohne sie</target>
+            </trans-unit>
+            <trans-unit id="runs.previewCapturedAtPause">
+                <source>Captured when the run paused — the target may have changed since.</source>
+                <target>Beim Pausieren des Laufs erstellt — das Ziel kann sich seitdem geändert haben.</target>
+            </trans-unit>
             <trans-unit id="runs.arguments">
                 <source>Arguments</source>
                 <target>Argumente</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -2071,6 +2071,15 @@
             <trans-unit id="runs.arguments">
                 <source>Arguments</source>
             </trans-unit>
+            <trans-unit id="runs.preview">
+                <source>What this call would do</source>
+            </trans-unit>
+            <trans-unit id="runs.previewUnavailable">
+                <source>No preview — you are deciding without one</source>
+            </trans-unit>
+            <trans-unit id="runs.previewCapturedAtPause">
+                <source>Captured when the run paused — the target may have changed since.</source>
+            </trans-unit>
             <trans-unit id="runs.approve">
                 <source>Approve</source>
             </trans-unit>

--- a/Resources/Private/Partials/Backend/AgentRun/ApprovalControls.html
+++ b/Resources/Private/Partials/Backend/AgentRun/ApprovalControls.html
@@ -9,6 +9,22 @@
         <f:if condition="{call.toolStillRegistered} == false">
             <span class="badge text-bg-warning"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:runs.toolGone" default="The tool for this call is no longer registered." /></span>
         </f:if>
+        <f:if condition="{call.previewLines}">
+            <div class="mt-1">
+                <strong>
+                    <f:if condition="{call.previewFailed}">
+                        <f:then><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:runs.previewUnavailable" default="No preview — you are deciding without one" /></f:then>
+                        <f:else><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:runs.preview" default="What this call would do" /></f:else>
+                    </f:if>:
+                </strong>
+                <ul class="mb-0">
+                    <f:for each="{call.previewLines}" as="line">
+                        <li>{line}</li>
+                    </f:for>
+                </ul>
+                <small class="text-body-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:runs.previewCapturedAtPause" default="Captured when the run paused — the target may have changed since." /></small>
+            </div>
+        </f:if>
         <details class="mt-1">
             <summary><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:runs.arguments" default="Arguments" /></summary>
             <pre class="mt-1 mb-0"><code>{call.argumentsJson}</code></pre>

--- a/Tests/Functional/Controller/Backend/AgentRunControllerTest.php
+++ b/Tests/Functional/Controller/Backend/AgentRunControllerTest.php
@@ -100,6 +100,37 @@ final class AgentRunControllerTest extends AbstractFunctionalTestCase
         self::assertStringContainsString('<fieldset', $body);
     }
 
+    /**
+     * ADR-136: the approval card renders the preview the loop captured, and a
+     * FAILED preview renders its reason under a heading that says so — never a
+     * silently empty section.
+     */
+    #[Test]
+    public function listActionRendersTheCapturedPreviewAndAFailedOnesReason(): void
+    {
+        $this->suspendApproval('update_page_metadata', ['uid' => 42], [
+            ['index' => 0, 'tool' => 'update_page_metadata', 'lines' => ['description: "Old text" → "New text"'], 'failed' => false],
+        ]);
+        $this->suspendApproval('write_thing', ['uid' => 7], [
+            ['index' => 0, 'tool' => 'write_thing', 'lines' => ['The preview for this call failed (RuntimeException).'], 'failed' => true],
+        ]);
+
+        $controller = $this->makeController(
+            new ToolRegistry([new FakeTool('update_page_metadata'), new FakeTool('write_thing')]),
+            self::createStub(AgentRuntimeInterface::class),
+        );
+        $this->setRequest($controller, 'list');
+
+        $body = (string)$controller->listAction()->getBody();
+
+        self::assertStringContainsString('What this call would do', $body);
+        self::assertStringContainsString('description: &quot;Old text&quot; → &quot;New text&quot;', $body);
+        // The failed one is labelled as a failure, so the approver knows the
+        // absence of a preview is the exception, not the norm.
+        self::assertStringContainsString('No preview — you are deciding without one', $body);
+        self::assertStringContainsString('The preview for this call failed (RuntimeException).', $body);
+    }
+
     #[Test]
     public function submitInputWithInvalidDataReRendersInPlaceWith422(): void
     {
@@ -207,15 +238,16 @@ final class AgentRunControllerTest extends AbstractFunctionalTestCase
     private ?string $lastUuid = null;
 
     /**
-     * @param array<string, mixed> $arguments
+     * @param array<string, mixed>                                                     $arguments
+     * @param list<array{index: int, tool: string, lines: list<string>, failed: bool}> $callPreviews
      */
-    private function suspendApproval(string $tool, array $arguments): void
+    private function suspendApproval(string $tool, array $arguments, array $callPreviews = []): void
     {
         $handle = $this->persister->begin(null, 1);
         self::assertNotNull($handle);
         self::assertTrue($this->persister->suspend(
             $handle,
-            new SuspendedRunState([], [ToolCall::function('c1', $tool, $arguments)->toArray()], 1, 0, 0),
+            new SuspendedRunState([], [ToolCall::function('c1', $tool, $arguments)->toArray()], 1, 0, 0, null, [], null, [], $callPreviews),
         ));
         $this->lastUuid = $handle->uuid;
     }

--- a/Tests/Functional/Controller/Backend/AgentRunControllerTest.php
+++ b/Tests/Functional/Controller/Backend/AgentRunControllerTest.php
@@ -31,6 +31,7 @@ use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 use Netresearch\NrLlm\Tests\Fixture\FixedPrivacyPolicy;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\PreviewingApprovalTool;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Log\NullLogger;
@@ -116,7 +117,10 @@ final class AgentRunControllerTest extends AbstractFunctionalTestCase
         ]);
 
         $controller = $this->makeController(
-            new ToolRegistry([new FakeTool('update_page_metadata'), new FakeTool('write_thing')]),
+            new ToolRegistry([
+                new PreviewingApprovalTool('update_page_metadata'),
+                new PreviewingApprovalTool('write_thing'),
+            ]),
             self::createStub(AgentRuntimeInterface::class),
         );
         $this->setRequest($controller, 'list');
@@ -129,6 +133,33 @@ final class AgentRunControllerTest extends AbstractFunctionalTestCase
         // absence of a preview is the exception, not the norm.
         self::assertStringContainsString('No preview — you are deciding without one', $body);
         self::assertStringContainsString('The preview for this call failed (RuntimeException).', $body);
+    }
+
+    /**
+     * ADR-136: the read-side gate reaches the rendered page. A viewer the tool
+     * refuses gets the withheld notice instead of the captured lines — the
+     * `agent_approve` grant is tool-level and decides nothing per record.
+     */
+    #[Test]
+    public function listActionWithholdsThePreviewFromAViewerTheToolRefuses(): void
+    {
+        $this->suspendApproval('update_page_metadata', ['uid' => 42], [
+            ['index' => 0, 'tool' => 'update_page_metadata', 'lines' => ['description: "Old text" → "New text"'], 'failed' => false],
+        ]);
+
+        $controller = $this->makeController(
+            new ToolRegistry([new PreviewingApprovalTool('update_page_metadata', viewerMayRead: false)]),
+            self::createStub(AgentRuntimeInterface::class),
+        );
+        $this->setRequest($controller, 'list');
+
+        $body = (string)$controller->listAction()->getBody();
+
+        self::assertStringNotContainsString('Old text', $body);
+        self::assertStringContainsString('you hold no permission on the record it describes', $body);
+        self::assertStringContainsString('No preview — you are deciding without one', $body);
+        // The decision itself is untouched: the card still offers the form.
+        self::assertStringContainsString('name="approve"', $body);
     }
 
     #[Test]

--- a/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
+++ b/Tests/Functional/Controller/Backend/ToolPlaygroundControllerTest.php
@@ -19,6 +19,7 @@ use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\Provider;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
 use Netresearch\NrLlm\Domain\Repository\SkillRepository;
@@ -47,6 +48,7 @@ use Netresearch\NrLlm\Service\Tool\ToolAvailabilityService;
 use Netresearch\NrLlm\Service\Tool\ToolCallPolicy;
 use Netresearch\NrLlm\Service\Tool\ToolDataClassResolver;
 use Netresearch\NrLlm\Service\Tool\ToolGroupStateRepository;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Service\Tool\ToolLoopService;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 use Netresearch\NrLlm\Service\Tool\ToolStateRepository;
@@ -58,6 +60,7 @@ use Netresearch\NrLlm\Tests\Functional\Service\Fixtures\ApprovalEventFailingRunR
 use Netresearch\NrLlm\Tests\Functional\Service\Fixtures\ScriptedToolAdapter;
 use Netresearch\NrLlm\Tests\LlmServiceManagerTestFactory;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\PreviewingApprovalTool;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\RecordingAgentRunRepository;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -910,6 +913,154 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
     }
 
     /**
+     * ADR-136: the batch approval payload carries the preview the loop captured
+     * at the suspend, per pending call.
+     */
+    #[Test]
+    public function runActionCarriesTheCapturedPreviewIntoTheApprovalPayload(): void
+    {
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        [$controller] = $this->scriptedController(tool: new PreviewingApprovalTool('fetch_logs', ['would read 5 log rows']));
+
+        $response = $controller->runAction(
+            (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/run'))->withParsedBody(['configuration' => 1, 'prompt' => 'analyse the logs']),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $payload = json_decode((string)$response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($payload);
+        self::assertSame('awaiting_approval', $payload['status']);
+        $call = $this->firstPendingTool($payload);
+        self::assertSame('fetch_logs', $call['name'] ?? null);
+        $preview = $call['preview'] ?? null;
+        self::assertIsArray($preview);
+        self::assertSame(['would read 5 log rows'], $preview['lines'] ?? null);
+        self::assertFalse($preview['failed'] ?? null);
+    }
+
+    /**
+     * The streamed surface must carry it too — same reasoning as the turn digest
+     * in ADR-132: both surfaces show a turn, so both must show the same turn.
+     */
+    #[Test]
+    public function streamRunEmitsThePreviewWithTheAwaitingApprovalEvent(): void
+    {
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        [$controller, $config] = $this->scriptedController(tool: new PreviewingApprovalTool('fetch_logs', ['would read 5 log rows']));
+
+        $events = [];
+        $emit   = static function (array $event) use (&$events): void {
+            $events[] = $event;
+        };
+
+        $method = new ReflectionMethod($controller, 'streamRun');
+        $method->invoke(
+            $controller,
+            $emit,
+            new AgentRunRequest(
+                configuration: $config,
+                messages: [ChatMessage::user('analyse the logs')],
+                actor: AiActorContext::anonymous(),
+                allowedToolNames: ['fetch_logs'],
+                options: new ToolOptions(),
+            ),
+            false,
+        );
+
+        $last = end($events);
+        self::assertIsArray($last);
+        self::assertSame('awaiting_approval', $last['event']);
+        $preview = $this->firstPendingTool($last)['preview'] ?? null;
+        self::assertIsArray($preview);
+        self::assertSame(['would read 5 log rows'], $preview['lines'] ?? null);
+        self::assertFalse($preview['failed'] ?? null);
+    }
+
+    /**
+     * @param array<array-key, mixed> $payload
+     *
+     * @return array<array-key, mixed>
+     */
+    private function firstPendingTool(array $payload): array
+    {
+        $pending = $payload['pendingTools'] ?? null;
+        self::assertIsArray($pending);
+        $first = $pending[0] ?? null;
+        self::assertIsArray($first);
+
+        return $first;
+    }
+
+    /**
+     * ADR-136: a row suspended before the preview field existed carries no
+     * `callPreviews` key at all. A running installation has such rows, and every
+     * one of them must still resume — the field degrades, it never blocks.
+     */
+    #[Test]
+    public function aRunSuspendedBeforeThePreviewFieldExistedStillResumes(): void
+    {
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        $repository = new AgentRunRepository($this->toolConnectionPool(), $this->get(AgentStateCodec::class));
+        $persister  = new AgentRunPersister($repository, FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL), new NullLogger());
+
+        $handle = $persister->begin(null, 1);
+        self::assertNotNull($handle);
+
+        $state = new SuspendedRunState(
+            [['role' => 'user', 'content' => 'read the logs']],
+            [ToolCall::function('call_1', 'fetch_logs', [])->toArray()],
+            1,
+            5,
+            2,
+            ['fetch_logs'],
+        );
+
+        // Persist the PRE-ADR-136 shape: the state JSON as it was written before
+        // the field existed, through the repository (so it is encrypted exactly
+        // like a real row) rather than through the current value object.
+        $legacy = $state->toArray();
+        unset($legacy['callPreviews']);
+        $legacyJson = json_encode($legacy, JSON_THROW_ON_ERROR);
+        self::assertStringNotContainsString('callPreviews', $legacyJson);
+        self::assertTrue($repository->suspendRun($handle->runUid, $legacyJson));
+
+        $config = new LlmConfiguration();
+        $config->setIdentifier('cfg');
+
+        $configurationRepository = $this->createMock(LlmConfigurationRepository::class);
+        $configurationRepository->method('findByUid')->willReturn($config);
+
+        $answer  = new CompletionResponse('resumed and done', 'm', new UsageStatistics(1, 1, 2), 'stop', 'scripted-fake');
+        $manager = $this->createMock(LlmServiceManagerInterface::class);
+        $manager->method('chatWithToolsForConfiguration')->willReturn($answer);
+        $manager->method('chatWithConfiguration')->willReturn($answer);
+
+        $registry   = new ToolRegistry([new PreviewingApprovalTool('fetch_logs', ['would read the logs'])]);
+        $controller = $this->makeController($configurationRepository, $registry, $this->loopFor($manager, $registry, new NullLogger()), $persister);
+
+        // The digest is computed over the pending calls only, so the legacy row
+        // and a current one produce the same value — which is the point: the new
+        // field is not part of the binding.
+        $digest   = (new PendingTurnDigest())->forState(SuspendedRunState::fromArray($legacy));
+        $response = $controller->resumeAction(
+            (new GuzzleServerRequest('POST', '/ajax/nrllm/tool/resume'))
+                ->withParsedBody(['runUuid' => $handle->uuid, 'approve' => '1', 'turnDigest' => $digest]),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $payload = json_decode((string)$response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($payload);
+        self::assertTrue($payload['success']);
+        self::assertSame('resumed and done', $payload['finalContent']);
+    }
+
+    /**
      * A run suspended for approval on ONE write-declaring call, in the real
      * database, behind a controller whose provider must never be reached.
      *
@@ -973,7 +1124,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
      *
      * @return array{0: ToolPlaygroundController, 1: LlmConfiguration}
      */
-    private function scriptedController(string $finalContent = 'Here are your recent logs.'): array
+    private function scriptedController(string $finalContent = 'Here are your recent logs.', ?ToolInterface $tool = null): array
     {
         $provider = new Provider();
         $provider->setIdentifier('fake-provider');
@@ -1010,7 +1161,7 @@ final class ToolPlaygroundControllerTest extends AbstractFunctionalTestCase
             self::createStub(CacheManagerInterface::class),
         );
 
-        $toolRegistry    = new ToolRegistry([new FakeTool('fetch_logs')]);
+        $toolRegistry    = new ToolRegistry([$tool ?? new FakeTool('fetch_logs')]);
         $toolLoopService = $this->loopFor($manager, $toolRegistry, new NullLogger());
 
         return [$this->makeController($configurationRepository, $toolRegistry, $toolLoopService), $config];

--- a/Tests/Functional/Service/Tool/UpdatePageMetadataToolTest.php
+++ b/Tests/Functional/Service/Tool/UpdatePageMetadataToolTest.php
@@ -172,6 +172,69 @@ final class UpdatePageMetadataToolTest extends AbstractFunctionalTestCase
         self::assertSame([], $this->sysLogUserIdsFor(self::PAGE_ADMIN_ONLY));
     }
 
+    /**
+     * ADR-136: the arguments on the approval card ARE the new values, so the
+     * preview's job is the other column — what the write would replace.
+     */
+    #[Test]
+    public function thePreviewShowsTheStoredValueNextToTheProposedOne(): void
+    {
+        $admin = $this->setUpBackendUser(1);
+
+        $lines = $this->tool->previewCall(
+            ['uid' => self::PAGE_ADMIN_ONLY, 'title' => 'Home', 'description' => 'New description'],
+            ToolExecutionContext::fromBackendUser($admin),
+        );
+
+        self::assertSame('Page [1] "Home" — 2 field(s):', $lines[0]);
+        // A field whose proposed value equals the stored one is named as such —
+        // an approver should not have to diff two identical strings by eye.
+        self::assertSame('title: unchanged ("Home")', $lines[1]);
+        self::assertSame('description: "Old description" → "New description"', $lines[2]);
+
+        // A preview reads; it must not write.
+        self::assertSame('Old description', $this->pageRow(self::PAGE_ADMIN_ONLY)['description'] ?? null);
+        self::assertSame([], $this->sysLogUserIdsFor(self::PAGE_ADMIN_ONLY));
+    }
+
+    /**
+     * The preview authorises against the run's EXPLICIT acting user, exactly
+     * like the write — otherwise it would be a read-anything oracle wearing the
+     * write tool's name.
+     */
+    #[Test]
+    public function thePreviewRefusesAPageTheActingUserMayNotEditWithTheSameNeutralString(): void
+    {
+        $editor  = $this->setUpBackendUser(2);
+        $context = ToolExecutionContext::fromBackendUser($editor);
+
+        $denied  = $this->tool->previewCall(['uid' => self::PAGE_ADMIN_ONLY, 'title' => 'Hijacked'], $context);
+        $missing = $this->tool->previewCall(['uid' => self::PAGE_MISSING, 'title' => 'Hijacked'], $context);
+
+        self::assertSame(['Page not found or not permitted.'], $denied);
+        // Byte-identical, as in execute(): the preview may not confirm that a
+        // page exists either.
+        self::assertSame($missing, $denied);
+    }
+
+    /**
+     * A call the tool would refuse previews as that refusal. The approver needs
+     * to know a release would achieve nothing.
+     */
+    #[Test]
+    public function thePreviewOfARefusableCallIsTheRefusal(): void
+    {
+        $admin = $this->setUpBackendUser(1);
+
+        $lines = $this->tool->previewCall(
+            ['uid' => self::PAGE_ADMIN_ONLY, 'slug' => '/hijacked'],
+            ToolExecutionContext::fromBackendUser($admin),
+        );
+
+        self::assertCount(1, $lines);
+        self::assertStringContainsString('not an editable page metadata field', $lines[0]);
+    }
+
     #[Test]
     public function anUnknownFieldIsRefusedAndNothingIsWritten(): void
     {

--- a/Tests/Functional/Service/Tool/UpdatePageMetadataToolTest.php
+++ b/Tests/Functional/Service/Tool/UpdatePageMetadataToolTest.php
@@ -218,6 +218,32 @@ final class UpdatePageMetadataToolTest extends AbstractFunctionalTestCase
     }
 
     /**
+     * ADR-136, read side: the approver is a different person from the run owner
+     * and holds a tool-level grant only, so the card asks the tool whether THIS
+     * viewer may see the record at all.
+     */
+    #[Test]
+    public function theViewerGateAnswersPerRecordAndNotPerTool(): void
+    {
+        $admin  = $this->setUpBackendUser(1);
+        $editor = $this->setUpBackendUser(2);
+
+        self::assertTrue($this->tool->mayViewerReadPreview(['uid' => self::PAGE_ADMIN_ONLY], $admin));
+        // Same tool, same call, different viewer: the editor holds no edit
+        // right on this page, so the lines the run owner produced stay hidden.
+        self::assertFalse($this->tool->mayViewerReadPreview(['uid' => self::PAGE_ADMIN_ONLY], $editor));
+    }
+
+    #[Test]
+    public function theViewerGateRefusesAMissingPageExactlyLikeAForbiddenOne(): void
+    {
+        $admin = $this->setUpBackendUser(1);
+
+        self::assertFalse($this->tool->mayViewerReadPreview(['uid' => self::PAGE_MISSING], $admin));
+        self::assertFalse($this->tool->mayViewerReadPreview(['uid' => 0], $admin));
+    }
+
+    /**
      * A call the tool would refuse previews as that refusal. The approver needs
      * to know a release would achieve nothing.
      */

--- a/Tests/Fuzzy/Security/UpdatePageMetadataArgumentsFuzzyTest.php
+++ b/Tests/Fuzzy/Security/UpdatePageMetadataArgumentsFuzzyTest.php
@@ -115,6 +115,38 @@ final class UpdatePageMetadataArgumentsFuzzyTest extends AbstractFuzzyTestCase
             });
     }
 
+    /**
+     * The twin of the property above for the ADR-136 preview: it is a SECOND
+     * public entry taking the same model-chosen arguments, and its output
+     * reaches the approval card. The refusal it produces must be sanitised
+     * exactly like the executed one, or the same input would be safe on one path
+     * and not on the other.
+     */
+    #[Test]
+    public function anyFieldOutsideTheAllowListIsRefusedByThePreviewToo(): void
+    {
+        $this
+            ->forAll(
+                // @phpstan-ignore function.notFound (Eris Generator loaded at runtime)
+                Generator\map(
+                    static fn(string $suffix): string => 'x_' . $suffix,
+                    // @phpstan-ignore function.notFound
+                    Generator\string(),
+                ),
+                // @phpstan-ignore function.notFound
+                Generator\string(),
+            )
+            ->then(function (string $field, string $value): void {
+                $lines = $this->tool->previewCall(['uid' => 1, $field => $value], $this->context);
+
+                self::assertCount(1, $lines);
+                self::assertMatchesRegularExpression(
+                    '/^Refused: "[A-Za-z0-9_]*" is not an editable page metadata field\. Allowed: [a-z_, ]+\.$/',
+                    $lines[0],
+                );
+            });
+    }
+
     #[Test]
     public function anyValueBeyondTheDeclaredBoundIsRefusedWithoutWriting(): void
     {

--- a/Tests/Unit/Api/api-surface.txt
+++ b/Tests/Unit/Api/api-surface.txt
@@ -753,6 +753,7 @@ Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState (class)
   method toArray(): array
   method toolCalls(): array
   property readonly allowedToolNames: ?array
+  property readonly callPreviews: array
   property readonly completionTokens: int
   property readonly inputSchema: array
   property readonly inputToolName: ?string

--- a/Tests/Unit/Domain/ValueObject/SuspendedRunStateTest.php
+++ b/Tests/Unit/Domain/ValueObject/SuspendedRunStateTest.php
@@ -73,4 +73,53 @@ final class SuspendedRunStateTest extends TestCase
         self::assertNull($restored->inputToolName);
         self::assertSame([], $restored->inputSchema);
     }
+
+    /**
+     * ADR-136: an entry that is not an array at all is dropped from
+     * `pendingCalls` AND renumbers the calls behind it. The preview indices
+     * count the raw list, so they must be translated onto the filtered one —
+     * otherwise every preview after the dropped entry describes its neighbour.
+     */
+    #[Test]
+    public function previewIndicesFollowTheirCallWhenAnEntryIsDroppedEntirely(): void
+    {
+        $restored = SuspendedRunState::fromArray([
+            'messages'     => [],
+            'pendingCalls' => [
+                'not-an-array',
+                ['id' => 'c1', 'type' => 'function', 'function' => ['name' => 'update_page_metadata', 'arguments' => ['uid' => 1]]],
+                ['id' => 'c2', 'type' => 'function', 'function' => ['name' => 'update_page_metadata', 'arguments' => ['uid' => 2]]],
+            ],
+            'callPreviews' => [
+                ['index' => 1, 'tool' => 'update_page_metadata', 'lines' => ['about uid 1'], 'failed' => false],
+                ['index' => 2, 'tool' => 'update_page_metadata', 'lines' => ['about uid 2'], 'failed' => false],
+            ],
+        ]);
+
+        self::assertCount(2, $restored->pendingCalls);
+        self::assertSame(
+            [
+                ['index' => 0, 'tool' => 'update_page_metadata', 'lines' => ['about uid 1'], 'failed' => false],
+                ['index' => 1, 'tool' => 'update_page_metadata', 'lines' => ['about uid 2'], 'failed' => false],
+            ],
+            $restored->callPreviews,
+        );
+    }
+
+    #[Test]
+    public function aPreviewWhoseCallDidNotSurviveIsDropped(): void
+    {
+        $restored = SuspendedRunState::fromArray([
+            'messages'     => [],
+            'pendingCalls' => [
+                'not-an-array',
+                ['id' => 'c1', 'type' => 'function', 'function' => ['name' => 'write_thing', 'arguments' => []]],
+            ],
+            'callPreviews' => [
+                ['index' => 0, 'tool' => 'write_thing', 'lines' => ['about the unusable entry'], 'failed' => false],
+            ],
+        ]);
+
+        self::assertSame([], $restored->callPreviews);
+    }
 }

--- a/Tests/Unit/Service/Agent/Inbox/WaitingRunViewFactoryTest.php
+++ b/Tests/Unit/Service/Agent/Inbox/WaitingRunViewFactoryTest.php
@@ -228,6 +228,104 @@ final class WaitingRunViewFactoryTest extends TestCase
     }
 
     /**
+     * ADR-136: the card shows what the call WOULD do, not only its arguments.
+     */
+    #[Test]
+    public function anApprovalCallCarriesItsCapturedPreview(): void
+    {
+        $call  = ToolCall::function('c1', 'update_page_metadata', ['uid' => 7])->toArray();
+        $state = json_encode(
+            (new SuspendedRunState([], [$call], 1, 0, 0, null, [], null, [], [
+                ['index' => 0, 'tool' => 'update_page_metadata', 'lines' => ['Page [7] "Home" — 1 field(s):', 'title: "Home" → "New"'], 'failed' => false],
+            ]))->toArray(),
+            JSON_THROW_ON_ERROR,
+        );
+
+        $view = $this->factory(new FakeTool('update_page_metadata'))->buildWaiting([$this->makeRun('a', $state)])[0];
+
+        self::assertSame(WaitingRunView::MODE_APPROVAL, $view->mode);
+        self::assertSame(['Page [7] "Home" — 1 field(s):', 'title: "Home" → "New"'], $view->pendingCalls[0]->previewLines);
+        self::assertFalse($view->pendingCalls[0]->previewFailed);
+    }
+
+    #[Test]
+    public function aFailedPreviewRendersItsReasonAndIsFlaggedAsSuch(): void
+    {
+        $call  = ToolCall::function('c1', 'write_thing', [])->toArray();
+        $state = json_encode(
+            (new SuspendedRunState([], [$call], 1, 0, 0, null, [], null, [], [
+                ['index' => 0, 'tool' => 'write_thing', 'lines' => ['The preview for this call failed (RuntimeException).'], 'failed' => true],
+            ]))->toArray(),
+            JSON_THROW_ON_ERROR,
+        );
+
+        $view = $this->factory(new FakeTool('write_thing'))->buildWaiting([$this->makeRun('a', $state)])[0];
+
+        // The card renders a line and says it is a failure, so the approver
+        // knows they are deciding blind instead of seeing an empty section.
+        self::assertTrue($view->pendingCalls[0]->previewFailed);
+        self::assertNotSame([], $view->pendingCalls[0]->previewLines);
+    }
+
+    /**
+     * A corrupt call is skipped, so the surviving calls shift position. The
+     * preview must follow the call it was captured for, never the one that
+     * happens to land at its index afterwards.
+     */
+    #[Test]
+    public function aPreviewStaysWithItsCallEvenWhenAnEarlierCallIsCorrupt(): void
+    {
+        $good  = ToolCall::function('c2', 'write_thing', [])->toArray();
+        $state = json_encode(
+            (new SuspendedRunState([], [['not' => 'a call'], $good], 1, 0, 0, null, [], null, [], [
+                ['index' => 1, 'tool' => 'write_thing', 'lines' => ['would write'], 'failed' => false],
+            ]))->toArray(),
+            JSON_THROW_ON_ERROR,
+        );
+
+        $view = $this->factory(new FakeTool('write_thing'))->buildWaiting([$this->makeRun('a', $state)])[0];
+
+        self::assertCount(1, $view->pendingCalls);
+        self::assertSame(['would write'], $view->pendingCalls[0]->previewLines);
+    }
+
+    #[Test]
+    public function aPreviewNamingADifferentToolIsDropped(): void
+    {
+        $call  = ToolCall::function('c1', 'write_thing', [])->toArray();
+        $state = json_encode(
+            (new SuspendedRunState([], [$call], 1, 0, 0, null, [], null, [], [
+                ['index' => 0, 'tool' => 'some_other_tool', 'lines' => ['would write something else'], 'failed' => false],
+            ]))->toArray(),
+            JSON_THROW_ON_ERROR,
+        );
+
+        $view = $this->factory(new FakeTool('write_thing'))->buildWaiting([$this->makeRun('a', $state)])[0];
+
+        // Showing a claim about the wrong call is worse than showing none.
+        self::assertSame([], $view->pendingCalls[0]->previewLines);
+    }
+
+    /**
+     * A row suspended before ADR-136 has no `callPreviews` key at all. It must
+     * still render — a running installation is full of such rows.
+     */
+    #[Test]
+    public function aStateWithoutThePreviewFieldStillRendersTheCard(): void
+    {
+        $call    = ToolCall::function('c1', 'write_thing', [])->toArray();
+        $legacy  = (new SuspendedRunState([], [$call], 1, 0, 0))->toArray();
+        unset($legacy['callPreviews']);
+        $encoded = json_encode($legacy, JSON_THROW_ON_ERROR);
+
+        $view = $this->factory(new FakeTool('write_thing'))->buildWaiting([$this->makeRun('a', $encoded)])[0];
+
+        self::assertSame(WaitingRunView::MODE_APPROVAL, $view->mode);
+        self::assertSame([], $view->pendingCalls[0]->previewLines);
+        self::assertFalse($view->pendingCalls[0]->previewFailed);
+    }
+
+    /**
      * @param array<string, mixed> $arguments
      */
     private function approvalState(string $toolName, array $arguments): string

--- a/Tests/Unit/Service/Agent/Inbox/WaitingRunViewFactoryTest.php
+++ b/Tests/Unit/Service/Agent/Inbox/WaitingRunViewFactoryTest.php
@@ -16,18 +16,30 @@ use Netresearch\NrLlm\Service\Agent\Inbox\WaitingRunView;
 use Netresearch\NrLlm\Service\Agent\Inbox\WaitingRunViewFactory;
 use Netresearch\NrLlm\Service\Agent\PendingTurnDigest;
 use Netresearch\NrLlm\Service\Tool\SchemaPropertyClassifier;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\PreviewingApprovalTool;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 
 #[CoversClass(WaitingRunViewFactory::class)]
 final class WaitingRunViewFactoryTest extends TestCase
 {
-    private function factory(FakeTool ...$tools): WaitingRunViewFactory
+    private function factory(ToolInterface ...$tools): WaitingRunViewFactory
     {
         return new WaitingRunViewFactory(new ToolRegistry($tools), new SchemaPropertyClassifier(), new PendingTurnDigest());
+    }
+
+    /**
+     * The person the card is rendered for. Which records they may read is
+     * answered by the TOOL, so the double here needs no configuration.
+     */
+    private function viewer(): BackendUserAuthentication
+    {
+        return self::createStub(BackendUserAuthentication::class);
     }
 
     #[Test]
@@ -257,11 +269,66 @@ final class WaitingRunViewFactoryTest extends TestCase
             JSON_THROW_ON_ERROR,
         );
 
-        $view = $this->factory(new FakeTool('update_page_metadata'))->buildWaiting([$this->makeRun('a', $state)])[0];
+        $view = $this->factory(new PreviewingApprovalTool('update_page_metadata'))
+            ->buildWaiting([$this->makeRun('a', $state)], $this->viewer())[0];
 
         self::assertSame(WaitingRunView::MODE_APPROVAL, $view->mode);
         self::assertSame(['Page [7] "Home" — 1 field(s):', 'title: "Home" → "New"'], $view->pendingCalls[0]->previewLines);
         self::assertFalse($view->pendingCalls[0]->previewFailed);
+    }
+
+    /**
+     * ADR-136: producing a preview and showing it are two authorisations. The
+     * `agent_approve` grant is tool-level, so an approver whose remit does not
+     * include this page must not read its current metadata off the card.
+     */
+    #[Test]
+    public function aPreviewIsWithheldFromAViewerWithoutPermissionOnItsRecord(): void
+    {
+        $view = $this->factory(new PreviewingApprovalTool('update_page_metadata', viewerMayRead: false))
+            ->buildWaiting([$this->makeRun('a', $this->previewState())], $this->viewer())[0];
+
+        self::assertSame(
+            ['The preview is not shown: you hold no permission on the record it describes.'],
+            $view->pendingCalls[0]->previewLines,
+        );
+        // Flagged, so the card says the decision is being made without a
+        // preview instead of rendering an empty section.
+        self::assertTrue($view->pendingCalls[0]->previewFailed);
+        // The card itself still works — withholding the preview never blocks
+        // the approval.
+        self::assertSame(WaitingRunView::MODE_APPROVAL, $view->mode);
+    }
+
+    #[Test]
+    public function aPreviewIsWithheldWhenNoViewerCanBeEstablished(): void
+    {
+        $view = $this->factory(new PreviewingApprovalTool('update_page_metadata'))
+            ->buildWaiting([$this->makeRun('a', $this->previewState())], null)[0];
+
+        self::assertTrue($view->pendingCalls[0]->previewFailed);
+        self::assertSame(
+            ['The preview is not shown: you hold no permission on the record it describes.'],
+            $view->pendingCalls[0]->previewLines,
+        );
+    }
+
+    /**
+     * The persisted preview outlives the registration that produced it. A tool
+     * that is gone — or one under that name that offers no preview contract —
+     * cannot be asked whether this viewer may see the lines, so it is not shown.
+     */
+    #[Test]
+    public function aPreviewIsWithheldWhenTheToolCanNoLongerBeAsked(): void
+    {
+        $view = $this->factory(new FakeTool('update_page_metadata'))
+            ->buildWaiting([$this->makeRun('a', $this->previewState())], $this->viewer())[0];
+
+        self::assertTrue($view->pendingCalls[0]->previewFailed);
+        self::assertSame(
+            ['The preview is not shown: you hold no permission on the record it describes.'],
+            $view->pendingCalls[0]->previewLines,
+        );
     }
 
     #[Test]
@@ -275,12 +342,13 @@ final class WaitingRunViewFactoryTest extends TestCase
             JSON_THROW_ON_ERROR,
         );
 
-        $view = $this->factory(new FakeTool('write_thing'))->buildWaiting([$this->makeRun('a', $state)])[0];
+        $view = $this->factory(new PreviewingApprovalTool('write_thing'))
+            ->buildWaiting([$this->makeRun('a', $state)], $this->viewer())[0];
 
         // The card renders a line and says it is a failure, so the approver
         // knows they are deciding blind instead of seeing an empty section.
         self::assertTrue($view->pendingCalls[0]->previewFailed);
-        self::assertNotSame([], $view->pendingCalls[0]->previewLines);
+        self::assertSame(['The preview for this call failed (RuntimeException).'], $view->pendingCalls[0]->previewLines);
     }
 
     /**
@@ -299,7 +367,8 @@ final class WaitingRunViewFactoryTest extends TestCase
             JSON_THROW_ON_ERROR,
         );
 
-        $view = $this->factory(new FakeTool('write_thing'))->buildWaiting([$this->makeRun('a', $state)])[0];
+        $view = $this->factory(new PreviewingApprovalTool('write_thing'))
+            ->buildWaiting([$this->makeRun('a', $state)], $this->viewer())[0];
 
         self::assertCount(1, $view->pendingCalls);
         self::assertSame(['would write'], $view->pendingCalls[0]->previewLines);
@@ -339,6 +408,21 @@ final class WaitingRunViewFactoryTest extends TestCase
         self::assertSame(WaitingRunView::MODE_APPROVAL, $view->mode);
         self::assertSame([], $view->pendingCalls[0]->previewLines);
         self::assertFalse($view->pendingCalls[0]->previewFailed);
+    }
+
+    /**
+     * One `update_page_metadata` call carrying a captured preview.
+     */
+    private function previewState(): string
+    {
+        $call = ToolCall::function('c1', 'update_page_metadata', ['uid' => 7])->toArray();
+
+        return json_encode(
+            (new SuspendedRunState([], [$call], 1, 0, 0, null, [], null, [], [
+                ['index' => 0, 'tool' => 'update_page_metadata', 'lines' => ['Page [7] "Home" — 1 field(s):'], 'failed' => false],
+            ]))->toArray(),
+            JSON_THROW_ON_ERROR,
+        );
     }
 
     /**

--- a/Tests/Unit/Service/Agent/Inbox/WaitingRunViewFactoryTest.php
+++ b/Tests/Unit/Service/Agent/Inbox/WaitingRunViewFactoryTest.php
@@ -303,8 +303,10 @@ final class WaitingRunViewFactoryTest extends TestCase
     #[Test]
     public function aPreviewIsWithheldWhenNoViewerCanBeEstablished(): void
     {
+        // No viewer argument at all, which is the caller that cannot establish
+        // one -- the default is null and Rector rejects spelling it out.
         $view = $this->factory(new PreviewingApprovalTool('update_page_metadata'))
-            ->buildWaiting([$this->makeRun('a', $this->previewState())], null)[0];
+            ->buildWaiting([$this->makeRun('a', $this->previewState())])[0];
 
         self::assertTrue($view->pendingCalls[0]->previewFailed);
         self::assertSame(

--- a/Tests/Unit/Service/Tool/Fixtures/PreviewingApprovalTool.php
+++ b/Tests/Unit/Service/Tool/Fixtures/PreviewingApprovalTool.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
 use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Service\Tool\ToolPreviewInterface;
 use RuntimeException;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 
 /**
  * A tool that pauses for approval AND offers a preview (ADR-136).
@@ -28,13 +29,20 @@ use RuntimeException;
 final readonly class PreviewingApprovalTool implements ToolInterface, RequiresApprovalInterface, ToolPreviewInterface
 {
     /**
-     * @param list<string>|null $lines null ⇒ derive one line from the arguments
+     * @param list<string>|null $lines         null ⇒ derive one line from the arguments
+     * @param bool              $viewerMayRead the answer this double gives the read-side gate (ADR-136)
      */
     public function __construct(
         private string $name,
         private ?array $lines = null,
         private bool $throw = false,
+        private bool $viewerMayRead = true,
     ) {}
+
+    public function mayViewerReadPreview(array $arguments, BackendUserAuthentication $viewer): bool
+    {
+        return $this->viewerMayRead;
+    }
 
     public function previewCall(array $arguments, ToolExecutionContext $context): array
     {

--- a/Tests/Unit/Service/Tool/Fixtures/PreviewingApprovalTool.php
+++ b/Tests/Unit/Service/Tool/Fixtures/PreviewingApprovalTool.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures;
+
+use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Service\Tool\RequiresApprovalInterface;
+use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolPreviewInterface;
+use RuntimeException;
+
+/**
+ * A tool that pauses for approval AND offers a preview (ADR-136).
+ *
+ * Three shapes in one double, because all three are behaviour the loop must
+ * handle: lines derived from the call's arguments (the normal case), an empty
+ * preview, and a preview that throws. The thrown message is deliberately
+ * distinctive so a test can assert it never reaches the persisted state.
+ */
+final readonly class PreviewingApprovalTool implements ToolInterface, RequiresApprovalInterface, ToolPreviewInterface
+{
+    /**
+     * @param list<string>|null $lines null ⇒ derive one line from the arguments
+     */
+    public function __construct(
+        private string $name,
+        private ?array $lines = null,
+        private bool $throw = false,
+    ) {}
+
+    public function previewCall(array $arguments, ToolExecutionContext $context): array
+    {
+        if ($this->throw) {
+            throw new RuntimeException('boom with secret', 1784600136);
+        }
+
+        $uid = $arguments['uid'] ?? 0;
+
+        return $this->lines ?? ['would touch page ' . (is_numeric($uid) ? (int)$uid : 0)];
+    }
+
+    public function getSpec(): ToolSpec
+    {
+        return ToolSpec::function($this->name, 'previewable ' . $this->name, ['type' => 'object', 'properties' => []]);
+    }
+
+    /**
+     * @param array<string, mixed> $arguments
+     */
+    public function execute(array $arguments, ToolExecutionContext $context): ToolResult
+    {
+        return ToolResult::text('DONE');
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return true;
+    }
+
+    public function requiresAdmin(): bool
+    {
+        return false;
+    }
+
+    public function getGroup(): string
+    {
+        return 'test';
+    }
+}

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -1198,6 +1198,53 @@ final class ToolLoopServiceTest extends TestCase
     }
 
     /**
+     * ADR-136 sells the bound as the reason a preview may be persisted at all:
+     * it goes into the encrypted state and is re-read on every resume. The one
+     * shipped implementor cannot reach it, so only a foreign implementor of the
+     * exported ToolPreviewInterface can — which is exactly why the loop, not the
+     * tool, has to hold the line.
+     */
+    #[Test]
+    public function anOversizedPreviewIsCappedInLinesAndInLineLengthBeforeItIsPersisted(): void
+    {
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturn($this->response('', [new ToolCall('call_1', 'preview_thing', [])]));
+        $service = $this->service($mgr, new ToolRegistry([
+            new PreviewingApprovalTool('preview_thing', lines: array_fill(0, 25, str_repeat('x', 600))),
+        ]));
+
+        $lines = $this->suspend($service)->callPreviews[0]['lines'];
+
+        // Twenty lines kept, each cut to 500 characters, plus one line that
+        // says the list was cut — a silent truncation would read as a complete
+        // preview.
+        self::assertCount(21, $lines);
+        self::assertSame(500, mb_strlen($lines[0]));
+        self::assertSame('… and 5 more line(s), not shown.', $lines[20]);
+    }
+
+    /**
+     * Whitespace is collapsed on the same pass, so a tool cannot pad the card
+     * (or a log line) with newlines and runs of spaces.
+     */
+    #[Test]
+    public function previewLinesAreCollapsedToSingleSpacesAndTrimmed(): void
+    {
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturn($this->response('', [new ToolCall('call_1', 'preview_thing', [])]));
+        $service = $this->service($mgr, new ToolRegistry([
+            new PreviewingApprovalTool('preview_thing', lines: ["  title:\n\n\t\"old\"    →   \"new\"  "]),
+        ]));
+
+        self::assertSame(
+            ['title: "old" → "new"'],
+            $this->suspend($service)->callPreviews[0]['lines'],
+        );
+    }
+
+    /**
      * The preview follows the approval scan's own fail-closed rule: a tool the
      * run never offered is refused at execution, so previewing it would both
      * describe a call that cannot happen and read data the run may not reach.

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -56,6 +56,7 @@ use Netresearch\NrLlm\Service\Tool\TrustZoneResolver;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeInputTool;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeToolAvailability;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\PreviewingApprovalTool;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -1119,6 +1120,113 @@ final class ToolLoopServiceTest extends TestCase
     private function writeTool(string $name, ToolEffect $effect): ToolInterface
     {
         return new FakeTool($name, 'WROTE', true, false, 'test', [], $effect);
+    }
+
+    /**
+     * ADR-136: the preview is produced by the LOOP, at the suspend, and travels
+     * with the state — that placement is the whole reason ADR-122's two
+     * objections (no caller, wrong request context) no longer apply.
+     */
+    #[Test]
+    public function suspendCapturesThePreviewOfThePendingCall(): void
+    {
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturn($this->response('', [new ToolCall('call_1', 'preview_thing', ['uid' => 7])]));
+        $service = $this->service($mgr, new ToolRegistry([new PreviewingApprovalTool('preview_thing')]));
+
+        $state = $this->suspend($service);
+
+        self::assertCount(1, $state->callPreviews);
+        self::assertSame(0, $state->callPreviews[0]['index'], 'the preview points at the call it describes');
+        self::assertSame('preview_thing', $state->callPreviews[0]['tool']);
+        self::assertFalse($state->callPreviews[0]['failed']);
+        // The tool saw the model's arguments, so the lines describe THIS call.
+        self::assertSame(['would touch page 7'], $state->callPreviews[0]['lines']);
+    }
+
+    #[Test]
+    public function aToolWithoutAPreviewContributesNoEntry(): void
+    {
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturn($this->response('', [new ToolCall('call_1', 'delete_thing', [])]));
+        $service = $this->service($mgr, new ToolRegistry([$this->approvalTool()]));
+
+        // Opt-in means silent for the forty-odd tools that do not implement it —
+        // the card falls back to the arguments, exactly as before ADR-136.
+        self::assertSame([], $this->suspend($service)->callPreviews);
+    }
+
+    /**
+     * A preview that throws must not kill the run, and must not vanish either:
+     * an approver who cannot tell "no preview offered" from "preview broke"
+     * would take a missing warning for the absence of anything to warn about.
+     */
+    #[Test]
+    public function aThrowingPreviewBecomesAMarkedLineInsteadOfKillingTheRun(): void
+    {
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturn($this->response('', [new ToolCall('call_1', 'preview_thing', [])]));
+        $service = $this->service($mgr, new ToolRegistry([new PreviewingApprovalTool('preview_thing', throw: true)]));
+
+        // Still a suspension, not a failure: suspend() fails the test otherwise.
+        $state = $this->suspend($service);
+
+        self::assertCount(1, $state->callPreviews);
+        self::assertTrue($state->callPreviews[0]['failed']);
+        self::assertCount(1, $state->callPreviews[0]['lines']);
+        // The exception CLASS names the culprit; its message is withheld, like
+        // every other exception body in this loop (it may carry credentials).
+        self::assertStringContainsString(RuntimeException::class, $state->callPreviews[0]['lines'][0]);
+        self::assertStringNotContainsString('boom with secret', $state->callPreviews[0]['lines'][0]);
+    }
+
+    #[Test]
+    public function anEmptyPreviewIsReportedAsAFailureNotAsABlank(): void
+    {
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturn($this->response('', [new ToolCall('call_1', 'preview_thing', [])]));
+        $service = $this->service($mgr, new ToolRegistry([new PreviewingApprovalTool('preview_thing', lines: [])]));
+
+        $state = $this->suspend($service);
+
+        self::assertTrue($state->callPreviews[0]['failed']);
+        self::assertNotSame([], $state->callPreviews[0]['lines']);
+    }
+
+    /**
+     * The preview follows the approval scan's own fail-closed rule: a tool the
+     * run never offered is refused at execution, so previewing it would both
+     * describe a call that cannot happen and read data the run may not reach.
+     */
+    #[Test]
+    public function aNotOfferedToolIsNeverPreviewed(): void
+    {
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturn($this->response('', [
+                new ToolCall('call_1', 'offered_thing', []),
+                new ToolCall('call_2', 'hidden_thing', []),
+            ]));
+        $registry = new ToolRegistry([
+            new PreviewingApprovalTool('offered_thing'),
+            new PreviewingApprovalTool('hidden_thing'),
+        ]);
+        $service = $this->service($mgr, $registry);
+
+        $state = null;
+        try {
+            $service->runLoop([$this->userTurn('go')], $this->localConfiguration(), ToolExecutionContext::none(), ['offered_thing']);
+        } catch (ToolApprovalRequiredException $e) {
+            $state = $e->state;
+        }
+
+        self::assertNotNull($state);
+        self::assertCount(1, $state->callPreviews);
+        self::assertSame('offered_thing', $state->callPreviews[0]['tool']);
     }
 
     #[Test]


### PR DESCRIPTION
> **Stacked on #657** → #651 → #644, with #642 merged in. Base is `feat/update-page-metadata-tool`; GitHub retargets as the chain merges.

## Description

ADR-122 deferred the preview for two reasons: it had **no caller and no display**, and it would have had to run in the reviewing administrator's request rather than the run's actor context, which ADR-083 forbids.

**Producing it at suspend removes both objections at once.** The caller is the loop, the display is the approval card, and the context is the run's.

Opt-in `ToolPreviewInterface`, marker-style like `ToolEffectInterface` — no framework.

### Degradation is not optional here

The preview is a tenth optional promoted property on `SuspendedRunState`. `fromArray()` normalises entry-by-entry and degrades a missing or malformed value to `[]`, because a running installation has suspended runs in the database right now. A functional test covers resuming an old row.

### A failed preview is a rendered reason, never a dead run

A tool whose preview throws must not kill the run — but the approver must see that they are deciding blind. The exception **text** is withheld and only the class name shown: the value is persisted and rendered, and exception bodies here can carry DBAL credentials.

### Matching by index, not by position

Previews are matched to pending calls by their **recorded index**. A skipped corrupt call would otherwise shift every mapping after it, and the card would show one call's preview against another's arguments. Additionally dropped when the stored tool name disagrees.

## The decision the ADR had to make: target changed between preview and execution

**The preview is a snapshot of the pause, not a precondition.** A changed target does **not** block the approval, and the card says so. Four reasons, in ADR-136:

- The shipped writer sets **absolute** values, so a concurrent human edit changes what the approver *read*, never what the approval *does*.
- A resource fence has no repair path: the model cannot re-issue the call and the approver cannot edit the arguments, so any unrelated page edit would dead-end an already-decided approval.
- ADR-132's digest binds the **tool call**, which the loop owns on both sides. Extending it to a resource owned by TYPO3 and edited by people turns an exact check into a lossy one.
- TYPO3 itself has no such fence — two backend editors overwrite each other.

**Revisit condition, named:** the first writing tool that writes a *relative* change (append, increment) makes the "before" an operand rather than decoration, and needs a precondition token.

## One security decision raised rather than settled — #662

The preview is authorised against the **run owner** and displayed to the **approver**, whose authority is checked at tool level (ADR-130/133), never per record. So an approver who may run this tool but holds no permission on *this* page now sees its current metadata.

Bounded — only the fields the call would write, 120-character excerpts, never the row — and there is a real argument for it (an approver who cannot see what is being replaced cannot meaningfully approve). But the argument is not airtight: execution runs under the owner's identity, so the approver does not actually hold write authority on that page. Filed as **#662** with three options, so the current behaviour is on record as a choice rather than an oversight.

## Related Issue

Closes #628 · raises #662

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

`SuspendedRunState` gains one **additive** optional property; old rows degrade rather than fail.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `composer ci` and all checks pass — unit, PHPStan (level 10), cgl and fuzzy re-run independently of the authoring pass: all SUCCESS; the three functional classes executed for real (40 tests, 515 assertions). Rector green under an 8.2 resolve, then restored to 8.4 and the suites re-run on that tree.
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation accordingly
- [x] I have added a `CHANGELOG.md` entry under `## [Unreleased]`
- [x] I have added an ADR under `Documentation/Adr/` if this changes the public surface — ADR-136
- [x] My changes generate no new warnings

### Snapshot

One added line under `SuspendedRunState`: `property readonly callPreviews: array`. Additive, regenerated the prescribed way.

### ADR-135 amended

It said this tool needs "no preview (the approval card already shows the arguments, which for this tool ARE the new values)". That is now false. The idempotency-scope half of that bullet stays deferred; the preview half points at ADR-136. Two ADRs contradicting each other would have been worse than the edit.

### One correction to the issue text

"It reads the page anyway — reuse that read." There is no single read to share: the preview runs at suspend, the write after approval, in a different request possibly days later — which is exactly *why* the before is a snapshot. The private `fetchPage()` helper is reused so each path does one read, and the docblock says so.