### PR TITLE
fix(backend): tell the admin which setting is wrong, not just that something is

### DIFF
--- a/Classes/Controller/Backend/ModelDiscoveryController.php
+++ b/Classes/Controller/Backend/ModelDiscoveryController.php
@@ -15,7 +15,6 @@ use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Service\SetupWizard\DTO\DetectedProvider;
 use Netresearch\NrLlm\Service\SetupWizard\ModelDiscoveryInterface;
-use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
@@ -41,12 +40,9 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 #[AsController]
 final class ModelDiscoveryController extends ActionController
 {
-    // This controller serialises its JSON by hand rather than through
-    // ErrorResponse, so the redaction that class performs at the response
-    // boundary has to happen here explicitly.
-    use ErrorMessageSanitizerTrait;
     use RequiresBackendAdminTrait;
     use DefensiveLocalizationTrait;
+    use ProviderMisconfigurationTrait;
 
     private const ERROR_NO_PROVIDER_UID = 'No provider UID specified';
 
@@ -131,12 +127,7 @@ final class ModelDiscoveryController extends ActionController
                 'source' => $this->modelDiscovery->wasLastDiscoveryFromFallback() ? 'fallback' : 'live',
             ]);
         } catch (ProviderConfigurationException $e) {
-            // A misconfiguration is our own diagnostic, not a provider response
-            // body: the message names the setting at fault and is what the
-            // administrator on this screen has to act on. ErrorResponse redacts
-            // credential-bearing URL parameters at the boundary.
-            $this->logger->warning('Model fetchAvailableModels: provider is misconfigured', ['exception' => $e]);
-            $error = $this->sanitizeErrorMessage($e->getMessage());
+            $error = $this->describeMisconfiguration($e, $this->logger, 'Model detectLimits');
             $status = 502;
         } catch (ProviderException $e) {
             $this->logger->warning('Model fetchAvailableModels: provider error', ['exception' => $e]);

--- a/Classes/Controller/Backend/ModelDiscoveryController.php
+++ b/Classes/Controller/Backend/ModelDiscoveryController.php
@@ -11,9 +11,11 @@ namespace Netresearch\NrLlm\Controller\Backend;
 
 use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
+use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Service\SetupWizard\DTO\DetectedProvider;
 use Netresearch\NrLlm\Service\SetupWizard\ModelDiscoveryInterface;
+use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
@@ -39,6 +41,10 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 #[AsController]
 final class ModelDiscoveryController extends ActionController
 {
+    // This controller serialises its JSON by hand rather than through
+    // ErrorResponse, so the redaction that class performs at the response
+    // boundary has to happen here explicitly.
+    use ErrorMessageSanitizerTrait;
     use RequiresBackendAdminTrait;
     use DefensiveLocalizationTrait;
 
@@ -124,6 +130,14 @@ final class ModelDiscoveryController extends ActionController
                 'providerName' => $provider->getName(),
                 'source' => $this->modelDiscovery->wasLastDiscoveryFromFallback() ? 'fallback' : 'live',
             ]);
+        } catch (ProviderConfigurationException $e) {
+            // A misconfiguration is our own diagnostic, not a provider response
+            // body: the message names the setting at fault and is what the
+            // administrator on this screen has to act on. ErrorResponse redacts
+            // credential-bearing URL parameters at the boundary.
+            $this->logger->warning('Model fetchAvailableModels: provider is misconfigured', ['exception' => $e]);
+            $error = $this->sanitizeErrorMessage($e->getMessage());
+            $status = 502;
         } catch (ProviderException $e) {
             $this->logger->warning('Model fetchAvailableModels: provider error', ['exception' => $e]);
             $error = 'LLM provider error while fetching model IDs. See system log for details.';
@@ -242,6 +256,14 @@ final class ModelDiscoveryController extends ActionController
                 'costInput' => $foundModel->costInput,
                 'costOutput' => $foundModel->costOutput,
             ]);
