### PR TITLE
chore(harness): one pre-push gate, and refuse a self-repeating CHANGELOG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,3 +152,21 @@ jobs:
       run-mutation-tests: ${{ github.event_name == 'schedule' }}
       mutation-min-msi: 70
       mutation-min-covered-msi: 74
+
+  # CI half of the CHANGELOG gate. `Build/captainhook.json` runs the same
+  # composer script on pre-commit; this exists because a hook reaches only the
+  # machines that installed it, and the failure it guards against reached `main`
+  # through two pull requests on 2026-08-10. Deterministic and sub-second, so it
+  # gets its own tiny job rather than a slot in the matrix.
+  changelog:
+    name: CHANGELOG
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: none
+      - run: php Build/Scripts/check-changelog-unreleased.php

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,9 +164,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: shivammathur/setup-php@v2
+      # Actions must be SHA-pinned (repo and org both set sha_pinning_required),
+      # and no setup-php step: the runner image already ships a PHP the check
+      # runs on, and it needs no extensions.
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          php-version: '8.4'
-          coverage: none
+          persist-credentials: false
       - run: php Build/Scripts/check-changelog-unreleased.php

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,15 +80,18 @@ The full `./Build/Scripts/runTests.sh -s functional` run includes ~34 provider-c
 2. Use `make` shortcuts (`make test-unit`, `make phpstan`, `make cgl`) — they delegate to `runTests.sh`.
 3. Pre-commit hooks via `Build/captainhook.json` (auto-installed by composer plugin) run cgl + phpstan + commit-msg checks.
 4. Sign commits with `git commit -S --signoff` (DCO required).
-5. Pre-push gate parity with CI is these six suites — CI runs all six, and `rector`/`fuzzy` are the two habitually forgotten ones:
-   - `unit`
-   - `functional -d sqlite`
-   - `phpstan`
-   - `cgl`
-   - `rector -n`
-   - `fuzzy`
+5. **Pre-push gate: `make gate`.** It runs the six suites CI runs — `cgl`,
+   `phpstan`, `unit`, `fuzzy`, `rector -n` (pinned to PHP 8.2, as in CI) and
+   `functional -d sqlite` — plus the CHANGELOG check. Run it as one command:
+   invoking the six by hand is how `rector` and `fuzzy` get skipped, which is
+   then found by the CI matrix a push later.
 
-   Contract changes (setter clamps, validation ranges) have assertion twins in `Tests/Fuzzy/` — grep there before pushing.
+   `make ci` is **not** this gate. It is an older set that carries `integration`
+   and omits `rector` and `functional`; both targets are kept because they
+   answer different questions.
+
+   Contract changes (setter clamps, validation ranges) have assertion twins in
+   `Tests/Fuzzy/` — grep there before pushing.
 6. PRs target `main`. CI matrix: PHP 8.2–8.5 × TYPO3 `^13.4` / `^14.3`; merged via `--merge` strategy (preserves signatures).
 <!-- AGENTS-GENERATED:END development -->
 
@@ -256,6 +259,16 @@ Prefer looking at real code in this repo over inventing new patterns. Canonical 
   it; only create one when it genuinely is not there. (Three duplicates in one
   session, 2026-07-30.)
 
+  **Merging `main` into a series of sibling branches duplicates the whole
+  section.** Any resolution that assumes "ours holds only my additions" is
+  right for the first merge of a series and wrong for every later one — by then
+  "ours" already carries what the previous merge brought in. No conflict
+  markers, plausible diff: on 2026-08-10 ten bullets ended up standing three and
+  four times over and two PRs carried it to `main`. Rebuild the section instead
+  of merging it — take the incoming version verbatim and re-insert your own
+  block under the matching heading. `composer ci:test:changelog` (pre-commit,
+  and its own CI job) refuses the repeated result.
+
 - **A fresh worktree needs its own dependency resolution.** `.Build/` is not
   tracked, so a new worktree has none; copying it from `main/.Build` is the usual
   shortcut and avoids the WSL2 segfault on a fresh composer resolve. But that copy
@@ -278,6 +291,17 @@ Prefer looking at real code in this repo over inventing new patterns. Canonical 
   test cells red; a control on unmodified `main` with an uncapped local resolve
   reproduced the same 53 files, proving the finding was the environment, not the
   code.
+
+  **And in a worktree it may not run at all.** `composer install` writes
+  `.Build/vendor/composer/platform_check.php` from the PHP it resolved under,
+  and that file FATALS rather than warns on an older runtime — so a `.Build`
+  resolved at 8.4 makes the pinned `-p 8.2` die with `Composer detected issues
+  in your platform: … require a PHP version ">= 8.4.1". You are running
+  8.2.30.` The suite did not fail; it never started. `make gate` names that
+  case explicitly. Recognise the message as an environment mismatch, then
+  either keep a second `.Build` resolved at 8.2 for this one gate or accept CI
+  as the only place it runs — and **say so** when reporting which gates were
+  run, rather than listing it as green.
 
 - **A local gate run covers one matrix cell; CI covers eight.** The six pre-push
   suites run against a single PHP version and a single TYPO3 constraint. CI runs

