### PR TITLE
fix(tools): pin the live workspace where the FAL tools read metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- The two FAL tools that read `sys_file_metadata` pin the live workspace
+  (#674). The table carries `'versioningWS' => true`, so a file with a draft
+  version has more than one row for the same `file` uid:
+  - `read_fal_asset_meta` returned an arbitrary one — potentially an
+    unpublished draft — as the current value, with nothing in the answer
+    saying so. It now adds `WorkspaceRestriction(0)`, `ORDER BY uid ASC` and
+    `setMaxResults(1)`, the same three things core's own
+    `MetaDataRepository::findByFileUid()` pins.
+  - `search_fal_files` joined the table without a workspace condition, so a
+    search for text that exists only in a draft returned the file, and a file
+    with a draft version was listed twice. The join now requires
+    `t3ver_wsid = 0`.
+
+  Both defects are read-only: the answer could be wrong, nothing was
+  corrupted. The same defect in the writing tool is fixed separately in the
+  `set_file_alternative_text` branch, where it mattered more.
+
 ## [0.26.0] - 2026-08-06
 
 ### Added

--- a/Classes/Service/Tool/Builtin/ReadFalAssetMetaTool.php
+++ b/Classes/Service/Tool/Builtin/ReadFalAssetMetaTool.php
@@ -16,6 +16,8 @@ use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\WorkspaceRestriction;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Example tool: return read-only metadata for a single managed file (FAL).
@@ -41,6 +43,10 @@ final readonly class ReadFalAssetMetaTool implements ToolInterface
     private const FILE_TABLE = 'sys_file';
 
     private const METADATA_TABLE = 'sys_file_metadata';
+
+    private const LIVE_WORKSPACE = 0;
+
+    private const DEFAULT_LANGUAGE = 0;
 
     /**
      * @param list<int> $allowedStorages sys_file_storage uids this tool may read from
@@ -104,7 +110,15 @@ final readonly class ReadFalAssetMetaTool implements ToolInterface
         ];
 
         $metaQuery = $this->connectionPool->getQueryBuilderForTable(self::METADATA_TABLE);
-        $metaQuery->getRestrictions()->removeAll();
+        // Live only. sys_file_metadata carries 'versioningWS' => true, so a
+        // file with a draft version has more than one row for the same `file`
+        // uid and an unrestricted query returns an arbitrary one — a value no
+        // visitor sees, reported as the current one. Core's own
+        // MetaDataRepository::findByFileUid() pins the same three things.
+        $metaQuery->getRestrictions()
+            ->removeAll()
+            ->add(GeneralUtility::makeInstance(WorkspaceRestriction::class, self::LIVE_WORKSPACE));
+
         $meta = $metaQuery
             ->select('title', 'alternative')
             ->from(self::METADATA_TABLE)
@@ -115,8 +129,13 @@ final readonly class ReadFalAssetMetaTool implements ToolInterface
                 // otherwise an arbitrary translated row could replace the original
                 // metadata. (The table has no soft-delete capability, hence no
                 // `deleted` column to filter.)
-                $metaQuery->expr()->eq('sys_language_uid', $metaQuery->createNamedParameter(0, Connection::PARAM_INT)),
+                $metaQuery->expr()->eq('sys_language_uid', $metaQuery->createNamedParameter(self::DEFAULT_LANGUAGE, Connection::PARAM_INT)),
             )
+            // Deterministic even where the data is not: two live rows for one
+            // file should not exist, and if they do the answer is at least
+            // stable and the same one the writing tool targets.
+            ->orderBy('uid', 'ASC')
+            ->setMaxResults(1)
             ->executeQuery()
             ->fetchAssociative();
 

--- a/Classes/Service/Tool/Builtin/SearchFalFilesTool.php
+++ b/Classes/Service/Tool/Builtin/SearchFalFilesTool.php
@@ -117,6 +117,13 @@ final readonly class SearchFalFilesTool implements ToolInterface
             ->leftJoin('f', 'sys_file_metadata', 'm', (string)$queryBuilder->expr()->and(
                 $queryBuilder->expr()->eq('m.file', $queryBuilder->quoteIdentifier('f.uid')),
                 $queryBuilder->expr()->eq('m.sys_language_uid', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+                // Live only. sys_file_metadata is workspace-aware, so a file
+                // with a draft version has two joinable rows: without this the
+                // file matches text that exists only in the unpublished draft,
+                // and is listed twice when both rows match. Spelled out rather
+                // than added as a WorkspaceRestriction because the restriction
+                // applies to the query's own FROM table, not to a join alias.
+                $queryBuilder->expr()->eq('m.t3ver_wsid', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
             ))
             ->where(
                 $queryBuilder->expr()->in(

--- a/Tests/Functional/Fixtures/sys_file_metadata_workspace.csv
+++ b/Tests/Functional/Fixtures/sys_file_metadata_workspace.csv
@@ -1,0 +1,4 @@
+"sys_file_metadata"
+,"uid","pid","file","sys_language_uid","title","alternative","t3ver_wsid","t3ver_oid","t3ver_state"
+,1,0,1,0,"Draft title","Draft alt",1,2,0
+,2,0,1,0,"Live title","Live alt",0,0,0

--- a/Tests/Functional/Service/Tool/ReadFalAssetMetaToolTest.php
+++ b/Tests/Functional/Service/Tool/ReadFalAssetMetaToolTest.php
@@ -84,4 +84,23 @@ final class ReadFalAssetMetaToolTest extends AbstractFunctionalTestCase
 
         self::assertSame(self::NOT_PERMITTED, $this->tool->execute(['uid' => 999999], ToolExecutionContext::none())->content);
     }
+
+    /**
+     * `sys_file_metadata` is workspace-aware, so a file with a draft version
+     * has more than one row for the same `file` uid. The fixture gives the
+     * DRAFT the lower uid, so an unpinned query reports it as the current
+     * value — a value no visitor sees, with nothing in the answer saying so.
+     */
+    #[Test]
+    public function aDraftVersionIsNotReportedAsTheLiveValue(): void
+    {
+        $this->importFixture('sys_file_tools.csv');
+        $this->importFixture('sys_file_metadata_workspace.csv');
+
+        $output = $this->tool->execute(['uid' => 1], ToolExecutionContext::none())->content;
+
+        self::assertStringContainsString('Live title', $output);
+        self::assertStringContainsString('Live alt', $output);
+        self::assertStringNotContainsString('Draft', $output);
+    }
 }

