### PR TITLE
test(agent): make the deferred input-path gate self-enforcing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `InputPauseCoverageTest` pins that no builtin can suspend a run for
+  operator input (#649). The input path authorises the submitter with
+  `agent_approve` alone and never against the tool whose input they supply,
+  while the resume executes under the run owner's context (ADR-083) — the
+  confused deputy the approval path closed in #622. It is unreachable only
+  because nothing implements `RequiresInputInterface`, so the first tool
+  that does now turns a latent gap into a red build. The gate itself is
+  deliberately not built ahead of that tool: #622's cannot be copied,
+  because an input-requiring tool declares no effect to gate on (ADR-105
+  makes the two markers mutually exclusive) and the input path has no turn
+  digest (ADR-132).
+
 ## [0.26.0] - 2026-08-06
 
 ### Added

--- a/Tests/Functional/Service/Tool/InputPauseCoverageTest.php
+++ b/Tests/Functional/Service/Tool/InputPauseCoverageTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Service\Tool\RequiresInputInterface;
+use Netresearch\NrLlm\Service\Tool\ToolInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Which registered tools can suspend a run for operator input (ADR-105).
+ *
+ * The answer today is none, and that is what makes an open authorisation gap
+ * on the input path harmless (#649). `ResumeCoordinator::submitInput()`
+ * authorises the submitter with `agent_approve` and nothing else — it never
+ * checks them against the tool whose input they supply — while
+ * `ToolLoopService::resumeWithInput()` executes the pending calls under the RUN
+ * OWNER's context (ADR-083). A non-admin could therefore satisfy an admin-only
+ * tool that then runs on the owner's authority: the same confused deputy the
+ * approval path closed (#622).
+ *
+ * It is unreachable only because nothing implements the interface. This test
+ * pins that, so the first tool that does turns a latent gap into a red build
+ * rather than into a shipped one.
+ *
+ * The gate is deliberately NOT built ahead of that tool, because #622's cannot
+ * simply be copied and the difference is not a detail:
+ *
+ * - **No write axis.** #622 gates the calls that WRITE, since a write is what
+ *   must not happen unattended. An input-requiring tool declares no effect —
+ *   the two markers are mutually exclusive at registration (ADR-105) — so
+ *   there is no "which calls matter" axis. Gating every input submission is a
+ *   broader policy, and a different decision.
+ * - **No digest.** The approval path binds a decision to the reviewed turn
+ *   (ADR-132). The input path has no equivalent, so a submission cannot be
+ *   shown to belong to the turn it was written for.
+ *
+ * Whoever makes this test fail owns both questions: on what axis the submitter
+ * is gated against the tool, and whether the input path gets a turn digest of
+ * its own.
+ */
+#[CoversClass(ToolRegistry::class)]
+final class InputPauseCoverageTest extends AbstractFunctionalTestCase
+{
+    /**
+     * Tools that suspend a run for operator input. Empty on purpose.
+     *
+     * Adding a name here is a decision, not bookkeeping — see the class
+     * docblock for the two questions it commits you to.
+     *
+     * @var list<string>
+     */
+    private const INPUT_REQUIRING_TOOLS = [];
+
+    #[Test]
+    public function onlyToolsListedHereCanSuspendARunForInput(): void
+    {
+        $registry = $this->get(ToolRegistry::class);
+        self::assertInstanceOf(ToolRegistry::class, $registry);
+
+        $builtins = $registry->builtinNames();
+        // Guards the guard: an empty registry would make the assertion below
+        // pass while proving nothing at all.
+        self::assertNotSame([], $builtins, 'The builtin set must not be empty, or this test proves nothing.');
+
+        $inputRequiring = [];
+        foreach ($builtins as $name) {
+            $tool = $registry->get($name);
+            if ($tool instanceof ToolInterface && $tool instanceof RequiresInputInterface) {
+                $inputRequiring[] = $name;
+            }
+        }
+
+        sort($inputRequiring);
+
+        $expected = self::INPUT_REQUIRING_TOOLS;
+        sort($expected);
+
+        self::assertSame(
+            $expected,
+            $inputRequiring,
+            "A tool can now suspend a run for input, which makes the open authorisation gap on that path\n"
+            . "reachable (#649): the submitter is authorised with agent_approve alone and never against the\n"
+            . "tool, while the resume runs under the OWNER's context. Decide the gate and the digest before\n"
+            . "listing it here:\n"
+            . implode("\n", $inputRequiring),
+        );
+    }
+}


### PR DESCRIPTION
## Description

`ResumeCoordinator::submitInput()` authorises the submitter with `agent_approve` and nothing else — it never checks them against the tool whose input they supply — while `ToolLoopService::resumeWithInput()` executes the pending calls under the **run owner's** context (ADR-083). A non-admin holding `agent_approve` could therefore satisfy an admin-only tool that then runs on the owner's authority: the confused deputy #622 closed on the approval side.

It is latent, not live. **No production class implements `RequiresInputInterface`** — the only references are the loop's own `instanceof` checks and the registration ban in `ToolRegistry`. Nothing can suspend for input at all.

## No gate is built here, on purpose

#622's fix cannot be copied, and the difference is not a detail:

- **No write axis.** #622 gates the calls that WRITE, because a write is what must not happen unattended. An input-requiring tool declares no effect — ADR-105 makes the two markers mutually exclusive at registration — so there is no "which calls matter" axis. Gating *every* input submission is a broader policy and a different decision.
- **No digest.** The approval path binds a decision to the reviewed turn (ADR-132). The input path has no equivalent, so a submission cannot be shown to belong to the turn it was written for.

Choosing an axis and a binding now would be guessing at a policy for a tool nobody has proposed — which is what ADR-120 exists to prevent. The issue says the same thing in its own suggested direction.

## What ships instead

The tripwire, in the shape `ToolEffectCoverageTest` already established for the write side: the empty set is pinned, so the first tool that can suspend for input fails the build. Its author then owns the two questions, named in the docblock — on what axis the submitter is gated against the tool, and whether the input path gets a turn digest of its own.

A note in an issue nobody re-reads becomes a red build at exactly the moment the deferral stops being safe.

## Related Issue

Closes #649.

## Type of Change

- [x] New feature (non-breaking change that adds functionality) — a test, not behaviour

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run the gates — unit, PHPStan (level 10), cgl, fuzzy, functional, Rector (8.2 resolve, as CI pins it)
- [x] I have added a `CHANGELOG.md` entry under `## [Unreleased]`
- [ ] ADR — none: this records a deferral, it does not decide anything
- [x] My changes generate no new warnings

### Verification

A test that can only ever pass is worthless, so it was made to fire rather than assumed to work: giving `ReadFalAssetMetaTool` the interface turned the test red and named the tool in the failure message. Reverted after the probe — `git diff` on `Classes/` is empty.
