### PR TITLE
docs(tools): widen the group table so its longest key fits the column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- The tool-group table in the administration chapter renders its
+  `configuration` row correctly (#673). The RST simple table's first column
+  was two characters narrower than the longest key, so `render-guides`
+  logged `Malformed table` and the row's closing backticks were swallowed:
+  the group name printed as `` ``configuration `` in plain text instead of
+  as inline code. The row itself was present — the render error is real,
+  the missing row the issue suspected was not.
+
 ## [0.26.0] - 2026-08-06
 
 ### Added

--- a/Documentation/Administration/Tools.rst
+++ b/Documentation/Administration/Tools.rst
@@ -342,27 +342,27 @@ Tool groups
 Every tool belongs to a **group** (its ``getGroup()`` value). The built-in
 taxonomy:
 
-===============  ============================================================
-Group            Tools
-===============  ============================================================
-``content``      ``search_records``, ``get_page_content``, ``read_records``,
-                 ``get_record_history``
-``structure``    ``get_pagetree``, ``get_tca``, ``read_fal_asset_meta``,
-                 ``get_full_tca``, ``get_table_schema``, ``get_flexform_schema``,
-                 ``resolve_url``, ``validate_tca``
-``system``       ``get_env`` (+ raw), ``get_php_info`` (+ raw),
-                 ``fetch_logs``, ``probe_url``, ``list_extensions``,
-                 ``list_scheduler_tasks``, ``get_system_status``,
-                 ``list_deprecations``, ``list_middlewares``
-``accounts``     ``list_be_users`` (+ raw), ``list_be_groups``
+=================  ============================================================
+Group              Tools
+=================  ============================================================
+``content``        ``search_records``, ``get_page_content``, ``read_records``,
+                   ``get_record_history``
+``structure``      ``get_pagetree``, ``get_tca``, ``read_fal_asset_meta``,
+                   ``get_full_tca``, ``get_table_schema``, ``get_flexform_schema``,
+                   ``resolve_url``, ``validate_tca``
+``system``         ``get_env`` (+ raw), ``get_php_info`` (+ raw),
+                   ``fetch_logs``, ``probe_url``, ``list_extensions``,
+                   ``list_scheduler_tasks``, ``get_system_status``,
+                   ``list_deprecations``, ``list_middlewares``
+``accounts``       ``list_be_users`` (+ raw), ``list_be_groups``
 ``configuration``  ``get_typoscript``, ``get_tsconfig``, ``fluid_resolve``,
-                 ``check_typoscript``, ``get_site_config``
-``code``         ``get_last_exception``, ``read_source``, ``search_code``
-``files``        ``list_fal_storages``, ``browse_fal_folder``,
-                 ``search_fal_files``, ``get_fal_references``,
-                 ``find_missing_files``
-``rag``          ``site_rag_query``, ``site_fetch_source``
-===============  ============================================================
+                   ``check_typoscript``, ``get_site_config``
+``code``           ``get_last_exception``, ``read_source``, ``search_code``
+``files``          ``list_fal_storages``, ``browse_fal_folder``,
+                   ``search_fal_files``, ``get_fal_references``,
+                   ``find_missing_files``
+``rag``            ``site_rag_query``, ``site_fetch_source``
+=================  ============================================================
 
 Groups can be switched on three levels, and the result cascades
 **fail-closed** — a tool is offered only when *every* level permits it:


### PR DESCRIPTION
## Description

`Documentation/Administration/Tools.rst` uses an RST simple table whose first column is fifteen characters wide. `` ``configuration`` `` is seventeen, so it spills into the column gap and `render-guides` logs a hard `Malformed table` error.

The column is widened to seventeen and every row re-aligned. No content changes.

## What it actually broke

The issue suspected the row was dropped or mangled but had only the render log. Rendering both states with the same container settles it: **the row is not dropped.** The overflow swallowed the key's closing backticks, so the group name rendered as plain text carrying two literal backticks rather than as inline code:

```
before:  ``configuration   get_typoscript, get_tsconfig, …
after:   configuration     get_typoscript, get_tsconfig, …
```

Smaller than feared, and worth stating because the issue text says otherwise.

## Related Issue

Closes #673.

## Type of Change

- [x] Documentation update

## Checklist

- [x] I have added a `CHANGELOG.md` entry under `## [Unreleased]`
- [x] My changes generate no new warnings

### Verification

`ghcr.io/typo3-documentation/render-guides:latest` against the same tree, before and after: one `Malformed table` error before, none after. The remaining warnings in that run (unresolved references, PHP-domain signatures in `Api/`) are pre-existing and untouched.
