### PR TITLE
fix(discovery): seed the capabilities the provider reports, not a guess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Model discovery seeds capabilities the provider actually reports (#671).
+  Six of the seven discoverers wrote tokens no response substantiated:
+  Groq and OpenRouter a flat `chat`, Mistral `chat, tools` for every model
+  including vision-only ones, Gemini `chat, vision` for any id outside its
+  built-in table, and Ollama `tools` for any tag containing `qwen`,
+  `llama3`, `mistral` or `mixtral` — a guess from the model NAME that was
+  wrong in both directions. Mistral's per-model `capabilities` object,
+  OpenRouter's `supported_parameters` and `architecture.input_modalities`,
+  Ollama's `/api/show` `capabilities` array and Gemini's
+  `supportedGenerationMethods` are read instead. Groq's listing carries no
+  capability field, so its models stay `chat` and the administration
+  chapter says so.
+  This matters beyond the wizard: `Model::$capabilities` began reaching the
+  entity in 0.26, so configurations selecting a model by criteria match
+  against these values for the first time.
+  Also dropped: the `reasoning` token, written by two discoverers, absent
+  from `ModelCapability` — `CapabilitySet` discarded it and the TCA
+  checkbox list could not show it.
+  Existing `tx_nrllm_model` rows keep their values; re-run **Fetch Models**
+  to refresh them.
+- `OpenRouterProvider::fetchModels()` reported no capabilities for any
+  model. It read `supports_function_calling`, which is not a field the
+  catalogue returns, and compared `architecture.modality` against
+  `"multimodal"`, which is not a value it takes — the field is a display
+  string such as `text+image->text`. Measured against the live catalogue:
+  400 models, 0 with either signal, against 333 that list `tools` among
+  their supported parameters and 237 that accept image input.
+
 ## [0.26.0] - 2026-08-06
 
 ### Added

--- a/Classes/Provider/OpenRouterProvider.php
+++ b/Classes/Provider/OpenRouterProvider.php
@@ -248,8 +248,16 @@ final class OpenRouterProvider extends AbstractProvider implements
                         'completion' => $this->asFloat($pricing['completion'] ?? 0),
                     ],
                     'capabilities' => [
-                        'vision' => $this->getString($architecture, 'modality') === 'multimodal',
-                        'function_calling' => $this->getBool($modelArray, 'supports_function_calling'),
+                        // `input_modalities`, not `modality`: the latter is a
+                        // display string ("text->text", "text+image->text") and
+                        // never the literal "multimodal", so the old comparison
+                        // was false for every model in the catalogue.
+                        'vision' => in_array('image', $this->getList($architecture, 'input_modalities'), true),
+                        // `supports_function_calling` is not a field OpenRouter
+                        // returns. It read as false for all 400 models,
+                        // including the 333 that list `tools` among their
+                        // supported parameters -- which is where the answer is.
+                        'function_calling' => in_array('tools', $this->getList($modelArray, 'supported_parameters'), true),
                     ],
                     'provider' => $this->extractProviderFromModelId($modelId),
                 ];

