### PR TITLE
feat: gate the landing page on axe, in a real browser

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,6 +28,11 @@ jobs:
       contents: read
     with:
       setup-uv: true
+      # Node is here only for the accessibility gate: axe needs a real browser
+      # and resolved CSS, which is exactly the class of defect verify.py cannot
+      # decide from markup.
+      setup-node: true
+      node-version: '22'
       artifact-path: landingpage/public
       # verify.py gates the rendered artefact: unresolved content placeholders,
       # a manifest that disagrees with ext_emconf.php, a version on the page the
@@ -37,6 +42,9 @@ jobs:
         NRLLM_BASE="$PAGES_BASE_PATH" NRLLM_ORIGIN="$PAGES_ORIGIN"
         uv run landingpage/build/build.py
         && python3 landingpage/build/verify.py
+        && npm ci --ignore-scripts
+        && npx playwright install chromium
+        && node landingpage/axe-audit.mjs landingpage/public "$PAGES_BASE_PATH"
 
   deploy:
     needs: build

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,7 +43,7 @@ jobs:
         uv run landingpage/build/build.py
         && python3 landingpage/build/verify.py
         && npm ci --ignore-scripts
-        && npx playwright install chromium
+        && ./node_modules/.bin/playwright install chromium
         && node landingpage/axe-audit.mjs landingpage/public "$PAGES_BASE_PATH"
 
   deploy:

--- a/landingpage/axe-audit.mjs
+++ b/landingpage/axe-audit.mjs
@@ -38,8 +38,9 @@ const DIST = process.argv[2] ?? 'landingpage/public';
 
 /** The path the site is served from, with exactly one slash at each end. */
 const baseSegments = (process.argv[3] ?? process.env.PAGES_BASE_PATH ?? '/')
-  .replace(/^\/+/, '')
-  .replace(/\/+$/, '');
+  .split('/')
+  .filter(Boolean)
+  .join('/');
 const BASE = baseSegments ? `/${baseSegments}/` : '/';
 
 // WCAG 2.1 AA, which is what the pages claim. 'best-practice' is deliberately

--- a/landingpage/axe-audit.mjs
+++ b/landingpage/axe-audit.mjs
@@ -10,9 +10,11 @@
  *
  *   node landingpage/axe-audit.mjs [output-dir]
  *
- * Exits non-zero on any WCAG 2.1 AA violation. Uses Playwright's Chromium
- * because the repository already installs it for the end-to-end tests; adding a
- * second browser stack for one gate would not buy anything.
+ * Exits non-zero on any WCAG 2.1 AA violation. Uses the Playwright Chromium and
+ * the AxeBuilder the repository already runs against the backend modules;
+ * a second browser stack or a second axe package for one gate would not buy
+ * anything. The target is different — Tests/E2E covers the TYPO3 backend
+ * against a live instance, this covers the published landing page.
  *
  * Serves the output over loopback rather than opening file:// URLs: the pages
  * reference their stylesheet by path, and an unstyled page has no contrast
@@ -28,11 +30,8 @@ import { createServer } from 'node:http';
 import { readFile } from 'node:fs/promises';
 import { readdirSync, statSync, readFileSync } from 'node:fs';
 import { join, extname, relative, sep } from 'node:path';
-import { createRequire } from 'node:module';
 import { chromium } from '@playwright/test';
-
-const require = createRequire(import.meta.url);
-const axePath = require.resolve('axe-core/axe.min.js');
+import AxeBuilder from '@axe-core/playwright';
 
 const DIST = process.argv[2] ?? 'landingpage/public';
 
@@ -182,12 +181,8 @@ async function auditPage(browser, port, route, scheme) {
   });
 
   await page.goto(`http://127.0.0.1:${port}${BASE}${route.slice(1)}`, { waitUntil: 'networkidle' });
-  await page.addScriptTag({ path: axePath });
 
-  const results = await page.evaluate(
-    async (tags) => await window.axe.run(document, { runOnly: { type: 'tag', values: tags } }),
-    TAGS,
-  );
+  const results = await new AxeBuilder({ page }).withTags(TAGS).analyze();
   await context.close();
 
   const found = results.violations.map((violation) => ({ route, scheme, violation }));

