### PR TITLE
docs(changelog): remove the entries the merge resolver wrote twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,16 +15,17 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   makes the guarantee hold for entry points that do not exist yet: a new caller
   that forgets to claim its run cannot execute a write. Read-only tools are
   unaffected — repeating a read is always safe.
+
 - `WritePathAcceptanceTest` asserts the fence on the segment that executes the
   write: stamped with the declared effect before the tool, cleared after, both
   under the lease the resume claimed. Its docblock carried a detailed account of
   why the fence could never arm; that account is now the history of what
   ADR-141 closed.
+
 - `AgentRuntimeWiringTest` asks the container whether the write fence's effect
   resolver is actually injected. Without it every tool reads as READ_ONLY, so no
   write is fenced and none is refused — the axis fails open silently while every
   hand-wired test still passes.
-
 
 - **An operator can declare that a snippet or a skill must not leave a trust
   zone** (ADR-144, closes #689). Tool OUTPUT has been data-classified since
@@ -75,6 +76,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     days is right for a controlled cloud, and a deviation is a question worth
     asking rather than a defect.
 
+
 ### Changed
 
 - The `main-branch-rules` ruleset requires `All security checks` instead of the
@@ -82,24 +84,27 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   dependency-review, scorecard and pr-quality run on every pull request and
   could not block one; they can now. This is what `checks.yml`'s own header
   comment always described, and what this repository was not doing.
+
 - `fuzz-mutation / Fuzz Tests` replaces `fuzz / Fuzz Tests` as a required
   context. The required one came from `checks.yml`, which passes no inputs to
   the fuzz reusable and is therefore always `skipped` — a requirement that
   enforced nothing. The fuzzy suite that actually runs is `ci.yml`'s, verified
   green on three merge-queue runs before it was required.
+
 - `BASELINE.md`, `SECURITY_AUDIT.md` and the CI diagram state the new
   enforcement: 16 required contexts, and SonarCloud as the one check that
   reports without blocking.
+
 - The four documentation diagrams that stood as `.. TODO:` placeholders are
   drawn: architecture overview, tool-calling sequence, streaming data flow, CI
   pipeline. Committed as SVG rather than PNG so they are reviewable in a diff
   and need no build step. Each was traced against the code it depicts, so the
   streaming figure shows the sliding redaction window and the tool figure shows
   the gate running before the model is offered anything.
+
 - The PlantUML source block on the architecture page is marked `text`. It was
   labelled `plantuml`, which no highlighter in the docs build knows, and every
   render emitted a warning for it.
-
 
 - **Every executing segment holds a lease, so writes are fenced wherever they
   run** (ADR-141). 0.27.0 shipped two writing tools and stated the gap in the
@@ -119,6 +124,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `enqueue()` instead was rejected: it loses the result and the `$onStep`
   closure the streamed Playground run is built on, and — decisively — it does
   not reach the resume at all, which is where writes actually execute.
+
 - A stale RUNNING run that stored no request payload is dead-lettered rather
   than reclaimed onto the queue. A leased synchronous run or resume is now
   visible to `nrllm:agent:reap` (which is the point — an abandoned one settles
@@ -126,34 +132,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and a worker refuses a QUEUED row it cannot rehydrate. Reclaiming one would
   strand it QUEUED forever. The fence check keeps priority, so a run caught mid
   non-idempotent write is still refused for that stronger reason first.
+
 - An interactive run renews its lease at every step boundary. Previously only
   queue workers did, and a test pinned that as an invariant; it now pins the
   opposite, because the heartbeat is what an ownership-guarded fence write needs
   to match against.
-
-- The `main-branch-rules` ruleset requires `All security checks` instead of the
-  nine individual contexts that gate job already covers. gitleaks, zizmor,
-  dependency-review, scorecard and pr-quality run on every pull request and
-  could not block one; they can now. This is what `checks.yml`'s own header
-  comment always described, and what this repository was not doing.
-- `fuzz-mutation / Fuzz Tests` replaces `fuzz / Fuzz Tests` as a required
-  context. The required one came from `checks.yml`, which passes no inputs to
-  the fuzz reusable and is therefore always `skipped` — a requirement that
-  enforced nothing. The fuzzy suite that actually runs is `ci.yml`'s, verified
-  green on three merge-queue runs before it was required.
-- `BASELINE.md`, `SECURITY_AUDIT.md` and the CI diagram state the new
-  enforcement: 16 required contexts, and SonarCloud as the one check that
-  reports without blocking.
-- The four documentation diagrams that stood as `.. TODO:` placeholders are
-  drawn: architecture overview, tool-calling sequence, streaming data flow, CI
-  pipeline. Committed as SVG rather than PNG so they are reviewable in a diff
-  and need no build step. Each was traced against the code it depicts, so the
-  streaming figure shows the sliding redaction window and the tool figure shows
-  the gate running before the model is offered anything.
-- The PlantUML source block on the architecture page is marked `text`. It was
-  labelled `plantuml`, which no highlighter in the docs build knows, and every
-  render emitted a warning for it.
-
 
 - **An automatic model selection can say why** (ADR-142). Criteria-mode routing
   always had exactly one production path, but it returned a model and nothing
@@ -167,11 +150,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   so `OPERATION_CAPABILITY_MISSING` means "would have served, but not this
   operation" and the misconfiguration error it raises cannot name a model the
   criteria excluded anyway.
+
 - The routing predicates exist once. `ModelSelectionService::modelMatchesCriteria()`
   and the decision point share one `EligibilityEvaluator` instead of keeping two
   copies that could drift, and the candidate comparator moved into
   `CandidateRanker` with it. Behaviour is unchanged, which the existing suite
   passing untouched is the evidence for.
+
 - Evaluation quality (ADR-060) and recent provider health (ADR-063) can now
   rank candidates, under a new `routing.policyMode` setting. It defaults to
   `providerPriority`, which reproduces the previous ordering exactly; the three
@@ -182,59 +167,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   contributes nothing rather than a zero, so an absence never reads as a bad
   score. `ProviderHealthService::reorder()` is untouched: it orders the fallback
   chain, which is a different axis.
+
 - ADR-060 left first-class quality wiring as a follow-up and shipped
   `QualityAwareModelSelector` as an opt-in hook meanwhile. That follow-up is
   this. The hook is unchanged and still has no core consumer — its hard
   `minQuality` filter has no equivalent in the ranking on purpose, because a
   minimum quality is a constraint and constraints stay out of ranking.
-
-- The `main-branch-rules` ruleset requires `All security checks` instead of the
-  nine individual contexts that gate job already covers. gitleaks, zizmor,
-  dependency-review, scorecard and pr-quality run on every pull request and
-  could not block one; they can now. This is what `checks.yml`'s own header
-  comment always described, and what this repository was not doing.
-- `fuzz-mutation / Fuzz Tests` replaces `fuzz / Fuzz Tests` as a required
-  context. The required one came from `checks.yml`, which passes no inputs to
-  the fuzz reusable and is therefore always `skipped` — a requirement that
-  enforced nothing. The fuzzy suite that actually runs is `ci.yml`'s, verified
-  green on three merge-queue runs before it was required.
-- `BASELINE.md`, `SECURITY_AUDIT.md` and the CI diagram state the new
-  enforcement: 16 required contexts, and SonarCloud as the one check that
-  reports without blocking.
-- The four documentation diagrams that stood as `.. TODO:` placeholders are
-  drawn: architecture overview, tool-calling sequence, streaming data flow, CI
-  pipeline. Committed as SVG rather than PNG so they are reviewable in a diff
-  and need no build step. Each was traced against the code it depicts, so the
-  streaming figure shows the sliding redaction window and the tool figure shows
-  the gate running before the model is offered anything.
-- The PlantUML source block on the architecture page is marked `text`. It was
-  labelled `plantuml`, which no highlighter in the docs build knows, and every
-  render emitted a warning for it.
-
-
-- The `main-branch-rules` ruleset requires `All security checks` instead of the
-  nine individual contexts that gate job already covers. gitleaks, zizmor,
-  dependency-review, scorecard and pr-quality run on every pull request and
-  could not block one; they can now. This is what `checks.yml`'s own header
-  comment always described, and what this repository was not doing.
-- `fuzz-mutation / Fuzz Tests` replaces `fuzz / Fuzz Tests` as a required
-  context. The required one came from `checks.yml`, which passes no inputs to
-  the fuzz reusable and is therefore always `skipped` — a requirement that
-  enforced nothing. The fuzzy suite that actually runs is `ci.yml`'s, verified
-  green on three merge-queue runs before it was required.
-- `BASELINE.md`, `SECURITY_AUDIT.md` and the CI diagram state the new
-  enforcement: 16 required contexts, and SonarCloud as the one check that
-  reports without blocking.
-- The four documentation diagrams that stood as `.. TODO:` placeholders are
-  drawn: architecture overview, tool-calling sequence, streaming data flow, CI
-  pipeline. Committed as SVG rather than PNG so they are reviewable in a diff
-  and need no build step. Each was traced against the code it depicts, so the
-  streaming figure shows the sliding redaction window and the tool figure shows
-  the gate running before the model is offered anything.
-- The PlantUML source block on the architecture page is marked `text`. It was
-  labelled `plantuml`, which no highlighter in the docs build knows, and every
-  render emitted a warning for it.
-
 
 - `TrustZoneResolver` and `DataClassEnforcementResolver` moved from
   `Service\Tool` to `Service\Governance`. Neither is about tools — a trust zone
@@ -245,7 +183,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `EffectivePolicyReadout` existed for the same reason and is gone with them, so
   the seam rule now passes with a shorter exception list than before. Both
   classes are `@internal`.
+
 - `Skill` gains `getDataClass()` / `getDataClassEnum()` on the `@api` surface.
+
 
 ### Fixed
 
@@ -275,99 +215,23 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   terminal, the first point that knows the resolved model; for a stream it runs
   inside the opener, before the adapter is asked for the first chunk, because
   once a stream is open there is nothing left to prune.
+
 - A completion **reports** rather than prunes. A raw prompt is a single unit —
   there are no older turns to drop, and shortening a caller's prompt behind
   their back would change what they asked for. An overflowing completion is now
   named, with the model and the budget it exceeded, instead of surfacing later
   as an opaque provider error.
+
 - A payload that overflows even at its floor is still sent, matching what
   `ConversationService` already did: the estimate errs high, so it may well
   succeed, and if it does not the provider's own error is what the caller would
   have received anyway.
+
 - `LlmServiceManager` gained two optional constructor arguments (the context
   window manager and a logger). Both default to null and every existing
   construction keeps its exact previous behaviour — a null context window means
   "bounded by the provider", which is what these paths did.
 
-- **A criteria-mode configuration was sized against the wrong context window**
-  (ADR-143). `ContextWindowManager` read the window from
-  `$configuration->getLlmModel()`, but a criteria-mode record carries no model
-  relation — `ConfigurationCallPlanner` deliberately does not write the
-  resolution back, because that would mark the entity dirty and Extbase would
-  persist `model_uid`, silently converting a dynamic configuration into a fixed
-  one. So every dynamically-selected call fell through to the unknown-model
-  fallback and budgeted against a number unrelated to the model on the wire; the
-  response reserve came off the same empty relation. The window and the reserve
-  now come from the model that actually serves the send. This is a behaviour
-  change on the paths that already bound a window: a transcript that previously
-  slipped through against a 128k assumption is pruned against the 4k model
-  answering it.
-
-- **Chat, tool calling and streaming through `LlmServiceManager` are bounded
-  like a conversation or an agent loop** (ADR-143, closes #688). A tool-calling
-  send counts its tool schemas against the same budget, because they are on the
-  wire with the transcript. Embeddings are deliberately not bounded: they carry
-  neither skills nor snippets nor a transcript, and their limit is the
-  provider's own input limit rather than a window to prune turns out of. Only
-  `ConversationService` and `ToolLoopService` bound their sends, so which API a
-  consumer happened to call decided whether a long transcript was pruned or
-  handed to the provider whole. The bind sits inside the middleware-pipeline
-  terminal, the first point that knows the resolved model; for a stream it runs
-  inside the opener, before the adapter is asked for the first chunk, because
-  once a stream is open there is nothing left to prune.
-- A completion **reports** rather than prunes. A raw prompt is a single unit —
-  there are no older turns to drop, and shortening a caller's prompt behind
-  their back would change what they asked for. An overflowing completion is now
-  named, with the model and the budget it exceeded, instead of surfacing later
-  as an opaque provider error.
-- A payload that overflows even at its floor is still sent, matching what
-  `ConversationService` already did: the estimate errs high, so it may well
-  succeed, and if it does not the provider's own error is what the caller would
-  have received anyway.
-- `LlmServiceManager` gained two optional constructor arguments (the context
-  window manager and a logger). Both default to null and every existing
-  construction keeps its exact previous behaviour — a null context window means
-  "bounded by the provider", which is what these paths did.
-
-- **A criteria-mode configuration was sized against the wrong context window**
-  (ADR-143). `ContextWindowManager` read the window from
-  `$configuration->getLlmModel()`, but a criteria-mode record carries no model
-  relation — `ConfigurationCallPlanner` deliberately does not write the
-  resolution back, because that would mark the entity dirty and Extbase would
-  persist `model_uid`, silently converting a dynamic configuration into a fixed
-  one. So every dynamically-selected call fell through to the unknown-model
-  fallback and budgeted against a number unrelated to the model on the wire; the
-  response reserve came off the same empty relation. The window and the reserve
-  now come from the model that actually serves the send. This is a behaviour
-  change on the paths that already bound a window: a transcript that previously
-  slipped through against a 128k assumption is pruned against the 4k model
-  answering it.
-
-- **Chat, tool calling and streaming through `LlmServiceManager` are bounded
-  like a conversation or an agent loop** (ADR-143, closes #688). A tool-calling
-  send counts its tool schemas against the same budget, because they are on the
-  wire with the transcript. Embeddings are deliberately not bounded: they carry
-  neither skills nor snippets nor a transcript, and their limit is the
-  provider's own input limit rather than a window to prune turns out of. Only
-  `ConversationService` and `ToolLoopService` bound their sends, so which API a
-  consumer happened to call decided whether a long transcript was pruned or
-  handed to the provider whole. The bind sits inside the middleware-pipeline
-  terminal, the first point that knows the resolved model; for a stream it runs
-  inside the opener, before the adapter is asked for the first chunk, because
-  once a stream is open there is nothing left to prune.
-- A completion **reports** rather than prunes. A raw prompt is a single unit —
-  there are no older turns to drop, and shortening a caller's prompt behind
-  their back would change what they asked for. An overflowing completion is now
-  named, with the model and the budget it exceeded, instead of surfacing later
-  as an opaque provider error.
-- A payload that overflows even at its floor is still sent, matching what
-  `ConversationService` already did: the estimate errs high, so it may well
-  succeed, and if it does not the provider's own error is what the caller would
-  have received anyway.
-- `LlmServiceManager` gained two optional constructor arguments (the context
-  window manager and a logger). Both default to null and every existing
-  construction keeps its exact previous behaviour — a null context window means
-  "bounded by the provider", which is what these paths did.
 ## [0.28.0] - 2026-08-10
 Four user-facing changes, three of them found by looking at the demo instance
 rather than at the code: a backend module that told an administrator nothing


### PR DESCRIPTION
The `[Unreleased]` section carries ten top-level bullets three or four times over.

**Cause.** The script used to resolve `CHANGELOG.md` conflicts while merging `main` into five feature branches in sequence folds *ours* into *theirs* per heading. After the first merge, *ours* already contained `main`'s bullets — so every following merge appended them again. It reached `main` through #705 and #706.

**Fix.** 25 repeated blocks removed, first occurrence kept. Nothing else changes: every heading, every surviving bullet and every released section are byte-identical, which is asserted by diffing everything from `## [0.28.0]` down before and after.

48 top-level bullets → 23. Headings still `### Added`, `### Changed`, `### Fixed`.