--- a/Tests/Functional/Service/Tool/SearchFalFilesToolTest.php
+++ b/Tests/Functional/Service/Tool/SearchFalFilesToolTest.php
@@ -80,6 +80,61 @@ final class SearchFalFilesToolTest extends AbstractFunctionalTestCase
         return ToolExecutionContext::fromBackendUser($user);
     }
 
+    /**
+     * A draft metadata row must not make its file findable. `sys_file_metadata`
+     * is workspace-aware, so the joined title can come from an unpublished
+     * version — and then a search for text that exists only in a draft returns
+     * a file whose live metadata does not contain it at all.
+     */
+    #[Test]
+    public function textThatExistsOnlyInADraftMetadataRowDoesNotMatch(): void
+    {
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $files = $connectionPool->getConnectionForTable('sys_file_metadata');
+        self::assertInstanceOf(Connection::class, $files);
+
+        // A draft version of file 10's metadata, carrying a word the live row
+        // does not have.
+        $files->insert('sys_file_metadata', [
+            'uid' => 101, 'file' => 10, 'sys_language_uid' => 0,
+            'title' => 'Unpublished draft wording', 't3ver_wsid' => 1, 't3ver_oid' => 102,
+        ]);
+        $files->insert('sys_file_metadata', [
+            'uid' => 102, 'file' => 10, 'sys_language_uid' => 0, 'title' => 'Published wording',
+        ]);
+
+        $output = $this->tool->execute(['query' => 'Unpublished'], $this->contextForBackendUser(1))->content;
+
+        self::assertStringNotContainsString('brochure-2026.pdf', $output);
+    }
+
+    /**
+     * The counterpart: the live row still matches, and exactly once. A file
+     * with a draft version has two joinable metadata rows, so an unpinned join
+     * can also list the same file twice.
+     */
+    #[Test]
+    public function theLiveMetadataRowStillMatchesAndTheFileIsListedOnce(): void
+    {
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $files = $connectionPool->getConnectionForTable('sys_file_metadata');
+        self::assertInstanceOf(Connection::class, $files);
+
+        $files->insert('sys_file_metadata', [
+            'uid' => 101, 'file' => 10, 'sys_language_uid' => 0,
+            'title' => 'Published wording', 't3ver_wsid' => 1, 't3ver_oid' => 102,
+        ]);
+        $files->insert('sys_file_metadata', [
+            'uid' => 102, 'file' => 10, 'sys_language_uid' => 0, 'title' => 'Published wording',
+        ]);
+
+        $output = $this->tool->execute(['query' => 'Published wording'], $this->contextForBackendUser(1))->content;
+
+        self::assertSame(1, substr_count($output, '[10] 1:/brochure-2026.pdf'));
+    }
+
     #[Test]
     public function matchesFileNameAndMetadataTitleWithinAllowedStorages(): void
     {


### PR DESCRIPTION
## Description

`sys_file_metadata` carries `'versioningWS' => true`, so a file with a draft version has more than one row for the same `file` uid. Neither of the two tools that read it said which row it wanted.

**`read_fal_asset_meta`** returned whichever row the database happened to give — an unpublished draft as readily as the live value — and reported it as current. A model reading it gets a value no visitor sees; a human reading the transcript cannot tell. Now pinned with `WorkspaceRestriction(0)`, `ORDER BY uid ASC` and `setMaxResults(1)`: the same three things core's own `MetaDataRepository::findByFileUid()` pins for the identical lookup.

## The sweep found a second one

The issue asked whether any other builtin reads a workspace-aware table unrestricted. **`search_fal_files`** does, and the consequence is worse than a wrong field:

- a search for a word that appears **only in an unpublished draft** returns the file;
- a file with a draft version is **listed twice**, because both rows join.

Measured before fixing, not argued from the query — the two new tests were red at `Unpublished` matching and at `2 is identical to 1`. The join now requires `t3ver_wsid = 0`, spelled out rather than added as a `WorkspaceRestriction` because the restriction applies to the query's own FROM table, not to a join alias.

## Deliberately not touched

`GetTsConfigTool` and `GetRecordHistoryTool` also query the workspace-aware `pages` table without a restriction, and both are staying as they are: they look up `uid = <the value the caller passed>`, which returns exactly the row that was asked for. There is no arbitrary-row problem. Whether a tool should accept a *version* uid at all is a different question, and not this fix's.

The remaining `removeAll()` readers touch `sys_file`, `be_users`, `be_groups` and `tx_scheduler_task`, none of which are workspace-aware.

## Related Issue

Closes #674.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run the gates — unit, PHPStan (level 10), cgl, fuzzy, functional, Rector (8.2 resolve, as CI pins it)
- [x] I have added tests that prove my fix works
- [x] I have added a `CHANGELOG.md` entry under `## [Unreleased]`
- [ ] ADR — none: this makes two queries do what the surrounding contract already assumed
- [x] My changes generate no new warnings

### Tests

The acceptance test the issue asked for: a live row and a draft version whose uid sorts **before** it, so an unpinned query prefers the draft. Red without the fix, green with it.

Two more for the search tool: draft-only text must not match, and a file with a draft version must be listed once. Both red before the fix.

### Note

Both defects are read-only — the answer could be wrong, nothing was corrupted. The same unpinned query in the *writing* tool is fixed on the `set_file_alternative_text` branch, where a wrong write is reported as success.