--- a/Classes/Service/SetupWizard/Discovery/GeminiModelDiscoverer.php
+++ b/Classes/Service/SetupWizard/Discovery/GeminiModelDiscoverer.php
@@ -91,6 +91,42 @@ final class GeminiModelDiscoverer extends AbstractModelDiscoverer
     }
 
     /**
+     * What the listing itself says about a model the curated table does not
+     * know — a Gemini release newer than this extension.
+     *
+     * `supportedGenerationMethods` is the only capability-bearing field the
+     * listing carries. It substantiates chat, streaming and embeddings, and
+     * says nothing about vision or tools; the previous fallback claimed
+     * `vision` for every unknown model, which is how a text-only release
+     * ended up advertising image input.
+     *
+     * @param array<string, mixed> $apiData
+     *
+     * @return list<string>
+     */
+    private function capabilitiesFrom(array $apiData): array
+    {
+        $methods = isset($apiData['supportedGenerationMethods']) && is_array($apiData['supportedGenerationMethods'])
+            ? $apiData['supportedGenerationMethods']
+            : [];
+
+        $capabilities = [];
+        if (in_array('generateContent', $methods, true)) {
+            $capabilities[] = 'chat';
+        }
+
+        if (in_array('streamGenerateContent', $methods, true)) {
+            $capabilities[] = 'streaming';
+        }
+
+        if (in_array('embedContent', $methods, true)) {
+            $capabilities[] = 'embeddings';
+        }
+
+        return $capabilities === [] ? ['chat'] : $capabilities;
+    }
+
+    /**
      * Enrich Gemini model with specifications.
      *
      * @param array<string, mixed> $apiData
@@ -110,7 +146,9 @@ final class GeminiModelDiscoverer extends AbstractModelDiscoverer
             'gemini-3-pro' => [
                 'name' => 'Gemini 3 Pro',
                 'description' => 'Advanced reasoning for agentic workflows',
-                'capabilities' => ['chat', 'vision', 'tools', 'streaming', 'reasoning'],
+                // No `reasoning`: it is not in ModelCapability, so CapabilitySet
+                // drops it and the TCA checkbox list cannot even show it.
+                'capabilities' => ['chat', 'vision', 'tools', 'streaming'],
                 'costInput' => 125,
                 'costOutput' => 500,
                 'recommended' => true,
@@ -153,7 +191,7 @@ final class GeminiModelDiscoverer extends AbstractModelDiscoverer
             modelId: $modelId,
             name: $spec['name'] ?? $displayName,
             description: $spec['description'] ?? $apiDescription,
-            capabilities: $spec['capabilities'] ?? ['chat', 'vision'],
+            capabilities: $spec['capabilities'] ?? $this->capabilitiesFrom($apiData),
             contextLength: $inputTokenLimit,
             maxOutputTokens: $outputTokenLimit,
             costInput: $spec['costInput'] ?? 0,
@@ -185,7 +223,7 @@ final class GeminiModelDiscoverer extends AbstractModelDiscoverer
                 modelId: 'gemini-3-pro',
                 name: 'Gemini 3 Pro',
                 description: 'Advanced reasoning for agentic workflows',
-                capabilities: ['chat', 'vision', 'tools', 'streaming', 'reasoning'],
+                capabilities: ['chat', 'vision', 'tools', 'streaming'],
                 contextLength: 1000000,
                 maxOutputTokens: 65536,
                 costInput: 125,

--- a/Classes/Service/SetupWizard/Discovery/GroqModelDiscoverer.php
+++ b/Classes/Service/SetupWizard/Discovery/GroqModelDiscoverer.php
@@ -50,6 +50,14 @@ final class GroqModelDiscoverer extends AbstractModelDiscoverer
                     modelId: $modelId,
                     name: $modelId,
                     description: 'Groq-accelerated model',
+                    // `chat` alone, and it stays that way until Groq reports
+                    // more. Their listing returns id, object, created,
+                    // owned_by, active, context_window, max_completion_tokens
+                    // and public_apps — no capability field of any kind. Most
+                    // models here do handle tools, but this seed says what the
+                    // API said, and the operator completes the record in the
+                    // backend (the field is an editable checkbox list). A
+                    // name-pattern guess is what this change removed elsewhere.
                     capabilities: ['chat'],
                     contextLength: $contextWindow,
                     maxOutputTokens: 0,

--- a/Classes/Service/SetupWizard/Discovery/MistralModelDiscoverer.php
+++ b/Classes/Service/SetupWizard/Discovery/MistralModelDiscoverer.php
@@ -46,7 +46,7 @@ final class MistralModelDiscoverer extends AbstractModelDiscoverer
                     modelId: $modelId,
                     name: $modelId,
                     description: 'Mistral AI model',
-                    capabilities: ['chat', 'tools'],
+                    capabilities: $this->capabilitiesFrom($model),
                     contextLength: 0,
                     maxOutputTokens: 0,
                     costInput: 0,
@@ -64,6 +64,44 @@ final class MistralModelDiscoverer extends AbstractModelDiscoverer
     }
 
     /**
+     * The tokens Mistral's own `capabilities` object substantiates, and nothing
+     * else. The listing reports `completion_chat`, `completion_fim`,
+     * `function_calling`, `fine_tuning`, `vision` and `classification` per
+     * model; only the three that map onto this extension's vocabulary are read.
+     *
+     * `streaming` is deliberately absent even though every Mistral chat model
+     * streams: the listing does not say so, and a token nothing substantiates
+     * is the defect this method exists to remove. A model whose entry carries
+     * no `capabilities` object at all yields `chat` — the weakest claim that
+     * still describes a model returned by a chat listing.
+     *
+     * @param array<int|string, mixed> $model
+     *
+     * @return list<string>
+     */
+    private function capabilitiesFrom(array $model): array
+    {
+        $flags = isset($model['capabilities']) && is_array($model['capabilities'])
+            ? $model['capabilities']
+            : [];
+
+        $capabilities = [];
+        if (($flags['completion_chat'] ?? true) === true) {
+            $capabilities[] = 'chat';
+        }
+
+        if (($flags['function_calling'] ?? false) === true) {
+            $capabilities[] = 'tools';
+        }
+
+        if (($flags['vision'] ?? false) === true) {
+            $capabilities[] = 'vision';
+        }
+
+        return $capabilities;
+    }
+
+    /**
      * Get Mistral fallback models.
      *
      * @return array<DiscoveredModel>
@@ -75,7 +113,7 @@ final class MistralModelDiscoverer extends AbstractModelDiscoverer
                 modelId: 'mistral-large-latest',
                 name: 'Mistral Large',
                 description: 'Flagship model for complex tasks',
-                capabilities: ['chat', 'tools', 'streaming'],
+                capabilities: ['chat', 'tools'],
                 contextLength: 128000,
                 maxOutputTokens: 8192,
                 costInput: 200,
@@ -86,7 +124,7 @@ final class MistralModelDiscoverer extends AbstractModelDiscoverer
                 modelId: 'mistral-medium-latest',
                 name: 'Mistral Medium',
                 description: 'Balanced performance',
-                capabilities: ['chat', 'tools', 'streaming'],
+                capabilities: ['chat', 'tools'],
                 contextLength: 32000,
                 maxOutputTokens: 8192,
                 costInput: 100,

--- a/Classes/Service/SetupWizard/Discovery/OllamaModelDiscoverer.php
+++ b/Classes/Service/SetupWizard/Discovery/OllamaModelDiscoverer.php
@@ -152,7 +152,7 @@ final class OllamaModelDiscoverer extends AbstractModelDiscoverer
 
             $contextLength = $this->extractOllamaContextLength($data);
             $modelIdLower = strtolower($modelId);
-            $capabilities = $this->detectOllamaCapabilities($modelIdLower);
+            $capabilities = $this->extractOllamaCapabilities($data);
 
             // Ollama doesn't expose max output tokens, so derive sensible defaults
             // Most models can output up to 1/4 of context, with reasonable caps
@@ -201,25 +201,53 @@ final class OllamaModelDiscoverer extends AbstractModelDiscoverer
     }
 
     /**
-     * Detect Ollama model capabilities based on the model family.
+     * The capabilities Ollama reports for the model, from the `capabilities`
+     * array `/api/show` returns.
      *
-     * @return array<string>
+     * This replaces a guess from the model NAME — `tools` for anything
+     * containing `qwen`, `llama3`, `mistral` or `mixtral`, `vision` for
+     * anything containing `vision` or `llava`. That guess was wrong in both
+     * directions: a tool-capable model outside those four families never got
+     * the token, and a distilled or quantised variant carrying one of those
+     * words in its tag got it without being able to call a tool.
+     *
+     * Ollama's own vocabulary differs from this extension's, so only the
+     * overlapping tokens are mapped. `thinking`, `insert` and `embedding` have
+     * no counterpart in the model's capability field and are dropped rather
+     * than invented. A response without the array — Ollama below 0.6 — yields
+     * `chat`, which is what a model in the chat listing at least does.
+     *
+     * @param array<int|string, mixed> $data
+     *
+     * @return list<string>
      */
