### PR TITLE
docs(agents): name what exists instead of counting it

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -12,17 +12,22 @@ GitHub Actions workflows and CI/CD automation
 | File | Purpose |
 |------|---------|
 | `auto-merge-deps.yml` | Auto-merge dependency PRs |
-| `ci.yml` | CI |
-| `community.yml` | Community |
-| `docs.yml` | Documentation |
-| `e2e.yml` | E2E Tests |
-| `release.yml` | Release |
-| `ter-publish.yml` | Publish to TER (manual) |
+| `check-template-drift.yml` | Template drift against the org's typo3-extension template |
+| `checks.yml` | Security, gitleaks, zizmor, fuzz, licence audit, CodeQL, scorecard, dependency review, PR quality |
+| `ci.yml` | Lint, PHPStan, unit/functional tests, Rector, fuzz + weekly mutation, docs |
+| `community.yml` | Community health |
+| `dco.yml` | DCO sign-off |
+| `docs.yml` | Documentation rendering |
+| `e2e.yml` | Playwright E2E tests |
+| `labeler.yml` | PR auto-labelling |
+| `pages.yml` | Landing page (GitHub Pages) |
+| `release.yml` | Release with SBOM, Cosign signing, SLSA attestation; publishes TER + Packagist |
+| `republish.yml` | Re-publish an existing tag (`workflow_dispatch` fallback) |
 <!-- AGENTS-GENERATED:END filemap -->
 
 <!-- AGENTS-GENERATED:START golden-samples -->
 ## Workflow files
-- Workflows: 7 workflow file(s)
+- One file per concern; the Key Files table above lists all of them.
 <!-- AGENTS-GENERATED:END golden-samples -->
 
 <!-- AGENTS-GENERATED:START structure -->
@@ -37,10 +42,15 @@ GitHub Actions workflows and CI/CD automation
   ISSUE_TEMPLATE/
   workflows/
     ci.yml              → Main CI workflow (lint, test, build)
+    checks.yml          → Security, licence, CodeQL, scorecard, PR quality
     release.yml         → Release/deploy workflow
+    republish.yml       → Re-publish an existing tag (manual)
     e2e.yml             → Playwright E2E tests
     docs.yml            → Documentation rendering
-    ter-publish.yml     → Manual TER publish
+    pages.yml           → Landing page (GitHub Pages)
+    dco.yml             → DCO sign-off
+    labeler.yml         → PR auto-labelling
+    check-template-drift.yml → Template drift
     auto-merge-deps.yml → Auto-merge dependency PRs
     community.yml       → Community health
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,7 @@ Three-tier model: **Provider → Model → Configuration**. See `Documentation/A
 ### Directory Structure
 ```
 nr_llm/
-├── Classes/                    # 264 PHP source files
+├── Classes/                    # PHP source
 │   ├── Attribute/              # #[AsLlmProvider] auto-registration attribute
 │   ├── Controller/Backend/     # Backend controllers, DTOs, Response objects
 │   ├── DependencyInjection/    # Compiler passes (ProviderCompilerPass)
@@ -131,8 +131,8 @@ nr_llm/
 │   ├── Utility/                # SafeCastTrait, ErrorMessageSanitizerTrait
 │   └── Widgets/DataProvider/   # Backend dashboard widgets (cost, requests)
 ├── Configuration/              # TYPO3 config (TCA, services, caching, icons, routes)
-├── Documentation/              # 86 RST files + guides.xml + brand assets
-│   └── Adr/                    # 38 Architecture Decision Records
+├── Documentation/              # RST docs + guides.xml + brand assets
+│   └── Adr/                    # Architecture Decision Records
 ├── Tests/                      # Unit, Integration, Functional, Fuzzy, Architecture, E2E
 ├── Resources/                  # Templates, XLIFF (EN+DE), icons, CSS, JS
 └── Build/                      # PHPStan, Rector, Fractor configs + runTests.sh
