### PR TITLE
fix(tools): gate FAL files on the acting user's mounts, not the ambient one's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- `FalStorageGate::isFileAccessible()` enforces the mounts of the user it is
+  passed, not of whoever is in `$GLOBALS['BE_USER']` (#672). The storage
+  allow-list half already used the passed user; the mount half did not, and
+  the two disagreed whenever the acting and ambient user differ — which is
+  exactly the approval path, where a run resumes under its owner's identity
+  (ADR-083) while the approver is ambient. A broader-mounted approver
+  authorised a file the owner could not reach; a narrower one refused a
+  legitimate read.
+  Two request-shared caches caused it, and neither is reachable through a
+  per-user API: `StorageRepository::findByUid()` returns the cached
+  `ResourceStorage` whose mounts the core `StoragePermissionsAspect`
+  attached once for the ambient user, and
+  `BackendUserAuthentication::getFileMountRecords()` memoises into the
+  runtime cache under one key with no user in it — so the first user to ask
+  in a request answers for every later one. The gate now builds its own
+  storage from the record via `createFromRecord()` (which dispatches no
+  initialization event and never enters the instance cache) and reads the
+  mount rows for that user's own mount uids.
+  Behaviour is unchanged for the three read-only FAL tools shipped today:
+  they run synchronously in their owner's request, where both users are the
+  same person.
+
 ## [0.26.0] - 2026-08-06
 
 ### Added

--- a/Classes/Service/Tool/FalStorageGate.php
+++ b/Classes/Service/Tool/FalStorageGate.php
@@ -219,13 +219,9 @@ final class FalStorageGate
      */
     private function fileMountRecordsFor(BackendUserAuthentication $user): array
     {
-        if (!$this->connectionPool instanceof ConnectionPool) {
-            return [];
-        }
-
         $declared  = $user->groupData['filemounts'] ?? '';
         $mountUids = is_scalar($declared) ? GeneralUtility::intExplode(',', (string)$declared, true) : [];
-        if ($mountUids === []) {
+        if ($mountUids === [] || !$this->connectionPool instanceof ConnectionPool) {
             return [];
         }
 

--- a/Classes/Service/Tool/FalStorageGate.php
+++ b/Classes/Service/Tool/FalStorageGate.php
@@ -9,10 +9,17 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool;
 
+use Doctrine\DBAL\Exception as DbalException;
 use Throwable;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
+use TYPO3\CMS\Core\Resource\Exception\FolderDoesNotExistException;
 use TYPO3\CMS\Core\Resource\ResourceStorage;
 use TYPO3\CMS\Core\Resource\StorageRepository;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Shared storage gate of the FAL tools (ADR-047).
@@ -29,16 +36,28 @@ use TYPO3\CMS\Core\Resource\StorageRepository;
  * each file with {@see self::isFileAccessible()}, which enforces the acting
  * user's file-mount boundaries via the storage API.
  */
-final readonly class FalStorageGate
+final class FalStorageGate
 {
+    /**
+     * Storages built for one acting user, keyed `<userUid>:<storageUid>`. Two
+     * of the three consumers call {@see self::isFileAccessible()} once per
+     * result row, and each miss builds a storage driver.
+     *
+     * Not `readonly` on the class for this alone: the cache is the reason.
+     *
+     * @var array<string, ResourceStorage|null>
+     */
+    private array $userStorages = [];
+
     /**
      * @param list<int> $allowedStorages sys_file_storage uids the FAL tools may touch
      */
     public function __construct(
-        private array $allowedStorages = [1],
+        private readonly array $allowedStorages = [1],
         // Optional so the storage-set-only unit construction keeps working;
         // autowired in production and required for isFileAccessible().
-        private ?StorageRepository $storageRepository = null,
+        private readonly ?StorageRepository $storageRepository = null,
+        private readonly ?ConnectionPool $connectionPool = null,
     ) {}
 
     /**
@@ -78,12 +97,21 @@ final readonly class FalStorageGate
      * only checks the storage; a non-admin with a subfolder file mount passes
      * that for every file in the storage.
      *
-     * The storage object is resolved inside the running backend request, where
-     * the core StoragePermissionsAspect has attached the acting user's file
-     * mounts; with evaluatePermissions on, checkFileActionPermission('read')
-     * then returns false for a file outside those mounts. NB getFile() alone
-     * does NOT assert — it only resolves the record — so the explicit
-     * permission check is load-bearing. Admins bypass mount checks.
+     * The check runs against a storage built FOR `$user`, not against the
+     * request-shared instance. `StorageRepository::findByUid()` returns the
+     * cached object whose mounts and permissions the core
+     * `StoragePermissionsAspect` attached once, for whoever was in
+     * `$GLOBALS['BE_USER']` when it was first created — and `ResourceStorage`
+     * holds no reference to that global afterwards. On the approval path the
+     * ambient user is the APPROVER while the acting user is the run owner
+     * (ADR-083), so the shared instance answers for the wrong person in both
+     * directions: it permits a write the owner could not make when the
+     * approver's mounts are broader, and refuses a legitimate one when they
+     * are narrower.
+     *
+     * NB `getFile()` alone does NOT assert — it only resolves the record — so
+     * the explicit permission check is load-bearing. Admins bypass mount
+     * checks, which is why they return before any of this.
      */
     public function isFileAccessible(?BackendUserAuthentication $user, int $storageUid, string $identifier): bool
     {
@@ -95,33 +123,186 @@ final readonly class FalStorageGate
             return true;
         }
 
-        if (!$this->storageRepository instanceof StorageRepository) {
-            return false;
-        }
-
         try {
-            $storage = $this->storageRepository->findByUid($storageUid);
+            $storage = $this->storageFor($user, $storageUid);
             if (!$storage instanceof ResourceStorage) {
                 return false;
             }
 
-            // findByUid returns a request-shared, cached storage; restore its
-            // prior evaluatePermissions so this check does not leak into other
-            // consumers of the same instance in the request.
-            $previous = $storage->getEvaluatePermissions();
-            $storage->setEvaluatePermissions(true);
-            try {
-                $file = $storage->getFile($identifier);
-                if ($file === null) {
-                    return false;
-                }
-
-                return $storage->checkFileActionPermission('read', $file);
-            } finally {
-                $storage->setEvaluatePermissions($previous);
+            $file = $storage->getFile($identifier);
+            if ($file === null) {
+                return false;
             }
+
+            return $storage->checkFileActionPermission('read', $file);
         } catch (Throwable) {
             return false;
         }
+    }
+
+    /**
+     * A storage carrying `$user`'s own mounts and file permissions, private to
+     * this gate.
+     *
+     * `createFromRecord()` is the seam that makes this possible: it builds a
+     * storage WITHOUT dispatching `AfterResourceStorageInitializationEvent`,
+     * so no listener attaches the ambient user's state and nothing lands in
+     * `StorageRepository`'s instance cache. What the aspect would have done is
+     * done here instead, reading `$user` rather than a global.
+     */
+    private function storageFor(BackendUserAuthentication $user, int $storageUid): ?ResourceStorage
+    {
+        $key = $user->getUserId() . ':' . $storageUid;
+        if (array_key_exists($key, $this->userStorages)) {
+            return $this->userStorages[$key];
+        }
+
+        return $this->userStorages[$key] = $this->buildStorageFor($user, $storageUid);
+    }
+
+    private function buildStorageFor(BackendUserAuthentication $user, int $storageUid): ?ResourceStorage
+    {
+        if (!$this->storageRepository instanceof StorageRepository || !$this->connectionPool instanceof ConnectionPool) {
+            return null;
+        }
+
+        $record = $this->storageRecord($storageUid);
+        if ($record === null) {
+            return null;
+        }
+
+        $storage = $this->storageRepository->createFromRecord($record);
+        $storage->setEvaluatePermissions(true);
+        $storage->setUserPermissions($this->filePermissionsFor($user, $storageUid));
+
+        foreach ($this->fileMountRecordsFor($user) as $mount) {
+            $identifier = is_string($mount['identifier'] ?? null) ? $mount['identifier'] : '';
+            if (!str_contains($identifier, ':')) {
+                // An identifier without a storage prefix names no storage —
+                // the core skips these too rather than guessing a base.
+                continue;
+            }
+
+            [$base, $path] = GeneralUtility::trimExplode(':', $identifier, false, 2);
+            if ((int)$base !== $storageUid) {
+                continue;
+            }
+
+            try {
+                $storage->addFileMount($path, $mount);
+            } catch (FolderDoesNotExistException) {
+                // A mount pointing at a folder that is gone grants nothing.
+                // Skipping it leaves the gate narrower, never wider.
+            }
+        }
+
+        return $storage;
+    }
+
+    /**
+     * The file-mount records of THIS user, read directly.
+     *
+     * `BackendUserAuthentication::getFileMountRecords()` cannot be used here,
+     * and the reason is worth stating because it is not obvious: it memoises
+     * into the runtime cache under the single key
+     * `backendUserAuthenticationFileMountRecords`, with no user in it. The
+     * first backend user to ask in a request populates it, and every other
+     * user object then receives that user's mounts. Two users in one request
+     * is exactly the situation this gate exists for, so the public accessor
+     * answers for the wrong person just as the shared storage did.
+     *
+     * `groupData` is core-internal, and using it is deliberate: it is the only
+     * per-user source. If it ever disappears the list is empty, the storage
+     * gets no mounts, and the gate denies — loudly, and closed.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function fileMountRecordsFor(BackendUserAuthentication $user): array
+    {
+        if (!$this->connectionPool instanceof ConnectionPool) {
+            return [];
+        }
+
+        $declared  = $user->groupData['filemounts'] ?? '';
+        $mountUids = is_scalar($declared) ? GeneralUtility::intExplode(',', (string)$declared, true) : [];
+        if ($mountUids === []) {
+            return [];
+        }
+
+        try {
+            $queryBuilder = $this->connectionPool->getQueryBuilderForTable('sys_filemounts');
+            $queryBuilder->getRestrictions()
+                ->removeAll()
+                ->add(GeneralUtility::makeInstance(DeletedRestriction::class))
+                ->add(GeneralUtility::makeInstance(HiddenRestriction::class));
+
+            $records = $queryBuilder
+                ->select('*')
+                ->from('sys_filemounts')
+                ->where($queryBuilder->expr()->in(
+                    'uid',
+                    $queryBuilder->createNamedParameter($mountUids, Connection::PARAM_INT_ARRAY),
+                ))
+                ->executeQuery()
+                ->fetchAllAssociative();
+        } catch (DbalException) {
+            return [];
+        }
+
+        return array_values(array_filter($records, is_array(...)));
+    }
+
+    /**
+     * The user's file permissions for this storage: the global set, overlaid
+     * with any `permissions.file.storage.<uid>` User TSconfig. Mirrors what
+     * the core aspect computes, for the passed user.
+     *
+     * @return array<string, bool>
+     */
+    private function filePermissionsFor(BackendUserAuthentication $user, int $storageUid): array
+    {
+        $permissions = [];
+        foreach ($user->getFilePermissions() as $permission => $value) {
+            $permissions[(string)$permission] = (bool)$value;
+        }
+
+        // Walked one level at a time: getTSConfig() is typed array<string,
+        // mixed>, so every nested offset is mixed to the analyser.
+        $section = $user->getTSConfig()['permissions.'] ?? null;
+        $files   = is_array($section) ? ($section['file.'] ?? null) : null;
+        $storages = is_array($files) ? ($files['storage.'] ?? null) : null;
+        $perStorage = is_array($storages) ? ($storages[$storageUid . '.'] ?? null) : null;
+        if (is_array($perStorage)) {
+            foreach ($perStorage as $permission => $value) {
+                $permissions[(string)$permission] = (bool)$value;
+            }
+        }
+
+        return $permissions;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function storageRecord(int $storageUid): ?array
+    {
+        if (!$this->connectionPool instanceof ConnectionPool) {
+            return null;
+        }
+
+        try {
+            $queryBuilder = $this->connectionPool->getQueryBuilderForTable('sys_file_storage');
+            $queryBuilder->getRestrictions()->removeAll();
+            $record = $queryBuilder
+                ->select('*')
+                ->from('sys_file_storage')
+                ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($storageUid)))
+                ->executeQuery()
+                ->fetchAssociative();
+        } catch (DbalException) {
+            return null;
+        }
+
+        return is_array($record) ? $record : null;
     }
 }

--- a/Tests/Functional/Service/Tool/FalStorageGateActingUserTest.php
+++ b/Tests/Functional/Service/Tool/FalStorageGateActingUserTest.php
@@ -1,0 +1,230 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\FalStorageGate;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Resource\StorageRepository;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * The per-file mount check follows the user it is PASSED, not the one who
+ * happens to be in `$GLOBALS['BE_USER']` (#672).
+ *
+ * Two editors with disjoint mounts on the same storage make the difference
+ * observable in both directions. Every test here logs one in and asks the gate
+ * about the other; on the previous implementation — which read the
+ * request-shared `ResourceStorage` whose mounts the core aspect attached for
+ * the ambient user — each of the two assertions fails the opposite way: the
+ * acting user's own file is refused, and a file only the ambient user may
+ * reach is permitted.
+ *
+ * That is not a hypothetical arrangement. On the approval path the run resumes
+ * under the OWNER's identity (ADR-083) while the ambient user is the approver.
+ */
+#[CoversClass(FalStorageGate::class)]
+final class FalStorageGateActingUserTest extends AbstractFunctionalTestCase
+{
+    private const STORAGE_CONFIGURATION = '<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<T3FlexForms>
+    <data>
+        <sheet index="sDEF">
+            <language index="lDEF">
+                <field index="basePath"><value index="vDEF">fileadmin/</value></field>
+                <field index="pathType"><value index="vDEF">relative</value></field>
+                <field index="caseSensitive"><value index="vDEF">1</value></field>
+            </language>
+        </sheet>
+    </data>
+</T3FlexForms>';
+
+    /** Mounted by DOCS_EDITOR only. */
+    private const DOCS_FILE = '/docs/manual.txt';
+
+    /** Mounted by PRIVATE_EDITOR only. */
+    private const PRIVATE_FILE = '/private/notes.txt';
+
+    private const DOCS_EDITOR = 2;
+
+    private const PRIVATE_EDITOR = 3;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importFixture('BeUsers.csv');
+
+        GeneralUtility::mkdir_deep($this->instancePath . '/fileadmin/docs');
+        GeneralUtility::mkdir_deep($this->instancePath . '/fileadmin/private');
+        file_put_contents($this->instancePath . self::DOCS_FILE_PATH, 'The manual');
+        file_put_contents($this->instancePath . self::PRIVATE_FILE_PATH, 'Private notes');
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+
+        $connection = $connectionPool->getConnectionForTable('sys_file_storage');
+        self::assertInstanceOf(Connection::class, $connection);
+        $connection->insert('sys_file_storage', [
+            'uid' => 1, 'pid' => 0, 'name' => 'Main storage', 'driver' => 'Local',
+            'configuration' => self::STORAGE_CONFIGURATION,
+            'is_online' => 1, 'is_browsable' => 1, 'is_public' => 1, 'is_writable' => 1,
+        ]);
+
+        // Two mounts on the SAME storage, disjoint. The storage allow-list
+        // cannot tell them apart — only the mount check can.
+        $connection->insert('sys_filemounts', ['uid' => 1, 'pid' => 0, 'title' => 'Docs', 'identifier' => '1:/docs/']);
+        $connection->insert('sys_filemounts', ['uid' => 2, 'pid' => 0, 'title' => 'Private', 'identifier' => '1:/private/']);
+
+        $connection->insert('be_groups', [
+            'uid' => 9, 'pid' => 0, 'title' => 'Docs readers',
+            'file_mountpoints' => '1', 'file_permissions' => 'readFolder,readFile',
+        ]);
+        $connection->insert('be_groups', [
+            'uid' => 10, 'pid' => 0, 'title' => 'Private readers',
+            'file_mountpoints' => '2', 'file_permissions' => 'readFolder,readFile',
+        ]);
+
+        // options=3: inherit db AND file mounts from groups.
+        $connection->update('be_users', ['usergroup' => '9', 'options' => 3], ['uid' => self::DOCS_EDITOR]);
+        $connection->insert('be_users', [
+            'uid' => self::PRIVATE_EDITOR, 'pid' => 0, 'username' => 'private-editor',
+            'password' => '$2y$12$RJxT/2Y6d3oRm5d5ohJi9.CmZlVW.7N4vMHXiQ/D6xJBPfqfNMpBm',
+            'admin' => 0, 'usergroup' => '10', 'options' => 3, 'disable' => 0, 'deleted' => 0,
+        ]);
+
+        $fileConnection = $connectionPool->getConnectionForTable('sys_file');
+        self::assertInstanceOf(Connection::class, $fileConnection);
+        $this->indexFile($fileConnection, 10, self::DOCS_FILE, 'manual.txt');
+        $this->indexFile($fileConnection, 11, self::PRIVATE_FILE, 'notes.txt');
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['TYPO3_REQUEST']);
+        parent::tearDown();
+    }
+
+    private const DOCS_FILE_PATH = '/fileadmin/docs/manual.txt';
+
+    private const PRIVATE_FILE_PATH = '/fileadmin/private/notes.txt';
+
+    #[Test]
+    public function theActingUsersOwnFileIsReachableWhileAnotherUserIsAmbient(): void
+    {
+        $acting = $this->userWithoutLogin(self::DOCS_EDITOR);
+        $this->loginInBackendRequest(self::PRIVATE_EDITOR);
+
+        self::assertTrue($this->gate()->isFileAccessible($acting, 1, self::DOCS_FILE));
+    }
+
+    #[Test]
+    public function aFileOnlyTheAmbientUserMayReachIsRefusedForTheActingUser(): void
+    {
+        $acting = $this->userWithoutLogin(self::DOCS_EDITOR);
+        $this->loginInBackendRequest(self::PRIVATE_EDITOR);
+
+        // The reverse direction, and the one that matters for a write: the
+        // ambient user's broader reach must not become the acting user's.
+        self::assertFalse($this->gate()->isFileAccessible($acting, 1, self::PRIVATE_FILE));
+    }
+
+    #[Test]
+    public function theSameTwoVerdictsHoldWithTheRolesSwapped(): void
+    {
+        $acting = $this->userWithoutLogin(self::PRIVATE_EDITOR);
+        $this->loginInBackendRequest(self::DOCS_EDITOR);
+
+        $gate = $this->gate();
+        self::assertTrue($gate->isFileAccessible($acting, 1, self::PRIVATE_FILE));
+        self::assertFalse($gate->isFileAccessible($acting, 1, self::DOCS_FILE));
+    }
+
+    /**
+     * Sanity: with one user in both roles the gate answers as it always did.
+     * Without this, a gate that refused everything would satisfy half the
+     * assertions above.
+     */
+    #[Test]
+    public function anEditorActingInTheirOwnRequestKeepsTheirOwnMount(): void
+    {
+        $user = $this->loginInBackendRequest(self::DOCS_EDITOR);
+
+        $gate = $this->gate();
+        self::assertTrue($gate->isFileAccessible($user, 1, self::DOCS_FILE));
+        self::assertFalse($gate->isFileAccessible($user, 1, self::PRIVATE_FILE));
+    }
+
+    private function gate(): FalStorageGate
+    {
+        $gate = $this->get(FalStorageGate::class);
+        self::assertInstanceOf(FalStorageGate::class, $gate);
+
+        return $gate;
+    }
+
+    /**
+     * The acting user, resolved WITHOUT becoming the ambient one — the shape
+     * `ActingBackendUserResolver` produces on the approval path.
+     */
+    private function userWithoutLogin(int $uid): BackendUserAuthentication
+    {
+        $ambient = $GLOBALS['BE_USER'] ?? null;
+        $user    = $this->setUpBackendUser($uid);
+
+        if ($ambient !== null) {
+            $GLOBALS['BE_USER'] = $ambient;
+        }
+
+        return $user;
+    }
+
+    private function loginInBackendRequest(int $uid): BackendUserAuthentication
+    {
+        $user = $this->setUpBackendUser($uid);
+        // The core StoragePermissionsAspect only attaches mounts to a storage
+        // built inside a BACKEND request.
+        $GLOBALS['TYPO3_REQUEST'] = (new ServerRequest('https://typo3-testing.local/typo3/'))
+            ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE);
+
+        // Force the request-shared storage into existence NOW, under this user.
+        // Without it the first gate call would create it, and the defect this
+        // test describes would depend on call order rather than on the bug.
+        $repository = $this->get(StorageRepository::class);
+        self::assertInstanceOf(StorageRepository::class, $repository);
+        $repository->findByUid(1);
+
+        return $user;
+    }
+
+    private function indexFile(Connection $connection, int $uid, string $identifier, string $name): void
+    {
+        // TYPO3's own sha1 identifier-hash algorithm, so getFile() resolves the
+        // index row exactly as core does. A fixture, not a security context.
+        $connection->insert('sys_file', [
+            'uid'             => $uid,
+            'pid'             => 0,
+            'storage'         => 1,
+            'identifier'      => $identifier,
+            'identifier_hash' => sha1($identifier),
+            'folder_hash'     => sha1(dirname($identifier)),
+            'name'            => $name,
+            'extension'       => 'txt',
+            'mime_type'       => 'text/plain',
+            'size'            => 10,
+            'missing'         => 0,
+        ]);
+    }
+}


