### PR TITLE
build(deps): require nr-vault ^0.15.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require": {
         "php": "^8.2",
-        "netresearch/nr-vault": "^0.14.0",
+        "netresearch/nr-vault": "^0.15.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/log": "^2.0 || ^3.0",


### PR DESCRIPTION
nr-vault 0.15.0 adds `vault:store --as-provisioner` and the `provisioningBeUserUid` option, which the TYPO3 demo needs to put its OpenAI key in place from the deploy instead of by hand.

## Why this repo blocks that

The cap at `^0.14.0` made it impossible for the **whole tree**, not just for nr-llm. Composer refused the demo's own bump with:

```
netresearch/nr-llm v0.26.0 requires netresearch/nr-vault ^0.14.0
-> found netresearch/nr-vault[v0.14.0] but it conflicts with your root
   composer.json require (^0.15)
```

So no package in that install can reach 0.15 while this one pins below it.

## Moving the floor, not widening the range

`^0.15.0` rather than `^0.14 || ^0.15`. 0.15 only **adds** an option and a CLI flag, nothing in this repo uses either, and carrying two supported lines of a dependency developed in lockstep with this one buys nothing while doubling what CI has to keep honest.

## Verification

Against the actually resolved `netresearch/nr-vault v0.15.0`, not against the constraint on paper:

| Suite | Result |
|---|---|
| unit | 6361 tests, 19501 assertions |
| functional (sqlite) | 1481 tests, 15620 assertions |
| phpstan | No errors |

`composerUpdate` confirms what was installed: `Locking netresearch/nr-vault (v0.15.0)`.