--- a/Build/Scripts/check-changelog-unreleased.php
+++ b/Build/Scripts/check-changelog-unreleased.php
@@ -1,0 +1,101 @@
+#!/usr/bin/env php
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+/*
+ * Refuse a CHANGELOG whose `## [Unreleased]` section repeats itself.
+ *
+ * Merging `main` into a series of sibling branches duplicates append-only
+ * sections whenever the conflict resolution assumes "ours holds only my
+ * additions". That is true for the first merge of a series and false for every
+ * later one, and the result has no conflict markers and a plausible diff — on
+ * 2026-08-10 ten bullets ended up standing three and four times over, and two
+ * pull requests carried it to `main` before anyone counted.
+ *
+ * Two things are checked, both cheap and both deterministic:
+ *
+ *   1. no heading appears twice inside `[Unreleased]` (a second `### Changed`
+ *      splits the section so the duplicate sits forty lines from the original),
+ *   2. no top-level bullet's first line appears twice.
+ *
+ * Only `[Unreleased]` is examined. Released sections are history and may
+ * legitimately repeat a line that was true in two releases.
+ */
+
+$path = $argv[1] ?? dirname(__DIR__, 2) . '/CHANGELOG.md';
+
+if (!is_readable($path)) {
+    fwrite(STDERR, sprintf("check-changelog-unreleased: cannot read %s\n", $path));
+    exit(2);
+}
+
+$text = (string)file_get_contents($path);
+
+$start = strpos($text, '## [Unreleased]');
+if ($start === false) {
+    // A CHANGELOG without the section is not this check's business.
+    exit(0);
+}
+
+$bodyStart = $start + strlen('## [Unreleased]');
+$rest      = substr($text, $bodyStart);
+$section   = preg_match('/^## \[/m', $rest, $m, PREG_OFFSET_CAPTURE) === 1
+    ? substr($rest, 0, $m[0][1])
+    : $rest;
+
+$lines = explode("\n", $section);
+
+/** @var array<string, int> $headings */
+$headings = [];
+/** @var array<string, int> $bullets */
+$bullets = [];
+foreach ($lines as $line) {
+    if (str_starts_with($line, '### ')) {
+        $key            = trim($line);
+        $headings[$key] = ($headings[$key] ?? 0) + 1;
+
+        continue;
+    }
+
+    // Top-level bullets only: a nested `  - ` may legitimately repeat.
+    if (str_starts_with($line, '- ')) {
+        $key           = trim($line);
+        $bullets[$key] = ($bullets[$key] ?? 0) + 1;
+    }
+}
+
+$problems = [];
+foreach ($headings as $key => $count) {
+    if ($count > 1) {
+        $problems[] = sprintf('  %dx heading  %s', $count, $key);
+    }
+}
+
+foreach ($bullets as $key => $count) {
+    if ($count > 1) {
+        $problems[] = sprintf('  %dx bullet   %s', $count, mb_substr($key, 0, 90));
+    }
+}
+
+if ($problems === []) {
+    exit(0);
+}
+
+fwrite(STDERR, sprintf(
+    "The [Unreleased] section of %s repeats itself:\n\n%s\n\n"
+    . "This is what merging `main` into a series of sibling branches produces when the\n"
+    . "conflict resolution assumes \"ours\" holds only your own additions — true for the\n"
+    . "first merge, false for every later one. Rebuild the section instead of merging it:\n"
+    . "take the incoming version verbatim and re-insert your own block under the matching\n"
+    . "heading.\n",
+    $path,
+    implode("\n", $problems),
+));
+
+exit(1);

--- a/Build/captainhook.json
+++ b/Build/captainhook.json
@@ -31,6 +31,9 @@
             {
                 "action": "composer ci:test:php:phpstan",
                 "conditions": []
+            },
+            {
+                "action": "composer ci:test:changelog"
             }
         ]
     },

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 RUNTESTS := Build/Scripts/runTests.sh
 
-.PHONY: help up start down restart install install-all sync seed seed-tasks ollama test test-unit test-integration test-func test-fuzzy test-e2e coverage mutation cgl cgl-fix phpstan rector rector-fix docs clean ci ci-full
+.PHONY: help up start down restart install install-all sync seed seed-tasks ollama test test-unit test-integration test-func test-fuzzy test-e2e coverage mutation cgl cgl-fix phpstan rector rector-fix changelog gate docs clean ci ci-full
 
 # Default target
 help:
@@ -132,6 +132,32 @@ rector: ## Run Rector dry-run
 
 rector-fix:
 	$(RUNTESTS) -s rector