@@ -195,14 +195,18 @@ nr_llm/
 
 | Workflow | Purpose |
 |----------|---------|
-| `ci.yml` | Lint, PHPStan, unit/functional tests, Rector, mutation |
-| `e2e.yml` | Playwright E2E tests |
-| `docs.yml` | Documentation rendering |
-| `security.yml` | Gitleaks, dependency review, composer audit |
-| `release.yml` | Release with SBOM, Cosign signing, SLSA attestation |
-| `ter-publish.yml` | Manual TER publish |
 | `auto-merge-deps.yml` | Auto-merge dependency PRs |
+| `check-template-drift.yml` | Template drift against the org's typo3-extension template |
+| `checks.yml` | Security, gitleaks, zizmor, fuzz, licence audit, CodeQL, scorecard, dependency review, PR quality |
+| `ci.yml` | Lint, PHPStan, unit/functional tests, Rector, fuzz + weekly mutation, docs |
 | `community.yml` | Community health |
+| `dco.yml` | DCO sign-off |
+| `docs.yml` | Documentation rendering |
+| `e2e.yml` | Playwright E2E tests |
+| `labeler.yml` | PR auto-labelling |
+| `pages.yml` | Landing page (GitHub Pages) |
+| `release.yml` | Release with SBOM, Cosign signing, SLSA attestation; publishes TER + Packagist |
+| `republish.yml` | Re-publish an existing tag (`workflow_dispatch` fallback) |
 <!-- AGENTS-GENERATED:END ci -->
 
 <!-- AGENTS-GENERATED:START examples -->
@@ -225,8 +229,8 @@ Prefer looking at real code in this repo over inventing new patterns. Canonical 
 <!-- AGENTS-GENERATED:START help -->
 ## When Stuck
 - Run tests: `./Build/Scripts/runTests.sh -s unit` (NEVER phpunit directly)
-- Check ADRs in `Documentation/Adr/` for design rationale (38 ADRs)
-- API docs: `Documentation/Api/` (9 reference pages)
+- Check ADRs in `Documentation/Adr/` for design rationale; `Adr/Index.rst` documents the record lifecycle
+- API docs: `Documentation/Api/`
 - Issues: https://github.com/netresearch/t3x-nr-llm/issues
 - Discussions: https://github.com/netresearch/t3x-nr-llm/discussions
 <!-- AGENTS-GENERATED:END help -->
@@ -234,7 +238,7 @@ Prefer looking at real code in this repo over inventing new patterns. Canonical 
 <!-- Hand-maintained; intentionally outside the AGENTS-GENERATED blocks above. -->
 ## Release & dependency automation (agent notes)
 