-    private function detectOllamaCapabilities(string $modelIdLower): array
+    private function extractOllamaCapabilities(array $data): array
     {
-        $capabilities = ['chat'];
+        $reported = isset($data['capabilities']) && is_array($data['capabilities'])
+            ? $data['capabilities']
+            : [];
+        if ($reported === []) {
+            return ['chat'];
+        }
 
-        // Vision models
-        if (str_contains($modelIdLower, 'vision') || str_contains($modelIdLower, 'llava')) {
+        $capabilities = [];
+        // `completion` is Ollama's token for a text-generating model, which is
+        // what `chat` means here; a model that reports neither is not one this
+        // extension can send a conversation to.
+        if (in_array('completion', $reported, true)) {
+            $capabilities[] = 'chat';
+        }
+
+        if (in_array('tools', $reported, true)) {
+            $capabilities[] = 'tools';
+        }
+
+        if (in_array('vision', $reported, true)) {
             $capabilities[] = 'vision';
         }
 
-        // Tool-use models (qwen, llama 3.x, mistral, etc.)
-        if (str_contains($modelIdLower, 'qwen')
-            || str_contains($modelIdLower, 'llama3')
-            || str_contains($modelIdLower, 'mistral')
-            || str_contains($modelIdLower, 'mixtral')) {
-            $capabilities[] = 'tools';
+        if (in_array('embedding', $reported, true)) {
+            $capabilities[] = 'embeddings';
         }
 
         return $capabilities;

--- a/Classes/Service/SetupWizard/Discovery/OpenAiModelDiscoverer.php
+++ b/Classes/Service/SetupWizard/Discovery/OpenAiModelDiscoverer.php
@@ -159,7 +159,7 @@ final class OpenAiModelDiscoverer extends AbstractModelDiscoverer
             'gpt-5.5' => [
                 'name' => 'GPT-5.5',
                 'description' => 'Latest flagship model with enhanced reasoning',
-                'capabilities' => ['chat', 'vision', 'tools', 'streaming', 'reasoning'],
+                'capabilities' => ['chat', 'vision', 'tools', 'streaming'],
                 'contextLength' => 400000,
                 'maxOutputTokens' => 128000,
                 'costInput' => 500,
@@ -169,7 +169,7 @@ final class OpenAiModelDiscoverer extends AbstractModelDiscoverer
             'gpt-5.3' => [
                 'name' => 'GPT-5.3',
                 'description' => 'Flagship model with enhanced reasoning',
-                'capabilities' => ['chat', 'vision', 'tools', 'streaming', 'reasoning'],
+                'capabilities' => ['chat', 'vision', 'tools', 'streaming'],
                 'contextLength' => 400000,
                 'maxOutputTokens' => 128000,
                 'costInput' => 175,
@@ -199,7 +199,7 @@ final class OpenAiModelDiscoverer extends AbstractModelDiscoverer
             'gpt-5.2' => [
                 'name' => 'GPT-5.2 Thinking',
                 'description' => 'Flagship model for coding, reasoning, and agentic tasks',
-                'capabilities' => ['chat', 'vision', 'tools', 'streaming', 'reasoning'],
+                'capabilities' => ['chat', 'vision', 'tools', 'streaming'],
                 'contextLength' => 400000,
                 'maxOutputTokens' => 128000,
                 'costInput' => 175,
@@ -209,7 +209,7 @@ final class OpenAiModelDiscoverer extends AbstractModelDiscoverer
             'gpt-5.2-pro' => [
                 'name' => 'GPT-5.2 Pro',
                 'description' => 'Extended thinking for complex tasks',
-                'capabilities' => ['chat', 'vision', 'tools', 'streaming', 'reasoning'],
+                'capabilities' => ['chat', 'vision', 'tools', 'streaming'],
                 'contextLength' => 400000,
                 'maxOutputTokens' => 128000,
                 'costInput' => 350,
@@ -229,7 +229,7 @@ final class OpenAiModelDiscoverer extends AbstractModelDiscoverer
             'gpt-5' => [
                 'name' => 'GPT-5',
                 'description' => 'Previous generation flagship model',
-                'capabilities' => ['chat', 'vision', 'tools', 'streaming', 'reasoning'],
+                'capabilities' => ['chat', 'vision', 'tools', 'streaming'],
                 'contextLength' => 200000,
                 'maxOutputTokens' => 64000,
                 'costInput' => 150,
@@ -249,7 +249,7 @@ final class OpenAiModelDiscoverer extends AbstractModelDiscoverer
             'o4-mini' => [
                 'name' => 'O4 Mini',
                 'description' => 'Fast reasoning for math, coding, visual tasks',
-                'capabilities' => ['chat', 'vision', 'tools', 'reasoning'],
+                'capabilities' => ['chat', 'vision', 'tools'],
                 'contextLength' => 200000,
                 'maxOutputTokens' => 100000,
                 'costInput' => 110,
@@ -259,7 +259,7 @@ final class OpenAiModelDiscoverer extends AbstractModelDiscoverer
             'o3' => [
                 'name' => 'O3',
                 'description' => 'Advanced reasoning model',
-                'capabilities' => ['chat', 'vision', 'tools', 'reasoning'],
+                'capabilities' => ['chat', 'vision', 'tools'],
                 'contextLength' => 200000,
                 'maxOutputTokens' => 100000,
                 'costInput' => 200,

--- a/Classes/Service/SetupWizard/Discovery/OpenRouterModelDiscoverer.php
+++ b/Classes/Service/SetupWizard/Discovery/OpenRouterModelDiscoverer.php
@@ -83,12 +83,54 @@ final class OpenRouterModelDiscoverer extends AbstractModelDiscoverer
             modelId: $modelId,
             name: $modelName,
             description: $modelDescription,
-            capabilities: ['chat'],
+            capabilities: $this->capabilitiesFrom($model),
             contextLength: $contextLength,
             maxOutputTokens: 0,
             costInput: (int)($promptCost * 100000000),
             costOutput: (int)($completionCost * 100000000),
             recommended: false,
         );
+    }
+
+    /**
+     * The tokens the catalogue entry itself substantiates.
+     *
+     * OpenRouter reports per-model `supported_parameters` (the request
+     * parameters the upstream provider accepts) and
+     * `architecture.input_modalities`. `tools` in the former is the same signal
+     * the runtime's own model filter reads for this purpose, and `image` in the
+     * latter is what makes a model multimodal on the INPUT side — which is what
+     * `vision` means here. An entry that reports neither yields `chat` alone.
+     *
+     * Not derived: `streaming`. Every OpenRouter model streams, but the
+     * catalogue does not say so per model, and this method reports the
+     * catalogue rather than what is generally true of the vendor.
+     *
+     * @param array<int|string, mixed> $model
+     *
+     * @return list<string>
+     */
+    private function capabilitiesFrom(array $model): array
+    {
+        $parameters = isset($model['supported_parameters']) && is_array($model['supported_parameters'])
+            ? $model['supported_parameters']
+            : [];
+        $architecture = isset($model['architecture']) && is_array($model['architecture'])
+            ? $model['architecture']
+            : [];
+        $inputModalities = isset($architecture['input_modalities']) && is_array($architecture['input_modalities'])
+            ? $architecture['input_modalities']
+            : [];
+
+        $capabilities = ['chat'];
+        if (in_array('tools', $parameters, true)) {
+            $capabilities[] = 'tools';
+        }
+
+        if (in_array('image', $inputModalities, true)) {
+            $capabilities[] = 'vision';
+        }
+
+        return $capabilities;
     }
 }

--- a/Documentation/Administration/Wizards.rst
+++ b/Documentation/Administration/Wizards.rst
@@ -112,6 +112,63 @@ provider API. This auto-populates available models
 with their capabilities, context length, and
 pricing metadata.
 
+.. _administration-wizards-capability-seed:
+
+What the capability checkboxes are seeded with
+----------------------------------------------
+
+Discovery writes only the capabilities the provider's
+own response states. How much that is differs per
+provider:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Provider
+     - Reported by the API
+   * - Mistral
+     - chat, tools, vision (per-model ``capabilities``)
+   * - OpenRouter
+     - chat, tools, vision (``supported_parameters``,
+       ``architecture.input_modalities``)
+   * - Ollama
+     - chat, tools, vision, embeddings (``/api/show``,
+       Ollama 0.6 and newer)
+   * - Gemini
+     - chat, streaming, embeddings
+       (``supportedGenerationMethods``); vision and
+       tools come from the built-in table for known
+       model ids
+   * - Anthropic
+     - chat, vision, tools, streaming for every model
+       the listing returns — it returns Claude chat
+       models only, and they all have them
+   * - OpenAI
+     - from the built-in table, keyed by model id; an
+       id outside it is seeded from its prefix
+       (``dall-e-``, ``tts-``, ``whisper-``) and
+       otherwise chat alone
+   * - Groq
+     - chat only — the listing carries no capability
+       field at all
+
+Where the API reports nothing, the record is seeded
+with the narrowest true statement rather than a
+guess. **Check the capability checkboxes after
+discovery** and tick what the model actually does:
+the field is yours to edit, and configurations that
+select models by criteria match against it.
+
+.. note::
+
+   Models discovered by an earlier version carry
+   capabilities that were partly guessed from the
+   model name. Run :guilabel:`Fetch Models` again
+   after upgrading, or correct the checkboxes by
+   hand — an upgrade cannot tell an operator's
+   deliberate edit from a stale seed, so it does not
+   overwrite either.
+
 .. _administration-workflow:
 
 Recommended workflow

--- a/Tests/Unit/Provider/OpenRouterProviderTest.php
+++ b/Tests/Unit/Provider/OpenRouterProviderTest.php
@@ -478,9 +478,9 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
                     'id' => 'anthropic/claude-3.5-sonnet',
                     'name' => 'Claude 3.5 Sonnet',
                     'context_length' => 200000,
-                    'architecture' => ['modality' => 'multimodal'],
+                    'architecture' => ['modality' => 'text+image->text', 'input_modalities' => ['text', 'image']],
                     'pricing' => ['prompt' => 0.003, 'completion' => 0.015],
-                    'supports_function_calling' => true,
+                    'supported_parameters' => ['tools'],
                 ],
             ],
         ];
@@ -505,9 +505,9 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
                     'id' => 'test/model',
                     'name' => 'Test Model',
                     'context_length' => 8000,
-                    'architecture' => ['modality' => 'text'],
+                    'architecture' => ['modality' => 'text->text', 'input_modalities' => ['text']],
                     'pricing' => ['prompt' => 0.001, 'completion' => 0.002],
-                    'supports_function_calling' => false,
+                    'supported_parameters' => [],
                 ],
             ],
         ];
@@ -988,17 +988,17 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
                     'id' => 'expensive/model',
                     'name' => 'Expensive',
                     'context_length' => 8000,
-                    'architecture' => ['modality' => 'text'],
+                    'architecture' => ['modality' => 'text->text', 'input_modalities' => ['text']],
                     'pricing' => ['prompt' => 0.01, 'completion' => 0.03],
-                    'supports_function_calling' => false,
+                    'supported_parameters' => [],
                 ],
                 [
                     'id' => 'cheap/model',
                     'name' => 'Cheap',
                     'context_length' => 8000,
-                    'architecture' => ['modality' => 'text'],
+                    'architecture' => ['modality' => 'text->text', 'input_modalities' => ['text']],
                     'pricing' => ['prompt' => 0.0001, 'completion' => 0.0002],
-                    'supports_function_calling' => false,
+                    'supported_parameters' => [],
                 ],
             ],
         ];
