### PR TITLE
chore(release): 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-08-09
+
 ### Added
 
 - A read-only **Governance** tab on the LLM Overview showing the effective
@@ -2572,7 +2574,8 @@ setting now either works or is gone. Three breaking changes — see below.
 
 Initial public release. See git history for prior commits.
 
-[Unreleased]: https://github.com/netresearch/t3x-nr-llm/compare/v0.26.0...HEAD
+[Unreleased]: https://github.com/netresearch/t3x-nr-llm/compare/v0.27.0...HEAD
+[0.27.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.25.1...v0.26.0
 [0.25.1]: https://github.com/netresearch/t3x-nr-llm/compare/v0.25.0...v0.25.1
 [0.25.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.24.0...v0.25.0

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -11,8 +11,8 @@
 >
     <project
         title="TYPO3 LLM Extension"
-        version="0.26.0"
-        release="0.26.0"
+        version="0.27.0"
+        release="0.27.0"
         copyright="since 2025 by Netresearch DTT GmbH"
     />
 

--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
                 "providesPackages": {}
             },
             "extension-key": "nr_llm",
-            "version": "0.26.0",
+            "version": "0.27.0",
             "web-dir": ".Build/Web"
         }
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => '',
     'author_company' => 'Netresearch DTT GmbH',
     'state' => 'beta',
-    'version' => '0.26.0',
+    'version' => '0.27.0',
     'constraints' => [
         // composer.json is the authoritative dependency constraint
         // ("typo3/cms-core": "^13.4 || ^14.3"). The TER `depends` format only


### PR DESCRIPTION
Vier Versionsflächen auf `0.27.0`: `ext_emconf.php`, `composer.json` (`extra.typo3/cms.version`), `Documentation/guides.xml` (`version` und `release`), `CHANGELOG.md`.

Der Abschnitt `## [0.27.0]` trägt 37 Einträge, `## [Unreleased]` ist leer, die Vergleichslinks sind ergänzt.

**Breaking:** `ApprovalDecision` nimmt ein drittes Konstruktor-Argument.

Umfang: die Issues #626–#629, #632–#636, #638–#640, #645, #649, #652, #658, #662, #671–#675 — gemergt über die Sammel-PRs #685 und #686.

Gates lokal auf dem Endstand nach `main`-Merge: unit, phpstan, cgl, fuzzy.