### PR DESCRIPTION
## Description

`FalStorageGate::isFileAccessible()` evaluated two halves against two different people:

- the allow-list (`isAllowed()`) and the admin shortcut used the **passed** user;
- the mount and permission half used whoever was in `$GLOBALS['BE_USER']`.

Harmless today: the three read-only FAL tools run synchronously inside their owner's request, so both users are the same person. It stops being harmless on the approval path, where a run resumes under its **owner's** identity (ADR-083) while the **approver** is ambient. A broader-mounted approver authorises a file the owner cannot reach; a narrower one refuses a legitimate read. The docblock claimed the opposite.

## Two contaminated caches, not one

This is the part the issue did not have, and it changes the fix.

1. `StorageRepository::findByUid()` returns the request-shared instance whose mounts and permissions the core `StoragePermissionsAspect` attached **once**, for the ambient user at creation time. `ResourceStorage` keeps no reference to the global afterwards. So the issue's suggested direction — `BackendUserAuthentication::getFileStorages()` — resolves through the same repository and returns the same objects. It would have changed nothing.

2. `BackendUserAuthentication::getFileMountRecords()` memoises into the runtime cache under the single key `backendUserAuthenticationFileMountRecords`, with no user in it. The first backend user to ask in a request populates it and every later user object receives **that** user's mounts.