@@ -1030,17 +1030,17 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
                     'id' => 'slow/opus',
                     'name' => 'Slow Opus',
                     'context_length' => 200000,
-                    'architecture' => ['modality' => 'text'],
+                    'architecture' => ['modality' => 'text->text', 'input_modalities' => ['text']],
                     'pricing' => ['prompt' => 0.01, 'completion' => 0.03],
-                    'supports_function_calling' => true,
+                    'supported_parameters' => ['tools'],
                 ],
                 [
                     'id' => 'fast/flash',
                     'name' => 'Fast Flash',
                     'context_length' => 100000,
-                    'architecture' => ['modality' => 'text'],
+                    'architecture' => ['modality' => 'text->text', 'input_modalities' => ['text']],
                     'pricing' => ['prompt' => 0.001, 'completion' => 0.002],
-                    'supports_function_calling' => true,
+                    'supported_parameters' => ['tools'],
                 ],
             ],
         ];
@@ -1072,17 +1072,17 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
                     'id' => 'small/context',
                     'name' => 'Small Context',
                     'context_length' => 4000,
-                    'architecture' => ['modality' => 'text'],
+                    'architecture' => ['modality' => 'text->text', 'input_modalities' => ['text']],
                     'pricing' => ['prompt' => 0.0001, 'completion' => 0.0001],
-                    'supports_function_calling' => false,
+                    'supported_parameters' => [],
                 ],
                 [
                     'id' => 'large/context',
                     'name' => 'Large Context',
                     'context_length' => 128000,
-                    'architecture' => ['modality' => 'text'],
+                    'architecture' => ['modality' => 'text->text', 'input_modalities' => ['text']],
                     'pricing' => ['prompt' => 0.001, 'completion' => 0.002],
-                    'supports_function_calling' => false,
+                    'supported_parameters' => [],
                 ],
             ],
         ];
@@ -1113,17 +1113,17 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
                     'id' => 'text/only',
                     'name' => 'Text Only',
                     'context_length' => 8000,
-                    'architecture' => ['modality' => 'text'],
+                    'architecture' => ['modality' => 'text->text', 'input_modalities' => ['text']],
                     'pricing' => ['prompt' => 0.0001, 'completion' => 0.0001],
-                    'supports_function_calling' => false,
+                    'supported_parameters' => [],
                 ],
                 [
                     'id' => 'vision/model',
                     'name' => 'Vision Model',
                     'context_length' => 8000,
-                    'architecture' => ['modality' => 'multimodal'],
+                    'architecture' => ['modality' => 'text+image->text', 'input_modalities' => ['text', 'image']],
                     'pricing' => ['prompt' => 0.001, 'completion' => 0.002],
-                    'supports_function_calling' => false,
+                    'supported_parameters' => [],
                 ],
             ],
         ];
@@ -1154,17 +1154,17 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
                     'id' => 'no/tools',
                     'name' => 'No Tools',
                     'context_length' => 8000,
-                    'architecture' => ['modality' => 'text'],
+                    'architecture' => ['modality' => 'text->text', 'input_modalities' => ['text']],
                     'pricing' => ['prompt' => 0.0001, 'completion' => 0.0001],
-                    'supports_function_calling' => false,
+                    'supported_parameters' => [],
                 ],
                 [
                     'id' => 'with/tools',
                     'name' => 'With Tools',
                     'context_length' => 8000,
-                    'architecture' => ['modality' => 'text'],
+                    'architecture' => ['modality' => 'text->text', 'input_modalities' => ['text']],
                     'pricing' => ['prompt' => 0.001, 'completion' => 0.002],
-                    'supports_function_calling' => true,
+                    'supported_parameters' => ['tools'],
                 ],
             ],
         ];
