### PR TITLE
build(rector): follow 2.6.2's removal of the numbered PHPUnit sets

### DIFF
--- a/Build/rector/rector.php
+++ b/Build/rector/rector.php
@@ -45,8 +45,15 @@ return static function (RectorConfig $rectorConfig) use ($configure): void {
     ));
 
     $rectorConfig->sets([
-        // PHPUnit sets - modernize tests
-        PHPUnitSetList::PHPUNIT_110,
+        // PHPUnit sets - modernize tests.
+        //
+        // COMPOSER_BASED, not a numbered set: rector 2.6.2 removed PHPUNIT_40
+        // through PHPUNIT_130 and left this one, which reads the PHPUnit
+        // version composer actually installed. That suits this repository
+        // better than the constant did — the rector job is pinned to PHP 8.2
+        // precisely so the rules match the phpunit ^11 that resolves there,
+        // and this set derives the same thing instead of restating it.
+        PHPUnitSetList::COMPOSER_BASED,
 
         // TYPO3 Sets - CRITICAL for TYPO3 migrations
         Typo3SetList::CODE_QUALITY,

--- a/Tests/Unit/AdrLifecycleTest.php
+++ b/Tests/Unit/AdrLifecycleTest.php
@@ -138,9 +138,9 @@ final class AdrLifecycleTest extends AbstractUnitTestCase
             }
 
             $contents = (string)file_get_contents($file);
-            self::assertSame(
-                1,
-                preg_match('/^:(?:Amended|Superseded):[ \t]*\S/m', $contents),
+            self::assertMatchesRegularExpression(
+                '/^:(?:Amended|Superseded):[ \t]*\S/m',
+                $contents,
                 basename($file) . ' says another record overtook part of it but carries no '
                 . ':Amended: / :Superseded: field. The amending ADR owns that edit.',
             );
@@ -277,9 +277,9 @@ final class AdrLifecycleTest extends AbstractUnitTestCase
                 continue;
             }
 
-            self::assertSame(
-                1,
-                preg_match('/^:Superseded:[ \t]*\S/m', (string)file_get_contents($file)),
+            self::assertMatchesRegularExpression(
+                '/^:Superseded:[ \t]*\S/m',
+                (string)file_get_contents($file),
                 basename($file) . ' is Superseded but does not say by what.',
             );
         }

--- a/Tests/Unit/BaselineConsistencyTest.php
+++ b/Tests/Unit/BaselineConsistencyTest.php
@@ -98,9 +98,9 @@ final class BaselineConsistencyTest extends AbstractUnitTestCase
         // Asserted rather than skipped over: BASELINE.md states this positively
         // ("runs on the weekly schedule only"), so the day it stops being true
         // the attestation is wrong and must fail, not go quiet.
-        self::assertSame(
-            1,
-            preg_match('/run-mutation-tests:\s*\$\{\{[^}]*schedule[^}]*\}\}/', $this->ciWorkflow()),
+        self::assertMatchesRegularExpression(
+            '/run-mutation-tests:\s*\$\{\{[^}]*schedule[^}]*\}\}/',
+            $this->ciWorkflow(),
             'BASELINE.md says mutation runs on the weekly schedule only. ci.yml no longer gates it that way.',
         );
     }
@@ -108,9 +108,9 @@ final class BaselineConsistencyTest extends AbstractUnitTestCase
     #[Test]
     public function baselineDoesNotPresentMutationTestingAsAnEnforcedMinimum(): void
     {
-        self::assertSame(
-            0,
-            preg_match('/\b(minimum|required|enforced)\s+(covered\s+)?MSI\b/i', $this->baseline()),
+        self::assertDoesNotMatchRegularExpression(
+            '/\b(minimum|required|enforced)\s+(covered\s+)?MSI\b/i',
+            $this->baseline(),
             'ci.yml gates the mutation job on the weekly schedule, so MSI is a target, not a minimum. '
             . 'State it as monitored in BASELINE.md.',
         );

--- a/Tests/Unit/ProductFactsConsistencyTest.php
+++ b/Tests/Unit/ProductFactsConsistencyTest.php
@@ -224,12 +224,9 @@ final class ProductFactsConsistencyTest extends AbstractUnitTestCase
         // True until ADR-135. A writing tool shipping does not make the claim
         // stale everywhere by itself — someone has to go and change the prose,
         // and for four months nobody did.
-        self::assertSame(
-            0,
-            preg_match(
-                '/\b(?:all|every\s+one\s+of\s+the|alle|jedes\s+der)\s+\d+\s+(?:built-in|builtin|eingebaute|Built-in-Tools)/iu',
-                $this->surfaceContents($surface),
-            ),
+        self::assertDoesNotMatchRegularExpression(
+            '/\b(?:all|every\s+one\s+of\s+the|alle|jedes\s+der)\s+\d+\s+(?:built-in|builtin|eingebaute|Built-in-Tools)/iu',
+            $this->surfaceContents($surface),
             $surface . ' still claims that every builtin tool is read-only. Two write (ADR-134, ADR-135).',
         );
     }

--- a/Tests/Unit/Provider/ResponseParserTraitTest.php
+++ b/Tests/Unit/Provider/ResponseParserTraitTest.php
@@ -15,6 +15,7 @@ use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Netresearch\NrLlm\Provider\ResponseParserTrait;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\Test;
 
 /**
@@ -473,12 +474,11 @@ class ResponseParserTraitTest extends AbstractUnitTestCase
     // ==================== guardStreamLineBuffer tests ====================
 
     #[Test]
+    #[DoesNotPerformAssertions]
     public function guardStreamLineBufferAllowsBufferAtLimit(): void
     {
         // A single unterminated line up to the limit is tolerated (no throw).
         $this->subject->guardStreamLineBuffer(str_repeat('a', 1_048_576));
-
-        $this->addToAssertionCount(1);
     }
 
     #[Test]

--- a/Tests/Unit/Service/Tool/Builtin/GetEnvToolTest.php
+++ b/Tests/Unit/Service/Tool/Builtin/GetEnvToolTest.php
@@ -188,12 +188,9 @@ final class GetEnvToolTest extends TestCase
         // "STRIPE" to the name pattern, these cases would start passing for the
         // wrong reason and stop covering the value-shape path.
         foreach ([self::SHAPED_PAT_KEY, self::SHAPED_STRIPE_KEY, self::SHAPED_JWT_KEY] as $name) {
-            self::assertSame(
-                0,
-                preg_match(
-                    '/PASS|PASSWORD|PWD|SECRET|TOKEN|KEY|SALT|CREDENTIAL|AUTH|PRIVATE|MASTER|ENCRYPT|DSN|DATABASE_URL|APIKEY|API_KEY/i',
-                    $name,
-                ),
+            self::assertDoesNotMatchRegularExpression(
+                '/PASS|PASSWORD|PWD|SECRET|TOKEN|KEY|SALT|CREDENTIAL|AUTH|PRIVATE|MASTER|ENCRYPT|DSN|DATABASE_URL|APIKEY|API_KEY/i',
+                $name,
                 sprintf('"%s" is now matched by the NAME rule, so it no longer tests the value rule.', $name),
             );
         }


### PR DESCRIPTION
rector/rector 2.6.2 dropped PHPUnitSetList::PHPUNIT_40 through PHPUNIT_130. Build/rector/rector.php named PHPUNIT_110, so the Rector job died with 'Undefined constant …::PHPUNIT_110' the moment a run resolved 2.6.2 — which ejected a clean PR from the merge queue three times before the cause was visible, the branch job having still hit a warm Composer cache with 2.6.1.

COMPOSER_BASED is what replaced them: it reads the PHPUnit version composer installed rather than restating it. That fits this repository better than the constant did, because the Rector job is pinned to PHP 8.2 exactly so the rules match the phpunit ^11 resolving there.

The successor set is wider, and the five changes it makes are narrowings:

- assertSame(1, preg_match(...)) becomes assertMatchesRegularExpression(...) and assertSame(0, ...) becomes assertDoesNotMatchRegularExpression(...) in four tests. preg_match returns false on error, which the old form read as 'no match'; the dedicated assertions tell the two apart and say what failed.
- One addToAssertionCount(1) becomes #[DoesNotPerformAssertions]. The suite reports one assertion fewer for that reason, and the test stays non-risky under failOnRisky.

No CHANGELOG entry: nothing here reaches a user of the extension.
