### PR TITLE
chore: prepare release v0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.29.0] - 2026-08-12
+
 ### Added
 
 - **One contract every provider adapter answers to** (ADR-160).
@@ -3495,7 +3497,8 @@ setting now either works or is gone. Three breaking changes — see below.
 
 Initial public release. See git history for prior commits.
 
-[Unreleased]: https://github.com/netresearch/t3x-nr-llm/compare/v0.28.0...HEAD
+[Unreleased]: https://github.com/netresearch/t3x-nr-llm/compare/v0.29.0...HEAD
+[0.29.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.28.0...v0.29.0
 [0.28.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.27.0...v0.28.0
 [0.27.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.25.1...v0.26.0

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -11,8 +11,8 @@
 >
     <project
         title="TYPO3 LLM Extension"
-        version="0.28.0"
-        release="0.28.0"
+        version="0.29.0"
+        release="0.29.0"
         copyright="since 2025 by Netresearch DTT GmbH"
     />
 

--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
                 "providesPackages": {}
             },
             "extension-key": "nr_llm",
-            "version": "0.28.0",
+            "version": "0.29.0",
             "web-dir": ".Build/Web"
         }
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => '',
     'author_company' => 'Netresearch DTT GmbH',
     'state' => 'beta',
-    'version' => '0.28.0',
+    'version' => '0.29.0',
     'constraints' => [
         // composer.json is the authoritative dependency constraint
         // ("typo3/cms-core": "^13.4 || ^14.3"). The TER `depends` format only


### PR DESCRIPTION
Bumps the four version surfaces and closes the Unreleased section.

0.29.0 and not 0.28.1: three constructor and interface signatures changed. InputSubmission takes a turn digest, ContextFitResult takes a required ninth argument, and ModelSelectionServiceInterface gains resolveModelForCall(). This extension is pre-1.0, so a breaking change is a minor bump.

One release rather than the four the plan sketched (0.29 through 0.32): a version describes the delta from the last release, and numbering three intermediate releases that were never published would claim they exist.
