### PR TITLE
fix(skills): place the block on a multimodal user turn, and stop losing it silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- The skill block reaches a multimodal user turn (#645).
+  `SkillInjectionService` recognised an array-shaped message as a user
+  message only when its `content` was a **string**, so a conversation whose
+  first user turn carries content as a list of parts had the block prepended
+  to some later text turn — or, with no later text turn, not at all. Silently.
+  Multimodal content is a supported input shape, not an accident:
+  `MessageShaper::normalise()` converts only the exact 2-key string/string
+  form into a `ChatMessage` and passes everything else through for the
+  adapters to convert. The block is now prepended as a leading
+  `{type: 'text'}` part, the shape every adapter reads
+  (`ClaudeProvider::convertMultimodalContent()` translates it into Claude's
+  own format). Existing parts keep their order and are never merged into,
+  because a part may be an image.
+  An associative content array is still not an injection site — prepending
+  to it would produce a shape no adapter reads — so such a message is left
+  for the next candidate.
+- A composed skill block that finds no user message is logged instead of
+  vanishing. The message list is still returned unchanged, since the block is
+  never escalated into the system role, but skills carry instructions and
+  constraints and "silently absent" is the failure mode that matters. A call
+  with no skills stays silent — the warning marks a lost block, not every
+  skill-less call.
+
 ## [0.26.0] - 2026-08-06
 
 ### Added

--- a/Classes/Service/Skill/SkillInjectionService.php
+++ b/Classes/Service/Skill/SkillInjectionService.php
@@ -103,6 +103,20 @@ final readonly class SkillInjectionService
             $augmented[] = $message;
         }
 
+        if (!$injected) {
+            // The list is still returned unchanged — the block is never
+            // escalated into the system role to satisfy a missing user turn.
+            // But a composed block that reached no message is a skill set the
+            // model never sees, and skills carry instructions and constraints,
+            // so silence is the wrong way to report it.
+            $this->logger->warning(
+                'Skill block composed but not applied: no user message to prepend it to. '
+                . "The configuration's skills did not reach the model for this call.",
+            );
+
+            return $messages;
+        }
+
         return $augmented;
     }
 
@@ -157,8 +171,23 @@ final readonly class SkillInjectionService
             return $message->isUser();
         }
 
