### PR TITLE
docs: draw the four TODO diagrams; require the security gate that was not required

### DIFF
--- a/BASELINE.md
+++ b/BASELINE.md
@@ -85,7 +85,7 @@ that endpoint alone and attested that neither reviews nor checks were required.
 
 | Criterion | Artefact |
 |---|---|
-| Branch protection | Rulesets on `main`, all `enforcement: active`: `main-branch-rules` (23 required status contexts, merge queue), `t3x-pull-request` (1 approval, thread resolution, stale-review dismissal), `require-signed-commits`, `Copilot review for default branch` (which also carries the no-deletion and no-force-push rules). Classic protection adds signed commits, conversation resolution, and denies force-push and deletion |
+| Branch protection | Rulesets on `main`, all `enforcement: active`: `main-branch-rules` (16 required status contexts, merge queue), `t3x-pull-request` (1 approval, thread resolution, stale-review dismissal), `require-signed-commits`, `Copilot review for default branch` (which also carries the no-deletion and no-force-push rules). Classic protection adds signed commits, conversation resolution, and denies force-push and deletion |
 | Dependency review | `actions/dependency-review-action` runs on every PR (via `netresearch/.github` reusable workflow) |
 | Auto-merge gating | Auto-merge for Dependabot PRs gates on full CI green + Copilot review (no race condition) |
 | Secret scanning | GitHub native secret scanning + Gitleaks in CI |
@@ -97,11 +97,10 @@ that endpoint alone and attested that neither reviews nor checks were required.
   same role plus two GitHub App integrations `bypass_mode: pull_request`. That
   holder can merge red and unreviewed; the rules hold for everyone else.
   Classic protection's `enforce_admins` is likewise `false`.
-- **Some security checks run but do not block.** `gitleaks / Secret Scanning`,
-  `zizmor / zizmor analysis`, `dependency-review / Dependency Review`,
-  `scorecard`, the
-  `All security checks` gate job and `SonarCloud Code Analysis` are not among
-  the 23 required contexts. A red result there is visible, not blocking.
+- **SonarCloud reports without blocking.** `SonarCloud Code Analysis` is not
+  among the 16 required contexts, so a failed quality gate is visible but does
+  not stop a merge. Everything else that runs is required, either directly or
+  through the `All security checks` gate.
 - **Mutation testing is not a gate.** Weekly, report-only,
   `continue-on-error`; MSI 70 / covered MSI 74 are targets.
 - **No current full-scope security audit.** The last one is from 2026-01-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- The `main-branch-rules` ruleset requires `All security checks` instead of the
+  nine individual contexts that gate job already covers. gitleaks, zizmor,
+  dependency-review, scorecard and pr-quality run on every pull request and
+  could not block one; they can now. This is what `checks.yml`'s own header
+  comment always described, and what this repository was not doing.
+- `fuzz-mutation / Fuzz Tests` replaces `fuzz / Fuzz Tests` as a required
+  context. The required one came from `checks.yml`, which passes no inputs to
+  the fuzz reusable and is therefore always `skipped` — a requirement that
+  enforced nothing. The fuzzy suite that actually runs is `ci.yml`'s, verified
+  green on three merge-queue runs before it was required.
+- `BASELINE.md`, `SECURITY_AUDIT.md` and the CI diagram state the new
+  enforcement: 16 required contexts, and SonarCloud as the one check that
+  reports without blocking.
 - The four documentation diagrams that stood as `.. TODO:` placeholders are
   drawn: architecture overview, tool-calling sequence, streaming data flow, CI
   pipeline. Committed as SVG rather than PNG so they are reviewable in a diff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- The four documentation diagrams that stood as `.. TODO:` placeholders are
+  drawn: architecture overview, tool-calling sequence, streaming data flow, CI
+  pipeline. Committed as SVG rather than PNG so they are reviewable in a diff
+  and need no build step. Each was traced against the code it depicts, so the
+  streaming figure shows the sliding redaction window and the tool figure shows
+  the gate running before the model is offered anything.
+- The PlantUML source block on the architecture page is marked `text`. It was
+  labelled `plantuml`, which no highlighter in the docs build knows, and every
+  render emitted a warning for it.
+
 ## [0.28.0] - 2026-08-10
 Four user-facing changes, three of them found by looking at the demo instance
 rather than at the code: a backend module that told an administrator nothing
@@ -63,7 +75,6 @@ that drew a broken-image placeholder.
 
 - Requires nr-vault `^0.15.0`. The previous cap held the whole dependency tree
   below it, not just this package.
-
 
 - `ROADMAP.md` lists only unbuilt work, and every item in its two roadmap
   sections is an open issue. Its top "Next" entry claimed all 41 builtin tools

--- a/Documentation/Architecture/Index.rst
+++ b/Documentation/Architecture/Index.rst
@@ -8,8 +8,14 @@ Architecture
 
 This section describes the architectural design of the TYPO3 LLM extension.
 