-- **Releasing is a tag push, and the tag publishes TER automatically.** Pushing an annotated signed tag `vX.Y.Z` on `main` triggers `release.yml`, which calls the reusable `netresearch/typo3-ci-workflows/.github/workflows/release-typo3-extension.yml` with `TYPO3_TER_ACCESS_TOKEN` wired in: it produces the SBOM / Cosign / SLSA artifacts, creates the GitHub release, **and publishes to TER + Packagist**. `ter-publish.yml` ("Manual TER publish" in the workflow table) is only a `workflow_dispatch` re-publish fallback — it is *not* the primary path and does not need to be run for a normal release. Verify a release by checking Packagist (`repo.packagist.org/p2/netresearch/nr-llm.json`, tags are `v`-prefixed), TER (`extensions.typo3.org/api/v1/extension/nr_llm/versions`) and the docs 0.X URL — do not assume TER is a separate manual step.
+- **Releasing is a tag push, and the tag publishes TER automatically.** Pushing an annotated signed tag `vX.Y.Z` on `main` triggers `release.yml`, which calls the reusable `netresearch/typo3-ci-workflows/.github/workflows/release-typo3-extension.yml` with `TYPO3_TER_ACCESS_TOKEN` wired in: it produces the SBOM / Cosign / SLSA artifacts, creates the GitHub release, **and publishes to TER + Packagist**. `republish.yml` is only a `workflow_dispatch` fallback that re-publishes an existing tag — it is *not* the primary path and does not need to be run for a normal release. Verify a release by checking Packagist (`repo.packagist.org/p2/netresearch/nr-llm.json`, tags are `v`-prefixed), TER (`extensions.typo3.org/api/v1/extension/nr_llm/versions`) and the docs 0.X URL — do not assume TER is a separate manual step.
 - **The `chore(release): X.Y.Z` commit bumps four files:** `ext_emconf.php`, `composer.json` (`extra.typo3/cms.version`), `Documentation/guides.xml`, and `CHANGELOG.md` (not `Changelog.rst`). Version bumps belong to this release flow, never to a feature PR.
 - **Renovate/Dependabot PRs auto-merge via `auto-merge-deps.yml` — do not hand-merge them by default.** Known gap (2026-07-24): `auto-merge-deps.yml` did **not** auto-merge #511/#509 and they were admin-merged manually to unblock the 0.24.0 release; root cause (merge-queue interaction vs an unmet workflow condition) is **not yet verified**. Investigate the workflow's condition/queue behaviour before relying on it for the next release rather than reflexively hand-merging.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,24 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Landing-page copy matches the shipped tool set: 43 built-in tools in 9
   groups, 41 of them read-only. It advertised "41 read-only tools in 8
   toggleable groups" and version 0.22.0.
+- The `AGENTS.md` files name what exists instead of counting it. Nine of the
+  twelve hand-maintained file counts in them were wrong: 264 PHP source files
+  against 638, 26 ADRs and 38 Architecture Decision Records against 139, 69 and
+  86 RST files against 202, 9 API reference pages against 15, 7 workflow files
+  against 12, 13 backend controllers against 21, 9 Response objects against 20,
+  3 architecture test files against 5, 10 Playwright specs against 8. Three
+  were right at the time — 4 request DTOs, 4 test-guide pages, 9 E2E backend
+  files — and went with them, because the problem is the shape, not the
+  arithmetic. Counts that do not move with a file stay and were verified: seven
+  registered provider adapters, thirteen seeded demo tasks.
+- The workflow tables in `AGENTS.md` and `.github/workflows/AGENTS.md` list the
+  twelve workflows that exist. They named seven, two of which — `security.yml`
+  and `ter-publish.yml` — are gone; the release note built on the latter now
+  names `republish.yml`. The `Api/`, `Administration/` and `Developer/` rows in
+  `Documentation/AGENTS.md` named 9, 5 and 4 pages against 15, 16 and 11, and
+  ten rows of the `Classes/AGENTS.md` table were the same shape — `Domain/Enum/`
+  named 5 of 32, `Exception/` 3 of 10, `Domain/Model/` 5 of 16. One of them said
+  `ChatMessage` is "currently unused"; 32 classes use it.
 
 ### Added
 
@@ -61,6 +79,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `Tests/Unit/BaselineConsistencyTest.php` fails when `BASELINE.md` names a
   TYPO3 matrix `ci.yml` does not run, or calls the MSI target a minimum while
   the mutation job is gated on the weekly schedule.
+- `Tests/Unit/AgentDocsCountConventionTest.php` rejects a reintroduced file
+  count in any `AGENTS.md` — both `<number> <file-noun>` and the
+  `<noun> (<number>)` form the removed `Controller/Backend/` row used. It does
+  not assert the counts: a number that changes when anyone adds a file would
+  turn every new file into a red build.
 
 ## [0.27.0] - 2026-08-09
 

--- a/Classes/AGENTS.md
+++ b/Classes/AGENTS.md
@@ -4,7 +4,7 @@
 
 <!-- AGENTS-GENERATED:START overview -->
 ## Overview
-PHP 8.2+ source code (264 files) with strict typing, PSR-12, PHPStan level 10. Three-tier domain: Providers -> Models -> Configurations.
+PHP 8.2+ source code with strict typing, PSR-12, PHPStan level 10. Three-tier domain: Providers -> Models -> Configurations.
 <!-- AGENTS-GENERATED:END overview -->
 
 <!-- AGENTS-GENERATED:START setup -->
