### PR TITLE
docs: make the roadmap and the ADR statuses say what is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- `ROADMAP.md` lists only unbuilt work, and every item is an open issue. Its
-  top "Next" entry claimed all 41 builtin tools were read-only and that the
-  first writer had yet to arrive — two had shipped. Everything already released
-  moved out to `CHANGELOG.md` and the ADRs.
-- The package-split timing is stated in ADR-090 and nowhere else. `ROADMAP.md`
-  said "only after 1.0" while ADR-090 and the README said "with or before 1.0",
-  and cited ADR-090 for the opposite of what it decided.
+- `ROADMAP.md` lists only unbuilt work, and every item in its two roadmap
+  sections is an open issue. Its top "Next" entry claimed all 41 builtin tools
+  were read-only and that the first writer had yet to arrive — two had shipped.
+  Everything already released moved out to `CHANGELOG.md` and the ADRs.
+- ADR-090 decides the package-split timing; the README repeats it where it
+  explains the anticipated seams and must keep matching. `ROADMAP.md` said
+  "only after 1.0" while ADR-090 and the README said "with or before 1.0", and
+  cited ADR-090 for the opposite of what it decided.
 - ADRs carry a lifecycle. `Documentation/Adr/Index.rst` documents the status
   vocabulary and the paired `:Amends:` / `:Amended:` and `:Supersedes:` /
   `:Superseded:` fields. ADR-122 stood at plain `Accepted` while asserting
@@ -26,8 +27,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `Tests/Unit/AdrLifecycleTest.php` fails when a record uses an unknown status
   word, when a status names another record without the matching lifecycle
-  field, when a field points at a record that does not exist, or when only one
-  end of an amend/supersede pair is written.
+  field, when a cross-reference in a lifecycle field or a status line points at
+  a record that does not exist, or when only one end of an ADR-to-ADR
+  amend/supersede pair is written. Field values are read across RST
+  continuation lines, so a wrapped field cannot hide a reference.
 
 ## [0.27.0] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- `ROADMAP.md` lists only unbuilt work, and every item is an open issue. Its
+  top "Next" entry claimed all 41 builtin tools were read-only and that the
+  first writer had yet to arrive — two had shipped. Everything already released
+  moved out to `CHANGELOG.md` and the ADRs.
+- The package-split timing is stated in ADR-090 and nowhere else. `ROADMAP.md`
+  said "only after 1.0" while ADR-090 and the README said "with or before 1.0",
+  and cited ADR-090 for the opposite of what it decided.
+- ADRs carry a lifecycle. `Documentation/Adr/Index.rst` documents the status
+  vocabulary and the paired `:Amends:` / `:Amended:` and `:Supersedes:` /
+  `:Superseded:` fields. ADR-122 stood at plain `Accepted` while asserting
+  "all 44 builtin tools read"; it and ADR-084 now name what expired. The twelve
+  early records that kept their status in a prose section were converted to the
+  field form.
+
+### Added
+
+- `Tests/Unit/AdrLifecycleTest.php` fails when a record uses an unknown status
+  word, when a status names another record without the matching lifecycle
+  field, when a field points at a record that does not exist, or when only one
+  end of an amend/supersede pair is written.
+
 ## [0.27.0] - 2026-08-09
 
 ### Added

--- a/Documentation/AGENTS.md
+++ b/Documentation/AGENTS.md
@@ -95,7 +95,9 @@ Subsection (~)
 - `.. note::` / `.. warning::` / `.. tip::` for admonitions
 
 ### ADR Format (Adr/)
-ADRs use numbered naming: `AdrNNNTitle.rst`. 26 exist; follow existing format for new ADRs.
+ADRs use numbered naming: `AdrNNNTitle.rst`; follow the existing format for new ones.
+
+`Adr/Index.rst` documents the record lifecycle — the `:Status:` vocabulary and the paired `:Amends:` / `:Amended:` and `:Supersedes:` / `:Superseded:` fields. An ADR that overturns part of an earlier one edits that earlier record in the same change; `Tests/Unit/AdrLifecycleTest.php` fails the build when only one end of the link is written.
 
 ### Branding
 Documentation uses Netresearch branding: teal underline SVG for headings, emoji icons for feature cards, footer card with company info. See `guides.xml` `<extension>` attributes for project links.

--- a/Documentation/AGENTS.md
+++ b/Documentation/AGENTS.md
@@ -97,7 +97,7 @@ Subsection (~)
 ### ADR Format (Adr/)
 ADRs use numbered naming: `AdrNNNTitle.rst`; follow the existing format for new ones.
 
-`Adr/Index.rst` documents the record lifecycle — the `:Status:` vocabulary and the paired `:Amends:` / `:Amended:` and `:Supersedes:` / `:Superseded:` fields. An ADR that overturns part of an earlier one edits that earlier record in the same change; `Tests/Unit/AdrLifecycleTest.php` fails the build when only one end of the link is written.
+`Adr/Index.rst` documents the record lifecycle — the `:Status:` vocabulary and the paired `:Amends:` / `:Amended:` and `:Supersedes:` / `:Superseded:` fields. An ADR that overturns part of an earlier one edits that earlier record in the same change; `Tests/Unit/AdrLifecycleTest.php` fails the build when only one end of an ADR-to-ADR link is written. A record superseded by something that is not an ADR names it in prose and has no counterpart — see `Adr/Index.rst` for that carve-out.
 
 ### Branding
 Documentation uses Netresearch branding: teal underline SVG for headings, emoji icons for feature cards, footer card with company info. See `guides.xml` `<extension>` attributes for project links.

--- a/Documentation/Adr/Adr001ProviderAbstractionLayer.rst
+++ b/Documentation/Adr/Adr001ProviderAbstractionLayer.rst
@@ -6,11 +6,9 @@
 ADR-001: Provider Abstraction Layer
 ===================================
 
-.. _adr-001-status:
-
-Status
-======
-**Accepted** (2024-01)
+:Status: Accepted
+:Date: 2024-01
+:Authors: Netresearch DTT GmbH
 
 .. _adr-001-context:
 

--- a/Documentation/Adr/Adr002FeatureServicesArchitecture.rst
+++ b/Documentation/Adr/Adr002FeatureServicesArchitecture.rst
@@ -6,11 +6,9 @@
 ADR-002: Feature Services Architecture
 ========================================
 
-.. _adr-002-status:
-
-Status
-======
-**Accepted** (2024-02)
+:Status: Accepted
+:Date: 2024-02
+:Authors: Netresearch DTT GmbH
 
 .. _adr-002-context:
 

