### PR TITLE
fix(dashboard): use a registered icon for the monthly cost widget

### DIFF
--- a/Configuration/Services.Dashboard.php
+++ b/Configuration/Services.Dashboard.php
@@ -47,7 +47,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set('dashboard.widget.nrllm.monthly_cost', NumberWithIconWidget::class)
         ->arg('$dataProvider', service(MonthlyCostDataProvider::class))
         ->arg('$options', [
-            'icon'     => 'actions-currency',
+            // 'actions-currency' does not exist in the TYPO3 icon set — there is no
+            // money-themed icon in it at all — so the registry fell back to its
+            // missing-icon placeholder and the card rendered a red torn sheet.
+            'icon'     => 'content-widget-number',
             'title'    => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.monthly_cost.title',
             'subtitle' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.monthly_cost.subtitle',
         ])
@@ -56,7 +59,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             'groupNames'     => 'general',
             'title'          => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.monthly_cost.title',
             'description'    => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.monthly_cost.description',
-            'iconIdentifier' => 'actions-currency',
+            'iconIdentifier' => 'content-widget-number',
             'height'         => 'small',
             'width'          => 'small',
         ]);

--- a/Tests/Functional/DependencyInjection/DashboardWidgetRegistrationTest.php
+++ b/Tests/Functional/DependencyInjection/DashboardWidgetRegistrationTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Functional\DependencyInjection;
 
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Imaging\IconRegistry;
 use TYPO3\CMS\Dashboard\WidgetRegistry;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
@@ -93,5 +94,41 @@ final class DashboardWidgetRegistrationTest extends FunctionalTestCase
         self::assertArrayHasKey('nrllm-governance-blocks', $widgets);
         self::assertArrayHasKey('nrllm-tool-denials-by-reason', $widgets);
         self::assertArrayHasKey('nrllm-tool-usage-by-name', $widgets);
+    }
+
+    /**
+     * An unregistered icon identifier is not an error anywhere — the IconRegistry
+     * silently answers with its missing-icon placeholder, so the widget renders a
+     * red torn sheet and only a human looking at the dashboard ever notices.
+     * 'actions-currency' shipped that way on the monthly-cost card; the TYPO3 icon
+     * set carries no money-themed icon at all, so the name could never have
+     * resolved. Assert every icon this extension names, not just that one.
+     */
+    #[Test]
+    public function everyWidgetIconIdentifierIsRegistered(): void
+    {
+        $registry     = $this->get(WidgetRegistry::class);
+        $iconRegistry = $this->get(IconRegistry::class);
+        self::assertInstanceOf(WidgetRegistry::class, $registry);
+        self::assertInstanceOf(IconRegistry::class, $iconRegistry);
+
+        $checked = 0;
+        foreach ($registry->getAllWidgets() as $identifier => $widget) {
+            if (!str_starts_with((string)$identifier, 'nrllm-')) {
+                continue;
+            }
+
+            $icon = $widget->getIconIdentifier();
+            ++$checked;
+
+            self::assertTrue(
+                $iconRegistry->isRegistered($icon),
+                sprintf('Widget "%s" uses unregistered icon "%s".', $identifier, $icon),
+            );
+        }
+
+        // Guards the loop itself: a renamed prefix would otherwise assert nothing
+        // and still pass.
+        self::assertGreaterThan(0, $checked, 'No nrllm-* widget was checked.');
     }
 }


### PR DESCRIPTION
The "AI Cost this month" card on the dashboard renders TYPO3's missing-icon placeholder — the red torn sheet — instead of an icon.

## Cause

The widget names `actions-currency`, and that identifier is not registered. It is not in the core icon set and `Configuration/Icons.php` does not add it either. Checking the set makes it clear the name never could have worked: of its 787 icons, **not one** is a currency, coin, price or money symbol, so this was never a typo away from resolving.

`content-widget-number` is the core icon for exactly this shape of card — the widget is a `NumberWithIconWidget` — and it is registered. The identifier appeared twice, once as the in-card `icon` option and once as the registration's `iconIdentifier`; both are changed.

## Why a test comes with it

An unregistered identifier fails silently. `IconRegistry` answers with its placeholder, nothing throws and nothing is logged, so the only thing that ever detects it is a person looking at the dashboard — which is how this one was found, after shipping.

The new test therefore asserts the whole class rather than this one name: every `nrllm-*` widget's `getIconIdentifier()` must satisfy `IconRegistry::isRegistered()`. It also counts the widgets it inspected and asserts that count is non-zero, so a renamed identifier prefix cannot silently reduce it to a test that passes while asserting nothing.

## Verification

| Run | Result |
|---|---|
| functional (this class), with the fix | 2 tests, 24 assertions, SUCCESS |
| functional, with `actions-currency` put back | FAILURE — `Widget "nrllm-monthly-cost" uses unregistered icon "actions-currency".` |
| `cgl -n` | SUCCESS |
| `phpstan` | SUCCESS |

The failure run is the point: it proves the test detects this defect at this widget, not merely that the suite is green.

Found on the demo instance.