+
+changelog: ## Refuse a self-repeating [Unreleased] section
+	@php Build/Scripts/check-changelog-unreleased.php
+
+# The pre-push gate AGENTS.md documents, as one command. `ci` below is a
+# different, older set (it carries integration and omits rector and
+# functional), and running the six by hand is how `rector` and `fuzzy` get
+# forgotten — they are the two the CI matrix then finds.
+#
+# Rector is pinned to PHP 8.2 because its PHPUnit rules resolve against the
+# phpunit version composer installed, and CI pins the same. In a worktree whose
+# .Build was resolved under 8.4 that pin makes composer's platform_check FATAL,
+# so the failure is named rather than reported as a finding.
+gate: changelog cgl phpstan test-unit test-fuzzy
+	@echo "--- rector (pinned to PHP 8.2, as in CI) ---"
+	@$(RUNTESTS) -s rector -n -p 8.2 || { \
+		echo ""; \
+		echo "rector did not run to a verdict. If the output above is a"; \
+		echo "platform_check FATAL, this worktree's .Build was resolved under a"; \
+		echo "newer PHP than the pinned 8.2 — the gate cannot run here and CI is"; \
+		echo "the only place it will. Say so rather than reporting it green."; \
+		exit 1; \
+	}
+	@echo "--- functional (sqlite) ---"
+	@$(RUNTESTS) -s functional -d sqlite
+	@echo "Pre-push gate passed (the six suites AGENTS.md documents)"
 
 ci: cgl phpstan test-unit test-integration test-fuzzy
 	@echo "All CI checks passed"

--- a/composer.json
+++ b/composer.json
@@ -104,6 +104,7 @@
             "@ci",
             "@ci:test:php:functional"
         ],
+        "ci:test:changelog": "php Build/Scripts/check-changelog-unreleased.php",
         "ci:test:php:cgl": "sh -c 'if [ -f /.dockerenv ] || [ -n \"${CI:-}\" ]; then php-cs-fixer fix --dry-run --diff \"$@\"; else ./Build/Scripts/runTests.sh -s cgl -n \"$@\"; fi' --",
         "ci:test:php:functional": "sh -c 'if [ -f /.dockerenv ] || [ -n \"${CI:-}\" ]; then phpunit -c Build/FunctionalTests.xml \"$@\"; else ./Build/Scripts/runTests.sh -s functional \"$@\"; fi' --",
         "ci:test:php:fuzzy": "sh -c 'if [ -f /.dockerenv ] || [ -n \"${CI:-}\" ]; then phpunit -c Build/phpunit.xml --testsuite fuzzy \"$@\"; else ./Build/Scripts/runTests.sh -s fuzzy \"$@\"; fi' --",


### PR DESCRIPTION
Three findings from a `/retro` sweep of the session that shipped #699/#703/#705/#706/#707/#711/#712/#713. All three are about this repo's own harness rather than about code — the sweep initially routed everything to skills and proposed nothing here, which was the gap.

## 1. There was no `make gate`

Three files described "the gate" differently:

| Where | What it runs |
|---|---|
| `AGENTS.md` step 5 | unit, functional -d sqlite, phpstan, cgl, rector -n, fuzzy |
| `make ci` | cgl, phpstan, unit, **integration**, fuzzy |
| captainhook `pre-push` | check-tag-version, unit |

So the documented gate existed only as a list to execute by hand — and `rector` and `fuzzy` are, by AGENTS.md's own admission, "the two habitually forgotten ones". This session forgot `rector`, and CI found it a push later.

`make gate` is now that list, as one command. `ci` and `ci-full` are untouched and stay, because they answer a different question; AGENTS.md says which is which instead of leaving three definitions standing.

## 2. The rector pin has a failure mode that reads as success

`make gate` pins rector to PHP 8.2 as CI does (`rector-php-version: '8.2'`). In a worktree whose `.Build` was resolved under 8.4, that pin makes composer's `platform_check.php` **fatal**:

```
Fatal error: Uncaught RuntimeException: Composer detected issues in your platform:
Your Composer dependencies require a PHP version ">= 8.4.1". You are running 8.2.30.
```

The suite did not fail — it never started, which is easy to report as "ran, no findings". The target names that case rather than surfacing a generic non-zero, and AGENTS.md's rector note gains it too.

## 3. A self-repeating `[Unreleased]` reached `main`

`Build/Scripts/check-changelog-unreleased.php` refuses a `## [Unreleased]` section that repeats a heading or a top-level bullet.

Merging `main` into a series of sibling branches produces exactly that whenever the conflict resolution assumes *"ours holds only my additions"* — true for the first merge of a series, false for every later one. No conflict markers, plausible diff. On 2026-08-10 ten bullets ended up standing three and four times over, and it reached `main` through #705 and #706 before anyone counted; #711 removed 25 repeated blocks.

Wired into **both** `Build/captainhook.json` (pre-commit) and its own CI job — a hook reaches only the machines that installed it, and this one reached `main`.

## Verification

- The check was run against the state that actually reached `main` (`git show 112d0fc0:CHANGELOG.md`): it reports all ten bullets with their repeat counts and exits 1. Against `main` as repaired it exits 0.
- `make changelog` passes; `make -n gate` expands correctly; the rector fallback branch was exercised with a forced failure and exits non-zero with the intended message.
- `composer validate` clean; both edited JSON files re-parse; `ci.yml` parses and the new job's steps resolve.
- `composer.json` diff is exactly one added line — an earlier attempt also un-escaped two unrelated em dashes and was redone.