-        return ($message['role'] ?? null) === MessageRole::USER->value
-            && is_string($message[self::KEY_CONTENT] ?? null);
+        if (($message['role'] ?? null) !== MessageRole::USER->value) {
+            return false;
+        }
+
+        $content = $message[self::KEY_CONTENT] ?? null;
+
+        // A string is the plain turn. A LIST is the multimodal shape:
+        // MessageShaper::normalise() converts only the exact 2-key string/string
+        // form into a ChatMessage and passes everything else through for the
+        // adapters to convert, so a content array of OpenAI-style parts arrives
+        // here intact. Requiring a string sent the block to a later turn, or
+        // nowhere.
+        //
+        // array_is_list, not is_array: an associative content array is not a
+        // part list and prepending to it would produce a shape no adapter
+        // reads. Such a message is left for the next candidate.
+        return is_string($content) || (is_array($content) && array_is_list($content));
     }
 
     /**
@@ -172,7 +201,22 @@ final readonly class SkillInjectionService
             return ChatMessage::user($block . self::SEPARATOR . $message->content);
         }
 
-        $existing                  = $message[self::KEY_CONTENT] ?? '';
+        $existing = $message[self::KEY_CONTENT] ?? '';
+
+        if (is_array($existing)) {
+            // A leading text part, in the OpenAI-style block shape every
+            // adapter reads — ClaudeProvider::convertMultimodalContent()
+            // translates `{type: text}` into its own format, so this stays
+            // provider-neutral. The existing parts keep their order; nothing
+            // is merged into them, because a part may be an image.
+            $message[self::KEY_CONTENT] = [
+                ['type' => 'text', 'text' => $block],
+                ...$existing,
+            ];
+
+            return $message;
+        }
+
         $message[self::KEY_CONTENT] = $block . self::SEPARATOR . (is_string($existing) ? $existing : '');
 
         return $message;

--- a/Tests/Unit/Service/Skill/SkillInjectionServiceTest.php
+++ b/Tests/Unit/Service/Skill/SkillInjectionServiceTest.php
@@ -119,6 +119,85 @@ final class SkillInjectionServiceTest extends TestCase
         self::assertSame($messages, $subject->augmentMessages($messages, [$skill], []));
     }
 
+    /**
+     * A multimodal user turn carries `content` as a list of OpenAI-style parts
+     * (`{type: text}`, `{type: image_url}`), which `MessageShaper::normalise()`
+     * deliberately passes through untouched for the adapters to convert. The
+     * block belongs on THAT turn, as a leading text part -- previously the
+     * predicate required a string, so the block skipped ahead to a later turn.
+     */
+    #[Test]
+    public function augmentMessagesPrependsATextPartToAMultimodalUserMessage(): void
+    {
+        $subject  = $this->subject();
+        $skill    = $this->makeSkill('alpha', 'Alpha Skill', 'Always cite sources.');
+        $messages = [
+            ['role' => 'system', 'content' => 'You are a translator.'],
+            ['role' => 'user', 'content' => [
+                ['type' => 'text', 'text' => 'What is in this image?'],
+                ['type' => 'image_url', 'image_url' => ['url' => 'data:image/png;base64,AAAA']],
+            ]],
+            ['role' => 'user', 'content' => 'A later text-only turn.'],
+        ];
+
+        $augmented = $subject->augmentMessages($messages, [$skill], []);
+
+        self::assertIsArray($augmented[1]);
+        $content = $augmented[1]['content'];
+        self::assertIsArray($content);
+        self::assertCount(3, $content, 'the block is one added part, nothing is replaced');
+
+        $first = $content[0];
+        self::assertIsArray($first);
+        self::assertSame('text', $first['type']);
+        self::assertIsString($first['text']);
+        self::assertStringContainsString('### Skill: Alpha Skill', $first['text']);
+
+        // The original parts survive in order.
+        self::assertSame(['type' => 'text', 'text' => 'What is in this image?'], $content[1]);
+        self::assertSame(['type' => 'image_url', 'image_url' => ['url' => 'data:image/png;base64,AAAA']], $content[2]);
+
+        // And the later text turn is untouched: still only one injection site.
+        self::assertIsArray($augmented[2]);
+        self::assertSame('A later text-only turn.', $augmented[2]['content']);
+    }
+
+    /**
+     * The silent case the issue asks to close: a block was composed and there
+     * was nowhere to put it. Returning the list unchanged is right; doing it
+     * without a word is not.
+     */
+    #[Test]
+    public function augmentMessagesWarnsWhenAComposedBlockFindsNoUserMessage(): void
+    {
+        $logger  = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with(self::stringContains('no user message'));
+
+        $subject  = new SkillInjectionService(new SkillComposer(), $logger);
+        $skill    = $this->makeSkill('alpha', 'Alpha Skill', 'Always cite sources.');
+        $messages = [['role' => 'system', 'content' => 'You are a translator.']];
+
+        self::assertSame($messages, $subject->augmentMessages($messages, [$skill], []));
+    }
+
+    /**
+     * No skills, no block, nothing to warn about -- the warning must mark a
+     * lost block, not every skill-less call.
+     */
+    #[Test]
+    public function augmentMessagesIsSilentWhenThereIsNoBlockToPlace(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())->method('warning');
+
+        $subject  = new SkillInjectionService(new SkillComposer(), $logger);
+        $messages = [['role' => 'system', 'content' => 'You are a translator.']];
+
+        self::assertSame($messages, $subject->augmentMessages($messages, [], []));
+    }
+
     #[Test]
     public function augmentMessagesHandlesChatMessageValueObjects(): void
     {


### PR DESCRIPTION
## Description

`SkillInjectionService::isUserMessage()` recognised an array-shaped message as a user message only when its `content` was a **string**. `augmentMessages()` prepends to the *first* message satisfying that predicate, so a conversation whose first user turn is multimodal had the block prepended to some later text turn — or, with no later text turn, not at all. Silently, either way.

Multimodal content is a supported input shape, not an accident: `MessageShaper::normalise()` converts only the exact 2-key string/string form into a `ChatMessage` and passes everything else through, and its docblock names multimodal messages as the reason. The adapters expect to receive them.

## Both halves, not one

The issue offers two directions and says the "no injection site" branch should stop being silent whichever is chosen. Both are here, because they close different things:

**The behaviour.** The block is prepended as a leading `{type: 'text'}` part — the OpenAI-style shape every adapter reads, which `ClaudeProvider::convertMultimodalContent()` translates into Claude's own format. Existing parts keep their order and are never merged into, because a part may be an image.

An associative content array is still **not** an injection site: prepending to it would produce a shape no adapter reads, so such a message is left for the next candidate. `array_is_list`, not `is_array`.

**The silence.** A composed block that finds no user message is now logged. The list is still returned unchanged — the block is never escalated into the system role to satisfy a missing user turn — but skills carry instructions and constraints, and "silently absent" is the failure mode that matters. A call with **no** skills stays silent, so the warning marks a lost block rather than every skill-less call.

## Scope, since the issue asks

The issue's "not yet established" point stands, and the answer is not reassuring in either direction:

**No in-repo caller produces a multimodal message on the skill path.** The two callers of `augmentMessages()` are `LlmServiceManager::chat()` and `ToolLoopService`. The only place that builds image parts is `VisionService`, which dispatches through `llmManager->vision()` with `VisionContent` objects and never reaches skill injection — exactly as the issue said.

So the reachability is the **public API's**: `chat()` and `chatForConfiguration()` accept `array<string, mixed>` messages, and `MessageShaper` deliberately passes the multimodal shape through. This fixes the API surface, not an observed call. Stated plainly rather than dressed up as a live incident.

## Related Issue

Closes #645.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run the gates — unit, PHPStan (level 10), cgl, fuzzy, functional, Rector (8.2 resolve, as CI pins it)
- [x] I have added tests that prove my fix works
- [x] I have added a `CHANGELOG.md` entry under `## [Unreleased]`
- [ ] ADR — none: this makes the injection do what its own docblock describes
- [x] My changes generate no new warnings

### Tests

Written before the fix, and both were red against unchanged `Classes/`:

- a multimodal first turn receives the block as a leading text part, the original parts survive in order, and the later text-only turn stays untouched — one injection site, not two;
- a composed block with no user message warns.

A third test is green both ways on purpose: **no** skills means no block and no warning. Without it, a change that warned on every call would satisfy the second test.
