### PR TITLE
test(ci): run the three PHP tests that were in no suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ ALWAYS use the Docker test runner; never invoke `phpunit` / `phpstan` / `rector`
 ## Testing
 
 - Unit / Integration / Fuzzy / Functional / E2E suites — see `Tests/AGENTS.md` for layout details.
-- PHPUnit configs: `Build/phpunit.xml` (unit + integration + fuzzy), `Build/FunctionalTests.xml` (functional + e2e-backend).
+- PHPUnit configs: `Build/phpunit.xml` (unit + integration + fuzzy; the unit suite also lists the two workflow tests under `Tests/E2E/`), `Build/FunctionalTests.xml` (functional + e2e-backend + e2e-tca). Every PHP test must sit in one of these suites — a directory in none of them runs in no job and reads as coverage (#658).
 - Mutation: `infection.json.dist` (target MSI ≥ 70%).
 - Architecture tests: `Tests/Architecture/` (phpat) — enforce layered boundaries (Controller → Service → Provider).
 <!-- AGENTS-GENERATED:END testing -->

--- a/Build/FunctionalTests.xml
+++ b/Build/FunctionalTests.xml
@@ -21,6 +21,15 @@
         <testsuite name="e2e-backend">
             <directory>../Tests/E2E/Backend/</directory>
         </testsuite>
+        <!--
+            Tests/E2E/TCA holds plain PHPUnit tests over the TCA files. They
+            were in no suite at all and therefore ran in no job: a failing
+            assertion sat there unnoticed because nothing executed it (#658).
+            Listed here because this config is the one CI runs.
+        -->
+        <testsuite name="e2e-tca">
+            <directory>../Tests/E2E/TCA/</directory>
+        </testsuite>
     </testsuites>
     <!--
         Without <source> PHPUnit answers any coverage request with

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -489,11 +489,11 @@ case ${TEST_SUITE} in
             PARALLEL_JOBS=$(( ($(nproc) + 1) / 2 ))
         fi
 
-        # Both globs are required: Build/FunctionalTests.xml runs the `functional`
-        # AND the `e2e-backend` suites. Globbing only Tests/Functional silently
+        # All three globs are required: Build/FunctionalTests.xml runs the
+        # `functional`, `e2e-backend` AND `e2e-tca` suites. Globbing fewer silently
         # dropped all 8 Tests/E2E/Backend classes here — the same rot as #272,
         # where the suite was skipped wholesale and nobody noticed.
-        COMMAND="find Tests/Functional Tests/E2E/Backend -name '*Test.php' | xargs -P${PARALLEL_JOBS} -I{} php ${PHP_FUNCTIONAL_OPTS} -dxdebug.mode=off .Build/bin/phpunit -c Build/FunctionalTests.xml {}"
+        COMMAND="find Tests/Functional Tests/E2E/Backend Tests/E2E/TCA -name '*Test.php' | xargs -P${PARALLEL_JOBS} -I{} php ${PHP_FUNCTIONAL_OPTS} -dxdebug.mode=off .Build/bin/phpunit -c Build/FunctionalTests.xml {}"
         CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_sqlite --tmpfs ${ROOT_DIR}/.Build/Web/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid,mode=1777"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name functional-parallel-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${CONTAINERPARAMS} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?

--- a/Build/phpunit.xml
+++ b/Build/phpunit.xml
@@ -18,6 +18,15 @@
     <testsuites>
         <testsuite name="unit">
             <directory>../Tests/Unit</directory>
+            <!--
+                These two extend AbstractUnitTestCase and use mocked providers,
+                so they are unit tests that happen to live under Tests/E2E.
+                Listed explicitly because they were in no suite any job runs
+                (#658); a <directory> here would also pull in Tests/E2E/Backend,
+                which belongs to the functional config.
+            -->
+            <file>../Tests/E2E/ChatCompletionWorkflowTest.php</file>
+            <file>../Tests/E2E/EmbeddingWorkflowTest.php</file>
         </testsuite>
         <testsuite name="integration">
             <directory>../Tests/Integration</directory>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Three PHP test classes that no job executed now run in CI (#658).
+  `Tests/E2E/TCA/` was in neither suite of `Build/FunctionalTests.xml`, and
+  the two workflow tests directly under `Tests/E2E/` were in no suite at
+  all — `Build/phpunit.xml` declares an `e2e` suite over that directory, but
+  no `runTests.sh` selector invokes it (`-s e2e` runs Playwright). Verified
+  rather than assumed: all three answered `No tests executed` before, and
+  run now (15 + 11 tests). A test no job runs is worse than no test, because
+  it reads as coverage — which is how a failing assertion sat in
+  `TcaFieldCompletionTest` unnoticed.
+  The parallel functional runner globs its directories separately, so
+  `Tests/E2E/TCA` is added there too; without it the new suite would be
+  silently skipped in that mode, exactly as the comment above that line
+  warns.
+- `TcaFieldCompletionTest` passes again. It flagged
+  `tx_nrllm_configuration.preset_checksum` as label-less, which it is: the
+  column is `type => passthrough`, written by the preset importer and never
+  rendered by FormEngine, so a label would be a declaration nothing reads.
+  Passthrough columns are now skipped by their TCA type rather than by name,
+  so the rule holds for the next one instead of growing an exemption list.
+
 ## [0.26.0] - 2026-08-06
 
 ### Added

--- a/Tests/E2E/TCA/TcaFieldCompletionTest.php
+++ b/Tests/E2E/TCA/TcaFieldCompletionTest.php
@@ -73,6 +73,15 @@ final class TcaFieldCompletionTest extends TestCase
                 continue;
             }
 
+            // A passthrough column is never rendered by FormEngine, so a label
+            // and a description would be declarations nothing reads. Skipped by
+            // TYPO3's own type rather than by name, so the rule stays true for
+            // the next such column instead of growing a list.
+            $config = $fieldConfig['config'] ?? null;
+            if (is_array($config) && ($config['type'] ?? null) === 'passthrough') {
+                continue;
+            }
+
             // Check for label
             if (!isset($fieldConfig['label']) || $fieldConfig['label'] === '') {
                 $missingLabels[] = $fieldName;


### PR DESCRIPTION
## Description

`Tests/E2E/TCA/` was in neither suite of `Build/FunctionalTests.xml`. The issue asked whether anything else lives under `Tests/E2E/` outside `Backend/` — it does, and it is worse than expected:

| Test | was in | ran in |
|---|---|---|
| `Tests/E2E/TCA/TcaFieldCompletionTest` | no suite of `FunctionalTests.xml` | nothing |
| `Tests/E2E/ChatCompletionWorkflowTest` | `phpunit.xml`'s `e2e` suite | nothing |
| `Tests/E2E/EmbeddingWorkflowTest` | `phpunit.xml`'s `e2e` suite | nothing |

The third layer: `Build/phpunit.xml` **does** declare an `e2e` testsuite over `../Tests/E2E`, but no `runTests.sh` selector invokes it — `-s e2e` runs Playwright. A declaration with no reader.

Measured rather than assumed: all three answered `No tests executed` before this change, and run now (15 and 11 tests).

That is why a failing assertion could sit in `TcaFieldCompletionTest` unnoticed. The test is not weak; it was never executed. **A test no job runs is worse than no test, because it reads as coverage.**

## The label finding

The assertion it failed on is right, and so is the TCA. `tx_nrllm_configuration.preset_checksum` is `type => passthrough`, written by `ConfigurationPresetImportService` and — per the comment above it — never edited in FormEngine. It appears in no `showitem`. A label would itself be a declaration nothing reads, so the field is not given one.

Passthrough columns are now skipped **by their TCA type, not by name**, so the rule holds for the next such column instead of growing an exemption list.

## Where the tests went

- `Tests/E2E/TCA/` → a third `e2e-tca` suite in `FunctionalTests.xml`, which is the config CI runs.
- The two workflow tests extend `AbstractUnitTestCase` and use mocked providers, so they are unit tests that happen to live under `Tests/E2E/`. Listed as explicit `<file>` entries in the `unit` suite — a `<directory>` there would also pull in `Tests/E2E/Backend`, which belongs to the functional config.

The parallel functional runner globs its directories with `find`, so `Tests/E2E/TCA` is added there too. Without it the new suite would be silently skipped in that mode — exactly what the comment above that line already warns about.

## Related Issue

Closes #658.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run the gates — unit, PHPStan (level 10), cgl, fuzzy, functional, Rector (8.2 resolve, as CI pins it)
- [x] I have updated the documentation accordingly
- [x] I have added a `CHANGELOG.md` entry under `## [Unreleased]`
- [ ] ADR — none: this runs tests that already existed
- [x] My changes generate no new warnings

### Note for reviewers

The `AGENTS.md` line naming the PHPUnit suites sits inside an `AGENTS-GENERATED` block. There is no generator in the repo to update instead, and the line was factually wrong without the edit — worth a look if that block is regenerated from somewhere outside this repository.
