### PR TITLE
feat(backend): say what the task execute page does before asking for input

### DIFF
--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -2254,6 +2254,34 @@
                 <source>Presence Penalty</source>
                 <target>Präsenzstrafe</target>
             </trans-unit>
+            <trans-unit id="task.execute.intro.title" approved="yes">
+                <source>What this page does</source>
+                <target>Was diese Seite tut</target>
+            </trans-unit>
+            <trans-unit id="task.execute.intro.body" approved="yes">
+                <source>Run this task once and look at the result. The output is displayed below and stored nowhere — nothing in your content is changed, so this is the safe place to try a task out before other extensions or the API start using it.</source>
+                <target>Führt die Aufgabe einmal aus und zeigt das Ergebnis. Die Ausgabe erscheint weiter unten und wird nirgends gespeichert — an deinen Inhalten ändert sich nichts. Hier probierst du eine Aufgabe also gefahrlos aus, bevor andere Extensions oder die API sie benutzen.</target>
+            </trans-unit>
+            <trans-unit id="task.execute.intro.cost" approved="yes">
+                <source>It is a real request to the configured provider: it costs money and counts against your budget, exactly like a run triggered from anywhere else.</source>
+                <target>Es ist eine echte Anfrage an den konfigurierten Provider: Sie kostet Geld und zählt auf dein Budget, genau wie ein Lauf von irgendwo sonst.</target>
+            </trans-unit>
+            <trans-unit id="task.execute.intro.needs" approved="yes">
+                <source>It needs</source>
+                <target>Sie braucht</target>
+            </trans-unit>
+            <trans-unit id="task.execute.intro.needs.manual" approved="yes">
+                <source>text you type into the input field below</source>
+                <target>Text, den du unten ins Eingabefeld schreibst</target>
+            </trans-unit>
+            <trans-unit id="task.execute.intro.needs.resolved" approved="yes">
+                <source>input the task resolves by itself — review it below and refresh if it looks stale</source>
+                <target>Eingaben, die die Aufgabe selbst ermittelt — unten prüfen und bei Bedarf neu laden</target>
+            </trans-unit>
+            <trans-unit id="task.execute.intro.returns" approved="yes">
+                <source>It returns</source>
+                <target>Sie liefert</target>
+            </trans-unit>
             <trans-unit id="task.execute.title">
                 <source>Execute</source>
                 <target>Ausführen</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1705,6 +1705,27 @@
             <trans-unit id="field.presencePenalty">
                 <source>Presence Penalty</source>
             </trans-unit>
+            <trans-unit id="task.execute.intro.title">
+                <source>What this page does</source>
+            </trans-unit>
+            <trans-unit id="task.execute.intro.body">
+                <source>Run this task once and look at the result. The output is displayed below and stored nowhere — nothing in your content is changed, so this is the safe place to try a task out before other extensions or the API start using it.</source>
+            </trans-unit>
+            <trans-unit id="task.execute.intro.cost">
+                <source>It is a real request to the configured provider: it costs money and counts against your budget, exactly like a run triggered from anywhere else.</source>
+            </trans-unit>
+            <trans-unit id="task.execute.intro.needs">
+                <source>It needs</source>
+            </trans-unit>
+            <trans-unit id="task.execute.intro.needs.manual">
+                <source>text you type into the input field below</source>
+            </trans-unit>
+            <trans-unit id="task.execute.intro.needs.resolved">
+                <source>input the task resolves by itself — review it below and refresh if it looks stale</source>
+            </trans-unit>
+            <trans-unit id="task.execute.intro.returns">
+                <source>It returns</source>
+            </trans-unit>
             <trans-unit id="task.execute.title">
                 <source>Execute</source>
             </trans-unit>

--- a/Resources/Private/Templates/Backend/Task/Execute.html
+++ b/Resources/Private/Templates/Backend/Task/Execute.html
@@ -38,6 +38,41 @@
             </div>
         </f:if>
 
+        <f:comment>
+            Orientation. Without this the page opens on a configuration panel and
+            an empty input box, and never says what pressing the button will do —
+            that it sends a real, billed request, and that the result is shown
+            here and stored nowhere.
+        </f:comment>
+        <div class="callout callout-info mb-4">
+            <h2 class="h5 mb-2">
+                <core:icon identifier="actions-info-circle" size="small" />
+                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.intro.title" default="What this page does" />
+            </h2>
+            <f:if condition="{task.description}">
+                <p class="mb-2"><strong>{task.description}</strong></p>
+            </f:if>
+            <p class="mb-2">
+                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.intro.body" default="Run this task once and look at the result. The output is displayed below and stored nowhere — nothing in your content is changed, so this is the safe place to try a task out before other extensions or the API start using it." />
+            </p>
+            <p class="mb-2">
+                <core:icon identifier="actions-exclamation-triangle" size="small" />
+                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.intro.cost" default="It is a real request to the configured provider: it costs money and counts against your budget, exactly like a run triggered from anywhere else." />
+            </p>
+            <dl class="row mb-0">
+                <dt class="col-sm-3"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.intro.needs" default="It needs" /></dt>
+                <dd class="col-sm-9">
+                    <f:if condition="{requiresManualInput}">
+                        <f:then><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.intro.needs.manual" default="text you type into the input field below" /></f:then>
+                        <f:else><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.intro.needs.resolved" default="input the task resolves by itself — review it below and refresh if it looks stale" /></f:else>
+                    </f:if>
+                    <f:if condition="{task.inputType}"> <span class="text-body-secondary">({task.inputType})</span></f:if>
+                </dd>
+                <dt class="col-sm-3"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.intro.returns" default="It returns" /></dt>
+                <dd class="col-sm-9 mb-0">{task.outputFormat}</dd>
+            </dl>
+        </div>
+
         <f:render partial="Backend/Glossary" />
 
         <f:comment>Configuration & Model Details Panel</f:comment>


### PR DESCRIPTION
> *"i feel very lost on this page, keine Ahnung was ich da machen kann/soll"*

The execute form opens on a configuration panel and an empty input box. It never says what pressing the button will do — so the first question it raises, **is this a dry run or does it change something?**, goes unanswered, and people stop rather than find out.

## What the block says, and why those two facts

Both claims are read out of the code rather than assumed:

- **The output is stored nowhere.** `TaskExecutionService` packages the response as a `TaskExecutionResult` and touches no repository. So this genuinely is the safe place to try a task before other extensions or the API start using it — worth saying, because nothing on the page implied it.
- **The call is not free.** `BudgetMiddleware` pre-flights the per-user cap and `UsageMiddleware` records the usage against the calling user. It costs money and counts against the budget exactly like a run triggered anywhere else. That is the more important of the two and was nowhere on the screen.

It also names what the task expects and returns. The input wording comes from `requiresManualInput()`, so it matches what the form below actually renders instead of describing a field that may not be there, and the task's own description leads the block when it has one.

## Scope

Template plus labels. No controller or service change — everything shown was already assigned to the view.

Labels in EN and DE. Both files parse as XML, and every one of the seven keys the template uses resolves in both — checked, not assumed, since a missing key renders as the raw `LLL:` string in the UI.

Found while working through review findings on the demo instance.