@@ -32,22 +32,22 @@ Full test matrix in root `AGENTS.md` Setup section.
 | Directory | Purpose |
 |-----------|---------|
 | `Attribute/` | `#[AsLlmProvider]` auto-registration attribute |
-| `Controller/Backend/` | Backend module controllers (13), request DTOs (4), Response objects (9) |
+| `Controller/Backend/` | Backend module controllers, request DTOs, Response objects |
 | `DependencyInjection/` | ProviderCompilerPass |
-| `Domain/DTO/` | BudgetCheckResult, FallbackChain, ModelSelectionCriteria |
-| `Domain/Enum/` | ModelCapability, ModelSelectionMode, TaskCategory, TaskInputType, TaskOutputFormat |
-| `Domain/Model/` | Entities: Provider, Model, LlmConfiguration, Task, UserBudget |
-| `Domain/Repository/` | LlmConfiguration, Model, Provider, Task, UserBudget |
-| `Domain/ValueObject/` | ChatMessage (currently unused — tracked in audit 2026-04-23) |
-| `Exception/` | AccessDenied, ConfigurationNotFound, InvalidArgument |
-| `Form/` | ModelIdElement (TCA), ModelConstraintsWizard (field wizard) |
+| `Domain/DTO/` | BudgetCheckResult, CapabilitySet, FallbackChain, ModelSelectionCriteria, ProviderOptions |
+| `Domain/Enum/` | Backed enums for capabilities, task shape, agent-run state, tool data class / effect / egress, trust zone, governance |
+| `Domain/Model/` | Extbase entities (Provider, Model, LlmConfiguration, Task, UserBudget, Skill, SkillSource, PromptSnippet, BackendUserGroup) and the response/result types |
+| `Domain/Repository/` | LlmConfiguration, Model, PromptSnippet, Provider, Skill, SkillSource, Task, UserBudget |
+| `Domain/ValueObject/` | Immutable payloads across the runtime — `ChatMessage` is the central one (constructed via `::system()` / `::user()` / `::toolResult()`) |
+| `Exception/` | Core domain exceptions (access, configuration, budget, guardrail, context) — all implement `NrLlmExceptionInterface` |
+| `Form/` | ModelIdElement (TCA element), ModelConstraintsWizard (field wizard), and the GuardrailItems / SnippetTagItems / ToolGroupItems item providers |
 | `Provider/` | 7 adapters: OpenAI, Claude, Gemini, Groq, Mistral, Ollama, OpenRouter |
 | `Provider/Contract/` | ProviderInterface, Streaming/Tool/Vision/DocumentCapableInterface |
-| `Provider/Exception/` | 5 typed provider exceptions |
+| `Provider/Exception/` | Typed provider exceptions (authentication, configuration, connection, rate limit, response, unsupported feature, circuit open, fallback exhausted) |
 | `Service/` | LlmServiceManager, CacheManager, ModelSelectionService, WizardGeneratorService, BudgetService |
 | `Provider/Middleware/` | Middleware pipeline (Fallback, Budget, Usage, Cache) — see ADR-026 |
-| `Service/Feature/` | CompletionService, EmbeddingService, TranslationService, VisionService |
-| `Service/Option/` | ChatOptions, EmbeddingOptions, ToolOptions, TranslationOptions, VisionOptions |
+| `Service/Feature/` | CompletionService, ConversationService, EmbeddingService, ToolCallingService, TranslationService, VisionService — each with its interface |
+| `Service/Option/` | ChatOptions, EmbeddingOptions, ToolOptions, TranslationOptions, VisionOptions on `AbstractOptions`, plus the budget-aware trait and interface |
 | `Service/SetupWizard/` | ProviderDetector, ModelDiscovery (facade), ConfigurationGenerator + DTOs; `Discovery/` holds one model discoverer per provider |
 | `Specialized/` | Image (DALL-E, FAL), Speech (Whisper, TTS), Translation (DeepL, LLM) |
 | `Utility/` | SafeCastTrait, ErrorMessageSanitizerTrait |
