### PR TITLE
security(agent): an input-resume executed a write nobody approved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **An input-resume could execute a write nobody approved** (`#752`). The
+  approval scan suspends only for a tool the gate actually OFFERS — correct
+  while the turn is synchronous, because `invoke()` refuses an unoffered call
+  a moment later for the same reason. The input suspend broke that pairing:
+  the offered set is recomputed from the live configuration at resume, so a
+  write tool enabled while the run waited for the human became offered and ran
+  without ever passing an approval. `resumeWithInput()` now refuses an
+  approval-bound pending call outright; the model re-requests in a fresh turn,
+  which suspends for a real approval.
+
+  Reaching it needed the model to name a tool it was not offered — the
+  prose-steering case the approval scan is written for — and an operator
+  toggling that tool on mid-run. Unreachable on the approval-resume path,
+  which carries an approval by construction.
+
 ## [0.29.0] - 2026-08-12
 
 ### Added

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -634,6 +634,26 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                 // one submission satisfies one tool. Fail-closed refusal.
                 $result = sprintf('Error: tool "%s" requires input that was not provided.', $call->name);
                 $runTrace?->recordToolExecution($state->iterations, 0.0, $call->name, $call->arguments, $result, true);
+            } elseif (ToolApprovalRule::requiresApproval($this->registry->get($call->name))) {
+                // Nothing on THIS path ever approved anything — an input
+                // submission is not an approval. For a turn that suspended
+                // normally the branch is unreachable, because the approval scan
+                // has strict precedence and would have suspended first.
+                //
+                // It becomes reachable when the tool was not OFFERED at suspend
+                // time: the approval scan skips such a call by design (invoke()
+                // refuses it a moment later, so demanding approval for a tool
+                // the run never allowed would be a spurious prompt). The offered
+                // set is then recomputed from the live configuration at resume,
+                // so a write enabled while the run waited for the human becomes
+                // offered — and without this branch it would execute here having
+                // passed no approval at any point.
+                //
+                // Refusing rather than suspending keeps one approval per
+                // submission: the model re-requests in a fresh turn, which hits
+                // the approval scan and suspends for a real one.
+                $result = sprintf('Error: tool "%s" requires approval that was not given.', $call->name);
+                $runTrace?->recordToolExecution($state->iterations, 0.0, $call->name, $call->arguments, $result, true);
             } else {
                 $tt0 = hrtime(true);
                 $runTrace?->beforeToolExecution($call->name);

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -1430,6 +1430,78 @@ final class ToolLoopServiceTest extends TestCase
         self::assertNotSame([], $refused);
     }
 
+    /**
+     * The input-resume path must not execute a write that no human approved.
+     *
+     * The approval scan deliberately only suspends for an OFFERED tool, so a
+     * write the gate did not offer is skipped there — correct while the turn is
+     * synchronous, because invoke() then refuses it for the same reason. The
+     * input suspend breaks that pairing: the offered set is recomputed from the
+     * LIVE configuration at resume, so a write enabled while the run sat waiting
+     * for the human becomes offered, and the else branch executes it having
+     * passed no approval at any point.
+     *
+     * Reaching it needs the model to name a tool it was not offered — the
+     * prose-steering case the approval scan's own comment is written for — and
+     * an operator toggling that tool on mid-run, which is exactly what setting
+     * up an installation looks like.
+     */
+    #[Test]
+    public function inputResumeRefusesAWriteEnabledWhileTheRunWasSuspended(): void
+    {
+        $registry = new ToolRegistry([
+            new FakeInputTool('ask_user'),
+            new FakeTool('write_page', 'WRITTEN', effect: ToolEffect::NON_IDEMPOTENT_WRITE),
+        ]);
+
+        // Suspend: write_page is in the run's allow-list but the gate does not
+        // offer it, so the approval scan passes over it and the turn suspends
+        // for input — carrying the write call into the persisted state.
+        $suspending = self::createStub(LlmServiceManagerInterface::class);
+        $suspending->method('chatWithToolsForConfiguration')->willReturn($this->response('', [
+            new ToolCall('call_1', 'ask_user', []),
+            new ToolCall('call_2', 'write_page', ['uid' => 4]),
+        ]));
+        $before = new ToolLoopService(
+            $suspending,
+            $registry,
+            $this->realPolicy($registry, new FakeToolAvailability(['ask_user'])),
+        );
+
+        $state = null;
+        try {
+            $before->runLoop([$this->userTurn('go')], $this->localConfiguration(), ToolExecutionContext::none(), ['ask_user', 'write_page']);
+            self::fail('Expected the run to suspend for input.');
+        } catch (ToolInputRequiredException $e) {
+            $state = $e->state;
+        }
+
+        self::assertSame('ask_user', $state->inputToolName, 'the input scan suspended, not the approval scan');
+        self::assertCount(2, $state->toolCalls(), 'the unoffered write rides along in the suspended turn');
+
+        // Resume: the operator enabled write_page in the meantime.
+        $continuing = self::createStub(LlmServiceManagerInterface::class);
+        $continuing->method('chatWithToolsForConfiguration')->willReturn($this->response('done'));
+        $after = new ToolLoopService(
+            $continuing,
+            $registry,
+            $this->realPolicy($registry, new FakeToolAvailability(['ask_user', 'write_page'])),
+        );
+
+        $trace = new RunTrace();
+        $after->resumeWithInput($state, ['city' => 'Berlin'], $this->localConfiguration(), ToolExecutionContext::none(), null, $trace);
+
+        $writes = array_values(array_filter(
+            $trace->getSteps(),
+            static fn(RunStep $s): bool => $s->kind === RunStep::KIND_TOOL && $s->toolName === 'write_page',
+        ));
+        self::assertCount(1, $writes);
+        self::assertTrue(
+            $writes[0]->toolIsError,
+            'a write nobody approved must not execute just because it became offered while the run was suspended',
+        );
+    }
+
     #[Test]
     public function approvalResumeRefusesAnInputRequiringPendingCall(): void
     {


### PR DESCRIPTION
Closes #752, which was filed as a hypothesis from reading the control flow. It is a real defect: the test added here fails on main, getting four assertions in before the write executes.

The approval scan suspends only for a tool the gate actually OFFERS. That is right while the turn is synchronous — invoke() refuses an unoffered call a moment later for the same reason, so demanding approval for a tool the run never allowed would be a prompt about nothing.

The input suspend breaks the pairing. resumeWithInput() recomputes the offered set from the LIVE configuration, precisely so a tool disabled mid-run is not executed. The same recomputation widens the set in the other direction: a write enabled while the run sat waiting for the human becomes offered, falls into the else branch, and runs having passed no approval at any point. An input submission is not an approval.

Reaching it needs two things: the model naming a tool it was not offered — the prose-steering case the approval scan's own comment is written for — and an operator toggling that tool on while a run is suspended, which is what setting up an installation looks like. The reporter hit it while auditing whether update_page_metadata was safe to enable on a publicly reachable demo.

The guard refuses an approval-bound pending call rather than suspending for approval, which keeps one approval per submission: the model re-requests in a fresh turn, that turn hits the approval scan, and it suspends for a real one. For a turn that suspended normally the branch is unreachable — the approval scan has strict precedence — so this costs nothing on every legitimate path.

The approval-resume sibling needs no equivalent: it carries an operator approval by construction.

Tests: the new case drives the whole sequence rather than hand-building the suspended state — it suspends for input with the write disabled, asserts the INPUT scan is what fired and that the unoffered write rode along, then resumes against a second service whose gate now offers it.


Closes #752
