### PR TITLE
docs(tools): the write fence does cover the two writers

### DIFF
--- a/Classes/Service/Tool/Builtin/SetFileAlternativeTextTool.php
+++ b/Classes/Service/Tool/Builtin/SetFileAlternativeTextTool.php
@@ -106,8 +106,10 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * Effect: {@see ToolEffect::IDEMPOTENT_WRITE} — setting one scalar field to a
  * given value converges on repeat. Because the effect is a write, every call is
  * suspended for human approval (ADR-134); the tool carries no separate approval
- * marker. As with the first writer it is NOT covered by the ADR-112 write fence,
- * which arms only on the queued path (ADR-135).
+ * marker. As with the first writer, the ADR-112 write fence covers it: every
+ * executing segment claims a lease (ADR-141), so the guard arms on the
+ * interactive path too. ADR-135 recorded the opposite while that was still
+ * true; read ADR-141 for the current guarantee.
  */
 final readonly class SetFileAlternativeTextTool implements ToolInterface, ToolEffectInterface, ToolPreviewInterface, EditorActionInterface
 {

--- a/Classes/Service/Tool/Builtin/UpdatePageMetadataTool.php
+++ b/Classes/Service/Tool/Builtin/UpdatePageMetadataTool.php
@@ -69,8 +69,11 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * Effect: {@see ToolEffect::IDEMPOTENT_WRITE} — setting a scalar field to a
  * given value converges on repeat. Because the effect is a write, every call is
  * suspended for human approval (ADR-134); the tool carries no separate approval
- * marker. It is NOT covered by the ADR-112 write fence — that arms only on the
- * queued path, and no shipped entry point reaches it (ADR-135).
+ * marker. The ADR-112 write fence DOES cover it: every executing segment claims
+ * a lease (ADR-141), so the guard arms on the interactive path too, and it
+ * refuses a side-effecting tool it cannot fence rather than running it unfenced.
+ * ADR-135 recorded the opposite while that was still true; read ADR-141 for the
+ * current guarantee.
  *
  * The pause carries a field-by-field before/after ({@see self::previewCall()},
  * ADR-136): the arguments alone are the NEW values, and an approver deciding


### PR DESCRIPTION
Closes #751

Both writer docblocks describe the world before ADR-141:

> It is NOT covered by the ADR-112 write fence — that arms only on the queued path, and no shipped entry point reaches it (ADR-135).

ADR-135 itself already carries a note that this is history (*"Closed by ADR-141 … Every executing segment now claims a lease, so the statement below is history"*). Only the two docblocks were left behind.

## What the code says

| | |
|---|---|
| `AgentRuntime::run()` | passes `ExecutionIdentity::interactive()` as the lease owner |
| `ResumeCoordinator` | passes `ExecutionIdentity::resume()` |
| `AgentRunExecutor::trace()` | installs the before-tool guard either way, and *"REFUSES a side-effecting tool it cannot fence"* |

So the fence arms on the interactive path as well.

## Why a stale comment was worth a PR

It under-claimed rather than over-claimed, so nothing was unsafe. It still cost real time: deciding whether `update_page_metadata` was safe to enable on a publicly reachable demo meant tracing the call graph, because the docblock and the code disagreed — and the docblock is what a reader consults first. A statement that cannot be trusted in the safe direction cannot be trusted in the other one either.

## Verification

`runTests.sh -s cgl -p 8.4` exit 0, `-s phpstan -p 8.4` no errors. Comments only — no behaviour touched.