--- a/Documentation/Adr/Adr003TypedResponseObjects.rst
+++ b/Documentation/Adr/Adr003TypedResponseObjects.rst
@@ -6,11 +6,9 @@
 ADR-003: Typed Response Objects
 =================================
 
-.. _adr-003-status:
-
-Status
-======
-**Accepted** (2024-01)
+:Status: Accepted
+:Date: 2024-01
+:Authors: Netresearch DTT GmbH
 
 .. _adr-003-context:
 

--- a/Documentation/Adr/Adr004Psr14EventSystem.rst
+++ b/Documentation/Adr/Adr004Psr14EventSystem.rst
@@ -6,11 +6,10 @@
 ADR-004: PSR-14 Event System
 ==============================
 
-.. _adr-004-status:
-
-Status
-======
-**Superseded by** :ref:`ADR-026 <adr-026>` (2024-02, superseded 2026)
+:Status: Superseded
+:Date: 2024-02
+:Superseded: 2026 by :ref:`ADR-026 <adr-026>`
+:Authors: Netresearch DTT GmbH
 
 .. note::
 

--- a/Documentation/Adr/Adr005Typo3CachingFrameworkIntegration.rst
+++ b/Documentation/Adr/Adr005Typo3CachingFrameworkIntegration.rst
@@ -6,11 +6,9 @@
 ADR-005: TYPO3 Caching Framework Integration
 ==============================================
 
-.. _adr-005-status:
-
-Status
-======
-**Accepted** (2024-03)
+:Status: Accepted
+:Date: 2024-03
+:Authors: Netresearch DTT GmbH
 
 .. _adr-005-context:
 

--- a/Documentation/Adr/Adr006OptionObjectsVsArrays.rst
+++ b/Documentation/Adr/Adr006OptionObjectsVsArrays.rst
@@ -6,11 +6,10 @@
 ADR-006: Option Objects vs Arrays
 ===================================
 
-.. _adr-006-status:
-
-Status
-======
-**Superseded** by :ref:`ADR-011 <adr-011>` (2024-12)
+:Status: Superseded
+:Date: 2024-12
+:Superseded: 2024-12 by :ref:`ADR-011 <adr-011>`
+:Authors: Netresearch DTT GmbH
 
 .. _adr-006-context:
 

--- a/Documentation/Adr/Adr007MultiProviderStrategy.rst
+++ b/Documentation/Adr/Adr007MultiProviderStrategy.rst
@@ -6,11 +6,9 @@
 ADR-007: Multi-Provider Strategy
 ==================================
 
-.. _adr-007-status:
-
-Status
-======
-**Accepted** (2024-01)
+:Status: Accepted
+:Date: 2024-01
+:Authors: Netresearch DTT GmbH
 
 .. _adr-007-context:
 

--- a/Documentation/Adr/Adr008ErrorHandlingStrategy.rst
+++ b/Documentation/Adr/Adr008ErrorHandlingStrategy.rst
@@ -6,11 +6,9 @@
 ADR-008: Error Handling Strategy
 ==================================
 
-.. _adr-008-status:
-
-Status
-======
-**Accepted** (2024-02)
+:Status: Accepted
+:Date: 2024-02
+:Authors: Netresearch DTT GmbH
 
 .. _adr-008-context:
 

--- a/Documentation/Adr/Adr009StreamingImplementation.rst
+++ b/Documentation/Adr/Adr009StreamingImplementation.rst
@@ -6,11 +6,9 @@
 ADR-009: Streaming Implementation
 ===================================
 
-.. _adr-009-status:
-
-Status
-======
-**Accepted** (2024-03)
+:Status: Accepted
+:Date: 2024-03
+:Authors: Netresearch DTT GmbH
 
 .. _adr-009-context:
 

--- a/Documentation/Adr/Adr010ToolFunctionCallingDesign.rst
+++ b/Documentation/Adr/Adr010ToolFunctionCallingDesign.rst
@@ -6,11 +6,9 @@
 ADR-010: Tool/Function Calling Design
 =======================================
 
-.. _adr-010-status:
-
-Status
-======
-**Accepted** (2024-04)
+:Status: Accepted
+:Date: 2024-04
+:Authors: Netresearch DTT GmbH
 
 .. _adr-010-context:
 

--- a/Documentation/Adr/Adr011ObjectOnlyOptionsApi.rst
+++ b/Documentation/Adr/Adr011ObjectOnlyOptionsApi.rst
@@ -6,13 +6,10 @@
 ADR-011: Object-Only Options API
 ====================================
 
-.. _adr-011-status:
-
-Status
-======
-**Accepted** (2024-12)
-
-**Supersedes:** :ref:`ADR-006 <adr-006>`
+:Status: Accepted
+:Date: 2024-12
+:Supersedes: :ref:`ADR-006 <adr-006>`
+:Authors: Netresearch DTT GmbH
 
 .. _adr-011-context:
 

--- a/Documentation/Adr/Adr026ProviderMiddlewarePipeline.rst
+++ b/Documentation/Adr/Adr026ProviderMiddlewarePipeline.rst
@@ -8,6 +8,7 @@ ADR-026: Provider Middleware Pipeline
 
 :Status: Accepted
 :Date: 2026-04
+:Supersedes: :ref:`ADR-004 <adr-004>`
 :Authors: Netresearch DTT GmbH
 
 .. _adr-026-context:

--- a/Documentation/Adr/Adr028PublicServicesPolicy.rst
+++ b/Documentation/Adr/Adr028PublicServicesPolicy.rst
@@ -8,6 +8,7 @@ ADR-028: Public services policy in ``Configuration/Services.yaml``
 
 :Status: Accepted (count and Category 3 / tail rationale superseded by :ref:`adr-065`)
 :Date: 2026-04-30