+        } catch (ProviderConfigurationException $e) {
+            // A misconfiguration is our own diagnostic, not a provider response
+            // body: the message names the setting at fault and is what the
+            // administrator on this screen has to act on. ErrorResponse redacts
+            // credential-bearing URL parameters at the boundary.
+            $this->logger->warning('Model detectLimits: provider is misconfigured', ['exception' => $e]);
+            $error = $this->sanitizeErrorMessage($e->getMessage());
+            $status = 502;
         } catch (ProviderException $e) {
             $this->logger->warning('Model detectLimits: provider error', ['exception' => $e]);
             $error = 'LLM provider error while detecting model limits. See system log for details.';

--- a/Classes/Controller/Backend/ProviderController.php
+++ b/Classes/Controller/Backend/ProviderController.php
@@ -51,6 +51,7 @@ final class ProviderController extends ActionController
 {
     use RequiresBackendAdminTrait;
     use DefensiveLocalizationTrait;
+    use ProviderMisconfigurationTrait;
 
     private const TABLE_NAME = 'tx_nrllm_provider';
 
@@ -233,16 +234,13 @@ final class ProviderController extends ActionController
                 502,
             );
         } catch (ProviderConfigurationException $e) {
-            // A misconfiguration is our own diagnostic, not a provider response
-            // body: the message names the setting at fault and is what the
-            // administrator on this screen has to act on. ErrorResponse redacts
-            // credential-bearing URL parameters at the boundary.
-            $this->logger->error('Provider testConnection: provider is misconfigured', [
-                'exception'    => $e,
-                'provider_uid' => $uid,
-            ]);
             $response = new JsonResponse(
-                (new ErrorResponse($e->getMessage()))->jsonSerialize(),
+                (new ErrorResponse($this->describeMisconfiguration(
+                    $e,
+                    $this->logger,
+                    'Provider testConnection',
+                    ['provider_uid' => $uid],
+                )))->jsonSerialize(),
                 502,
             );
         } catch (ProviderException $e) {

--- a/Classes/Controller/Backend/ProviderController.php
+++ b/Classes/Controller/Backend/ProviderController.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Controller\Backend\Response\TestConnectionResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\ToggleActiveResponse;
 use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Repository\ProviderRepository;
+use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
@@ -229,6 +230,19 @@ final class ProviderController extends ActionController
             ]);
             $response = new JsonResponse(
                 (new ErrorResponse($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.provider.testUpstreamError', 'Upstream LLM provider returned an error during connection test.')))->jsonSerialize(),
+                502,
+            );
+        } catch (ProviderConfigurationException $e) {
+            // A misconfiguration is our own diagnostic, not a provider response
+            // body: the message names the setting at fault and is what the
+            // administrator on this screen has to act on. ErrorResponse redacts
+            // credential-bearing URL parameters at the boundary.
+            $this->logger->error('Provider testConnection: provider is misconfigured', [
+                'exception'    => $e,
+                'provider_uid' => $uid,
+            ]);
+            $response = new JsonResponse(
+                (new ErrorResponse($e->getMessage()))->jsonSerialize(),
                 502,
             );
         } catch (ProviderException $e) {

--- a/Classes/Controller/Backend/ProviderMisconfigurationTrait.php
+++ b/Classes/Controller/Backend/ProviderMisconfigurationTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package netresearch/nr-llm.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Netresearch\NrLlm\Controller\Backend;
+
+use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
+use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Turns a provider misconfiguration into a message the administrator can act on.
+ *
+ * REC #8b keeps raw provider error bodies out of the backend UI, because they
+ * carry endpoints, payloads and model internals. A ProviderConfigurationException
+ * is not one of those: every message of that type is authored in this extension
+ * and names the setting at fault — a missing API key identifier, an endpoint host
+ * rejected by the SSRF filter, a model without a provider. Withholding it buys no
+ * safety and costs the one person who can fix it a trip through the system log.
+ *
+ * Sanitizing here rather than at each call site is deliberate. Only some of the
+ * consumers reach the client through ErrorResponse, which redacts
+ * credential-bearing URL parameters at the response boundary; flash messages and
+ * hand-built JsonResponse payloads do not. Routing every site through this method
+ * means the redaction cannot be forgotten at the next one.
+ */
+trait ProviderMisconfigurationTrait
+{
+    use ErrorMessageSanitizerTrait;
+
+    /**
+     * Log the misconfiguration and return the message to show the administrator.
+     *
+     * @param string               $operation  what was attempted, for the log entry
+     * @param array<string, mixed> $logContext additional log context
+     */
+    protected function describeMisconfiguration(
+        ProviderConfigurationException $e,
+        LoggerInterface $logger,
+        string $operation,
+        array $logContext = [],
+    ): string {
+        $logger->error($operation . ': provider is misconfigured', ['exception' => $e] + $logContext);
+
+        return $this->sanitizeErrorMessage($e->getMessage());
+    }
+}

--- a/Classes/Controller/Backend/TaskExecutionController.php
+++ b/Classes/Controller/Backend/TaskExecutionController.php
@@ -71,6 +71,7 @@ final class TaskExecutionController extends ActionController
     use BackendUserUidTrait;
     use RequiresBackendAdminTrait;
     use DefensiveLocalizationTrait;
+    use ProviderMisconfigurationTrait;
 
     private const TABLE_NAME = 'tx_nrllm_task';
 
@@ -252,19 +253,12 @@ final class TaskExecutionController extends ActionController
             ]);
             $payload = (new ErrorResponse('Upstream LLM provider returned an error.'))->jsonSerialize();
         } catch (ProviderConfigurationException $e) {
-            // A misconfiguration is not a provider response. Every message of this
-            // type is authored in this extension and names the setting at fault
-            // ("API key identifier is required for provider OpenAI", "endpoint host
-            // is not allowed by the SSRF host filter") — which is precisely what the
-            // administrator looking at this screen needs, and what a bare "See system
-            // log for details" withholds from them. REC #8b is about provider
-            // response bodies; this is our own diagnostic. ErrorResponse still
-            // redacts credential-bearing URL parameters at the boundary.
-            $this->logger->error('Task execution failed: provider is misconfigured', [
-                'exception' => $e,
-                'task_uid'  => $task->getUid(),
-            ]);
-            $payload = (new ErrorResponse($e->getMessage()))->jsonSerialize();
+            $payload = (new ErrorResponse($this->describeMisconfiguration(
+                $e,
+                $this->logger,
+                'Task execution',
+                ['task_uid' => $task->getUid()],
+            )))->jsonSerialize();
         } catch (ProviderException $e) {
             // Other provider failures (connection / fallback exhausted /
             // unsupported feature). Log and surface a generic message — the underlying

--- a/Classes/Controller/Backend/TaskExecutionController.php
+++ b/Classes/Controller/Backend/TaskExecutionController.php
@@ -25,6 +25,7 @@ use Netresearch\NrLlm\Domain\Repository\TaskRepository;
 // `RecordTableReader::ensureNotExcluded` in `TaskRecordsController`).
 use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Exception\InvalidArgumentException as DomainInvalidArgumentException;
+use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
 use Netresearch\NrLlm\Service\Task\TaskExecutionServiceInterface;
@@ -250,8 +251,22 @@ final class TaskExecutionController extends ActionController
                 'task_uid'    => $task->getUid(),
             ]);
             $payload = (new ErrorResponse('Upstream LLM provider returned an error.'))->jsonSerialize();