Two users in one request is exactly the situation this gate exists for, so both public routes answer for the wrong person.

## What it does now

- builds its own storage from the `sys_file_storage` record via `StorageRepository::createFromRecord()`, which dispatches no `AfterResourceStorageInitializationEvent` and never enters the instance cache;
- applies the passed user's file permissions and `permissions.file.storage.<uid>` TSconfig, mirroring what the aspect computes;
- reads the `sys_filemounts` rows for that user's own mount uids.

`groupData` is core-`@internal` and used deliberately: it is the only per-user source. If it ever disappears, the mount list is empty, the storage gets no mounts and the gate denies — loudly, and closed. Preferred over depending on an undocumented cache key, where a rename would make the fix a silent no-op.

Per-user storages are memoised for the gate's lifetime because two of the three consumers call this once per result row, and each miss builds a driver. That is the only reason the class is no longer `readonly`.

## Related Issue

Closes #672.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run the gates — unit, PHPStan (level 10), cgl, fuzzy, functional, Rector (8.2 resolve, as CI pins it)
- [x] I have added tests that prove my fix works
- [x] I have added a `CHANGELOG.md` entry under `## [Unreleased]`
- [ ] ADR — none: this makes the code do what ADR-047 and the class docblock already said
- [x] My changes generate no new warnings

### Tests

`FalStorageGateActingUserTest` is the acceptance test the issue asked for: two editors with **disjoint** mounts on the same storage, so the storage allow-list cannot tell them apart and only the mount check can. Each test logs one in and asks the gate about the other, in both directions and with the roles swapped.

Against unchanged `Classes/`, three of its four tests fail. The fourth — one user in both roles — passes either way by design: without it, a gate that simply denied everything would satisfy half the assertions.

The test also forces the shared storage into existence under the ambient user before asking, so the defect depends on the bug rather than on call order.

Worth recording: the first attempt at this fix looked right and still left three assertions red. That is how the runtime-cache contamination surfaced — the test was written before the fix, not after it.