+:Amended: 2026-07-15 by :ref:`ADR-065 <adr-065>`
 :Slice: 25 (audit 2026-04-23 REC #9c)
 
 .. note::

--- a/Documentation/Adr/Adr049RagSiteSearchTools.rst
+++ b/Documentation/Adr/Adr049RagSiteSearchTools.rst
@@ -6,8 +6,9 @@
 ADR-049: RAG site-search tools over installed search indexes
 =============================================================
 
-:Status: Accepted
+:Status: Accepted (the Solr language filter is corrected by :ref:`ADR-067 <adr-067>`)
 :Date: 2026-07-09
+:Amended: 2026-07 by :ref:`ADR-067 <adr-067>`
 :Authors: Netresearch DTT GmbH
 
 .. _adr-049-context:

--- a/Documentation/Adr/Adr050RetrievalAndEmbeddingScopeBoundary.rst
+++ b/Documentation/Adr/Adr050RetrievalAndEmbeddingScopeBoundary.rst
@@ -7,6 +7,7 @@ ADR-050: Retrieval and embedding scope — the boundary with nr_ai_search
 =======================================================================
 
 :Status: Accepted (cross-encoder reranking placement amended by :ref:`adr-075`)
+:Amended: 2026-07-17 by :ref:`ADR-075 <adr-075>`
 :Date: 2026-07-11
 :Authors: Netresearch DTT GmbH
 

--- a/Documentation/Adr/Adr065ReducePublicServiceSurface.rst
+++ b/Documentation/Adr/Adr065ReducePublicServiceSurface.rst
@@ -8,6 +8,7 @@ ADR-065: Reduce the public service surface (ADR-028 follow-up)
 
 :Status: Accepted
 :Date: 2026-07-15
+:Supersedes: the count and Category 3 / tail rationale of :ref:`ADR-028 <adr-028>`
 :Authors: Netresearch DTT GmbH
 
 .. _adr-065-context:

--- a/Documentation/Adr/Adr067SolrPerLanguageCoreFilter.rst
+++ b/Documentation/Adr/Adr067SolrPerLanguageCoreFilter.rst
@@ -6,12 +6,15 @@
 ADR-067: Solr per-language core — no language filter query
 ============================================================
 
-.. _adr-067-status:
+:Status: Accepted
+:Date: 2026-07
+:Amends: :ref:`ADR-049 <adr-049>`
+:Authors: Netresearch DTT GmbH
 
-Status
-======
-**Accepted** (2026-07) — bug fix refining the Solr retrieval backend introduced
-in :ref:`ADR-049 <adr-049>`.
+.. note::
+
+   A bug fix refining the Solr retrieval backend introduced in
+   :ref:`ADR-049 <adr-049>`.
 
 .. _adr-067-context:
 

--- a/Documentation/Adr/Adr075RerankerProtocol.rst
+++ b/Documentation/Adr/Adr075RerankerProtocol.rst
@@ -8,6 +8,7 @@ ADR-075: Neutral cross-encoder reranker protocol
 
 :Status: Accepted
 :Date: 2026-07-17
+:Amends: :ref:`ADR-050 <adr-050>` (cross-encoder reranking placement)
 :Authors: Netresearch DTT GmbH
 
 .. _adr-075-context:

--- a/Documentation/Adr/Adr083ConversationSessions.rst
+++ b/Documentation/Adr/Adr083ConversationSessions.rst
@@ -7,6 +7,7 @@ ADR-083: Conversation sessions and memory
 ============================================================================
 
 :Status: Accepted (ownership and configuration binding superseded by :ref:`ADR-091 <adr-091>`)
+:Amended: 2026-07-20 by :ref:`ADR-091 <adr-091>`
 :Date: 2026-07-18
 :Authors: Netresearch DTT GmbH
 

--- a/Documentation/Adr/Adr084HumanInTheLoopApproval.rst
+++ b/Documentation/Adr/Adr084HumanInTheLoopApproval.rst
@@ -6,9 +6,19 @@
 ADR-084: Human-in-the-loop tool approval with suspend and resume
 ============================================================================
 
-:Status: Accepted
+:Status: Accepted (the trigger is widened by :ref:`ADR-134 <adr-134>`)
 :Date: 2026-07-18
+:Amended: 2026-08-09 by :ref:`ADR-134 <adr-134>`
 :Authors: Netresearch DTT GmbH
+
+.. note::
+
+   The suspend-and-resume mechanism below is what ships. What changed is when
+   it fires: the `RequiresApprovalInterface` marker is no longer the only
+   trigger — a builtin's declared write effect implies approval as well
+   (:ref:`ADR-134 <adr-134>`). The "41 shipped tools, which are read-only"
+   this record reasons from is a 2026-07 count; two builtins write since
+   :ref:`ADR-135 <adr-135>`, and both pause here.
 
 .. _adr-084-context:
 

--- a/Documentation/Adr/Adr091ConversationActorContext.rst
+++ b/Documentation/Adr/Adr091ConversationActorContext.rst
@@ -8,6 +8,7 @@ ADR-091: Sessions are owned — an explicit actor context on every turn
 
 :Status: Accepted
 :Date: 2026-07-20
+:Supersedes: the ownership and configuration binding of :ref:`ADR-083 <adr-083>`
 :Authors: Netresearch DTT GmbH
 
 .. _adr-091-context:

--- a/Documentation/Adr/Adr105TypedInputSuspension.rst
+++ b/Documentation/Adr/Adr105TypedInputSuspension.rst
@@ -7,6 +7,7 @@ ADR-105: Typed user-input suspension (WAITING_FOR_INPUT)
 ============================================================================
 
 :Status: Accepted (the approval+input registration ban is widened by :ref:`adr-134`)
+:Amended: 2026-08-09 by :ref:`ADR-134 <adr-134>`
 :Date: 2026-07-22
 :Authors: Netresearch DTT GmbH
 

--- a/Documentation/Adr/Adr109AgentRunsApprovalsInbox.rst
+++ b/Documentation/Adr/Adr109AgentRunsApprovalsInbox.rst
@@ -7,6 +7,7 @@ ADR-109: Agent Runs approvals inbox (backend module)
 ============================================================================
 
 :Status: Accepted (stale-review binding superseded by :ref:`ADR-132 <adr-132>`)
+:Amended: 2026-08-09 by :ref:`ADR-132 <adr-132>`
 :Date: 2026-07-22
 :Authors: Netresearch DTT GmbH
 

--- a/Documentation/Adr/Adr122ToolEffectContractDeferred.rst
+++ b/Documentation/Adr/Adr122ToolEffectContractDeferred.rst
@@ -6,9 +6,23 @@
 ADR-122: The side-effecting tool contract waits for a side-effecting tool
 ============================================================================
 
-:Status: Accepted
+:Status: Accepted (premise expired — see :ref:`ADR-135 <adr-135>` and :ref:`ADR-136 <adr-136>`)
 :Date: 2026-07-29
+:Amended: 2026-08-09 by :ref:`ADR-135 <adr-135>` and :ref:`ADR-136 <adr-136>`
 :Authors: Netresearch DTT GmbH
+
+.. note::
+
+   Two of the three facts this ADR reasons from have expired.
+
+   "All 44 builtin tools read" was true on 2026-07-29 and is not true now:
+   :ref:`ADR-135 <adr-135>` shipped ``update_page_metadata`` and a second
+   writer followed. "The preview has no caller and no display" was answered by
+   :ref:`ADR-136 <adr-136>`, which produces it at suspend time.
+
+   The decision still holds — no framework arrived with the first writer, and
+   the idempotency scope still has no reader. Read this record for why the
+   contract was not built ahead of a writing tool, not for what ships today.
 
 .. _adr-122-context:
 

--- a/Documentation/Adr/Adr132ApprovalAuditAndTurnBinding.rst
+++ b/Documentation/Adr/Adr132ApprovalAuditAndTurnBinding.rst
@@ -6,6 +6,7 @@ ADR-132: Fail-closed approval audit and turn binding
 
 :Status: Accepted
 :Date: 2026-08-09
+:Supersedes: the stale-review binding of :ref:`ADR-109 <adr-109>`
 
 Context
 =======

--- a/Documentation/Adr/Adr134WriteEffectImpliesApproval.rst
+++ b/Documentation/Adr/Adr134WriteEffectImpliesApproval.rst
@@ -8,6 +8,7 @@ ADR-134: A builtin's declared write effect implies human approval
 
 :Status: Accepted
 :Date: 2026-08-09
+:Amends: :ref:`ADR-084 <adr-084>` and :ref:`ADR-105 <adr-105>`
 :Authors: Netresearch DTT GmbH
 
 .. _adr-134-context:

--- a/Documentation/Adr/Adr135UpdatePageMetadataTool.rst
+++ b/Documentation/Adr/Adr135UpdatePageMetadataTool.rst
@@ -8,6 +8,7 @@ ADR-135: The first writing tool, and the contract it actually needed
 
 :Status: Accepted
 :Date: 2026-08-09
+:Amends: :ref:`ADR-122 <adr-122>` (its premise, not its reasoning)
 :Authors: Netresearch DTT GmbH
 
 .. _adr-135-context:

--- a/Documentation/Adr/Adr136WritePreviewAtSuspend.rst
+++ b/Documentation/Adr/Adr136WritePreviewAtSuspend.rst
@@ -8,6 +8,7 @@ ADR-136: The write preview is produced when the run suspends
 
 :Status: Accepted
 :Date: 2026-08-09
+:Amends: :ref:`ADR-122 <adr-122>` (the deferred preview)
 :Authors: Netresearch DTT GmbH
 
 .. _adr-136-context:

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -10,6 +10,47 @@ Architecture Decision Records
 This section documents significant architectural decisions made during the
 development of the TYPO3 LLM Extension.
 
+.. _adr-lifecycle:
+
+Record lifecycle
+================
+
+An ADR is a record of a decision at a point in time. It is expected to become
+historically wrong; what it must never do is *look* current when it is not. The
+``:Status:`` field is how a reader tells the difference.
+
+``Accepted``
+   Current. The decision and the facts it reasons from still hold.
+
+``Accepted`` with an ``:Amended:`` field
+   Still current as a whole, but a later ADR overturned, widened or expired
+   part of it. The status line names which part in parentheses; the
+   ``:Amended:`` field names the date and the amending record.
+
+``Superseded`` with a ``:Superseded:`` field
+   No longer current. The field names the date and the replacing record.
+
+``Deprecated``
+   What it decided is being removed, with no successor decision.
+
+The link is written from both ends. The newer record declares ``:Amends:`` or
+``:Supersedes:``; the older one declares ``:Amended:`` or ``:Superseded:`` with
+the date. ``Tests/Unit/AdrLifecycleTest.php`` fails when only one end is
+written.
+
+Two rules follow from that:
+
+**An amended record keeps its reasoning.** :ref:`ADR-122 <adr-122>` declined to
+build a side-effecting tool contract because no tool wrote. That premise expired
+with :ref:`ADR-135 <adr-135>`, but the reasoning — do not design a contract
+ahead of its first consumer — is why the writer shipped without a framework. The
+record stays; the status says the premise is gone.
+
+**Amending is the amender's job.** An ADR that overturns part of an earlier one
+edits that earlier record's ``:Status:`` and ``:Amended:`` in the same change.
+An accepted ADR with an expired premise and a clean ``Accepted`` status is a
+defect, not history.
+
 .. _adr-symbol-legend:
 
 Symbol legend

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -44,7 +44,7 @@ and has no counterpart. A field whose body references no ADR is outside the
 pairing check by construction — which is also why prose there must stay
 specific enough to follow.
 
-Two rules follow from that:
+Two rules follow from the pairing:
 
 **An amended record keeps its reasoning.** :ref:`ADR-122 <adr-122>` declined to
 build a side-effecting tool contract because no tool wrote. That premise expired

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -35,8 +35,14 @@ historically wrong; what it must never do is *look* current when it is not. The
 
 The link is written from both ends. The newer record declares ``:Amends:`` or
 ``:Supersedes:``; the older one declares ``:Amended:`` or ``:Superseded:`` with
-the date. ``Tests/Unit/AdrLifecycleTest.php`` fails when only one end is
-written.
+the date. ``Tests/Unit/AdrLifecycleTest.php`` fails when only one end of an
+**ADR-to-ADR** link is written.
+
+Not every successor is an ADR. :ref:`ADR-012 <adr-012>` was superseded by the
+nr-vault integration, which no record decided, so its field names that in prose
+and has no counterpart. A field whose body references no ADR is outside the
+pairing check by construction — which is also why prose there must stay
+specific enough to follow.
 
 Two rules follow from that:
 

--- a/README.md
+++ b/README.md
@@ -266,10 +266,9 @@ internal contracts between these subsystems still change often, and splitting
 now would freeze them into public cross-extension APIs prematurely and add
 coordinated multi-repo release friction. We keep the architecture *split-ready*
 instead — the phpat architecture tests enforce the vertical layering (Controller
-→ Service → Provider), and the horizontal module seams are kept clean by review
-(with phpat rules for those seams a planned split-readiness step) — and will
-revisit a split **with or before the 1.0 release**, once the seams have
-stabilized.
+→ Service → Provider) and `Tests/Architecture/ModuleSeamTest.php` enforces the
+horizontal module seams — and will revisit a split **with or before the 1.0
+release**, once the seams have stabilized.
 
 The anticipated seams, if/when we split:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,8 +4,10 @@ What is not built yet, ordered by priority. Nothing shipped appears here:
 released work is in [CHANGELOG.md](CHANGELOG.md) and the decisions behind it in
 `Documentation/Adr/`. No dates — items land when they meet the quality gate.
 