+        } catch (ProviderConfigurationException $e) {
+            // A misconfiguration is not a provider response. Every message of this
+            // type is authored in this extension and names the setting at fault
+            // ("API key identifier is required for provider OpenAI", "endpoint host
+            // is not allowed by the SSRF host filter") — which is precisely what the
+            // administrator looking at this screen needs, and what a bare "See system
+            // log for details" withholds from them. REC #8b is about provider
+            // response bodies; this is our own diagnostic. ErrorResponse still
+            // redacts credential-bearing URL parameters at the boundary.
+            $this->logger->error('Task execution failed: provider is misconfigured', [
+                'exception' => $e,
+                'task_uid'  => $task->getUid(),
+            ]);
+            $payload = (new ErrorResponse($e->getMessage()))->jsonSerialize();
         } catch (ProviderException $e) {
-            // Other provider failures (connection / configuration / fallback exhausted /
+            // Other provider failures (connection / fallback exhausted /
             // unsupported feature). Log and surface a generic message — the underlying
             // exception text often references provider internals.
             $this->logger->error('Task execution failed: provider error', [

--- a/Classes/Controller/Backend/TaskWizardController.php
+++ b/Classes/Controller/Backend/TaskWizardController.php
@@ -15,8 +15,10 @@ use Netresearch\NrLlm\Domain\Model\Task;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\ModelRepository;
 use Netresearch\NrLlm\Domain\Repository\TaskRepository;
+use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Service\WizardGeneratorService;
+use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
@@ -54,6 +56,9 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 #[AsController]
 final class TaskWizardController extends ActionController
 {
+    // Flash messages bypass ErrorResponse, which is where the redaction of
+    // credential-bearing URL parameters normally happens.
+    use ErrorMessageSanitizerTrait;
     use SafeCastTrait;
     use DefensiveLocalizationTrait;
 
@@ -139,7 +144,15 @@ final class TaskWizardController extends ActionController
             ]);
             return $moduleTemplate->renderResponse('Backend/Task/WizardPreview');
         } catch (Throwable $e) {
-            if ($e instanceof ProviderException) {
+            if ($e instanceof ProviderConfigurationException) {
+                // A misconfiguration is our own diagnostic, not provider output: it
+                // names the setting at fault, which is what the administrator in this
+                // wizard has to change. REC #8b below covers provider RESPONSE text;
+                // this message never contains any. Sanitized because a flash message
+                // does not pass ErrorResponse's boundary redaction.
+                $this->logger->error('Task wizard: provider is misconfigured', ['exception' => $e]);
+                $this->enqueueFlashMessage($this->sanitizeErrorMessage($e->getMessage()), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.error.title', 'Error'), ContextualFeedbackSeverity::ERROR);
+            } elseif ($e instanceof ProviderException) {
                 // REC #8b: provider error text often references endpoints / payloads /
                 // model names that aren't safe to render verbatim into the backend UI.
                 $this->logger->error('Task wizard: single-task generation failed (provider)', ['exception' => $e]);
@@ -190,7 +203,15 @@ final class TaskWizardController extends ActionController
             ]);
             return $moduleTemplate->renderResponse('Backend/Task/WizardChainPreview');
         } catch (Throwable $e) {
-            if ($e instanceof ProviderException) {
+            if ($e instanceof ProviderConfigurationException) {
+                // A misconfiguration is our own diagnostic, not provider output: it
+                // names the setting at fault, which is what the administrator in this
+                // wizard has to change. REC #8b below covers provider RESPONSE text;
+                // this message never contains any. Sanitized because a flash message
+                // does not pass ErrorResponse's boundary redaction.
+                $this->logger->error('Task wizard: provider is misconfigured', ['exception' => $e]);
+                $this->enqueueFlashMessage($this->sanitizeErrorMessage($e->getMessage()), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.error.title', 'Error'), ContextualFeedbackSeverity::ERROR);
+            } elseif ($e instanceof ProviderException) {
                 $this->logger->error('Task wizard: chain generation failed (provider)', ['exception' => $e]);
                 $this->enqueueFlashMessage($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.generationFailed.provider', 'Generation failed (LLM provider error). See system log for details.'), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.error.title', 'Error'), ContextualFeedbackSeverity::ERROR);
             } else {

--- a/Classes/Controller/Backend/TaskWizardController.php
+++ b/Classes/Controller/Backend/TaskWizardController.php
@@ -18,7 +18,6 @@ use Netresearch\NrLlm\Domain\Repository\TaskRepository;
 use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Service\WizardGeneratorService;
-use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
@@ -56,11 +55,9 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 #[AsController]
 final class TaskWizardController extends ActionController
 {
-    // Flash messages bypass ErrorResponse, which is where the redaction of
-    // credential-bearing URL parameters normally happens.
-    use ErrorMessageSanitizerTrait;
     use SafeCastTrait;
     use DefensiveLocalizationTrait;
+    use ProviderMisconfigurationTrait;
 
     public function __construct(
         private readonly ModuleTemplateFactory $moduleTemplateFactory,
@@ -145,13 +142,7 @@ final class TaskWizardController extends ActionController
             return $moduleTemplate->renderResponse('Backend/Task/WizardPreview');
         } catch (Throwable $e) {
             if ($e instanceof ProviderConfigurationException) {
-                // A misconfiguration is our own diagnostic, not provider output: it
-                // names the setting at fault, which is what the administrator in this
-                // wizard has to change. REC #8b below covers provider RESPONSE text;
-                // this message never contains any. Sanitized because a flash message
-                // does not pass ErrorResponse's boundary redaction.
-                $this->logger->error('Task wizard: provider is misconfigured', ['exception' => $e]);
-                $this->enqueueFlashMessage($this->sanitizeErrorMessage($e->getMessage()), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.error.title', 'Error'), ContextualFeedbackSeverity::ERROR);
+                $this->enqueueFlashMessage($this->describeMisconfiguration($e, $this->logger, 'Task wizard'), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.error.title', 'Error'), ContextualFeedbackSeverity::ERROR);
             } elseif ($e instanceof ProviderException) {
                 // REC #8b: provider error text often references endpoints / payloads /
                 // model names that aren't safe to render verbatim into the backend UI.
@@ -204,13 +195,7 @@ final class TaskWizardController extends ActionController
             return $moduleTemplate->renderResponse('Backend/Task/WizardChainPreview');
         } catch (Throwable $e) {
             if ($e instanceof ProviderConfigurationException) {
-                // A misconfiguration is our own diagnostic, not provider output: it
-                // names the setting at fault, which is what the administrator in this
-                // wizard has to change. REC #8b below covers provider RESPONSE text;
-                // this message never contains any. Sanitized because a flash message
-                // does not pass ErrorResponse's boundary redaction.
-                $this->logger->error('Task wizard: provider is misconfigured', ['exception' => $e]);
-                $this->enqueueFlashMessage($this->sanitizeErrorMessage($e->getMessage()), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.error.title', 'Error'), ContextualFeedbackSeverity::ERROR);
+                $this->enqueueFlashMessage($this->describeMisconfiguration($e, $this->logger, 'Task wizard'), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.error.title', 'Error'), ContextualFeedbackSeverity::ERROR);
             } elseif ($e instanceof ProviderException) {
                 $this->logger->error('Task wizard: chain generation failed (provider)', ['exception' => $e]);
                 $this->enqueueFlashMessage($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.generationFailed.provider', 'Generation failed (LLM provider error). See system log for details.'), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.error.title', 'Error'), ContextualFeedbackSeverity::ERROR);

--- a/Classes/Controller/Backend/TaskWizardController.php
+++ b/Classes/Controller/Backend/TaskWizardController.php
@@ -141,17 +141,7 @@ final class TaskWizardController extends ActionController
             ]);
             return $moduleTemplate->renderResponse('Backend/Task/WizardPreview');
         } catch (Throwable $e) {
-            if ($e instanceof ProviderConfigurationException) {
-                $this->enqueueFlashMessage($this->describeMisconfiguration($e, $this->logger, 'Task wizard'), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.error.title', 'Error'), ContextualFeedbackSeverity::ERROR);
-            } elseif ($e instanceof ProviderException) {
-                // REC #8b: provider error text often references endpoints / payloads /
-                // model names that aren't safe to render verbatim into the backend UI.
-                $this->logger->error('Task wizard: single-task generation failed (provider)', ['exception' => $e]);
-                $this->enqueueFlashMessage($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.generationFailed.provider', 'Generation failed (LLM provider error). See system log for details.'), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.error.title', 'Error'), ContextualFeedbackSeverity::ERROR);
-            } else {
-                $this->logger->error('Task wizard: single-task generation failed unexpectedly', ['exception' => $e]);
-                $this->enqueueFlashMessage($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.generationFailed.generic', 'Generation failed. See system log for details.'), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.error.title', 'Error'), ContextualFeedbackSeverity::ERROR);
-            }
+            $this->reportGenerationFailure($e, 'single-task');
 
             return new RedirectResponse($this->uriBuilder->reset()->uriFor('wizardForm'));
         }
@@ -194,15 +184,7 @@ final class TaskWizardController extends ActionController
             ]);
             return $moduleTemplate->renderResponse('Backend/Task/WizardChainPreview');
         } catch (Throwable $e) {
-            if ($e instanceof ProviderConfigurationException) {
-                $this->enqueueFlashMessage($this->describeMisconfiguration($e, $this->logger, 'Task wizard'), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.error.title', 'Error'), ContextualFeedbackSeverity::ERROR);
-            } elseif ($e instanceof ProviderException) {
-                $this->logger->error('Task wizard: chain generation failed (provider)', ['exception' => $e]);
-                $this->enqueueFlashMessage($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.generationFailed.provider', 'Generation failed (LLM provider error). See system log for details.'), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.error.title', 'Error'), ContextualFeedbackSeverity::ERROR);
-            } else {
-                $this->logger->error('Task wizard: chain generation failed unexpectedly', ['exception' => $e]);
-                $this->enqueueFlashMessage($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.generationFailed.generic', 'Generation failed. See system log for details.'), $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.error.title', 'Error'), ContextualFeedbackSeverity::ERROR);
-            }
+            $this->reportGenerationFailure($e, 'chain');
 
             return new RedirectResponse($this->uriBuilder->reset()->uriFor('wizardForm'));
         }
@@ -345,4 +327,39 @@ final class TaskWizardController extends ActionController
             ->getMessageQueueByIdentifier()
             ->addMessage($flashMessage);
     }
+
+    /**
+     * One failure path for both generation actions.
+     *
+     * They differed only in the words "single-task" and "chain", which is not
+     * enough of a difference to justify two copies of the same three-way
+     * decision — SonarCloud counted the pair as duplicated new code, and it was
+     * right.
+     *
+     * The ordering carries the reasoning: a misconfiguration is our own
+     * diagnostic and names the setting at fault, so it reaches the user; a
+     * provider RESPONSE stays generic under REC #8b because its text references
+     * endpoints, payloads and model names.
+     */
+    private function reportGenerationFailure(Throwable $e, string $what): void
+    {
+        $title = $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.error.title', 'Error');
+
+        if ($e instanceof ProviderConfigurationException) {
+            $this->enqueueFlashMessage($this->describeMisconfiguration($e, $this->logger, 'Task wizard'), $title, ContextualFeedbackSeverity::ERROR);
+
+            return;
+        }
+
+        if ($e instanceof ProviderException) {
+            $this->logger->error(sprintf('Task wizard: %s generation failed (provider)', $what), ['exception' => $e]);
+            $this->enqueueFlashMessage($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.generationFailed.provider', 'Generation failed (LLM provider error). See system log for details.'), $title, ContextualFeedbackSeverity::ERROR);
+
+            return;
+        }
+
+        $this->logger->error(sprintf('Task wizard: %s generation failed unexpectedly', $what), ['exception' => $e]);
+        $this->enqueueFlashMessage($this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:flash.task.generationFailed.generic', 'Generation failed. See system log for details.'), $title, ContextualFeedbackSeverity::ERROR);
+    }
+
 }


### PR DESCRIPTION
A misconfigured provider tells the administrator: `LLM provider error. See system log for details.`

On the demo instance that meant a dead AI module and a log dive to discover the exception had been saying `API key identifier is required for provider OpenAI` the whole time — the exact sentence needed to fix it, withheld from the one person who could act on it.

## Why it was generic, and why that does not apply here

The wording is deliberate. REC #8b keeps raw provider error bodies out of the UI because they carry endpoints, payloads and model internals.

`ProviderConfigurationException` is not a provider response. Every message of that type is authored in this extension:

- `API key identifier is required for provider %s`
- `Provider endpoint host "%s" is not allowed by the SSRF host filter`
- `Model "%s" has no associated provider`

Each names the setting at fault. None contains a provider response body, a key, or user content. It is caught ahead of `ProviderException` now, and `ProviderException` keeps its generic message unchanged.

## Five sites, two different redaction paths

The same gap existed in task execution, both task-wizard generation paths, the provider connection test, and both model-discovery endpoints.

They do **not** sanitize the same way, and that mattered:

| Site | Path | Redaction |
|---|---|---|
| `TaskExecutionController`, `ProviderController` | `ErrorResponse` | at the response boundary, already there |
| `TaskWizardController` (flash messages) | none | `sanitizeErrorMessage()` added |
| `ModelDiscoveryController` | hand-built `JsonResponse` | `sanitizeErrorMessage()` added |

`ModelDiscoveryController` serialises `['success' => false, 'error' => $error]` itself and never touches `ErrorResponse`. Copying the fix across without checking each site's path would have surfaced an unredacted message from precisely the two places the boundary redaction does not cover — the opposite of the intent.

## Verification

| Check | Result |
|---|---|
| unit suite | 6310 tests, 17532 assertions, no failures |
| `phpstan` | No errors |
| `cgl -n` | SUCCESS |

Found on the demo instance while tracking down why every AI module was dead.