--- a/landingpage/axe-audit.mjs
+++ b/landingpage/axe-audit.mjs
@@ -1,0 +1,203 @@
+/**
+ * Runs axe-core against every rendered product page, in a real browser.
+ *
+ * landingpage/build/check_accessibility.py covers what is decidable from markup
+ * alone. The defects it cannot see — colour contrast above all, because that
+ * needs resolved CSS and a compositing model — are what this file is for. This
+ * page passes today; the point of the gate is that it keeps passing, because
+ * the same audit found 213 failures on a sibling site whose static gate was
+ * equally green.
+ *
+ *   node landingpage/axe-audit.mjs [output-dir]
+ *
+ * Exits non-zero on any WCAG 2.1 AA violation. Uses Playwright's Chromium
+ * because the repository already installs it for the end-to-end tests; adding a
+ * second browser stack for one gate would not buy anything.
+ *
+ * Serves the output over loopback rather than opening file:// URLs: the pages
+ * reference their stylesheet by path, and an unstyled page has no contrast
+ * failures at all — it would pass for the wrong reason.
+ *
+ * The pages are built for a base path (/t3x-nr-llm/ on GitHub Pages), so the
+ * server mounts the output there. Serving it at / instead makes every absolute
+ * asset URL 404: the audit then measures a stylesheet-less page and reports the
+ * browser's default link colour, which is neither a defect nor a pass.
+ */
+
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { join, extname, relative } from 'node:path';
+import { createRequire } from 'node:module';
+import { chromium } from '@playwright/test';
+
+const require = createRequire(import.meta.url);
+const axePath = require.resolve('axe-core/axe.min.js');
+
+const OUTPUT = process.argv[2] ?? 'landingpage/public';
+
+/** The path the site is served from, with exactly one slash at each end. */
+const BASE = `/${(process.argv[3] ?? process.env.PAGES_BASE_PATH ?? '/').replace(/^\/+|\/+$/g, '')}/`
+  .replace(/^\/\/$/, '/');
+
+// WCAG 2.1 AA, which is what the page claims. 'best-practice' is deliberately
+// left out: it flags stylistic preferences, and a gate that fails on those gets
+// disabled instead of fixed.
+const TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
+
+// Both colour schemes: a dark palette is a separate set of colour pairs, so a
+// light-only audit says nothing about it.
+const SCHEMES = ['light', 'dark'];
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.woff2': 'font/woff2',
+  '.xml': 'application/xml; charset=utf-8',
+  '.txt': 'text/plain; charset=utf-8',
+};
+
+/**
+ * Every HTML page below the output directory, as the URL path a visitor uses.
+ *
+ * Not only index.html: the 152 ADR pages are named after their ADR, and a
+ * discovery that looks for index.html alone silently audits eight pages out of
+ * a hundred and sixty.
+ */
+function htmlRoutes(dir, base = dir) {
+  const routes = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      routes.push(...htmlRoutes(full, base));
+    } else if (entry === 'index.html') {
+      const path = `/${relative(base, dir)}`.replace(/\/$/, '');
+      routes.push(path === '/' || path === '/.' ? '/' : `${path}/`);
+    } else if (entry.endsWith('.html')) {
+      routes.push(`/${relative(base, full)}`);
+    }
+  }
+  return routes.sort();
+}
+
+/**
+ * The route shape a page belongs to: a named page collapses to '*.html'. Every
+ * ADR is the same template with different prose, so auditing all 152 costs ten
+ * minutes per deploy and finds what the first one already found.
+ */
+function routeShape(route) {
+  return route.replace(/\/[^/]+\.html$/, '/*.html');
+}
+
+/** One representative route per shape, plus what that left out. */
+function sample(routes) {
+  const groups = new Map();
+  for (const route of routes) {
+    const shape = routeShape(route);
+    if (!groups.has(shape)) groups.set(shape, []);
+    groups.get(shape).push(route);
+  }
+  return [...groups.entries()].map(([shape, members]) => ({
+    shape,
+    route: members[0],
+    skipped: members.length - 1,
+  }));
+}
+
+function serve(root) {
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url, 'http://localhost');
+    const path = decodeURIComponent(url.pathname);
+    if (!path.startsWith(BASE)) {
+      res.writeHead(404).end('outside the base path');
+      return;
+    }
+    let file = join(root, path.slice(BASE.length));
+    if (existsSync(file) && statSync(file).isDirectory()) file = join(file, 'index.html');
+    if (!file.startsWith(root) || !existsSync(file)) {
+      res.writeHead(404).end('not found');
+      return;
+    }
+    res.writeHead(200, { 'content-type': MIME[extname(file)] ?? 'application/octet-stream' });
+    res.end(await readFile(file));
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve({ server, port: server.address().port }));
+  });
+}
+
+async function main() {
+  const { server, port } = await serve(OUTPUT);
+  const routes = htmlRoutes(OUTPUT);
+  if (routes.length === 0) {
+    throw new Error(`no pages found in ${OUTPUT} — run landingpage/build/build.py first`);
+  }
+
+  const browser = await chromium.launch();
+  const failures = [];
+  let checked = 0;
+
+  const sampled = sample(routes);
+  for (const { shape, route, skipped } of sampled) {
+    if (skipped) {
+      console.log(`  ${shape} → auditing ${route} (${skipped} further page(s) of this shape not audited)`);
+    }
+  }
+
+  for (const { route } of sampled) {
+    for (const scheme of SCHEMES) {
+      const context = await browser.newContext({
+        colorScheme: scheme,
+        viewport: { width: 1280, height: 900 },
+      });
+      const page = await context.newPage();
+      await page.goto(`http://127.0.0.1:${port}${BASE}${route.slice(1)}`, { waitUntil: 'networkidle' });
+      await page.addScriptTag({ path: axePath });
+
+      const results = await page.evaluate(
+        async (tags) => await window.axe.run(document, { runOnly: { type: 'tag', values: tags } }),
+        TAGS,
+      );
+
+      checked += 1;
+      for (const violation of results.violations) failures.push({ route, scheme, violation });
+      await context.close();
+    }
+  }
+
+  await browser.close();
+  server.close();
+
+  for (const { route, scheme, violation } of failures) {
+    console.error(`\n✗ ${route} [${scheme}] — ${violation.id} (${violation.impact})`);
+    console.error(`  ${violation.help}`);
+    console.error(`  ${violation.helpUrl}`);
+    for (const node of violation.nodes.slice(0, 4)) {
+      console.error(`    ${node.target.join(' ')}`);
+      for (const line of (node.failureSummary ?? '').split('\n').filter(Boolean).slice(1)) {
+        console.error(`      ${line}`);
+      }
+    }
+    if (violation.nodes.length > 4) {
+      console.error(`    … and ${violation.nodes.length - 4} more element(s)`);
+    }
+  }
+
+  if (failures.length) {
+    console.error(
+      `\naxe: ${failures.length} violation(s) across ${checked} page renders (${sampled.length} route shapes × ${SCHEMES.length} colour schemes, sampled from ${routes.length} pages)`,
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `axe: no WCAG 2.1 AA violations in ${checked} page renders (${sampled.length} route shapes × ${SCHEMES.length} colour schemes, sampled from ${routes.length} pages) served from ${BASE}`,
+  );
+}
+
+await main();

--- a/landingpage/axe-audit.mjs
+++ b/landingpage/axe-audit.mjs
@@ -26,28 +26,24 @@
 
 import { createServer } from 'node:http';
 import { readFile } from 'node:fs/promises';
-import { existsSync, readdirSync, statSync } from 'node:fs';
-import { join, extname, relative } from 'node:path';
+import { readdirSync, statSync, readFileSync } from 'node:fs';
+import { join, extname, relative, sep } from 'node:path';
 import { createRequire } from 'node:module';
 import { chromium } from '@playwright/test';
 
 const require = createRequire(import.meta.url);
 const axePath = require.resolve('axe-core/axe.min.js');
 
-const OUTPUT = process.argv[2] ?? 'landingpage/public';
+const DIST = process.argv[2] ?? 'landingpage/public';
 
 /** The path the site is served from, with exactly one slash at each end. */
 const BASE = `/${(process.argv[3] ?? process.env.PAGES_BASE_PATH ?? '/').replace(/^\/+|\/+$/g, '')}/`
   .replace(/^\/\/$/, '/');
 
-// WCAG 2.1 AA, which is what the page claims. 'best-practice' is deliberately
-// left out: it flags stylistic preferences, and a gate that fails on those gets
-// disabled instead of fixed.
+// WCAG 2.1 AA, which is what the pages claim. 'best-practice' is deliberately
+// not included: it flags stylistic preferences, and a gate that fails on those
+// gets disabled instead of fixed.
 const TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
-
-// Both colour schemes: a dark palette is a separate set of colour pairs, so a
-// light-only audit says nothing about it.
-const SCHEMES = ['light', 'dark'];
 
 const MIME = {
   '.html': 'text/html; charset=utf-8',
@@ -57,45 +53,64 @@ const MIME = {
   '.json': 'application/json; charset=utf-8',
   '.svg': 'image/svg+xml',
   '.png': 'image/png',
+  '.webp': 'image/webp',
   '.woff2': 'font/woff2',
   '.xml': 'application/xml; charset=utf-8',
   '.txt': 'text/plain; charset=utf-8',
 };
 
 /**
- * Every HTML page below the output directory, as the URL path a visitor uses.
+ * Every servable file below the output directory, as URL path → absolute file.
  *
- * Not only index.html: the 152 ADR pages are named after their ADR, and a
- * discovery that looks for index.html alone silently audits eight pages out of
- * a hundred and sixty.
+ * The tree is indexed once and the request handler only looks paths up. Nothing
+ * is joined with, or stat'ed from, a request path: a URL cannot name a file the
+ * index does not already hold, so `..` has nothing to escape into.
  */
-function htmlRoutes(dir, base = dir) {
-  const routes = [];
+function indexFiles(dir, base = dir, into = new Map()) {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
     if (statSync(full).isDirectory()) {
-      routes.push(...htmlRoutes(full, base));
-    } else if (entry === 'index.html') {
-      const path = `/${relative(base, dir)}`.replace(/\/$/, '');
-      routes.push(path === '/' || path === '/.' ? '/' : `${path}/`);
-    } else if (entry.endsWith('.html')) {
-      routes.push(`/${relative(base, full)}`);
+      indexFiles(full, base, into);
+    } else {
+      const url = `/${relative(base, full).split(sep).join('/')}`;
+      into.set(url, full);
+      if (entry === 'index.html') into.set(url.replace(/index\.html$/, ''), full);
     }
   }
-  return routes.sort();
+  return into;
 }
 
 /**
- * The route shape a page belongs to: a named page collapses to '*.html'. Every
- * ADR is the same template with different prose, so auditing all 152 costs ten
- * minutes per deploy and finds what the first one already found.
+ * The routes a visitor can open: every directory with an index.html, plus every
+ * other .html file. Named pages matter — a discovery that looks for index.html
+ * alone silently skips whole sections and still reports success.
  */
-function routeShape(route) {
-  return route.replace(/\/[^/]+\.html$/, '/*.html');
+function htmlRoutes(files) {
+  return [...files.keys()]
+    .filter((url) => url.endsWith('/') || (url.endsWith('.html') && !url.endsWith('/index.html')))
+    .filter((url) => {
+      // A meta-refresh stub carries no content and the browser leaves it at
+      // once; auditing it measures whatever it redirected to, a second time.
+      const html = readFileSync(files.get(url), 'utf-8');
+      return !/<meta[^>]+http-equiv=["']refresh["']/i.test(html);
+    })
+    .sort((a, b) => a.localeCompare(b));
 }
 
-/** One representative route per shape, plus what that left out. */
-function sample(routes) {
+/**
+ * The route shape a page belongs to. Segments that name one repository, one
+ * date or one document collapse to '*': those pages are the same template with
+ * different data, and auditing all of them costs deploy time to re-find what
+ * the first one already found.
+ */
+function routeShape(route) {
+  return route
+    .replace(/(\/(?:repo|snapshot|adr)\/)[^/]+(\/|$)/g, '$1*$2')
+    .replace(/\/[^/]+\.html$/, '/*.html');
+}
+
+/** One representative route per shape, and how many that left out. */
+function sampleRoutes(routes) {
   const groups = new Map();
   for (const route of routes) {
     const shape = routeShape(route);
@@ -109,106 +124,116 @@ function sample(routes) {
   }));
 }
 
-function serve(root) {
+function serve(files) {
   const server = createServer(async (req, res) => {
-    const url = new URL(req.url, 'http://localhost');
-    const path = decodeURIComponent(url.pathname);
-    if (!path.startsWith(BASE)) {
-      res.writeHead(404).end('outside the base path');
-      return;
-    }
-    let file = join(root, path.slice(BASE.length));
-    if (existsSync(file) && statSync(file).isDirectory()) file = join(file, 'index.html');
-    if (!file.startsWith(root) || !existsSync(file)) {
+    const path = new URL(req.url, 'http://localhost').pathname;
+    const file = path.startsWith(BASE) ? files.get(`/${path.slice(BASE.length)}`) : undefined;
+    if (!file) {
       res.writeHead(404).end('not found');
       return;
     }
     res.writeHead(200, { 'content-type': MIME[extname(file)] ?? 'application/octet-stream' });
     res.end(await readFile(file));
   });
-  return new Promise((resolve) => {
-    server.listen(0, '127.0.0.1', () => resolve({ server, port: server.address().port }));
+  return new Promise((resolve_) => {
+    server.listen(0, '127.0.0.1', () => resolve_({ server, port: server.address().port }));
   });
 }
 
-async function main() {
-  const { server, port } = await serve(OUTPUT);
-  const routes = htmlRoutes(OUTPUT);
-  if (routes.length === 0) {
-    throw new Error(`no pages found in ${OUTPUT} — run landingpage/build/build.py first`);
+/**
+ * Both colour schemes. The dark palette is a separate set of colour pairs, so a
+ * light-only audit says nothing about it — and the pages ship dark mode.
+ */
+const SCHEMES = ['light', 'dark'];
+
+/** Prints one violation. Extracted so main() stays readable. */
+function report({ route, scheme, violation }) {
+  console.error(`\n✗ ${route} [${scheme}] — ${violation.id} (${violation.impact})`);
+  console.error(`  ${violation.help}`);
+  console.error(`  ${violation.helpUrl}`);
+  for (const node of violation.nodes.slice(0, 4)) {
+    console.error(`    ${node.target.join(' ')}`);
+    for (const line of (node.failureSummary ?? '').split('\n').filter(Boolean).slice(1)) {
+      console.error(`      ${line}`);
+    }
   }
+  if (violation.nodes.length > 4) {
+    console.error(`    … and ${violation.nodes.length - 4} more element(s)`);
+  }
+}
 
-  const browser = await chromium.launch();
-  const failures = [];
-  let checked = 0;
+/** Audits one page and returns the failures found on it. */
+async function auditPage(browser, port, route, scheme) {
+  const context = await browser.newContext({
+    colorScheme: scheme,
+    viewport: { width: 1280, height: 900 },
+  });
+  const page = await context.newPage();
 
-  const sampled = sample(routes);
+  // A page whose stylesheet 404s has no contrast failures at all, so a silent
+  // asset error turns this gate into a rubber stamp. Any request that does not
+  // succeed is therefore a failure in its own right.
+  const broken = [];
+  page.on('response', (response) => {
+    if (response.status() >= 400) broken.push(`${response.status()} ${response.url()}`);
+  });
+
+  await page.goto(`http://127.0.0.1:${port}${BASE}${route.slice(1)}`, { waitUntil: 'networkidle' });
+  await page.addScriptTag({ path: axePath });
+
+  const results = await page.evaluate(
+    async (tags) => await window.axe.run(document, { runOnly: { type: 'tag', values: tags } }),
+    TAGS,
+  );
+  await context.close();
+
+  const found = results.violations.map((violation) => ({ route, scheme, violation }));
+  if (broken.length) {
+    found.unshift({
+      route,
+      scheme,
+      violation: {
+        id: 'asset-not-served',
+        impact: 'critical',
+        help: 'Every asset the page requests must be served — an unstyled page passes for the wrong reason',
+        helpUrl: 'https://github.com/netresearch/t3x-nr-llm/blob/main/landingpage/axe-audit.mjs',
+        nodes: broken.map((entry) => ({ target: [entry], failureSummary: '' })),
+      },
+    });
+  }
+  return found;
+}
+
+async function main() {
+  const files = indexFiles(DIST);
+  const routes = htmlRoutes(files);
+  if (routes.length === 0) throw new Error(`no pages found in ${DIST} — run landingpage/build/build.py first`);
+  const { server, port } = await serve(files);
+
+  // A gate that silently covers a subset reads as if it covered everything.
+  const sampled = sampleRoutes(routes);
   for (const { shape, route, skipped } of sampled) {
     if (skipped) {
       console.log(`  ${shape} → auditing ${route} (${skipped} further page(s) of this shape not audited)`);
     }
   }
 
+  const browser = await chromium.launch();
+
+  const failures = [];
+  let checked = 0;
+
   for (const { route } of sampled) {
     for (const scheme of SCHEMES) {
-      const context = await browser.newContext({
-        colorScheme: scheme,
-        viewport: { width: 1280, height: 900 },
-      });
-      const page = await context.newPage();
-
-      // A page whose stylesheet 404s has no contrast failures at all, so a
-      // silent asset error turns this gate into a rubber stamp. Any request
-      // that does not succeed is therefore a failure in its own right.
-      const broken = [];
-      page.on('response', (response) => {
-        if (response.status() >= 400) broken.push(`${response.status()} ${response.url()}`);
-      });
-      await page.goto(`http://127.0.0.1:${port}${BASE}${route.slice(1)}`, { waitUntil: 'networkidle' });
-
-      if (broken.length) {
-        failures.push({
-          route,
-          scheme,
-          violation: {
-            id: 'asset-not-served',
-            impact: 'critical',
-            help: 'Every asset the page requests must be served — an unstyled page passes for the wrong reason',
-            helpUrl: 'https://github.com/netresearch/t3x-nr-llm/blob/main/landingpage/axe-audit.mjs',
-            nodes: broken.map((entry) => ({ target: [entry], failureSummary: '' })),
-          },
-        });
-      }
-      await page.addScriptTag({ path: axePath });
-
-      const results = await page.evaluate(
-        async (tags) => await window.axe.run(document, { runOnly: { type: 'tag', values: tags } }),
-        TAGS,
-      );
-
+      failures.push(...(await auditPage(browser, port, route, scheme)));
       checked += 1;
-      for (const violation of results.violations) failures.push({ route, scheme, violation });
-      await context.close();
     }
   }
 
   await browser.close();
   server.close();
 
-  for (const { route, scheme, violation } of failures) {
-    console.error(`\n✗ ${route} [${scheme}] — ${violation.id} (${violation.impact})`);
-    console.error(`  ${violation.help}`);
-    console.error(`  ${violation.helpUrl}`);
-    for (const node of violation.nodes.slice(0, 4)) {
-      console.error(`    ${node.target.join(' ')}`);
-      for (const line of (node.failureSummary ?? '').split('\n').filter(Boolean).slice(1)) {
-        console.error(`      ${line}`);
-      }
-    }
-    if (violation.nodes.length > 4) {
-      console.error(`    … and ${violation.nodes.length - 4} more element(s)`);
-    }
-  }
+  for (const failure of failures) report(failure);
 
   if (failures.length) {
     console.error(

--- a/landingpage/axe-audit.mjs
+++ b/landingpage/axe-audit.mjs
@@ -156,7 +156,29 @@ async function main() {
         viewport: { width: 1280, height: 900 },
       });
       const page = await context.newPage();
+
+      // A page whose stylesheet 404s has no contrast failures at all, so a
+      // silent asset error turns this gate into a rubber stamp. Any request
+      // that does not succeed is therefore a failure in its own right.
+      const broken = [];
+      page.on('response', (response) => {
+        if (response.status() >= 400) broken.push(`${response.status()} ${response.url()}`);
+      });
       await page.goto(`http://127.0.0.1:${port}${BASE}${route.slice(1)}`, { waitUntil: 'networkidle' });
+
+      if (broken.length) {
+        failures.push({
+          route,
+          scheme,
+          violation: {
+            id: 'asset-not-served',
+            impact: 'critical',
+            help: 'Every asset the page requests must be served — an unstyled page passes for the wrong reason',
+            helpUrl: 'https://github.com/netresearch/t3x-nr-llm/blob/main/landingpage/axe-audit.mjs',
+            nodes: broken.map((entry) => ({ target: [entry], failureSummary: '' })),
+          },
+        });
+      }
       await page.addScriptTag({ path: axePath });
 
       const results = await page.evaluate(

--- a/landingpage/axe-audit.mjs
+++ b/landingpage/axe-audit.mjs
@@ -37,8 +37,10 @@ const axePath = require.resolve('axe-core/axe.min.js');
 const DIST = process.argv[2] ?? 'landingpage/public';
 
 /** The path the site is served from, with exactly one slash at each end. */
-const BASE = `/${(process.argv[3] ?? process.env.PAGES_BASE_PATH ?? '/').replace(/^\/+|\/+$/g, '')}/`
-  .replace(/^\/\/$/, '/');
+const baseSegments = (process.argv[3] ?? process.env.PAGES_BASE_PATH ?? '/')
+  .replace(/^\/+/, '')
+  .replace(/\/+$/, '');
+const BASE = baseSegments ? `/${baseSegments}/` : '/';
 
 // WCAG 2.1 AA, which is what the pages claim. 'best-practice' is deliberately
 // not included: it flags stylistic preferences, and a gate that fails on those

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "devDependencies": {
         "@axe-core/playwright": "^4.12.1",
         "@playwright/test": "^1.61.1",
-        "@types/node": "^24.0.0"
+        "@types/node": "^24.0.0",
+        "axe-core": "^4.13.0"
       },
       "engines": {
         "node": ">=22.18.0 <25.0.0",
@@ -28,6 +29,16 @@
       },
       "peerDependencies": {
         "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright/node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@playwright/test": {
@@ -57,9 +68,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
-      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "devDependencies": {
         "@axe-core/playwright": "^4.12.1",
         "@playwright/test": "^1.61.1",
-        "@types/node": "^24.0.0",
-        "axe-core": "^4.13.0"
+        "@types/node": "^24.0.0"
       },
       "engines": {
         "node": ">=22.18.0 <25.0.0",
@@ -65,16 +64,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
-      }
-    },
-    "node_modules/axe-core": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
-      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/fsevents": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",
     "@playwright/test": "^1.61.1",
-    "@types/node": "^24.0.0",
-    "axe-core": "^4.13.0"
+    "@types/node": "^24.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,11 +14,13 @@
     "test:e2e:debug": "playwright test --debug",
     "test:e2e:report": "playwright show-report",
     "test:accessibility": "playwright test --grep @accessibility",
-    "test:a11y": "playwright test --grep @accessibility"
+    "test:a11y": "playwright test --grep @accessibility",
+    "axe": "node landingpage/axe-audit.mjs"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",
     "@playwright/test": "^1.61.1",
-    "@types/node": "^24.0.0"
+    "@types/node": "^24.0.0",
+    "axe-core": "^4.13.0"
   }
 }


### PR DESCRIPTION
## Why

`landingpage/build/check_accessibility.py` covers what markup alone decides — landmarks, headings, labels, table names, duplicate ids. Contrast is not in that set: it needs resolved CSS and a compositing model. The same audit found **213 contrast failures** on the impact dashboard, whose static gate was equally green, and 30 on the portfolio hub.

This page passes as it stands, dark palette included. The gate is what keeps it that way.

## Two things the audit had to get right

**Serve under the Pages base path.** The pages are built for `/t3x-nr-llm/`. Served at `/` instead, every absolute asset URL 404s — the first run reported `#9e9eff on #ffffff`, which is Chrome's default dark-mode link colour on an unstyled page. That is neither a defect nor a pass, and a gate that measures a stylesheet-less page is worse than none.

**Discover every `.html`, not only `index.html`.** The 146 ADR pages and the six feature pages are named after their content. A discovery that looks for `index.html` audits 8 pages out of 160 and reports success.

## Sampling, stated rather than silent

Every ADR is the same template with different prose. The gate audits one page per route shape and prints what it left out:

```
  /adr/*.html → auditing /adr/adr001-provider-abstraction-layer.html (145 further page(s) of this shape not audited)
  /de/features/*.html → auditing /de/features/providers-fallback-keys.html (2 further page(s) of this shape not audited)
  /en/features/*.html → auditing /en/features/providers-fallback-keys.html (2 further page(s) of this shape not audited)
axe: no WCAG 2.1 AA violations in 22 page renders (11 route shapes × 2 colour schemes, sampled from 160 pages) served from /t3x-nr-llm/
```

## Dependencies

`axe-core` is the only addition. Playwright and its Chromium are already devDependencies for the end-to-end tests, so this adds no second browser stack.