@@ -122,7 +122,7 @@ See `Tests/Architecture/` for enforcement tests.
 
 <!-- AGENTS-GENERATED:START help -->
 ## When Stuck
-- Architecture decisions: `Documentation/Adr/` (38 ADRs)
-- API reference: `Documentation/Api/` (9 pages)
+- Architecture decisions: `Documentation/Adr/`
+- API reference: `Documentation/Api/`
 - Run `./Build/Scripts/runTests.sh -s phpstan` to check types
 <!-- AGENTS-GENERATED:END help -->

--- a/Documentation/AGENTS.md
+++ b/Documentation/AGENTS.md
@@ -4,7 +4,7 @@
 
 <!-- AGENTS-GENERATED:START overview -->
 ## Overview
-TYPO3 RST documentation (69 files) restructured into granular sub-pages. Includes 26 ADRs, API reference (9 pages), and Netresearch branding. Built with `guides.xml` (TYPO3 docs theme, version 0.4.11).
+TYPO3 RST documentation restructured into granular sub-pages. Includes the ADRs, the API reference, and Netresearch branding. Built with `guides.xml` (TYPO3 docs theme, version 0.4.11).
 <!-- AGENTS-GENERATED:END overview -->
 
 <!-- AGENTS-GENERATED:START setup -->
@@ -33,19 +33,19 @@ Docs are rendered and validated in CI via `.github/workflows/docs.yml`. Local re
 | `Sitemap.rst` | Navigation |
 | `Changelog.rst` | Version history |
 
-### Documentation Sections (69 files total)
+### Documentation Sections
 
 | Section | Files | Content |
 |---------|-------|---------|
-| `Administration/` | Providers, Models, Configurations, Tasks, Wizards | Backend CRUD guides |
+| `Administration/` | one page per backend surface (Providers, Models, Configurations, Tasks, Wizards, Tools, Skills, Permissions, Analytics, Governance, AgentRuns, McpServers, PromptSnippets, SpecializedServices, UserBudgets, DataRetention) | Backend CRUD guides |
 | `Configuration/` | ProviderFields, ModelFields, ConfigFields, TaskFields, Settings | TCA field reference |
-| `Api/` | LlmServiceManager, CompletionService, EmbeddingService, VisionService, TranslationService, ResponseObjects, OptionClasses, ProviderInterface, Exceptions | PHP API reference |
+| `Api/` | one page per public service or contract; `Stability.rst` states the `@api` promise | PHP API reference |
 | `Testing/` | UnitTesting, FunctionalTesting, EndToEndTesting, CiConfiguration | Test guide |
-| `Developer/` | Streaming, ToolCalling, CustomProviders, FeatureServices/ | Integration guide |
+| `Developer/` | one page per integration topic (IntegrationGuide, Streaming, ToolCalling, CustomProviders, ProviderRegistration, FallbackChain, ConfigurationPresets, EndpointProtection, QualityEvaluation, SafeMarkdownRendering) plus `FeatureServices/` | Integration guide |
 | `Architecture/` | Index | Design patterns |
 | `Introduction/` | Index | Overview, features |
 | `Installation/` | Index | Setup instructions |
-| `Adr/` | 26 ADRs | Architecture Decision Records |
+| `Adr/` | `AdrNNNTitle.rst` | Architecture Decision Records |
 
 ### Brand Assets
 
@@ -135,5 +135,5 @@ Documentation uses Netresearch branding: teal underline SVG for headings, emoji 
 - TYPO3 docs guide: https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/
 - Render locally with Docker (see Setup above)
 - Check `guides.xml` for build configuration