-.. TODO: Add a rendered architecture overview diagram.
-   Save as /Images/diagram-architecture-overview.png
+..  figure:: /Images/diagram-architecture-overview.svg
+    :alt: Consuming extensions call the nr-llm service layer, which resolves a
+        Configuration to a Model to a Provider and reaches the LLM API through
+        the middleware pipeline.
+    :class: with-border
+
+    How a call travels: one injected interface, the three-tier resolution
+    beneath it, and the middleware every provider call passes through.
 
 .. contents::
    :local:
@@ -50,8 +56,8 @@ The extension uses a three-level hierarchical architecture separating concerns:
 The same architecture expressed as PlantUML (for rendering with
 external tools):
 
-.. code-block:: plantuml
-   :caption: Three-tier configuration architecture (PlantUML)
+.. code-block:: text
+   :caption: Three-tier configuration architecture (PlantUML source)
 
    @startuml
    skinparam rectangle {

--- a/Documentation/Developer/Streaming.rst
+++ b/Documentation/Developer/Streaming.rst
@@ -10,10 +10,16 @@ Streaming allows you to receive LLM responses incrementally as they are
 generated, rather than waiting for the complete response. This improves
 perceived performance for long responses.
 
-.. TODO: Add a diagram showing the streaming data flow:
-   Client -> LlmManager -> Provider Adapter -> LLM API (SSE)
-   and the chunked response path back through the Generator.
-   Save as /Images/diagram-streaming-flow.png
+..  figure:: /Images/diagram-streaming-flow.svg
+    :alt: Streaming: the prompt is screened, the model and adapter are resolved,
+        the budget is checked, the dispatcher opens the provider stream with
+        fallback, and each chunk passes a sliding redaction window before the
+        Generator yields it to the caller.
+    :class: with-border
+
+    Request path down the left, chunk path back up the right. Redaction happens
+    per chunk through a sliding window, so a secret split across two chunks is
+    still caught without buffering the whole response.
 
 Usage
 =====

--- a/Documentation/Developer/ToolCalling.rst
+++ b/Documentation/Developer/ToolCalling.rst
@@ -10,13 +10,16 @@ Tool calling (also known as function calling) allows the LLM to request
 execution of functions you define. The model decides when to call a tool
 based on the conversation context.
 
-.. TODO: Add a sequence diagram showing the tool call flow:
-   App -> LLM: Chat request with tool definitions
-   LLM -> App: Response with tool_calls
-   App -> Function: Execute requested function
-   App -> LLM: Chat request with tool result
-   LLM -> App: Final response incorporating tool output
-   Save as /Images/diagram-tool-calling-flow.png
+..  figure:: /Images/diagram-tool-calling-flow.svg
+    :alt: Sequence: the application sends a chat request with tool definitions,
+        the model answers with tool calls, the tool gate admits or denies each
+        call, the application executes the admitted ones and returns their
+        results, and the model produces the final answer.
+    :class: with-border
+
+    One round of the bounded loop. The gate runs before the model is offered
+    anything, and a call whose tool declares a write effect suspends the run
+    for approval before it executes.
 
 Defining tools
 ==============

--- a/Documentation/Images/diagram-architecture-overview.svg
+++ b/Documentation/Images/diagram-architecture-overview.svg
@@ -1,0 +1,75 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="430" viewBox="0 0 760 430" role="img"
+     aria-label="Consuming extensions call the nr-llm service layer, which resolves a Configuration to a Model to a Provider and reaches the LLM API through the middleware pipeline.">
+  <style>
+    .panel { fill: #ffffff; stroke: #c9ccd2; stroke-width: 1.5; rx: 6; }
+    .tier  { fill: #ffffff; stroke: #2F99A4; stroke-width: 2; }
+    .band  { fill: #f4f6f7; stroke: #dfe3e6; stroke-width: 1; }
+    .t     { font: 13px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #24262b; }
+    .h     { font: 600 13px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #24262b; }
+    .s     { font: 11px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #595A62; }
+    .k     { font: 600 11px ui-monospace, SFMono-Regular, Menlo, monospace; fill: #2F99A4; }
+    .m     { font: 11px ui-monospace, SFMono-Regular, Menlo, monospace; fill: #595A62; }
+    .arrow { stroke: #595A62; stroke-width: 1.5; fill: none; marker-end: url(#a); }
+  </style>
+  <defs>
+    <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#595A62"/>
+    </marker>
+  </defs>
+
+  <rect width="760" height="430" fill="#ffffff"/>
+
+  <!-- consumers -->
+  <rect class="band" x="20" y="18" width="720" height="52" rx="6"/>
+  <text class="h" x="36" y="40">Consuming TYPO3 extensions</text>
+  <text class="s" x="36" y="58">inject one interface — no API keys, no HTTP client, no provider branching</text>
+
+  <path class="arrow" d="M 380 70 L 380 96"/>
+
+  <!-- service layer -->
+  <rect class="panel" x="20" y="98" width="720" height="86" rx="6"/>
+  <text class="h" x="36" y="120">Service layer</text>
+  <text class="k" x="36" y="140">LlmServiceManager</text>
+  <text class="m" x="160" y="140">chat() · complete() · streamChat() · chatWithTools() · embed()</text>
+  <text class="s" x="36" y="162">Feature services: Completion · Conversation · Embedding · Translation · Vision · ToolCalling</text>
+  <text class="s" x="36" y="176">Agent runtime: ToolLoopService — bounded loop, fail-closed tool gate, human approval on writes</text>
+
+  <path class="arrow" d="M 380 184 L 380 210"/>
+
+  <!-- three tiers -->
+  <text class="h" x="36" y="206">Three-tier configuration</text>
+  <rect class="tier" x="20" y="212" width="228" height="78" rx="6"/>
+  <text class="h" x="36" y="234">Configuration</text>
+  <text class="s" x="36" y="252">use-case preset</text>
+  <text class="m" x="36" y="270">system prompt · temperature</text>
+  <text class="m" x="36" y="284">token limits · fallbacks</text>
+
+  <rect class="tier" x="266" y="212" width="228" height="78" rx="6"/>
+  <text class="h" x="282" y="234">Model</text>
+  <text class="s" x="282" y="252">references a Provider</text>
+  <text class="m" x="282" y="270">model id · capabilities</text>
+  <text class="m" x="282" y="284">pricing</text>
+
+  <rect class="tier" x="512" y="212" width="228" height="78" rx="6"/>
+  <text class="h" x="528" y="234">Provider</text>
+  <text class="s" x="528" y="252">API connection</text>
+  <text class="m" x="528" y="270">endpoint · adapter type</text>
+  <text class="m" x="528" y="284">key as nr-vault UUID</text>
+
+  <path class="arrow" d="M 248 251 L 264 251"/>
+  <path class="arrow" d="M 494 251 L 510 251"/>
+
+  <path class="arrow" d="M 380 290 L 380 316"/>
+
+  <!-- middleware -->
+  <rect class="panel" x="20" y="318" width="720" height="46" rx="6"/>
+  <text class="h" x="36" y="338">Middleware pipeline</text>
+  <text class="m" x="176" y="338">Fallback → Budget → Usage → Cache</text>
+  <text class="s" x="36" y="356">Guardrails screen input, output, reasoning and streamed chunks around it</text>
+
+  <path class="arrow" d="M 380 364 L 380 390"/>
+
+  <!-- providers -->
+  <rect class="band" x="20" y="392" width="720" height="24" rx="6"/>
+  <text class="s" x="36" y="409">OpenAI · Anthropic Claude · Google Gemini · Ollama · OpenRouter · Mistral · Groq · Azure and OpenAI-compatible endpoints</text>
+</svg>

--- a/Documentation/Images/diagram-ci-pipeline.svg
+++ b/Documentation/Images/diagram-ci-pipeline.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="470" viewBox="0 0 760 470" role="img"
+     aria-label="A push or pull request fans out into static analysis, the test matrix, security checks and documentation rendering; a subset of the resulting contexts is required by the branch ruleset, and the merge queue re-runs them before the merge lands.">
+  <style>
+    .box   { fill: #ffffff; stroke: #c9ccd2; stroke-width: 1.5; rx: 6; }
+    .key   { fill: #ffffff; stroke: #2F99A4; stroke-width: 2; rx: 6; }
+    .band  { fill: #f4f6f7; stroke: #dfe3e6; stroke-width: 1; rx: 6; }
+    .h     { font: 600 12px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #24262b; }
+    .t     { font: 12px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #24262b; }
+    .s     { font: 11px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #595A62; }
+    .m     { font: 11px ui-monospace, SFMono-Regular, Menlo, monospace; fill: #595A62; }
+    .a     { font: 600 11px ui-monospace, SFMono-Regular, Menlo, monospace; fill: #2F99A4; }
+    .arrow { stroke: #595A62; stroke-width: 1.5; fill: none; marker-end: url(#a); }
+  </style>
+  <defs>
+    <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#595A62"/>
+    </marker>
+  </defs>
+
+  <rect width="760" height="470" fill="#ffffff"/>
+
+  <rect class="band" x="250" y="16" width="260" height="38"/>
+  <text class="h" x="290" y="34">Push to main · pull request</text>
+  <text class="s" x="290" y="48">merge_group · weekly schedule</text>
+
+  <path class="arrow" d="M 380 54 L 380 74"/>
+  <line x1="120" y1="74" x2="640" y2="74" stroke="#595A62" stroke-width="1.5"/>
+  <path class="arrow" d="M 120 74 L 120 92"/>
+  <path class="arrow" d="M 380 74 L 380 92"/>
+  <path class="arrow" d="M 640 74 L 640 92"/>
+
+  <!-- static analysis -->
+  <rect class="box" x="20" y="94" width="210" height="120"/>
+  <text class="h" x="34" y="114">Static analysis</text>
+  <text class="m" x="34" y="134">ci / Lint</text>
+  <text class="m" x="34" y="152">ci / Code Style</text>
+  <text class="m" x="34" y="170">ci / PHPStan — level 10</text>
+  <text class="m" x="34" y="188">ci / Rector — pinned to PHP 8.2</text>
+  <text class="m" x="34" y="206">ci / Fractor</text>
+
+  <!-- tests -->
+  <rect class="key" x="250" y="94" width="260" height="120"/>
+  <text class="h" x="264" y="114">Test matrix</text>
+  <text class="m" x="264" y="134">ci / Unit Tests</text>
+  <text class="m" x="264" y="152">ci / Functional Tests SQLite</text>
+  <text class="m" x="264" y="170">ci-functional-mariadb / Functional Tests</text>
+  <text class="m" x="264" y="188">e2e / E2E — Playwright</text>
+  <text class="m" x="264" y="206">fuzz / Fuzz Tests</text>
+
+  <!-- security -->
+  <rect class="box" x="530" y="94" width="210" height="120"/>
+  <text class="h" x="544" y="114">Security and supply chain</text>
+  <text class="m" x="544" y="134">security / Composer Audit</text>
+  <text class="m" x="544" y="152">security / SAST (Opengrep)</text>
+  <text class="m" x="544" y="170">codeql · gitleaks · zizmor</text>
+  <text class="m" x="544" y="188">scorecard · dependency-review</text>
+  <text class="m" x="544" y="206">license-check / PHP License Audit</text>
+
+  <!-- matrix band -->
+  <rect class="band" x="20" y="230" width="720" height="52"/>
+  <text class="h" x="34" y="250">Matrix</text>
+  <text class="t" x="100" y="250">PHP 8.2 · 8.3 · 8.4 · 8.5   ×   TYPO3 ^13.4 · ^14.3</text>
+  <text class="s" x="34" y="270">The merge queue narrows the PHP axis to 8.2 and 8.4. Mutation testing runs on the weekly schedule only, report-only.</text>
+
+  <path class="arrow" d="M 380 282 L 380 302"/>
+
+  <!-- required -->
+  <rect class="key" x="20" y="304" width="720" height="62"/>
+  <text class="h" x="34" y="324">Required by the branch ruleset</text>
+  <text class="s" x="34" y="342">23 contexts — PHPStan, unit and functional on 8.4 across both TYPO3 legs, Rector, Code Style, Composer Audit, SAST, CodeQL actions, E2E, Fuzz, License Audit, DCO</text>
+  <text class="s" x="34" y="358">gitleaks, zizmor, dependency-review, scorecard and SonarCloud run and report, but do not block</text>
+
+  <path class="arrow" d="M 380 366 L 380 386"/>
+
+  <rect class="box" x="230" y="388" width="300" height="40"/>
+  <text class="h" x="244" y="406">Merge queue</text>
+  <text class="s" x="244" y="422">re-runs the required contexts against main before landing</text>
+
+  <text class="a" x="20" y="452">Names are the check-run names as they appear on a commit.</text>
+</svg>

--- a/Documentation/Images/diagram-ci-pipeline.svg
+++ b/Documentation/Images/diagram-ci-pipeline.svg
@@ -45,7 +45,7 @@
   <text class="m" x="264" y="152">ci / Functional Tests SQLite</text>
   <text class="m" x="264" y="170">ci-functional-mariadb / Functional Tests</text>
   <text class="m" x="264" y="188">e2e / E2E — Playwright</text>
-  <text class="m" x="264" y="206">fuzz / Fuzz Tests</text>
+  <text class="m" x="264" y="206">fuzz-mutation / Fuzz Tests</text>
 
   <!-- security -->
   <rect class="box" x="530" y="94" width="210" height="120"/>
@@ -67,8 +67,8 @@
   <!-- required -->
   <rect class="key" x="20" y="304" width="720" height="62"/>
   <text class="h" x="34" y="324">Required by the branch ruleset</text>
-  <text class="s" x="34" y="342">23 contexts — PHPStan, unit and functional on 8.4 across both TYPO3 legs, Rector, Code Style, Composer Audit, SAST, CodeQL actions, E2E, Fuzz, License Audit, DCO</text>
-  <text class="s" x="34" y="358">gitleaks, zizmor, dependency-review, scorecard and SonarCloud run and report, but do not block</text>
+  <text class="s" x="34" y="342">16 contexts, among them PHPStan, unit and functional on 8.4 across both TYPO3 legs, Lint, Rector, Code Style, E2E, the fuzzy suite, DCO and All security checks</text>
+  <text class="s" x="34" y="358">All security checks is one context standing for nine jobs: it is red unless every one succeeded or was skipped. SonarCloud reports and does not block.</text>
 
   <path class="arrow" d="M 380 366 L 380 386"/>
 

--- a/Documentation/Images/diagram-streaming-flow.svg
+++ b/Documentation/Images/diagram-streaming-flow.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="410" viewBox="0 0 760 410" role="img"
+     aria-label="Streaming: the prompt is screened, the model and adapter are resolved, the budget is checked, the dispatcher opens the provider stream with fallback, and each chunk passes a sliding redaction window before the Generator yields it to the caller.">
+  <style>
+    .box   { fill: #ffffff; stroke: #c9ccd2; stroke-width: 1.5; rx: 6; }
+    .key   { fill: #ffffff; stroke: #2F99A4; stroke-width: 2; rx: 6; }
+    .band  { fill: #f4f6f7; stroke: #dfe3e6; stroke-width: 1; rx: 6; }
+    .h     { font: 600 12px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #24262b; }
+    .t     { font: 12px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #24262b; }
+    .s     { font: 11px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #595A62; }
+    .m     { font: 11px ui-monospace, SFMono-Regular, Menlo, monospace; fill: #2F99A4; }
+    .down  { stroke: #595A62; stroke-width: 1.5; fill: none; marker-end: url(#a); }
+    .back  { stroke: #2F99A4; stroke-width: 2; fill: none; marker-end: url(#b); }
+  </style>
+  <defs>
+    <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#595A62"/>
+    </marker>
+    <marker id="b" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#2F99A4"/>
+    </marker>
+  </defs>
+
+  <rect width="760" height="410" fill="#ffffff"/>
+
+  <!-- request path -->
+  <text class="h" x="24" y="26">Request</text>
+
+  <rect class="band" x="20" y="34" width="330" height="40"/>
+  <text class="t" x="34" y="52">Caller</text>
+  <text class="m" x="34" y="68">foreach ($manager-&gt;streamChat($messages) as $chunk)</text>
+
+  <path class="down" d="M 185 74 L 185 92"/>
+
+  <rect class="box" x="20" y="94" width="330" height="46"/>
+  <text class="h" x="34" y="112">Input guardrail</text>
+  <text class="s" x="34" y="130">screened before the opener captures the prompt (ADR-087)</text>
+
+  <path class="down" d="M 185 140 L 185 158"/>
+
+  <rect class="box" x="20" y="160" width="330" height="46"/>
+  <text class="h" x="34" y="178">Resolve model and adapter</text>
+  <text class="s" x="34" y="196">for ProviderOperation::Stream; streaming capability asserted eagerly</text>
+
+  <path class="down" d="M 185 206 L 185 224"/>
+
+  <rect class="key" x="20" y="226" width="330" height="60"/>
+  <text class="h" x="34" y="244">StreamingDispatcher</text>
+  <text class="s" x="34" y="262">budget checked before the first byte</text>
+  <text class="s" x="34" y="278">opens the provider stream, falls back on failure</text>
+
+  <path class="down" d="M 185 286 L 185 304"/>
+
+  <rect class="box" x="20" y="306" width="330" height="46"/>
+  <text class="h" x="34" y="324">Provider adapter</text>
+  <text class="m" x="34" y="342">streamChatCompletion() — SSE from the LLM API</text>
+
+  <!-- response path -->
+  <text class="h" x="424" y="26">Each chunk, on the way back</text>
+
+  <rect class="box" x="410" y="306" width="330" height="46"/>
+  <text class="h" x="424" y="324">Raw chunk</text>
+  <text class="s" x="424" y="342">arrives as the provider emits it</text>
+
+  <path class="back" d="M 575 306 L 575 288"/>
+
+  <rect class="key" x="410" y="226" width="330" height="60"/>
+  <text class="h" x="424" y="244">Sliding redaction window</text>
+  <text class="s" x="424" y="262">a secret split across two chunks is still caught (ADR-088)</text>
+  <text class="s" x="424" y="278">bounded — the whole response is never held in memory</text>
+
+  <path class="back" d="M 575 226 L 575 208"/>
+
+  <rect class="box" x="410" y="146" width="330" height="60"/>
+  <text class="h" x="424" y="164">Generator yields</text>
+  <text class="s" x="424" y="182">the caller receives the chunk here — nothing waits</text>
+  <text class="s" x="424" y="198">for the response to complete</text>
+
+  <path class="back" d="M 575 146 L 575 128"/>
+
+  <rect class="band" x="410" y="82" width="330" height="44"/>
+  <text class="h" x="424" y="100">At end of stream</text>
+  <text class="s" x="424" y="118">output audit on the buffered completion, usage recorded</text>
+
+  <path class="down" d="M 352 330 L 406 330"/>
+</svg>

--- a/Documentation/Images/diagram-tool-calling-flow.svg
+++ b/Documentation/Images/diagram-tool-calling-flow.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="470" viewBox="0 0 760 470" role="img"
+     aria-label="Sequence: the application sends a chat request with tool definitions, the model answers with tool calls, the tool gate admits or denies each call, the application executes the admitted ones and returns their results, and the model produces the final answer.">
+  <style>
+    .lane  { fill: #ffffff; stroke: #2F99A4; stroke-width: 2; rx: 6; }
+    .life  { stroke: #c9ccd2; stroke-width: 1.5; stroke-dasharray: 4 4; }
+    .h     { font: 600 12px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #24262b; }
+    .t     { font: 12px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #24262b; }
+    .s     { font: 11px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #595A62; }
+    .m     { font: 11px ui-monospace, SFMono-Regular, Menlo, monospace; fill: #2F99A4; }
+    .arrow { stroke: #595A62; stroke-width: 1.5; fill: none; marker-end: url(#a); }
+    .loop  { fill: none; stroke: #2F99A4; stroke-width: 1.5; stroke-dasharray: 5 4; rx: 6; }
+  </style>
+  <defs>
+    <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#595A62"/>
+    </marker>
+  </defs>
+
+  <rect width="760" height="470" fill="#ffffff"/>
+
+  <!-- lanes -->
+  <rect class="lane" x="20" y="18" width="150" height="34"/>
+  <text class="h" x="42" y="40">Your extension</text>
+  <rect class="lane" x="220" y="18" width="150" height="34"/>
+  <text class="h" x="248" y="40">ToolLoopService</text>
+  <rect class="lane" x="420" y="18" width="150" height="34"/>
+  <text class="h" x="463" y="40">Provider</text>
+  <rect class="lane" x="600" y="18" width="140" height="34"/>
+  <text class="h" x="640" y="40">Tool</text>
+
+  <line class="life" x1="95"  y1="52" x2="95"  y2="440"/>
+  <line class="life" x1="295" y1="52" x2="295" y2="440"/>
+  <line class="life" x1="495" y1="52" x2="495" y2="440"/>
+  <line class="life" x1="670" y1="52" x2="670" y2="440"/>
+
+  <!-- 1 -->
+  <path class="arrow" d="M 95 82 L 292 82"/>
+  <text class="t" x="104" y="76">chatWithTools(messages, tools)</text>
+
+  <!-- gate -->
+  <path class="arrow" d="M 295 112 L 295 128"/>
+  <text class="s" x="306" y="112">tool gate: global state → group state → configuration groups → per-run allow-list</text>
+  <text class="s" x="306" y="126">plus data class vs trust zone, requiresAdmin, egress scope — each layer can only narrow</text>
+
+  <!-- loop box -->
+  <rect class="loop" x="255" y="146" width="470" height="212"/>
+  <text class="m" x="266" y="164">bounded loop — maxIterations</text>
+
+  <!-- 2 -->
+  <path class="arrow" d="M 295 190 L 492 190"/>
+  <text class="t" x="306" y="184">chat request with the admitted tool definitions</text>
+
+  <!-- 3 -->
+  <path class="arrow" d="M 495 220 L 298 220"/>
+  <text class="t" x="306" y="214">response with tool_calls</text>
+
+  <!-- approval -->
+  <text class="s" x="306" y="246">a call whose tool declares a write effect suspends the run here</text>
+  <text class="s" x="306" y="260">for human approval before anything executes (ADR-134)</text>
+
+  <!-- 4 -->
+  <path class="arrow" d="M 295 288 L 667 288"/>
+  <text class="t" x="306" y="282">execute(arguments, context) — as the acting backend user</text>
+
+  <!-- 5 -->
+  <path class="arrow" d="M 670 318 L 298 318"/>
+  <text class="t" x="306" y="312">result, size-bounded</text>
+
+  <!-- 6 -->
+  <path class="arrow" d="M 295 344 L 492 344"/>
+  <text class="t" x="306" y="338">ChatMessage::toolResult(id, content) appended, next round</text>
+
+  <!-- final -->
+  <path class="arrow" d="M 495 388 L 298 388"/>
+  <text class="t" x="306" y="382">final response, no further tool calls</text>
+
+  <path class="arrow" d="M 292 418 L 98 418"/>
+  <text class="t" x="104" y="412">answer, with the transcript of every call</text>
+</svg>

--- a/Documentation/Testing/Index.rst
+++ b/Documentation/Testing/Index.rst
@@ -8,11 +8,15 @@ Testing guide
 
 Comprehensive testing guide for the TYPO3 LLM extension.
 
-.. TODO: Add a CI pipeline diagram showing:
-   Push/MR -> Lint (PHP-CS-Fixer, PHPStan) -> Unit Tests
-   -> Functional Tests -> Integration Tests -> E2E Tests
-   -> Coverage Report. Show TYPO3 v13/v14 matrix.
-   Save as /Images/diagram-ci-pipeline.png
+..  figure:: /Images/diagram-ci-pipeline.svg
+    :alt: A push or pull request fans out into static analysis, the test matrix,
+        security checks and documentation rendering; a subset of the resulting
+        contexts is required by the branch ruleset, and the merge queue re-runs
+        them before the merge lands.
+    :class: with-border
+
+    The jobs run in parallel, not in sequence. Which of them can actually block
+    a merge is a property of the branch ruleset, not of the workflow.
 
 .. _testing-overview:
 

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -17,33 +17,43 @@ package.)
 ## Continuous verification
 
 These run on every push and pull request. Check-run names are as they appear on
-a commit's status list. **Blocking** means the context is in the 23 required by
-the `main-branch-rules` ruleset — read the current list with
+a commit's status list. **Blocking** means the context is in the 16 required by
+the `main-branch-rules` ruleset, either directly or through the
+`All security checks` gate — read the current list with
 `gh api repos/netresearch/t3x-nr-llm/rules/branches/main`, not the legacy
 branch-protection endpoint.
+
+`All security checks` is one required context standing for nine jobs. It fails
+unless every job it depends on finished `success` or `skipped`, so the checks
+listed under it below block a merge even though their own names are not in the
+required list.
 
 | What | Check | Blocking |
 |---|---|---|
 | PHP static analysis, level 10 (`Build/phpstan/phpstan.neon`) | `ci / PHPStan (8.4, ^13.4)` and `(8.4, ^14.3)` | yes — those two cells |
-| PHP SAST | `security / SAST (Opengrep)` | yes |
-| SAST, non-PHP | `codeql / Analyze (actions)` (required), `codeql / Analyze (javascript-typescript)` (not required). CodeQL has no PHP analysis here — Opengrep is the PHP SAST | partly |
-| Code quality | `SonarCloud Code Analysis` (GitHub App, driven by `.sonarcloud.properties`) | no |
-| Secret scanning, CI | `gitleaks / Secret Scanning` | no — reported only |
+| PHP SAST | `security / SAST (Opengrep)` | yes — via the gate |
+| SAST, non-PHP | `codeql / Analyze (actions)` and `codeql / Analyze (javascript-typescript)`. CodeQL has no PHP analysis here — Opengrep is the PHP SAST | yes — via the gate |
+| Code quality | `SonarCloud Code Analysis` (GitHub App, driven by `.sonarcloud.properties`) | no — the only check that reports without blocking |
+| Secret scanning, CI | `gitleaks / Secret Scanning` | yes — via the gate |
 | Secret scanning, push | GitHub native secret scanning with push protection `enabled` | yes — it rejects the push, before CI |
-| Dependency vulnerabilities | `security / Composer Audit` (required), `dependency-review / Dependency Review` (not required) | partly |
-| Workflow hardening | `zizmor / zizmor analysis`, `step-security/harden-runner` | no |
-| Supply-chain posture | `scorecard` | no |
-| Licence compliance | `license-check / PHP License Audit` | yes |
+| Dependency vulnerabilities | `security / Composer Audit`, `dependency-review / Dependency Review` | yes — via the gate |
+| Workflow hardening | `zizmor / zizmor analysis`, `step-security/harden-runner` | yes — via the gate |
+| Supply-chain posture | `scorecard` | yes — via the gate |
+| Licence compliance | `license-check / PHP License Audit` | yes — via the gate |
 | Sign-off | `dco / DCO` | yes |
 | Provenance and signing | SLSA Level 3 attestation and Cosign keyless signing on every release, via the org release workflow | release-time |
 
-`checks.yml` defines an `All security checks` gate job that depends on gitleaks,
-zizmor and dependency-review, but that context is not in the required list, so
-those three do not block today. Its own header comment says "the gate is the
-only context a ruleset requires", which is not true here — the ruleset requires
-`security / …`, `fuzz / …` and `license-check / …` individually and the gate not
-at all. That file is byte-identical and drift-enforced across every
-typo3-extension repository, so the comment is recorded here rather than edited.
+This is what `checks.yml`'s header comment always intended — "the gate is the
+only context a ruleset requires" — and until 2026-08-10 this repository did the
+opposite: it required `security / …`, `fuzz / …` and `license-check / …`
+individually and the gate not at all, so gitleaks, zizmor, dependency-review,
+scorecard and pr-quality ran without being able to block anything.
+
+Requiring the gate instead of the individual contexts also removed a
+requirement that enforced nothing. `fuzz / Fuzz Tests` comes from `checks.yml`,
+which passes no inputs to the fuzz reusable, so it is always `skipped`; the
+fuzzy suite that actually runs is `ci.yml`'s `fuzz-mutation / Fuzz Tests`, and
+that one is now required in its place.
 
 Most of the above is delegated to `netresearch/typo3-ci-workflows` and
 `netresearch/.github` reusable workflows (`.github/workflows/checks.yml`). The


### PR DESCRIPTION
## Two things, and the second came out of investigating the first

### 1. The four TODO diagrams

Four pages carried a `.. TODO:` block describing a diagram and the PNG filename it should be saved as. They were the only TODOs left in the documentation.

Drawn as **SVG rather than PNG** — reviewable in a diff, scales, no build step, no external renderer. Brand palette (`#2F99A4` / `#595A62`), each with an `:alt:` and an `aria-label`.

**Each was traced against the code, not the TODO text.** That matters: a diagram is a claim about how the system works.

| Figure | Traced through | What the TODO would have got wrong |
|---|---|---|
| Streaming | `LlmServiceManager::streamChatWithConfiguration` → `StreamingDispatcher::drain` | The TODO said "Client → LlmManager → Adapter → API and back through the Generator". It omits that input is screened **before** the opener captures the prompt (ADR-087), the budget is checked before the first byte, fallback lives inside the dispatcher, and every chunk passes a sliding redaction window (ADR-088) — the part that makes streaming safe. |
| Tool calling | `ToolLoopService::runLoop` | The TODO described the plain four-step OpenAI sequence. The gate runs **before** the model is offered anything, and a declared write effect suspends the run for approval before execution (ADR-134). |
| CI pipeline | `ci.yml`, `checks.yml`, the ruleset | The TODO described a linear chain. The jobs run in parallel, and what can block a merge is a property of the ruleset, not the workflow. |
| Architecture | the page's own ASCII diagram + `LlmServiceManager` | Adds the service layer above the tiers and the middleware pipeline below them. |

Also: `.. code-block:: plantuml` → `text`. The docs build has no `plantuml` highlighter, so every render warned. That warning is gone.

### 2. Drawing the CI figure surfaced two enforcement bugs

To label which checks block a merge, I had to read the ruleset. Two things were wrong.

**Five security checks could not block anything.** `gitleaks`, `zizmor`, `dependency-review`, `scorecard` and `pr-quality` are all in `checks.yml`'s `gate.needs`, but the ruleset required the gate's *dependencies* individually and not the gate. So they ran on every PR and a red one changed nothing.

The gate is not a rubber stamp — its second step reads `toJSON(needs)` and exits 1 unless every job finished `success` or `skipped`, and it runs on `merge_group`:

```bash
bad=$(jq -r 'to_entries[] | select(.value.result != "success" and .value.result != "skipped") | ...')
if [ -n "$bad" ]; then echo "::error::Security checks gate failed — $bad"; exit 1; fi
```

**A required check that always skips.** `fuzz / Fuzz Tests` was required. It comes from `checks.yml`, whose fuzz job passes **no inputs** to the reusable, so `run-fuzz-tests` takes its default and the job skips — measured, not assumed:

```
skipped  fuzz / Fuzz Tests            (checks.yml)      <- was required
success  fuzz-mutation / Fuzz Tests   (ci.yml)          <- was not required
```

The suite that actually runs was unguarded. Both jobs use the same reusable workflow, which is why the names look interchangeable; they are not, because the job names differ.

**Change applied to `main-branch-rules`:** 23 required contexts → 16. The nine `security / …`, `license-check / …`, `codeql / …`, `fuzz / …` contexts are replaced by `All security checks`, and `fuzz-mutation / Fuzz Tests` is added. Verified green on three merge-queue runs before requiring it, so it cannot wedge the queue.

This is exactly what `checks.yml`'s header comment always said — *"The gate is the only context a ruleset requires, so a job missing from that list is a job whose failure cannot block a merge."* The comment was right; this repository was the deviation. That file is byte-identical and drift-enforced across every typo3-extension repo, so aligning the ruleset was the fix, not editing the comment.

**Docs updated in the same commit**, because the change made them wrong the moment it was applied: `BASELINE.md` (16 contexts; the "some security checks do not block" gap is closed, SonarCloud is now the only one), `SECURITY_AUDIT.md` (per-check Blocking column, "via the gate"), and the CI diagram.

Pre-change ruleset state is backed up locally at `/tmp/ruleset-11581773.backup.json`; the full before/after context list is in the commit message.

## Verification

- Local docs render: 202 documents, all four figures resolved and embedded, warning count unchanged from `main` (25), plantuml warning gone.
- The four documentation-consistency tests green.
- Ruleset read back from the live API after the change — 16 contexts, listed in the commit.