### PR TITLE
docs(changelog): de-duplicate 0.27.0 and sort its entries into the right sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,15 +28,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `privacy.retentionDays` gets its own row — the overrides left at the
   shipped `0` resolve to the global window and stay out.
 
-### Changed
-
-- `ToolCallPolicy::enforcing()` moved verbatim into the new
-  `Service\Tool\DataClassEnforcementResolver`, which the tool gate and the
-  governance readout both ask. `ToolCallPolicy` no longer takes an optional
-  `ExtensionConfiguration` and instead requires the resolver; behaviour is
-  unchanged, including the fail-closed matrix of ADR-113.
-- `SkillComposerFactory::minTrustLevel()` is public so the readout can show
-  the level the composer is actually built with.
 - **`set_file_alternative_text` — the second writing tool** (ADR-135). It sets
   the alternative text (`sys_file_metadata.alternative`) of exactly ONE managed
   file, identified by its `sys_file` uid, through the `DataHandler`, as the
@@ -74,6 +65,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   row lookup, and `isEnabledByDefault()` / `requiresAdmin()` / `getGroup()` /
   `getEffect()` — identical today, still declared per tool so a third writer
   decides rather than inherits.
+
 - **A write preview, produced when the run suspends** (ADR-136). New opt-in
   `ToolPreviewInterface`: a tool that implements it describes, in plain lines,
   what the pending call would do. The lines are produced by `ToolLoopService` at
@@ -100,6 +92,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   whether the backend user it is being rendered for may see that record, and
   says the preview is withheld where the answer is no. It fails closed when the
   question cannot be asked — no viewer, or no registered tool under that name.
+
 - **`update_page_metadata` — the first writing tool** (ADR-135). It sets a fixed
   allow-list of descriptive fields (`title`, `subtitle`, `nav_title`,
   `abstract`, `description`, `keywords`, plus the EXT:seo titles/descriptions
@@ -127,6 +120,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   write fence arms only under a lease owner, which only `AgentRuntime::enqueue()`
   produces — no shipped entry point calls it, so an interactive write runs
   unfenced. The fail-closed write audit and the approval pause hold everywhere.
+
 - A configuration can attach prompt snippets by tag
   (`tx_nrllm_configuration.snippet_tags`, amendment to ADR-031). The
   active snippets carrying any selected tag are composed into the
@@ -151,6 +145,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `$effectiveSystemPrompt` argument, defaulting to the previous
   behaviour), so the ADR-107 budget counts the snippet block that goes on
   the wire.
+
 - New extension configuration key `skills.maxBytes` (default `24000`) for the
   byte budget of the composed skill block (ADR-036 §5). `SkillComposer` had
   accepted `maxBytes` as a constructor argument since the feature landed, but
@@ -166,6 +161,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   so a bad value cannot silently hide skills; a bad budget must not silently
   unbound the block. Lower `skills.maxBytes` to reserve more of the model's
   context window for the conversation itself.