-- Existing 69 files serve as reference patterns
+- Existing pages serve as reference patterns
 <!-- AGENTS-GENERATED:END help -->

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -32,11 +32,11 @@ Comprehensive test suite: PHPUnit 11/12/13 (cross-compatible), TYPO3 Testing Fra
 | `Unit/` | PHPUnit 11/12/13 | Fast isolated unit tests |
 | `Integration/` | PHPUnit + PSR-18 mocking | API client tests |
 | `Functional/` | TYPO3 Testing Framework | Database, repositories, controllers |
-| `Architecture/` | PHPat | Layer boundary enforcement (3 test files) |
+| `Architecture/` | PHPat | Layer boundary enforcement |
 | `Fuzzy/` | Eris | Property-based/fuzz testing |
-| `E2E/Backend/` | PHPUnit | Backend E2E tests (9 test files) |
+| `E2E/Backend/` | PHPUnit | Backend E2E tests |
 | `E2E/TCA/` | PHPUnit | TCA field tests |
-| `E2E/Playwright/` | Playwright (TS) | Browser-based UI tests (10 spec files) |
+| `E2E/Playwright/` | Playwright (TS) | Browser-based UI tests |
 <!-- AGENTS-GENERATED:END filemap -->
 
 <!-- AGENTS-GENERATED:START code-style -->
@@ -85,7 +85,7 @@ Comprehensive test suite: PHPUnit 11/12/13 (cross-compatible), TYPO3 Testing Fra
 
 <!-- AGENTS-GENERATED:START help -->
 ## When Stuck
-- Test docs: `Documentation/Testing/` (4 pages: Unit, Functional, E2E, CI)
+- Test docs: `Documentation/Testing/` — UnitTesting, FunctionalTesting, EndToEndTesting, CiConfiguration
 - PHPUnit 11/12/13 compat: see `MEMORY.md` PHPUnit section
 - Run with `-v` for verbose: `./Build/Scripts/runTests.sh -s unit -v`
 <!-- AGENTS-GENERATED:END help -->