-Every item below is an open GitHub issue. If a line here has no issue, it is
-not roadmap, it is a wish.
+Every item in the two sections below is an open GitHub issue. If a line there
+has no issue, it is not roadmap, it is a wish. The last two sections are not
+roadmap: one points at a decision recorded elsewhere, the other lists what this
+project does not do.
 
 ## Known gaps
 
@@ -41,10 +43,12 @@ label.
 ## Decisions that live elsewhere
 
 - **Package split.** [ADR-090](Documentation/Adr/Adr090SingleExtensionUntil10.rst)
-  is the single source: one extension until 1.0, split re-evaluated **with or
-  before** the 1.0 release, against the criteria listed there. Do not restate
-  the timing anywhere else — a roadmap and an ADR that disagreed about it is
-  what this line replaces.
+  decides it: one extension until 1.0, split re-evaluated **with or before**
+  the 1.0 release, against the criteria listed there. The README repeats the
+  timing where it explains the anticipated seams, and must keep matching
+  ADR-090. Nothing else states it — a roadmap and an ADR that disagreed, with
+  the roadmap citing the ADR for the opposite of its decision, is what this
+  line replaces.
 
 ## Non-goals
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,75 +1,66 @@
 # Roadmap
 
-The direction of nr_llm, ordered by priority. This is a living document: items
-can move, grow, or be dropped as reality feeds back. Architectural decisions
-behind each item live in `Documentation/Adr/`; anything already shipped is in
-[CHANGELOG.md](CHANGELOG.md), not here. No dates — items land when they meet
-the quality gate, not when a calendar says so.
+What is not built yet, ordered by priority. Nothing shipped appears here:
+released work is in [CHANGELOG.md](CHANGELOG.md) and the decisions behind it in
+`Documentation/Adr/`. No dates — items land when they meet the quality gate.
 
