### PR TITLE
chore: prepare release v0.29.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.29.1] - 2026-08-13
+
 ### Fixed
 
 - **An input-resume could execute a write nobody approved** (`#752`). The
@@ -3514,7 +3516,8 @@ setting now either works or is gone. Three breaking changes — see below.
 
 Initial public release. See git history for prior commits.
 
-[Unreleased]: https://github.com/netresearch/t3x-nr-llm/compare/v0.29.0...HEAD
+[Unreleased]: https://github.com/netresearch/t3x-nr-llm/compare/v0.29.1...HEAD
+[0.29.1]: https://github.com/netresearch/t3x-nr-llm/compare/v0.29.0...v0.29.1
 [0.29.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.28.0...v0.29.0
 [0.28.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.27.0...v0.28.0
 [0.27.0]: https://github.com/netresearch/t3x-nr-llm/compare/v0.26.0...v0.27.0

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -11,8 +11,8 @@
 >
     <project
         title="TYPO3 LLM Extension"
-        version="0.29.0"
-        release="0.29.0"
+        version="0.29.1"
+        release="0.29.1"
         copyright="since 2025 by Netresearch DTT GmbH"
     />
 

--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
                 "providesPackages": {}
             },
             "extension-key": "nr_llm",
-            "version": "0.29.0",
+            "version": "0.29.1",
             "web-dir": ".Build/Web"
         }
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => '',
     'author_company' => 'Netresearch DTT GmbH',
     'state' => 'beta',
-    'version' => '0.29.0',
+    'version' => '0.29.1',
     'constraints' => [
         // composer.json is the authoritative dependency constraint
         // ("typo3/cms-core": "^13.4 || ^14.3"). The TER `depends` format only


### PR DESCRIPTION
Bumps `ext_emconf.php`, `composer.json` (`extra.typo3/cms.version`), `Documentation/guides.xml` and `CHANGELOG.md`, and closes the Unreleased section.

## What is actually in the range

Reconciled against `v0.29.0..HEAD` rather than trusting the section that was written when the fix merged:

- `git log --first-parent` lists **two** merges — #753 and #755. *(Corrected after merging: #755 landed on `main` between this branch being prepared and the tag, which is the drift the release reference warns about. It is a docblock-only change closing #751 — two files, no executable line — and gets no CHANGELOG entry, matching how #726 and #749 were handled in the 0.29.0 range. The `[0.29.1]` section stays complete for what the tag ships.)*
- The diff touches three files: `CHANGELOG.md`, `Classes/Service/Tool/ToolLoopService.php`, `Tests/Unit/Service/Tool/ToolLoopServiceTest.php`.
- Stripped of comments and tests, the source change is **three lines**: one `elseif` branch in `resumeWithInput()` and the two statements inside it.
- `Tests/Unit/Api/api-surface.txt` is byte-identical to `v0.29.0` — no public signature moved.

The `[0.29.1]` entry describes that branch and nothing else, in both directions: nothing in the diff is undescribed, and nothing described is absent from the diff.

## Why patch and not minor

One fix, no feature, no signature change. The change makes a path that previously executed refuse instead, which is the point of it — a write reaching the input-resume branch had passed no approval at any stage.

## Issue gate

Five issues are open; none is a regression introduced here.

| Issue | Read |
|---|---|
| #754 | Decision item, filed while reviewing #753. Documents an absence in the governance audit that predates the fix and spans the whole approval mechanism, not this branch. |
| #751 | Docblock that *under*-claims protection. No code effect. |
| #747 | Test-only: the adapter contract's no-retry-on-timeout case is timing-coupled and flaked once. Already classified as a non-blocker. |
| #731, #691 | Deliberate roadmap items, both named in `ROADMAP.md`. |

Shipping is strictly better than holding: the range contains a security fix and nothing else.