--- a/Tests/Unit/AgentDocsCountConventionTest.php
+++ b/Tests/Unit/AgentDocsCountConventionTest.php
@@ -1,0 +1,181 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit;
+
+use FilesystemIterator;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use RecursiveCallbackFilterIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+/**
+ * Keeps file-count claims out of the AGENTS.md files.
+ *
+ * They rotted three times before this test existed: "264 PHP source files"
+ * against 638, "26 ADRs" against 139, "69 files" against 202, "38 Architecture
+ * Decision Records" against the same 139, "9 reference pages" against 15,
+ * "7 workflow file(s)" against 12, "13 controllers" against 21.
+ *
+ * The counts were removed rather than corrected — including three that were
+ * right at the time, because the problem is the shape and not the arithmetic.
+ * A number that changes when anyone adds a file cannot be asserted without
+ * turning every new file into a red build, and it tells a reader nothing an
+ * `ls` would not, so the rule is that agent docs name what exists rather than
+ * how much of it there is.
+ *
+ * Counts of things that do NOT change with a file are untouched: seven
+ * registered provider adapters, thirteen seeded demo tasks. This test rejects
+ * counting files only — see the two patterns below for where that line is
+ * drawn.
+ */
+#[CoversNothing]
+final class AgentDocsCountConventionTest extends AbstractUnitTestCase
+{
+    /**
+     * `<number> <file-noun>` — "69 RST files", "26 ADRs", "9 reference pages".
+     *
+     * Bare `records`, `pages` and `specs` are deliberately absent: "the wizard
+     * writes 2 records to sys_log" and "renders 3 pages behind one route"
+     * count things, not files, and this rule is only about files.
+     */
+    private const LEADING_COUNT_PATTERN
+        = '/\b\d+\s+(?:'
+        . 'files?|ADRs?|'
+        . '(?:PHP\s+)?source\s+files?|RST\s+files?|test\s+files?|spec\s+files?|'
+        . 'workflow\s+files?|Architecture\s+Decision\s+Records?|reference\s+pages?'
+        . ')\b/i';
+
+    /**
+     * `<plural-noun> (<number>)` — "controllers (13), request DTOs (4)".
+     *
+     * The first version of this test missed exactly this shape, which is the
+     * one the row it removed used: three of the nine stale numbers came from a
+     * single `Controller/Backend/` table cell written this way.
+     */
+    private const TRAILING_COUNT_PATTERN = '/\b[A-Za-z][A-Za-z]*s\s*\(\d+\)/';
+
+    /**
+     * Directories that hold no repository content: composer's install target,
+     * git's object store, npm's.
+     */
+    private const SKIPPED_DIRECTORIES = ['.Build', '.git', 'node_modules'];
+
+    private static function repoRoot(): string
+    {
+        return dirname(__DIR__, 2);
+    }
+
+    /**
+     * @return list<string> repo-relative paths
+     */
+    private static function agentDocs(): array
+    {
+        $found    = [];
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveCallbackFilterIterator(
+                new RecursiveDirectoryIterator(self::repoRoot(), FilesystemIterator::SKIP_DOTS),
+                static fn(SplFileInfo $file): bool => !$file->isDir()
+                    || !in_array($file->getFilename(), self::SKIPPED_DIRECTORIES, true),
+            ),
+        );
+
+        foreach ($iterator as $file) {
+            if ($file instanceof SplFileInfo && $file->isFile() && $file->getFilename() === 'AGENTS.md') {
+                $found[] = substr($file->getPathname(), strlen(self::repoRoot()) + 1);
+            }
+        }
+
+        sort($found);
+
+        return $found;
+    }
+
+    /**
+     * One case per document: a count in one file must not mask a count in the
+     * next, which a single loop with an assertion inside would do.
+     *
+     * @return list<array{string}>
+     */
+    public static function agentDocProvider(): array
+    {
+        return array_map(static fn(string $doc): array => [$doc], self::agentDocs());
+    }
+
+    #[Test]
+    public function theSweepFindsEveryAgentDoc(): void
+    {
+        // Without this the next test passes on an empty list.
+        $docs = self::agentDocs();
+
+        self::assertSame(
+            [
+                '.ddev/AGENTS.md',
+                '.github/workflows/AGENTS.md',
+                'AGENTS.md',
+                'Classes/AGENTS.md',
+                'Configuration/AGENTS.md',
+                'Documentation/AGENTS.md',
+                'Resources/AGENTS.md',
+                'Tests/AGENTS.md',
+            ],
+            $docs,
+            'The set of agent docs changed. Adding one is fine — update this list so a DELETED one '
+            . 'cannot silently stop being checked.',
+        );
+    }
+
+    /**
+     * The document split into `## ` sections, with the "Working in this repo"
+     * narrative dropped.
+     *
+     * That section recounts what a past run observed ("reproduced the same 53
+     * files") — a record of an event, not a claim about the tree. Splitting
+     * rather than matching a range keeps the exclusion to exactly that section:
+     * the root file grows by appending `## … (agent notes)` sections, and a
+     * range that ran to end-of-file would exempt every future one.
+     *
+     * @return list<string>
+     */
+    private function sectionsExcludingTheNarrative(string $contents): array
+    {
+        $sections = preg_split('/^(?=## )/m', $contents);
+        self::assertIsArray($sections);
+
+        return array_values(array_filter(
+            $sections,
+            static fn(string $section): bool => !str_starts_with($section, '## Working in this repo'),
+        ));
+    }
+
+    #[Test]
+    #[DataProvider('agentDocProvider')]
+    public function noAgentDocCountsFiles(string $doc): void
+    {
+        $contents = (string)file_get_contents(self::repoRoot() . '/' . $doc);
+
+        $body = implode('', $this->sectionsExcludingTheNarrative($contents));
+
+        $found = [];
+        foreach ([self::LEADING_COUNT_PATTERN, self::TRAILING_COUNT_PATTERN] as $pattern) {
+            preg_match_all($pattern, $body, $matches);
+            $found = array_merge($found, $matches[0]);
+        }
+
+        self::assertSame(
+            [],
+            $found,
+            $doc . ' counts files: "' . implode('", "', $found) . '". Name what exists instead — '
+            . "these counts have rotted three times. See this test's docblock.",
+        );
+    }
+}