@@ -1195,17 +1195,17 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
                     'id' => 'fast/haiku',
                     'name' => 'Fast Haiku',
                     'context_length' => 8000,
-                    'architecture' => ['modality' => 'text'],
+                    'architecture' => ['modality' => 'text->text', 'input_modalities' => ['text']],
                     'pricing' => ['prompt' => 0.0001, 'completion' => 0.0001],
-                    'supports_function_calling' => false,
+                    'supported_parameters' => [],
                 ],
                 [
                     'id' => 'balanced/sonnet',
                     'name' => 'Balanced Sonnet',
                     'context_length' => 200000,
-                    'architecture' => ['modality' => 'multimodal'],
+                    'architecture' => ['modality' => 'text+image->text', 'input_modalities' => ['text', 'image']],
                     'pricing' => ['prompt' => 0.003, 'completion' => 0.015],
-                    'supports_function_calling' => true,
+                    'supported_parameters' => ['tools'],
                 ],
             ],
         ];
@@ -1395,9 +1395,9 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
                     'id' => 'anthropic/claude-sonnet-4-5',
                     'name' => 'Claude Sonnet',
                     'context_length' => 200000,
-                    'architecture' => ['modality' => 'multimodal'],
+                    'architecture' => ['modality' => 'text+image->text', 'input_modalities' => ['text', 'image']],
                     'pricing' => ['prompt' => 0.003, 'completion' => 0.015],
-                    'supports_function_calling' => true,
+                    'supported_parameters' => ['tools'],
                 ],
             ],
         ];
@@ -1461,9 +1461,9 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
                     'id' => 'small/model',
                     'name' => 'Small Model',
                     'context_length' => 4000,
-                    'architecture' => ['modality' => 'text'],
+                    'architecture' => ['modality' => 'text->text', 'input_modalities' => ['text']],
                     'pricing' => ['prompt' => 0.0001, 'completion' => 0.0001],
-                    'supports_function_calling' => false,
+                    'supported_parameters' => [],
                 ],
             ],
         ];
@@ -1693,9 +1693,9 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
             'id' => $id,
             'name' => $id,
             'context_length' => 8000,
-            'architecture' => ['modality' => 'text'],
+            'architecture' => ['modality' => 'text->text', 'input_modalities' => ['text']],
             'pricing' => ['prompt' => $prompt, 'completion' => $completion],
-            'supports_function_calling' => false,
+            'supported_parameters' => [],
         ];
     }
 
@@ -2152,15 +2152,15 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
                     'id' => 'anthropic/claude-x',
                     'name' => 'Claude X',
                     'context_length' => 200000,
-                    'architecture' => ['modality' => 'multimodal'],
+                    'architecture' => ['modality' => 'text+image->text', 'input_modalities' => ['text', 'image']],
                     'pricing' => ['prompt' => 0.003, 'completion' => 0.015],
-                    'supports_function_calling' => true,
+                    'supported_parameters' => ['tools'],
                 ],
                 [
                     // No name, no pricing keys, text modality, no function calling.
                     'id' => 'openai/gpt',
                     'context_length' => 8000,
-                    'architecture' => ['modality' => 'text'],
+                    'architecture' => ['modality' => 'text->text', 'input_modalities' => ['text']],
                 ],
             ],
         ];
@@ -2204,9 +2204,9 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
                 'id' => 'first/model',
                 'name' => 'First',
                 'context_length' => 8000,
-                'architecture' => ['modality' => 'text'],
+                'architecture' => ['modality' => 'text->text', 'input_modalities' => ['text']],
                 'pricing' => ['prompt' => 0.001, 'completion' => 0.002],
-                'supports_function_calling' => false,
+                'supported_parameters' => [],
             ]],
         ];
         $secondResponse = [
@@ -2214,9 +2214,9 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
                 'id' => 'second/model',
                 'name' => 'Second',
                 'context_length' => 8000,
-                'architecture' => ['modality' => 'text'],
+                'architecture' => ['modality' => 'text->text', 'input_modalities' => ['text']],
                 'pricing' => ['prompt' => 0.001, 'completion' => 0.002],
-                'supports_function_calling' => false,
+                'supported_parameters' => [],
             ]],
         ];
 
@@ -2731,8 +2731,8 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
             [
                 $this->modelEntry('plain/cheap', 0.0001, 0.0001),
                 $this->modelEntry('able/model', 0.01, 0.01, [
-                    'architecture' => ['modality' => 'multimodal'],
-                    'supports_function_calling' => true,
+                    'architecture' => ['modality' => 'text+image->text', 'input_modalities' => ['text', 'image']],
+                    'supported_parameters' => ['tools'],
                 ]),
             ],
         );
@@ -2748,7 +2748,7 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
             [
                 $this->modelEntry('text/cheap', 0.0001, 0.0001),
                 $this->modelEntry('vision/pricier', 0.01, 0.01, [
-                    'architecture' => ['modality' => 'multimodal'],
+                    'architecture' => ['modality' => 'text+image->text', 'input_modalities' => ['text', 'image']],
                 ]),
             ],
             ['vision_required' => true],
@@ -2765,7 +2765,7 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
             [
                 $this->modelEntry('plain/cheap', 0.0001, 0.0001),
                 $this->modelEntry('tools/pricier', 0.01, 0.01, [
-                    'supports_function_calling' => true,
+                    'supported_parameters' => ['tools'],
                 ]),
             ],
             ['function_calling' => true],
@@ -2784,7 +2784,7 @@ class OpenRouterProviderTest extends AbstractUnitTestCase
         $model = $this->capturedVisionModel(
             [],
             [$this->modelEntry('anthropic/claude-3.5-sonnet', 0.003, 0.015, [
-                'architecture' => ['modality' => 'multimodal'],
+                'architecture' => ['modality' => 'text+image->text', 'input_modalities' => ['text', 'image']],
             ])],
         );
 