-## Where we are
+Every item below is an open GitHub issue. If a line here has no issue, it is
+not roadmap, it is a wish.
 
-The security-hardening arc is shipped: explicit actor context and fail-closed
-authorization through the whole agent runtime, at-least-once queue delivery
-with a declared tool-effect classification and a fail-closed write audit, tool
-data-class enforcement on by default, agent state encrypted at rest, and an
-operations dashboard with a queryable governance audit trail. The MCP
-client is shipped too: operator-configured servers are imported into the one
-tool registry, and origin does not change how a tool is authorised, approved
-or audited — one registry, one gate, one agent loop (ADR-116).
+## Known gaps
 
-## Next — agent runtime maturity
+Decisions that were deliberately not built. An accepted ADR that declines to
+build something closes the decision, not the gap — these stay open until code
+closes them, and carry the [`deferred`](https://github.com/netresearch/t3x-nr-llm/issues?q=is%3Aissue+is%3Aopen+label%3Adeferred)
+label.
 
-1. **A first-class contract for side-effecting tools — when one exists.**
-   The effect classification, the write fence and the fail-closed audit are in
-   place, but all 41 builtin tools read; nothing exercises the write path. The
-   proposed interface, idempotency scope and preview each had no reader and no
-   display, so they are deferred rather than guessed at (ADR-122). The
-   machinery and a coverage test that forces a new writer to declare itself are
-   waiting; the shape of the contract is a question the first writing tool
-   answers.
+- **[#688](https://github.com/netresearch/t3x-nr-llm/issues/688) — generic paths bind no context window.**
+  `LlmServiceManager`'s chat, completion and streaming paths inject skills and
+  send; only `ConversationService` and `ToolLoopService` bind a window. A long
+  transcript through the generic API is bounded by the provider, not by us
+  (ADR-139).
+- **[#689](https://github.com/netresearch/t3x-nr-llm/issues/689) — injected context has no trust-zone ceiling.**
+  Tool output is data-classified; skills, snippets, system prompt and task
+  input are not. They pass the mandatory input guardrail, so this is a missing
+  *classification*, not a missing check (ADR-139, ADR-094).
+- **[#690](https://github.com/netresearch/t3x-nr-llm/issues/690) — input-resume authorises the submitter against nothing.**
+  Unreachable today because no tool implements `RequiresInputInterface`, and
+  pinned by a coverage test that fails when one does. The gate and the turn
+  digest are the open half (ADR-105, ADR-132).
 
 ## Toward 1.0
 
-- **Role model and editor actions.** Shipped as a grant-set: explicit
-  per-group capability grants on `AiActorContext` (ADR-130) and the
-  editor-facing AI Tasks module that makes them observable (ADR-131) —
-  run prepared tasks, decide approvals, budget-bounded per user.
-  Remaining: a management grant once a management surface exists, and a
-  purpose-built editor action API rather than generic record CRUD.
-- **Complete structured outputs.** Shipped end to end: a named, fail-closed
-  strict subset (enum, pattern, `oneOf`, bounds, combinators — ADR-126) with
-  `$ref` resolution deliberately out; provider-native enforcement on all
-  seven adapters behind a conservative compatibility profile (ADR-128); and
-  the in-repo consumers — wizard, JSON tasks, judge grader — on the
-  pipeline (ADR-129).
-- **A public, versioned API surface.** Shipped: the surface is marked
-  (`@api` / extension points / `@internal`, ADR-127), the promise is
-  documented in `Documentation/Api/Stability.rst`, and the rendered
-  signatures are frozen in a snapshot test that also asserts the closure
-  rule.
-- **Enforced horizontal boundaries.** Shipped: `ModuleSeamTest` asserts that
-  specialized services and the tool/agent module do not depend on each other,
-  that guardrails depend on neither, that nothing outside the backend package
-  depends on it, and that core does not depend on the tool module — six named
-  classes excepted as that module's own surface in shared directories, each
-  recorded with the package it moves to in a split.
-- **Re-evaluate a package split only after 1.0.** The seams from the runtime
-  decomposition are the prerequisite; until they are stable, one package
-  (ADR-090) stays the right call.
+- **[#691](https://github.com/netresearch/t3x-nr-llm/issues/691) — a management grant, once a management surface exists.**
+  `BackendUserGrant` holds two cases, each with an enforcement point. A third
+  without a surface would be the checkbox ADR-117 had to remove (ADR-130).
+- **[#692](https://github.com/netresearch/t3x-nr-llm/issues/692) — a purpose-built editor action API.**
+  Not generic record CRUD: a `update_record(table, uid, fields)` tool has the
+  whole TCA as its blast radius, and its arguments are model-chosen (ADR-135).
+  The open question is what an editor action is as a unit.
+
+## Decisions that live elsewhere
+
+- **Package split.** [ADR-090](Documentation/Adr/Adr090SingleExtensionUntil10.rst)
+  is the single source: one extension until 1.0, split re-evaluated **with or
+  before** the 1.0 release, against the criteria listed there. Do not restate
+  the timing anywhere else — a roadmap and an ADR that disagreed about it is
+  what this line replaces.
 
 ## Non-goals
 
 Things nr_llm deliberately does not do, so the scope stays sharp:
 
-- **No general-purpose MCP server.** The direction matters: nr_llm *consumes*
-  MCP servers as a client and aggregates their tools (shipped — see "Where we
-  are" and ADR-116), but it
-  does not *expose* TYPO3 as an MCP server to third-party clients. That is a
-  different product with a different security model.
+- **No general-purpose MCP server.** nr_llm *consumes* MCP servers as a client
+  and aggregates their tools (ADR-116); it does not *expose* TYPO3 as an MCP
+  server to third-party clients. That is a different product with a different
+  security model.
 - **No backend coding agent.** The agent runtime automates editorial and
   operational work against declared tools — it does not write or deploy code.
-- **No further generic read-everything tools.** Tools stay purpose-built and
-  data-classified; broad generic accessors undermine the data-class gate.
+- **No generic read-everything or write-everything tools.** Tools stay
+  purpose-built and data-classified; a broad generic accessor undermines the
+  data-class gate on the read side and the review-time bound on the write side
+  (ADR-135).
 - **No multi-agent orchestration.** One run, one agent, one auditable
   transcript. Composition happens above nr_llm, not inside it.
-- **No package split before 1.0** (ADR-090).
+- **No `$ref` in the strict schema subset.** Deliberately outside the
+  supported subset, not a missing feature (ADR-126).

--- a/Tests/Unit/AdrLifecycleTest.php
+++ b/Tests/Unit/AdrLifecycleTest.php
@@ -18,8 +18,12 @@ use PHPUnit\Framework\Attributes\Test;
  * This checks form, not meaning: no test can tell that ADR-122's "all 44
  * builtin tools read" stopped being true. What it can tell is that a status
  * naming another record carries the matching :Amended: / :Superseded: field,
- * that the field points at a record that exists, and that nobody invents a
- * fifth status word.
+ * that every cross-reference resolves, and that nobody invents a status word
+ * outside the documented three.
+ *
+ * The pairing check covers ADR-to-ADR links only. A record superseded by
+ * something that is not an ADR — ADR-012, replaced by the nr-vault integration
+ * — names it in prose and has no counterpart to pair with.
  */
 #[CoversNothing]
 final class AdrLifecycleTest extends AbstractUnitTestCase
@@ -63,18 +67,46 @@ final class AdrLifecycleTest extends AbstractUnitTestCase
     }
 
     /**
-     * The `:Status:` value, joined across its RST continuation lines.
+     * Every value of the named RST field(s), each joined across its
+     * continuation lines.
+     *
+     * A field body wraps onto indented lines (ADR-021's status does), so a
+     * single-line match would drop the tail — and with it any cross-reference
+     * living there. The alternation is the field NAME, so `:php:` roles at
+     * column 0 inside a body cannot terminate or start a match.
+     *
+     * @return list<string>
      */
-    private function statusOf(string $file): string
+    private function fieldValues(string $contents, string $names): array
     {
-        $contents = (string)file_get_contents($file);
-        self::assertSame(
-            1,
-            preg_match('/^:Status:[ \t]*(.+?)(?=^:[A-Za-z-]+:)/ms', $contents, $matches),
-            basename($file) . ' must declare a :Status: field.',
+        preg_match_all(
+            '/^:(?:' . $names . '):[ \t]*(.*(?:\n[ \t]+\S.*)*)$/m',
+            $contents,
+            $matches,
         );
 
-        return trim((string)preg_replace('/\s+/', ' ', $matches[1]));
+        return array_map(
+            static fn(string $value): string => trim((string)preg_replace('/\s+/', ' ', $value)),
+            $matches[1],
+        );
+    }
+
+    private function statusOf(string $file): string
+    {
+        $values = $this->fieldValues((string)file_get_contents($file), 'Status');
+        self::assertCount(1, $values, basename($file) . ' must declare exactly one :Status: field.');
+
+        return $values[0];
+    }
+
+    /**
+     * @return list<string> the `adr-NNN` labels a field body cross-references
+     */
+    private function referencedLabels(string $value): array
+    {
+        preg_match_all('/:ref:`[^`]*?<?(adr-\d{3})>?`/', $value, $matches);
+
+        return $matches[1];
     }
 
     #[Test]
@@ -101,7 +133,7 @@ final class AdrLifecycleTest extends AbstractUnitTestCase
 
             // Section labels such as `adr-021-scope` are self-references, not
             // cross-record ones, and carry no lifecycle claim.
-            if (preg_match('/:ref:`[^`]*<?(adr-\d{3})>?`/', $status) !== 1) {
+            if ($this->referencedLabels($status) === []) {
                 continue;
             }
 
@@ -121,19 +153,22 @@ final class AdrLifecycleTest extends AbstractUnitTestCase
         $known = $this->knownAdrLabels();
 
         foreach ($this->adrFiles() as $file) {
-            preg_match_all(
-                '/^:(?:Amended|Superseded|Amends|Supersedes):[ \t]*(.+)$/m',
-                (string)file_get_contents($file),
-                $fields,
+            $contents = (string)file_get_contents($file);
+
+            // The status line names records too — `Accepted (… amended by
+            // :ref:`ADR-135 <adr-135>`)` — and a typo there renders as an
+            // unresolved reference just the same.
+            $values = array_merge(
+                $this->fieldValues($contents, 'Amended|Superseded|Amends|Supersedes'),
+                $this->fieldValues($contents, 'Status'),
             );
 
-            foreach ($fields[1] as $value) {
-                preg_match_all('/:ref:`[^`]*?<?(adr-\d{3})>?`/', $value, $refs);
-                foreach ($refs[1] as $label) {
+            foreach ($values as $value) {
+                foreach ($this->referencedLabels($value) as $label) {
                     self::assertContains(
                         $label,
                         $known,
-                        basename($file) . ' points its lifecycle field at ' . $label . ', which no record defines.',
+                        basename($file) . ' references ' . $label . ', which no record defines.',
                     );
                 }
             }
@@ -143,16 +178,13 @@ final class AdrLifecycleTest extends AbstractUnitTestCase
     /**
      * @return array<string, list<string>> file basename => ADR labels it names
      */
-    private function lifecycleLinks(string $pattern): array
+    private function lifecycleLinks(string $names): array
     {
         $links = [];
         foreach ($this->adrFiles() as $file) {
-            preg_match_all($pattern, (string)file_get_contents($file), $fields);
-
             $targets = [];
-            foreach ($fields[1] as $value) {
-                preg_match_all('/:ref:`[^`]*?<?(adr-\d{3})>?`/', $value, $refs);
-                foreach ($refs[1] as $label) {
+            foreach ($this->fieldValues((string)file_get_contents($file), $names) as $value) {
+                foreach ($this->referencedLabels($value) as $label) {
                     $targets[] = $label;
                 }
             }
@@ -181,8 +213,8 @@ final class AdrLifecycleTest extends AbstractUnitTestCase
         // "Amending is the amender's job" — the forward field on the newer
         // record and the backward field on the older one are written together
         // or the pair is incomplete.
-        $forward  = $this->lifecycleLinks('/^:(?:Amends|Supersedes):[ \t]*(.+)$/m');
-        $backward = $this->lifecycleLinks('/^:(?:Amended|Superseded):[ \t]*(.+)$/m');
+        $forward  = $this->lifecycleLinks('Amends|Supersedes');
+        $backward = $this->lifecycleLinks('Amended|Superseded');
 
         foreach ($forward as $file => $targets) {
             foreach ($targets as $target) {

--- a/Tests/Unit/AdrLifecycleTest.php
+++ b/Tests/Unit/AdrLifecycleTest.php
@@ -72,8 +72,8 @@ final class AdrLifecycleTest extends AbstractUnitTestCase
      *
      * A field body wraps onto indented lines (ADR-021's status does), so a
      * single-line match would drop the tail — and with it any cross-reference
-     * living there. The alternation is the field NAME, so `:php:` roles at
-     * column 0 inside a body cannot terminate or start a match.
+     * living there. A continuation line must be INDENTED, so a `:php:` role at
+     * column 0 in a body can neither extend a field nor start one.
      *
      * @return list<string>
      */
@@ -172,6 +172,23 @@ final class AdrLifecycleTest extends AbstractUnitTestCase
                     );
                 }
             }
+        }
+    }
+
+    #[Test]
+    public function theIndexResolvesEveryRecordItNames(): void
+    {
+        // `adrFiles()` globs Adr*.rst, so the page that documents the reference
+        // discipline is the one page the reference check would otherwise skip.
+        $known = $this->knownAdrLabels();
+        $index = (string)file_get_contents($this->adrDir() . '/Index.rst');
+
+        foreach ($this->referencedLabels($index) as $label) {
+            self::assertContains(
+                $label,
+                $known,
+                'Documentation/Adr/Index.rst references ' . $label . ', which no record defines.',
+            );
         }
     }
 

--- a/Tests/Unit/AdrLifecycleTest.php
+++ b/Tests/Unit/AdrLifecycleTest.php
@@ -1,0 +1,238 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Enforces the ADR record lifecycle documented in Documentation/Adr/Index.rst.
+ *
+ * This checks form, not meaning: no test can tell that ADR-122's "all 44
+ * builtin tools read" stopped being true. What it can tell is that a status
+ * naming another record carries the matching :Amended: / :Superseded: field,
+ * that the field points at a record that exists, and that nobody invents a
+ * fifth status word.
+ */
+#[CoversNothing]
+final class AdrLifecycleTest extends AbstractUnitTestCase
+{
+    private const ALLOWED_STATUSES = ['Accepted', 'Superseded', 'Deprecated'];
+
+    private function adrDir(): string
+    {
+        return dirname(__DIR__, 2) . '/Documentation/Adr';
+    }
+
+    /**
+     * @return list<string> absolute paths, Index.rst excluded
+     */
+    private function adrFiles(): array
+    {
+        $files = glob($this->adrDir() . '/Adr*.rst');
+        self::assertIsArray($files);
+        self::assertNotSame([], $files);
+
+        return $files;
+    }
+
+    /**
+     * The `.. _adr-NNN:` labels every record defines, so a cross-reference can
+     * be resolved without rendering the docs.
+     *
+     * @return list<string>
+     */
+    private function knownAdrLabels(): array
+    {
+        $labels = [];
+        foreach ($this->adrFiles() as $file) {
+            preg_match_all('/^\.\. _(adr-\d{3}):$/m', (string)file_get_contents($file), $matches);
+            foreach ($matches[1] as $label) {
+                $labels[] = $label;
+            }
+        }
+
+        return $labels;
+    }
+
+    /**
+     * The `:Status:` value, joined across its RST continuation lines.
+     */
+    private function statusOf(string $file): string
+    {
+        $contents = (string)file_get_contents($file);
+        self::assertSame(
+            1,
+            preg_match('/^:Status:[ \t]*(.+?)(?=^:[A-Za-z-]+:)/ms', $contents, $matches),
+            basename($file) . ' must declare a :Status: field.',
+        );
+
+        return trim((string)preg_replace('/\s+/', ' ', $matches[1]));
+    }
+
+    #[Test]
+    public function everyRecordUsesAKnownStatusWord(): void
+    {
+        foreach ($this->adrFiles() as $file) {
+            $status = $this->statusOf($file);
+            $word   = explode(' ', $status)[0];
+
+            self::assertContains(
+                $word,
+                self::ALLOWED_STATUSES,
+                basename($file) . ' has status "' . $status . '". The vocabulary is '
+                . implode(' / ', self::ALLOWED_STATUSES) . ' — see Documentation/Adr/Index.rst.',
+            );
+        }
+    }
+
+    #[Test]
+    public function aStatusNamingAnotherRecordCarriesTheLifecycleField(): void
+    {
+        foreach ($this->adrFiles() as $file) {
+            $status = $this->statusOf($file);
+
+            // Section labels such as `adr-021-scope` are self-references, not
+            // cross-record ones, and carry no lifecycle claim.
+            if (preg_match('/:ref:`[^`]*<?(adr-\d{3})>?`/', $status) !== 1) {
+                continue;
+            }
+
+            $contents = (string)file_get_contents($file);
+            self::assertSame(
+                1,
+                preg_match('/^:(?:Amended|Superseded):[ \t]*\S/m', $contents),
+                basename($file) . ' says another record overtook part of it but carries no '
+                . ':Amended: / :Superseded: field. The amending ADR owns that edit.',
+            );
+        }
+    }
+
+    #[Test]
+    public function everyLifecycleFieldPointsAtARecordThatExists(): void
+    {
+        $known = $this->knownAdrLabels();
+
+        foreach ($this->adrFiles() as $file) {
+            preg_match_all(
+                '/^:(?:Amended|Superseded|Amends|Supersedes):[ \t]*(.+)$/m',
+                (string)file_get_contents($file),
+                $fields,
+            );
+
+            foreach ($fields[1] as $value) {
+                preg_match_all('/:ref:`[^`]*?<?(adr-\d{3})>?`/', $value, $refs);
+                foreach ($refs[1] as $label) {
+                    self::assertContains(
+                        $label,
+                        $known,
+                        basename($file) . ' points its lifecycle field at ' . $label . ', which no record defines.',
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * @return array<string, list<string>> file basename => ADR labels it names
+     */
+    private function lifecycleLinks(string $pattern): array
+    {
+        $links = [];
+        foreach ($this->adrFiles() as $file) {
+            preg_match_all($pattern, (string)file_get_contents($file), $fields);
+
+            $targets = [];
+            foreach ($fields[1] as $value) {
+                preg_match_all('/:ref:`[^`]*?<?(adr-\d{3})>?`/', $value, $refs);
+                foreach ($refs[1] as $label) {
+                    $targets[] = $label;
+                }
+            }
+
+            if ($targets !== []) {
+                $links[basename($file)] = $targets;
+            }
+        }
+
+        return $links;
+    }
+
+    /**
+     * The label an ADR file defines, e.g. `adr-122`.
+     */
+    private function ownLabel(string $basename): string
+    {
+        self::assertSame(1, preg_match('/^Adr(\d{3})/', $basename, $matches));
+
+        return 'adr-' . $matches[1];
+    }
+
+    #[Test]
+    public function amendingAndAmendedRecordsPointAtEachOther(): void
+    {
+        // "Amending is the amender's job" — the forward field on the newer
+        // record and the backward field on the older one are written together
+        // or the pair is incomplete.
+        $forward  = $this->lifecycleLinks('/^:(?:Amends|Supersedes):[ \t]*(.+)$/m');
+        $backward = $this->lifecycleLinks('/^:(?:Amended|Superseded):[ \t]*(.+)$/m');
+
+        foreach ($forward as $file => $targets) {
+            foreach ($targets as $target) {
+                $targetFile = $this->fileDefining($target);
+                self::assertContains(
+                    $this->ownLabel($file),
+                    $backward[$targetFile] ?? [],
+                    $file . ' declares it amends/supersedes ' . $target . ', but ' . $targetFile
+                    . ' does not say so. Edit both in the same change.',
+                );
+            }
+        }
+
+        foreach ($backward as $file => $targets) {
+            foreach ($targets as $target) {
+                $targetFile = $this->fileDefining($target);
+                self::assertContains(
+                    $this->ownLabel($file),
+                    $forward[$targetFile] ?? [],
+                    $file . ' says ' . $target . ' overtook part of it, but ' . $targetFile
+                    . ' does not claim it. Edit both in the same change.',
+                );
+            }
+        }
+    }
+
+    private function fileDefining(string $label): string
+    {
+        foreach ($this->adrFiles() as $file) {
+            if (preg_match('/^\.\. _' . preg_quote($label, '/') . ':$/m', (string)file_get_contents($file)) === 1) {
+                return basename($file);
+            }
+        }
+
+        self::fail('No ADR defines the label ' . $label . '.');
+    }
+
+    #[Test]
+    public function aSupersededRecordSaysWhatReplacedIt(): void
+    {
+        foreach ($this->adrFiles() as $file) {
+            if (!str_starts_with($this->statusOf($file), 'Superseded')) {
+                continue;
+            }
+
+            self::assertSame(
+                1,
+                preg_match('/^:Superseded:[ \t]*\S/m', (string)file_get_contents($file)),
+                basename($file) . ' is Superseded but does not say by what.',
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Why

The code for 0.27.0 holds up. The documents around it do not: the roadmap's top "Next" item describes work that shipped, ADR-122 sits at plain `Accepted` while asserting a premise that expired, and two documents disagree about when the package split happens — one of them citing the other for the opposite of what it decided.

## What changed

**ROADMAP.md** lists unbuilt work only, and every item in the two roadmap sections links an open issue.

The removed "Next" item said: *"all 41 builtin tools read; nothing exercises the write path […] the shape of the contract is a question the first writing tool answers."* That tool is `update_page_metadata` (ADR-135), and a second writer followed. Everything else in the file was marked "Shipped:" — changelog entries wearing a roadmap's clothes.

New issues, all labelled `deferred`:

| Issue | Gap | Source |
|---|---|---|
| #688 | generic `LlmServiceManager` paths bind no context window | ADR-139 |
| #689 | injected context has no trust-zone ceiling | ADR-139, ADR-094 |
| #690 | input-resume authorises the submitter against nothing | ADR-105, #649 |
| #691 | management grant needs a management surface | ADR-130 |
| #692 | purpose-built editor action API | ADR-131, ADR-135 |

#688–#690 come out of issues that were closed as **completed** while their own text listed the work as deferred. Deciding not to build something closes the decision, not the gap. #636 and #649 now carry comments pointing at their open successors.

**Package split.** ROADMAP said "only after 1.0" and cited ADR-090; ADR-090 and the README both say "with or before 1.0". ADR-090 is the deciding record. The README repeats the timing where it explains the anticipated seams and must keep matching it — an earlier draft of this PR wrote "do not restate the timing anywhere else" while editing the very sentence that restates it, which was a rule the PR broke on arrival.

**ADR lifecycle.** `Documentation/Adr/Index.rst` documents the status vocabulary (`Accepted` / `Accepted` + `:Amended:` / `Superseded` / `Deprecated`) and the paired forward and backward fields. Applied to the records whose premises expired:

- ADR-122 — "all 44 builtin tools read" and "the preview has no display" were answered by ADR-135 and ADR-136. Decision stands, premise noted as gone. The third fact, "the idempotency scope has no reader", still holds.
- ADR-084 — the `RequiresApprovalInterface` marker is no longer the only approval trigger (ADR-134).
- ADR-049 — the Solr language filter is corrected by ADR-067.

Twelve early records kept their status in a prose section rather than a field; converting them surfaced two supersessions (ADR-004 → ADR-026, ADR-006 → ADR-011) that existed only as prose.

**The pairing rule has one documented exception.** Review caught the document claiming more than the test delivers: `Adr012ApiKeyEncryption.rst` is `Superseded` by the nr-vault integration, which no ADR decided, so its field names that in prose and has no counterpart — one end written, suite green. Index.rst and the test docblock now scope the check to ADR-to-ADR links and name ADR-012 as the case that falls outside it.

## Test

`Tests/Unit/AdrLifecycleTest.php` — unknown status words, a status naming another record without the matching lifecycle field, a reference to a record that does not exist (in the lifecycle fields **and** in the status line), and one-sided amend/supersede pairs all fail the build. Field values are joined across RST continuation lines: ADR-021's status wraps today and ADR-122's `:Amended:` is 92 characters, so a single-line match would drop the tail and any cross-reference in it.

Verified against the real defect — removing ADR-122's field again produces:

```
Adr135UpdatePageMetadataTool.rst declares it amends/supersedes adr-122,
but Adr122ToolEffectContractDeferred.rst does not say so.
```

It checks form, not meaning. No test can tell that a premise expired — hence the documented rule that amending is the amender's job, and the pointer to it from `Documentation/AGENTS.md`.

## Gates

unit, phpstan, cgl, `rector -n` (8.2), fuzzy, and a local docs render (202 documents, no warning from any changed file).