### PR DESCRIPTION
## Why

Every `AGENTS.md` in the repo carried hand-maintained file counts. Nine of the twelve were wrong, most by a wide margin — and this is the **third** round in which the same numbers were found stale (`560f942f`, `4bfa3270`, now this).

| Claimed | Actual |
|---|---|
| 264 PHP source files | 638 |
| 26 ADRs / 38 Architecture Decision Records | 139 |
| 69 RST files / 86 RST files | 202 |
| 9 API reference pages | 15 |
| 7 workflow file(s) | 12 |
| 13 backend controllers | 21 |
| 9 Response objects | 20 |
| 3 architecture test files | 5 |
| 10 Playwright spec files | 8 |

Three counts were **right** at the time — 4 request DTOs, the 4 named test-guide pages, 9 files under `Tests/E2E/Backend/`. They went with the rest anyway: the problem is the shape, not the arithmetic.

## What changed

**The counts are removed, not corrected.** A number that changes when anyone adds a file cannot be asserted without turning every new file into a red build, and it tells a reader nothing an `ls` would not. Where a list already stood next to the count, the list stays and the count goes.

**Three of those "lists" were the count in prose form** and are replaced by what the directory actually holds:

| Row in `Documentation/AGENTS.md` | Named | Exist |
|---|---|---|
| `Api/` | 9 pages | 15 |
| `Administration/` | 5 pages | 16 |
| `Developer/` | 4 pages | 11 |

**The workflow tables named seven files, two of which do not exist** — `security.yml` and `ter-publish.yml`. Twelve exist. Both tables (`AGENTS.md` and `.github/workflows/AGENTS.md`) now list them, and the release-notes paragraph that was built on `ter-publish.yml` names `republish.yml`, which is the `workflow_dispatch` fallback it described.

**Two counts stay** because they do not move with a file, and both were verified: seven registered provider adapters (seven classes carrying `#[AsLlmProvider]`; the eighth `Provider/*Provider.php` file is `AbstractProvider`) and thirteen seeded demo tasks (thirteen `INSERT` rows in `.ddev/sql/seed-tasks.sql`).

## Test

`Tests/Unit/AgentDocsCountConventionTest.php` rejects a reintroduced count in any `AGENTS.md`. It matches two shapes:

- `<number> <file-noun>` — "69 RST files", "26 ADRs"
- `<noun> (<number>)` — "controllers (13), request DTOs (4)"

The second exists because the first version of this test **missed it**, and that is the shape the removed `Controller/Backend/` row used — three of the nine stale numbers came from that single table cell. Review caught it by mutation.

Bare `records`, `pages` and `specs` are deliberately not matched: *"the wizard writes 2 records to sys_log"* counts things, not files.

One test case per document rather than one loop, so a count in the first file cannot mask one in the next — the earlier loop version hid exactly that. The document list is pinned so a **deleted** `AGENTS.md` cannot silently stop being checked.

Verified by mutation, both shapes at once:

```
AGENTS.md counts files: "139 ADRs".
Classes/AGENTS.md counts files: "controllers (21)", "DTOs (4)", "objects (20)".
Tests: 8, Assertions: 8, Failures: 2.
```

Note the first mutation used the **correct** number and still fails. That is the point: the rule is about the shape.

## Gates

unit (6361), functional sqlite (1482), phpstan, cgl, `rector -n` (8.2), fuzzy.

## Not fixed, flagged

`Documentation/AGENTS.md` and the root `AGENTS.md` keep these edits inside `AGENTS-GENERATED` blocks. Nothing in CI regenerates them, but whatever does regenerate them outside CI would need the same change.