### PR TITLE
fix(a11y): three status badges failed AA contrast, and nothing would have caught the next one

### DIFF
--- a/Build/Scripts/check-badge-contrast.php
+++ b/Build/Scripts/check-badge-contrast.php
@@ -1,0 +1,78 @@
+#!/usr/bin/env php
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+/*
+ * Refuse `text-bg-danger` on a badge in a Fluid template.
+ *
+ * White on the TYPO3 backend's danger red is 4.37:1 at the 11px a badge
+ * computes to, under the 4.5:1 WCAG AA needs for normal text. axe rates it
+ * `serious`. `text-bg-warning` is black on #e0a810 at 9.6:1 and is what the
+ * states this project marks actually are: an operator resolves them, they are
+ * not failures of the system.
+ *
+ * Do NOT reach for `.bg-danger-subtle` + `.text-danger-emphasis` instead. The
+ * backend CSS ships the background utility but not the text one — only the CSS
+ * variable — so the pair leaves the label at the body colour and inverts badly
+ * in one of the two themes. Checked against
+ * `typo3/cms-backend/Resources/Public/Css/backend.css`.
+ *
+ * This check enforces that decision; it does NOT measure contrast. The
+ * accessibility suite is the thing that measures, and it can only measure a
+ * state some fixture actually renders — which is how four of these survived
+ * a green suite until 2026-08-11 (#746). A static refusal covers the states no
+ * fixture reaches.
+ *
+ * Alerts are out of scope: `alert-danger` is dark text on a light tint, a
+ * different component with a different pairing.
+ */
+
+// Walked rather than globbed: `**` does not recurse in glob(), and a pattern
+// that silently matches one directory level would pass this check by missing
+// the file, which is the failure mode the check exists to prevent.
+$root  = dirname(__DIR__, 2);
+$files = [];
+foreach (['Templates', 'Partials'] as $dir) {
+    $path = $root . '/Resources/Private/' . $dir;
+    if (!is_dir($path)) {
+        continue;
+    }
+
+    /** @var SplFileInfo $file */
+    foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path)) as $file) {
+        if ($file->isFile() && $file->getExtension() === 'html') {
+            $files[] = $file->getPathname();
+        }
+    }
+}
+
+sort($files);
+
+$offenders = [];
+foreach ($files as $file) {
+    foreach (explode("\n", (string)file_get_contents($file)) as $number => $line) {
+        // The class attribute of a badge, not the word in a comment explaining
+        // why it is absent.
+        if (preg_match('/class="[^"]*\bbadge\b[^"]*\btext-bg-danger\b/', $line) === 1) {
+            $offenders[] = sprintf('%s:%d', substr($file, strlen($root) + 1), $number + 1);
+        }
+    }
+}
+
+if ($offenders === []) {
+    exit(0);
+}
+
+fwrite(STDERR, "text-bg-danger on a badge fails WCAG AA (4.37:1 at badge size).\n");
+fwrite(STDERR, "Use text-bg-warning — see the header of this script for why, and why not the subtle pair.\n\n");
+foreach ($offenders as $offender) {
+    fwrite(STDERR, '  ' . $offender . "\n");
+}
+
+exit(1);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -821,6 +821,18 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   string; the method is not part of the frozen API surface and `McpTool` is its
   only production caller. The run's control flow is unchanged: the loop still
   carries on and the model is still told plainly what failed.
+- **Three backend status badges were unreadable** (`#746`). White on the
+  danger red is 4.37:1 at the size a badge computes to, under the 4.5:1 WCAG
+  AA needs for normal text; axe rates it `serious`. The circuit-open badge on
+  Analytics and the sync-failed and orphaned badges on Skills now use the
+  warning pairing, black on amber at 9.6:1 — the same substitution two
+  configuration badges already had. None of these marks a failure of the
+  system; each marks a state an operator resolves.
+
+  They rendered only in states no accessibility fixture produces, so the suite
+  was green because it never reached them. `composer ci:test:badges` now
+  refuses `text-bg-danger` on a badge outright — it enforces the decision, it
+  does not measure contrast, and it covers the states no fixture reaches.
 
 ## [0.28.0] - 2026-08-10
 Four user-facing changes, three of them found by looking at the demo instance

--- a/Resources/Private/Templates/Backend/Analytics/Index.html
+++ b/Resources/Private/Templates/Backend/Analytics/Index.html
@@ -236,7 +236,9 @@
                                         <f:if condition="{health.circuitBreakerEnabled}">
                                             <f:then>
                                                 <f:switch expression="{p.circuit}">
-                                                    <f:case value="open"><span class="badge text-bg-danger"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.health.circuit.open" /></span></f:case>
+                                                    <f:comment>text-bg-warning, not -danger: white on the danger red is 4.37:1 at
+                                                    badge size, and an operator resolves this state rather than the system failing it.</f:comment>
+                                                    <f:case value="open"><span class="badge text-bg-warning"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.health.circuit.open" /></span></f:case>
                                                     <f:case value="half_open"><span class="badge text-bg-warning"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.health.circuit.halfOpen" /></span></f:case>
                                                     <f:defaultCase><span class="badge text-bg-success"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:analytics.health.circuit.closed" /></span></f:defaultCase>
                                                 </f:switch>