+
 - `InputPauseCoverageTest` pins that no builtin can suspend a run for
   operator input (#649). The input path authorises the submitter with
   `agent_approve` alone and never against the tool whose input they supply,
@@ -198,6 +194,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   period's rescues out of the list. `ProviderHealthRepository` is
   unchanged — its scores deliberately count only `fallback_attempts = 0`
   rows, so a rescued run still counts against the primary.
+
 - A **Provider health and circuits** table in the analytics module, the
   readout ADR-063 deferred: per provider the health score with the sample
   count and the rolling window it was taken over, plus the circuit state
@@ -224,6 +221,28 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (`ad-hoc:chat:openai`); the limitation is stated on `providerKeys()` and
   in the administration docs instead of being claimed away.
 
+- MCP servers carry an operator-declared `requires_approval` flag
+  (ADR-134). When it is set, every tool imported from that server pauses
+  the agent run for a human before it is called; the decision never comes
+  from the server, whose `readOnlyHint` annotation stays unread. It is on
+  by default for a newly configured server, and only a literal `0` reads
+  as "no approval" — an unreadable or missing value means approval is
+  required. The default reaches existing servers too: the schema update
+  writes it on every pre-existing row, and no upgrade wizard switches it
+  off again. Switch it off per server once you know what that server's
+  tools do.
+
+### Changed
+
+- `ToolCallPolicy::enforcing()` moved verbatim into the new
+  `Service\Tool\DataClassEnforcementResolver`, which the tool gate and the
+  governance readout both ask. `ToolCallPolicy` no longer takes an optional
+  `ExtensionConfiguration` and instead requires the resolver; behaviour is
+  unchanged, including the fail-closed matrix of ADR-113.
+
+- `SkillComposerFactory::minTrustLevel()` is public so the readout can show
+  the level the composer is actually built with.
+
 - The candidate walk over a primary configuration's fallback chain is
   implemented once, in the `@internal`
   `Provider\Fallback\FallbackCandidateResolver` (ADR-137). It owns the
@@ -236,6 +255,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   surface, which is unchanged. Streaming resolves the chain lazily now: when an
   early candidate serves, later entries are no longer looked up and a broken
   entry behind it no longer logs a skip warning.
+
 - Internal signature change: `ModelSelectionServiceInterface::resolveModel()`
   and `ConfigurationCallPlanner::resolveModel()` take a required
   `?ProviderOperation`; `ConfigurationCallPlanner::adapterFor()` likewise.
@@ -251,16 +271,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   fail-closed assumption about a body that cannot be inspected, so
   coupling it to approval would suspend every remote call. The remote axis
   has an operator-declared server-level source instead, below.
-- MCP servers carry an operator-declared `requires_approval` flag
-  (ADR-134). When it is set, every tool imported from that server pauses
-  the agent run for a human before it is called; the decision never comes
-  from the server, whose `readOnlyHint` annotation stays unread. It is on
-  by default for a newly configured server, and only a literal `0` reads
-  as "no approval" — an unreadable or missing value means approval is
-  required. The default reaches existing servers too: the schema update
-  writes it on every pre-existing row, and no upgrade wizard switches it
-  off again. Switch it off per server once you know what that server's
-  tools do.
+
 - `ToolRegistry` now also rejects a non-remote tool that declares a write
   **and** implements `RequiresInputInterface`: the approval scan runs before
   the input scan, so such a tool would suspend for approval, be refused by
@@ -268,21 +279,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   executing. The existing `RequiresApprovalInterface` + `RequiresInputInterface`
   ban (ADR-105) now covers the implicit form as well.
 
-- A builtin tool that declares a write effect (`ToolEffectInterface`,
-  ADR-111) now requires human approval in the agent loop even without the
-  `RequiresApprovalInterface` marker (ADR-134). Both write cases count;
-  `READ_ONLY` tools are unaffected, so nothing changes for the tools
-  shipped today — every builtin reads. Remote (MCP) tools are exempt:
-  `McpTool` declares `NON_IDEMPOTENT_WRITE` for every imported tool as a
-  fail-closed assumption about a body that cannot be inspected, so
-  coupling it to approval would suspend every remote call. The remote axis
-  gets an operator-declared server-level source separately.
-  `ToolRegistry` now also rejects a non-remote tool that declares a write
-  **and** implements `RequiresInputInterface`: the approval scan runs before
-  the input scan, so such a tool would suspend for approval, be refused by
-  the approval resume for its missing input, and suspend again — never
-  executing. The existing `RequiresApprovalInterface` + `RequiresInputInterface`
-  ban (ADR-105) now covers the implicit form as well.
+### Fixed
+
 - ADR-036 §5 claimed a ceiling derived from the model's context window ("with
   `Model::contextLength == 0` the absolute cap applies"). No such derivation
   was ever implemented. The section now says what the code does — the budget
@@ -292,6 +290,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `llmModel` is null in criteria selection mode (so the window read would not
   belong to the model that serves the call), and `ContextWindowManager`
   (ADR-107) already bounds the real send with a calibrated token estimator.
+
 - The `allowed-tools` documentation claimed the tool union and the injected
   prompt block are the same set (`Tools.rst`, ADR-038 §5,
   `AllowedToolsResolver`'s docblock: "exactly what SkillComposer injects").
@@ -304,6 +303,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   counting the budget there would let the drop of the last declaring skill
   collapse the allow-list to `null` ("no restriction" — every registered
   tool), making a tighter budget widen the gate.
+
 - Criteria-mode configurations no longer resolve a model that cannot serve
   the running operation (ADR-138). The operation is merged into the criteria
   before selection, so a tool call picks a tool-capable model instead of
@@ -315,6 +315,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `routing.operationCapabilityEnforcement` (default `enforce`, fail-closed
   like ADR-113) switches the axis to `observe`, which logs the mismatch and
   leaves selection untouched. Fixed-mode configurations are unaffected.
+
 - `Model::$capabilities` was dropped on every load from the database.
   Extbase resolved the property as an array (Symfony PropertyInfo infers a
   collection from the `addCapability()` / `removeCapability()` pair) and its
@@ -322,10 +323,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   back with an empty capability set — which also made every `capabilities`
   selection criterion match nothing. Anything reading `getCapabilities()`
   off a repository-loaded model now sees the persisted value.
+
 - The embedding cache key and the embedding call can no longer resolve
   different models for the same call. `embedForConfiguration()` resolves
   twice — once outside the pipeline for the key, once inside the terminal —
   and both now pass the same operation.
+
 - Model discovery seeds capabilities the provider actually reports (#671).
   Six of the seven discoverers wrote tokens no response substantiated:
   Groq and OpenRouter a flat `chat`, Mistral `chat, tools` for every model
@@ -346,6 +349,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   checkbox list could not show it.
   Existing `tx_nrllm_model` rows keep their values; re-run **Fetch Models**
   to refresh them.
+
 - `OpenRouterProvider::fetchModels()` reported no capabilities for any
   model. It read `supports_function_calling`, which is not a field the
   catalogue returns, and compared `architecture.modality` against
@@ -353,6 +357,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   string such as `text+image->text`. Measured against the live catalogue:
   400 models, 0 with either signal, against 333 that list `tools` among
   their supported parameters and 237 that accept image input.
+
 - The tool-group table in the administration chapter renders its
   `configuration` row correctly (#673). The RST simple table's first column
   was two characters narrower than the longest key, so `render-guides`
@@ -360,6 +365,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the group name printed as `` ``configuration `` in plain text instead of
   as inline code. The row itself was present — the render error is real,
   the missing row the issue suspected was not.
+
 - `FalStorageGate::isFileAccessible()` enforces the mounts of the user it is
   passed, not of whoever is in `$GLOBALS['BE_USER']` (#672). The storage
   allow-list half already used the passed user; the mount half did not, and
@@ -381,6 +387,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Behaviour is unchanged for the three read-only FAL tools shipped today:
   they run synchronously in their owner's request, where both users are the
   same person.
+
 - The two FAL tools that read `sys_file_metadata` pin the live workspace
   (#674). The table carries `'versioningWS' => true`, so a file with a draft
   version has more than one row for the same `file` uid:
@@ -397,6 +404,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Both defects are read-only: the answer could be wrong, nothing was
   corrupted. The same defect in the writing tool is fixed separately in the
   `set_file_alternative_text` branch, where it mattered more.
+
 - The Install Tool label for `tools.dataClassEnforcement` no longer promises
   a pin that usually does not happen (#675). It stated unconditionally that
   an upgraded install "is pinned to Observe by an upgrade wizard". The pin
@@ -409,6 +417,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   nothing to do, and the operator is on enforce while the label tells them
   otherwise, in the screen where they would look. The label now states the
   condition and says that the value shown is what applies.
+
 - Three PHP test classes that no job executed now run in CI (#658).
   `Tests/E2E/TCA/` was in neither suite of `Build/FunctionalTests.xml`, and
   the two workflow tests directly under `Tests/E2E/` were in no suite at
@@ -422,12 +431,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `Tests/E2E/TCA` is added there too; without it the new suite would be
   silently skipped in that mode, exactly as the comment above that line
   warns.
+
 - `TcaFieldCompletionTest` passes again. It flagged
   `tx_nrllm_configuration.preset_checksum` as label-less, which it is: the
   column is `type => passthrough`, written by the preset importer and never
   rendered by FormEngine, so a label would be a declaration nothing reads.
   Passthrough columns are now skipped by their TCA type rather than by name,
   so the rule holds for the next one instead of growing an exemption list.
+
 - The skill block reaches a multimodal user turn (#645).
   `SkillInjectionService` recognised an array-shaped message as a user
   message only when its `content` was a **string**, so a conversation whose
@@ -444,6 +455,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   An associative content array is still not an injection site — prepending
   to it would produce a shape no adapter reads — so such a message is left
   for the next candidate.
+
 - A composed skill block that finds no user message is logged instead of
   vanishing. The message list is still returned unchanged, since the block is
   never escalated into the system role, but skills carry instructions and
@@ -451,40 +463,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   with no skills stays silent — the warning marks a lost block, not every
   skill-less call.
 
-- The conversation context budget counts the skill block (#625).
-  `ConversationService` fitted the transcript and then dispatched into
-  `LlmServiceManager::chatForConfiguration()`, which prepends up to 24 000
-  bytes of skill block to the first user message — the fitted list and the
-  sent list were different lists. A criteria-mode configuration has no model
-  relation, so its window falls back to 8192 tokens, of which a full block is
-  roughly 7 900 estimated tokens against a budget of 6 946 (8192 minus the
-  1000-token response reserve minus the 3 % safety margin): the whole
-  configuration class overran. `ContextWindowManagerInterface::fit()` takes an
-  optional trailing `$injectedText` for payload that reaches the wire outside
-  the message list, and the conversation path composes the block once and
-  passes it. The injection stays where it is — the first user turn is the
-  never-droppable head, so injecting before the fit would drop the entire
-  history and still overflow. Known limit: a session opened without a
-  configuration resolves the installation default inside the manager, so its
-  block is still unaccounted for.
-
-### Fixed
-
-- A builtin tool that declares a write effect (`ToolEffectInterface`,
-  ADR-111) now requires human approval in the agent loop even without the
-  `RequiresApprovalInterface` marker (ADR-134). Both write cases count;
-  `READ_ONLY` tools are unaffected, so nothing changes for the tools
-  shipped today — every builtin reads. Remote (MCP) tools are exempt:
-  `McpTool` declares `NON_IDEMPOTENT_WRITE` for every imported tool as a
-  fail-closed assumption about a body that cannot be inspected, so
-  coupling it to approval would suspend every remote call. The remote axis
-  gets an operator-declared server-level source separately.
-  `ToolRegistry` now also rejects a non-remote tool that declares a write
-  **and** implements `RequiresInputInterface`: the approval scan runs before
-  the input scan, so such a tool would suspend for approval, be refused by
-  the approval resume for its missing input, and suspend again — never
-  executing. The existing `RequiresApprovalInterface` + `RequiresInputInterface`
-  ban (ADR-105) now covers the implicit form as well.
 - The conversation context budget counts the skill block (#625).
   `ConversationService` fitted the transcript and then dispatched into
   `LlmServiceManager::chatForConfiguration()`, which prepends up to 24 000
@@ -535,6 +513,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   work from. The decode after the claim remains and now covers only the race it
   is there for: the state CHANGED between the two reads and the row the claim
   won is the unreadable one.
+
 - **An approver may only release a write they could run themselves** (ADR-133).
   A resumed turn executes under the run OWNER's identity (ADR-083, unchanged),
   but the approver was never checked against the tool they were releasing:


### PR DESCRIPTION
Follow-up to the 0.27.0 release, found by a `/retro` sweep while writing the release notes.

The 0.27.0 section was assembled by merging the batch branches ([#685](https://github.com/netresearch/t3x-nr-llm/pull/685), [#686](https://github.com/netresearch/t3x-nr-llm/pull/686)) whose `CHANGELOG.md` conflicts were auto-resolved by keeping both sides. The text survived; the structure did not.

**Duplicates (3 removed of 37 entries)**

- The write-effect/approval entry appeared **three** times: its own form (kept), plus twice in a longer variant that folds in the `ToolRegistry` paragraph — which is already its own entry.
- The context-budget entry ([#625](https://github.com/netresearch/t3x-nr-llm/issues/625)) appeared under both `Changed` and `Fixed`.

**Section assignment**

Was 1 Added / 32 Changed / 4 Fixed — a union merge keeps whichever heading came first. Both new writing tools, the write preview, the Governance tab, the provider-health table, the `snippet_tags` field and the new `skills.maxBytes` key all sat under `Changed`; so did every bug fix carrying an issue number.

Now **10 Added / 6 Changed / 18 Fixed**, 34 entries.

**No text was edited.** Every retained entry was compared against the original set to confirm nothing was lost beyond the three redundant copies. Other version sections are untouched; `Unreleased` stays empty.

The published [v0.27.0](https://github.com/netresearch/t3x-nr-llm/releases/tag/v0.27.0) release notes are unaffected — they are prose written from this content, not generated from it.