--- a/Tests/Unit/Service/SetupWizard/Discovery/CapabilitySeedTest.php
+++ b/Tests/Unit/Service/SetupWizard/Discovery/CapabilitySeedTest.php
@@ -1,0 +1,301 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\SetupWizard\Discovery;
+
+use Netresearch\NrLlm\Domain\DTO\CapabilitySet;
+use Netresearch\NrLlm\Service\SetupWizard\Discovery\AbstractModelDiscoverer;
+use Netresearch\NrLlm\Service\SetupWizard\Discovery\GeminiModelDiscoverer;
+use Netresearch\NrLlm\Service\SetupWizard\Discovery\GroqModelDiscoverer;
+use Netresearch\NrLlm\Service\SetupWizard\Discovery\MistralModelDiscoverer;
+use Netresearch\NrLlm\Service\SetupWizard\Discovery\OllamaModelDiscoverer;
+use Netresearch\NrLlm\Service\SetupWizard\Discovery\OpenAiModelDiscoverer;
+use Netresearch\NrLlm\Service\SetupWizard\Discovery\OpenRouterModelDiscoverer;
+use Netresearch\NrLlm\Service\SetupWizard\DTO\DiscoveredModel;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use RuntimeException;
+
+/**
+ * A discoverer may only write a capability token the provider's own response
+ * substantiates.
+ *
+ * The payloads below are trimmed recordings of the real endpoints, keeping the
+ * capability-bearing fields verbatim. They are the point of the test: the
+ * previous seeds were derived from the model NAME or hardcoded per provider, so
+ * every one of them passed a test written against a hand-made fixture that
+ * agreed with the guess.
+ */
+#[CoversClass(GeminiModelDiscoverer::class)]
+#[CoversClass(GroqModelDiscoverer::class)]
+#[CoversClass(MistralModelDiscoverer::class)]
+#[CoversClass(OllamaModelDiscoverer::class)]
+#[CoversClass(OpenAiModelDiscoverer::class)]
+#[CoversClass(OpenRouterModelDiscoverer::class)]
+final class CapabilitySeedTest extends AbstractUnitTestCase
+{
+    #[Test]
+    public function mistralReadsTheCapabilitiesObjectRatherThanAssumingToolSupport(): void
+    {
+        // Recorded from GET /v1/models: Mistral reports six booleans per model.
+        $models = $this->discover(MistralModelDiscoverer::class, json_encode([
+            'data' => [
+                [
+                    'id'           => 'mistral-small-latest',
+                    'capabilities' => [
+                        'completion_chat'  => true,
+                        'completion_fim'   => false,
+                        'function_calling' => true,
+                        'fine_tuning'      => true,
+                        'vision'           => false,
+                        'classification'   => false,
+                    ],
+                ],
+                [
+                    'id'           => 'pixtral-12b',
+                    'capabilities' => [
+                        'completion_chat'  => true,
+                        'function_calling' => false,
+                        'vision'           => true,
+                    ],
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR));
+
+        self::assertSame(['chat', 'tools'], $this->capabilitiesOf($models, 'mistral-small-latest'));
+        // The old seed was ['chat', 'tools'] for EVERY model, so a vision model
+        // lost the one token that distinguishes it and gained one it lacks.
+        self::assertSame(['chat', 'vision'], $this->capabilitiesOf($models, 'pixtral-12b'));
+    }
+
+    #[Test]
+    public function openRouterDerivesToolsAndVisionFromTheCatalogueEntry(): void
+    {
+        // Recorded from GET /api/v1/models. `supported_parameters` is the field
+        // the runtime's own model filter reads for tool support; vision is an
+        // INPUT modality. Note `modality` is a display string and never the
+        // literal "multimodal" the provider used to compare against.
+        $models = $this->discover(OpenRouterModelDiscoverer::class, json_encode([
+            'data' => [
+                [
+                    'id'                   => 'openai/gpt-5.3',
+                    'context_length'       => 400000,
+                    'architecture'         => ['modality' => 'text+image->text', 'input_modalities' => ['text', 'image']],
+                    'supported_parameters' => ['max_tokens', 'tool_choice', 'tools'],
+                ],
+                [
+                    'id'                   => 'inclusionai/ling-3.0-tiny',
+                    'context_length'       => 32000,
+                    'architecture'         => ['modality' => 'text->text', 'input_modalities' => ['text']],
+                    'supported_parameters' => ['max_tokens', 'temperature'],
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR));
+
+        self::assertSame(['chat', 'tools', 'vision'], $this->capabilitiesOf($models, 'openai/gpt-5.3'));
+        // Both models used to be seeded a flat ['chat'].
+        self::assertSame(['chat'], $this->capabilitiesOf($models, 'inclusionai/ling-3.0-tiny'));
+    }
+
+    #[Test]
+    public function ollamaReadsTheReportedCapabilitiesInsteadOfGuessingFromTheName(): void
+    {
+        // Two tags chosen because the name guess gets both wrong: gemma3 is
+        // tool-capable but matches none of the four hardcoded families, and
+        // "mistral-small" matches one of them without the server reporting
+        // tools for this quantisation.
+        $models = $this->discoverOllama([
+            'gemma3:12b'          => ['completion', 'tools', 'vision'],
+            'mistral-small:22b-q4' => ['completion'],
+        ]);
+
+        self::assertSame(['chat', 'tools', 'vision'], $this->capabilitiesOf($models, 'gemma3:12b'));
+        self::assertSame(['chat'], $this->capabilitiesOf($models, 'mistral-small:22b-q4'));
+    }
+
+    #[Test]
+    public function ollamaFallsBackToChatWhenTheServerReportsNoCapabilities(): void
+    {
+        // Ollama below 0.6 has no `capabilities` key at all.
+        $models = $this->discoverOllama(['legacy-model:latest' => null]);
+
+        self::assertSame(['chat'], $this->capabilitiesOf($models, 'legacy-model:latest'));
+    }
+
+    #[Test]
+    public function anUnknownGeminiModelIsDescribedByItsSupportedMethodsNotByAGuess(): void
+    {
+        // A release newer than the curated table. `supportedGenerationMethods`
+        // is the listing's only capability-bearing field, and it says nothing
+        // about vision -- which the old fallback claimed for every unknown id.
+        $models = $this->discover(GeminiModelDiscoverer::class, json_encode([
+            'models' => [
+                [
+                    'name'                       => 'models/gemini-9-nano',
+                    'displayName'                => 'Gemini 9 Nano',
+                    'supportedGenerationMethods' => ['generateContent', 'streamGenerateContent', 'countTokens'],
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR));
+
+        self::assertSame(['chat', 'streaming'], $this->capabilitiesOf($models, 'gemini-9-nano'));
+    }
+
+    #[Test]
+    public function groqSeedsOnlyChatBecauseItsListingCarriesNoCapabilityField(): void
+    {
+        $models = $this->discover(GroqModelDiscoverer::class, json_encode([
+            'data' => [
+                ['id' => 'llama-3.3-70b-versatile', 'context_window' => 131072],
+            ],
+        ], JSON_THROW_ON_ERROR));
+
+        self::assertSame(['chat'], $this->capabilitiesOf($models, 'llama-3.3-70b-versatile'));
+    }
+
+    /**
+     * The token vocabulary is closed. `reasoning` was written by two
+     * discoverers and is not a ModelCapability, so CapabilitySet dropped it
+     * silently and the TCA checkbox list could not display it -- an entry in
+     * the stored CSV that nothing could read and nobody could edit.
+     *
+     * The static fallback catalogues are checked here because they are the one
+     * capability source that never touches an API and so never appears in the
+     * recorded-payload tests above. An unreachable endpoint is the shortest
+     * route into that branch.
+     */
+    #[Test]
+    public function everySeededTokenIsPartOfTheCapabilityVocabulary(): void
+    {
+        $checked = 0;
+        foreach ([GeminiModelDiscoverer::class, MistralModelDiscoverer::class, OpenAiModelDiscoverer::class] as $class) {
+            $models = $this->discovererFor($class, null)->discover('https://unreachable.invalid', 'k')->models;
+            foreach ($models as $model) {
+                $tokens = array_values($model->capabilities);
+                self::assertCount(
+                    count($tokens),
+                    CapabilitySet::fromArray($tokens)->capabilities,
+                    sprintf('%s seeds a token outside ModelCapability for %s: %s', $class, $model->modelId, implode(', ', $tokens)),
+                );
+                ++$checked;
+            }
+        }
+
+        // Guards the guard: a fallback branch that stopped returning models
+        // would make every assertion above vacuous.
+        self::assertGreaterThan(0, $checked);
+    }
+
+    /**
+     * @param list<DiscoveredModel> $models
+     *
+     * @return list<string>
+     */
+    private function capabilitiesOf(array $models, string $modelId): array
+    {
+        foreach ($models as $model) {
+            if ($model->modelId === $modelId) {
+                return array_values($model->capabilities);
+            }
+        }
+
+        self::fail(sprintf('No discovered model with id "%s".', $modelId));
+    }
+
+    /**
+     * @return list<DiscoveredModel>
+     */
+    private function discover(string $class, string $body): array
+    {
+        return array_values($this->discovererFor($class, $body)->discover('https://api.example.invalid', 'test-key')->models);
+    }
+
+    /**
+     * Ollama needs two different responses: `/api/tags` lists the pulled tags,
+     * and one `/api/show` per tag carries the capabilities.
+     *
+     * @param array<string, list<string>|null> $capabilitiesByTag
+     *
+     * @return list<DiscoveredModel>
+     */
+    private function discoverOllama(array $capabilitiesByTag): array
+    {
+        $tags = ['models' => []];
+        foreach (array_keys($capabilitiesByTag) as $tag) {
+            $tags['models'][] = ['name' => $tag, 'size' => 1024];
+        }
+
+        $bodies = [json_encode($tags, JSON_THROW_ON_ERROR)];
+        foreach ($capabilitiesByTag as $capabilities) {
+            $show = ['model_info' => ['general.context_length' => 8192]];
+            if ($capabilities !== null) {
+                $show['capabilities'] = $capabilities;
+            }
+
+            $bodies[] = json_encode($show, JSON_THROW_ON_ERROR);
+        }
+
+        return array_values(
+            $this->discovererFor(OllamaModelDiscoverer::class, $bodies)
+                ->discover('http://ollama.example.invalid:11434', '')
+                ->models,
+        );
+    }
+
+    /**
+     * @param string|list<string>|null $body a single response body, one body per
+     *                                       request in order, or null to make
+     *                                       every dispatch fail
+     */
+    private function discovererFor(string $class, string|array|null $body): AbstractModelDiscoverer
+    {
+        $client = self::createStub(ClientInterface::class);
+        if ($body === null) {
+            $client->method('sendRequest')->willThrowException(new RuntimeException('unreachable'));
+        } else {
+            $queue = is_array($body) ? $body : [$body];
+            $client->method('sendRequest')->willReturnCallback(
+                function () use (&$queue): ResponseInterface {
+                    $next = array_shift($queue) ?? '{}';
+
+                    return $this->jsonResponse($next);
+                },
+            );
+        }
+
+        /** @var AbstractModelDiscoverer $discoverer */
+        $discoverer = new $class(
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+        );
+        $discoverer->setHttpClient($client);
+
+        return $discoverer;
+    }
+
+    private function jsonResponse(string $body): ResponseInterface&Stub
+    {
+        $stream = self::createStub(StreamInterface::class);
+        $stream->method('getContents')->willReturn($body);
+
+        $response = self::createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('getBody')->willReturn($stream);
+
+        return $response;
+    }
+}

--- a/Tests/Unit/Service/SetupWizard/ModelDiscoveryTest.php
+++ b/Tests/Unit/Service/SetupWizard/ModelDiscoveryTest.php
@@ -932,9 +932,13 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
             ],
         ]);
 
+        // The capability comes from what the server reports, not from the tag
+        // containing "llava". Ollama's own token for a text-generating model is
+        // `completion`.
         $showResponse = (string)json_encode([
-            'model_info' => [],
-            'parameters' => '',
+            'model_info'   => [],
+            'parameters'   => '',
+            'capabilities' => ['completion', 'vision'],
         ]);
 
         $this->httpClientStub
@@ -975,8 +979,9 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         ]);
 
         $showResponse = (string)json_encode([
-            'model_info' => [],
-            'parameters' => 'num_ctx 32768',
+            'model_info'   => [],
+            'parameters'   => 'num_ctx 32768',
+            'capabilities' => ['completion', 'tools'],
         ]);
 
         $this->httpClientStub
@@ -3117,17 +3122,17 @@ class ModelDiscoveryTest extends AbstractUnitTestCase
         // caught. Values mirror ModelDiscovery::openAIModelSpecs().
         // [name, description, capabilities, contextLength, maxOutputTokens, costInput, costOutput, recommended]
         $expected = [
-            'gpt-5.5' => ['GPT-5.5', 'Latest flagship model with enhanced reasoning', ['chat', 'vision', 'tools', 'streaming', 'reasoning'], 400000, 128000, 500, 3000, true],
-            'gpt-5.3' => ['GPT-5.3', 'Flagship model with enhanced reasoning', ['chat', 'vision', 'tools', 'streaming', 'reasoning'], 400000, 128000, 175, 1400, true],
+            'gpt-5.5' => ['GPT-5.5', 'Latest flagship model with enhanced reasoning', ['chat', 'vision', 'tools', 'streaming'], 400000, 128000, 500, 3000, true],
+            'gpt-5.3' => ['GPT-5.3', 'Flagship model with enhanced reasoning', ['chat', 'vision', 'tools', 'streaming'], 400000, 128000, 175, 1400, true],
             'gpt-5.3-chat-latest' => ['GPT-5.3 Chat', 'Fast responses for interactive use', ['chat', 'vision', 'tools', 'streaming'], 400000, 32000, 100, 400, true],
             'gpt-5.3-mini' => ['GPT-5.3 Mini', 'Small, fast, cost-effective', ['chat', 'vision', 'tools', 'streaming'], 200000, 32000, 30, 120, true],
-            'gpt-5.2' => ['GPT-5.2 Thinking', 'Flagship model for coding, reasoning, and agentic tasks', ['chat', 'vision', 'tools', 'streaming', 'reasoning'], 400000, 128000, 175, 1400, false],
-            'gpt-5.2-pro' => ['GPT-5.2 Pro', 'Extended thinking for complex tasks', ['chat', 'vision', 'tools', 'streaming', 'reasoning'], 400000, 128000, 350, 2800, false],
+            'gpt-5.2' => ['GPT-5.2 Thinking', 'Flagship model for coding, reasoning, and agentic tasks', ['chat', 'vision', 'tools', 'streaming'], 400000, 128000, 175, 1400, false],
+            'gpt-5.2-pro' => ['GPT-5.2 Pro', 'Extended thinking for complex tasks', ['chat', 'vision', 'tools', 'streaming'], 400000, 128000, 350, 2800, false],
             'gpt-5.2-chat-latest' => ['GPT-5.2 Instant', 'Fast responses for interactive use', ['chat', 'vision', 'tools', 'streaming'], 400000, 32000, 100, 400, false],
-            'gpt-5' => ['GPT-5', 'Previous generation flagship model', ['chat', 'vision', 'tools', 'streaming', 'reasoning'], 200000, 64000, 150, 600, false],
+            'gpt-5' => ['GPT-5', 'Previous generation flagship model', ['chat', 'vision', 'tools', 'streaming'], 200000, 64000, 150, 600, false],
             'gpt-5-mini' => ['GPT-5 Mini', 'Smaller, faster, cost-effective', ['chat', 'vision', 'tools', 'streaming'], 128000, 32000, 30, 120, false],
-            'o4-mini' => ['O4 Mini', 'Fast reasoning for math, coding, visual tasks', ['chat', 'vision', 'tools', 'reasoning'], 200000, 100000, 110, 440, false],
-            'o3' => ['O3', 'Advanced reasoning model', ['chat', 'vision', 'tools', 'reasoning'], 200000, 100000, 200, 800, false],
+            'o4-mini' => ['O4 Mini', 'Fast reasoning for math, coding, visual tasks', ['chat', 'vision', 'tools'], 200000, 100000, 110, 440, false],
+            'o3' => ['O3', 'Advanced reasoning model', ['chat', 'vision', 'tools'], 200000, 100000, 200, 800, false],
             'gpt-4o' => ['GPT-4o', 'Legacy multimodal model', ['chat', 'vision', 'tools', 'streaming'], 128000, 16384, 250, 1000, false],
             'gpt-4.1' => ['GPT-4.1', 'Coding and instruction-following model', ['chat', 'vision', 'tools', 'streaming'], 1047576, 32768, 200, 800, false],
             'gpt-4.1-mini' => ['GPT-4.1 Mini', 'Fast coding model', ['chat', 'vision', 'tools', 'streaming'], 1047576, 32768, 40, 160, false],


### PR DESCRIPTION
## Description

Model discovery wrote capability tokens no provider response substantiated. Six of the seven discoverers were wrong, and the seeded values are what a criteria-mode configuration matches against — so the wrong data selects the wrong model, or none.

### What each provider actually reports

Verified against the live endpoints and the vendors' own API references, not inferred:

| Discoverer | wrote | reports | now reads |
|---|---|---|---|
| Mistral | `chat, tools` for every model | per-model `capabilities` object | `completion_chat`, `function_calling`, `vision` |
| OpenRouter | flat `chat` | `supported_parameters`, `architecture.input_modalities` | `tools`, image input |
| Ollama | `tools` if the tag contains `qwen`, `llama3`, `mistral` or `mixtral` | `/api/show` → `capabilities` | the reported array |
| Gemini | `chat, vision` for any id outside its table | `supportedGenerationMethods` | `generateContent`, `streamGenerateContent`, `embedContent` |
| Groq | `chat` | nothing — the listing has no capability field | unchanged, and the docs say why |
| OpenAI | id table, `chat` for unknown ids | — | unchanged |
| Anthropic | `chat, vision, tools, streaming` | — | unchanged; the listing returns Claude chat models only |

The Ollama guess was wrong in both directions: a tool-capable model outside those four families never got the token, and any distilled or quantised variant carrying one of those words in its tag got it without being able to call a tool.

### A second defect, found by checking the live API

`OpenRouterProvider::fetchModels()` reported **no** capabilities for **any** model:

- it read `supports_function_calling`, which is not a field the catalogue returns;
- it compared `architecture.modality` against `"multimodal"`, which is not a value that field takes — it is a display string such as `text+image->text`.

Measured against the live catalogue: 400 models, 0 carrying either signal, against 333 that list `tools` among their supported parameters and 237 that accept image input.

This survived 109 green tests because the fixtures used the same invented shape. The fixtures now carry the real one; the assertions are unchanged.

### `reasoning` is gone

Two discoverers wrote it. It is not a `ModelCapability`, so `CapabilitySet` discarded it and the TCA checkbox list could not display it — a value in the stored CSV that nothing read and nobody could edit.

### The decision behind "narrow rather than guess"

`capabilities` is an operator-editable checkbox list in the model record. The field is theirs; discovery seeds it. So a discoverer states what the API states, and where the API is silent (Groq) it makes the narrowest true claim instead of a plausible one. The administration chapter now says per provider how much is seeded and asks the operator to complete it.

**This bears on #653.** A capability check with `enforce` as its default judges an operator-owned field that the wizard only pre-fills. On any installation that never revisited it — every installation before this change — the check refuses models that work. Worth deciding on #653 itself, not here.

## Related Issue

Closes #671. Prerequisite for #653 / #635.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Migration

Existing `tx_nrllm_model` rows keep their values: an upgrade cannot tell an operator's deliberate edit from a stale seed, so it overwrites neither. Re-run **Fetch Models**, or correct the checkboxes by hand. Documented in the administration chapter.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run the gates — unit, PHPStan (level 10), cgl, fuzzy, functional and Rector (under an 8.2 resolve, as CI pins it)
- [x] I have added tests that prove my fix works
- [x] I have updated the documentation accordingly
- [x] I have added a `CHANGELOG.md` entry under `## [Unreleased]`
- [ ] ADR — none: this corrects data the existing ADR-018 discovery already promised, it does not change the surface
- [x] My changes generate no new warnings

### Tests

`CapabilitySeedTest` pins each discoverer against a trimmed recording of the real endpoint, plus a vocabulary test asserting no discoverer can emit a token outside `ModelCapability`.

Controlled before/after rather than plausibility: against the unchanged `Classes/`, 5 of its 7 tests fail. The two that pass in both are characterisation of behaviour deliberately left alone (Groq, and Ollama below 0.6).

Three existing tests asserted the old guesses and were rewritten rather than deleted: the two Ollama capability tests now source the capability from the server's report instead of the tag, keeping their assertions; the OpenAI spec test lost `reasoning` from its expectations.