--- a/Resources/Private/Templates/Backend/Skill/List.html
+++ b/Resources/Private/Templates/Backend/Skill/List.html
@@ -61,7 +61,9 @@
                                                 <f:case value="never_synced"><span class="badge text-bg-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.syncStatus.never" default="Never synced" /></span></f:case>
                                                 <f:case value="syncing"><span class="badge text-bg-info"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.syncStatus.syncing" default="Syncing" /></span></f:case>
                                                 <f:case value="partial"><span class="badge text-bg-warning"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.syncStatus.partial" default="Partial" /></span></f:case>
-                                                <f:case value="error"><span class="badge text-bg-danger"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.syncStatus.error" default="Failed" /></span></f:case>
+                                                <f:comment>text-bg-warning, not -danger: white on the danger red is 4.37:1 at
+                                                badge size, and an operator resolves this state rather than the system failing it.</f:comment>
+                                                <f:case value="error"><span class="badge text-bg-warning"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.syncStatus.error" default="Failed" /></span></f:case>
                                                 <f:defaultCase><code>{source.syncStatus}</code></f:defaultCase>
                                             </f:switch>
                                         </td>
@@ -133,7 +135,9 @@
                                         </td>
                                         <td>
                                             <f:if condition="{skill.isOrphaned}">
-                                                <span class="badge text-bg-danger"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.state.orphaned" default="Orphaned" /></span>
+                                                <f:comment>text-bg-warning, not -danger: white on the danger red is 4.37:1 at
+                                                badge size, and an operator resolves this state rather than the system failing it.</f:comment>
+                                                <span class="badge text-bg-warning"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.state.orphaned" default="Orphaned" /></span>
                                             </f:if>
                                             <f:if condition="{skill.isEnabled}">
                                                 <f:then><span class="badge text-bg-success"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:skill.state.enabled" default="Enabled" /></span></f:then>

--- a/composer.json
+++ b/composer.json
@@ -104,6 +104,7 @@
             "@ci",
             "@ci:test:php:functional"
         ],
+        "ci:test:badges": "php Build/Scripts/check-badge-contrast.php",
         "ci:test:changelog": "php Build/Scripts/check-changelog-unreleased.php",
         "ci:test:php:cgl": "sh -c 'if [ -f /.dockerenv ] || [ -n \"${CI:-}\" ]; then php-cs-fixer fix --dry-run --diff \"$@\"; else ./Build/Scripts/runTests.sh -s cgl -n \"$@\"; fi' --",
         "ci:test:php:functional": "sh -c 'if [ -f /.dockerenv ] || [ -n \"${CI:-}\" ]; then phpunit -c Build/FunctionalTests.xml \"$@\"; else ./Build/Scripts/runTests.sh -s functional \"$@\"; fi' --",
@@ -117,6 +118,7 @@
         "ci:test:php:rector": "sh -c 'if [ -f /.dockerenv ] || [ -n \"${CI:-}\" ]; then rector process --config Build/rector/rector.php --dry-run \"$@\"; else ./Build/Scripts/runTests.sh -s rector -n \"$@\"; fi' --",
         "ci:test:php:unit": "sh -c 'if [ -f /.dockerenv ] || [ -n \"${CI:-}\" ]; then phpunit -c Build/phpunit.xml --testsuite unit \"$@\"; else ./Build/Scripts/runTests.sh -s unit \"$@\"; fi' --",
         "ci:test:repo": [
+            "@ci:test:badges",
             "@ci:test:changelog",
             "@ci:test:workflows"
         ],


### PR DESCRIPTION
White on the backend's danger red is 4.37:1 at the 11px a badge computes to, under the 4.5:1 WCAG AA needs for normal text; axe rates it serious. The circuit-open badge on Analytics and the sync-failed and orphaned badges on Skills take the warning pairing instead — black on amber at 9.6:1, the same substitution two configuration badges already carry. None of the three marks a failure of the system; each marks a state an operator resolves.

#746 listed four and named Task/Execute.html as the fourth. That one was already fixed; three remained.

The reason they survived a green accessibility suite is the part worth fixing: they render only in states no fixture produces — an open circuit breaker, a skill source that failed to sync, an orphaned skill. So composer ci:test:badges refuses text-bg-danger on a badge outright. It enforces the decision rather than measuring contrast, which is honest about what a static check can prove, and it covers the states no fixture reaches.

Not .bg-danger-subtle + .text-danger-emphasis: the backend CSS ships the background utility but only the CSS variable for the text one, so the pair leaves the label at the body colour and inverts badly in one theme. Checked against typo3/cms-backend/Resources/Public/Css/backend.css.

Closes #746
