### PR TITLE
docs(governance): the blocks widget does not count tools held for approval

### DIFF
--- a/Documentation/Administration/Governance.rst
+++ b/Documentation/Administration/Governance.rst
@@ -253,8 +253,16 @@ ceiling. Two places show them:
   removal are the same row, with the same reason. Only the event's
   ``detail`` column separates them (``observedOnly=1`` marks a flag), and
   no view reads that column.
-- The :guilabel:`Governance blocks` widget for the wider picture, including
-  guardrail blocks and approvals.
+- The :guilabel:`Governance blocks` widget for the wider picture: tool-gate
+  denials, guardrail response blocks, and the guardrail's own
+  ``approval_required`` verdict on a response.
+
+  The ``approval_required`` bar is **not** a count of tools held for human
+  approval. A tool-approval suspend writes no row in this table,
+  deliberately: the approval trail lives on the run itself, under the
+  ``approval`` retention window described above, because a run waiting for
+  an approver carries resumable work and must outlive the telemetry-length
+  window this table uses. Read it per run in the run timeline, not here.
 
 The bar therefore answers "how often did the data-class axis fire in the
 last 30 days", not "how many tools would enforcement remove". Use it to see

--- a/Documentation/Administration/Governance.rst
+++ b/Documentation/Administration/Governance.rst
@@ -264,8 +264,9 @@ ceiling. Two places show them:
   an approver carries resumable work and must outlive the telemetry-length
   window this table uses. Read it per run in the run timeline, not here.
 
-The bar therefore answers "how often did the data-class axis fire in the
-last 30 days", not "how many tools would enforcement remove". Use it to see
+The :guilabel:`Trust zone ceiling` bar therefore answers "how often did the
+data-class axis fire in the last 30 days", not "how many tools would
+enforcement remove". Use it to see
 *that* the axis fires. Take the number you act on from the table.
 
 The list you actually need is one row per configuration and tool, and it


### PR DESCRIPTION
`Documentation/Administration/Governance.rst` described the Governance blocks widget as showing *"guardrail blocks and approvals"*. The only approval bar in that chart is the guardrail's `approval_required` verdict on a provider response — a tool suspended for a human approval writes no row in `tx_nrllm_governance_event` at all. An operator reading that sentence would go looking for tool approvals in a chart that cannot contain them.

The widget's own docblock is already precise (*"approval-required routings"*), so the loose wording was confined to the admin page.

## What the page now says

That the bar is the guardrail verdict, and that the absence of tool approvals is a decision rather than a gap — with the reason, so nobody re-derives the question:

`PrivacyDataCategory` scopes `GOVERNANCE` to *"tool-gate denials and guardrail blocks … purged like telemetry"*, while `APPROVAL` is a **separate** category with a deliberately longer window, because *"deleting a run that is merely waiting for an approver destroys work in flight"*. Writing the approval trail into this table would put an audit trail onto a telemetry retention window — the thing the separate category exists to prevent.

The page now points a reader at the run timeline for the per-run answer.

## Related

Follows #754, which asked whether the approval mechanism should write governance events and was closed with the reasoning above. #757 covers the one row that *is* wanted: the unapproved-write refusal from #753, which is neither an approval record nor a gate denial and gets its own decision case.

## Note on the surrounding text

The paragraph after this list begins "The bar therefore answers…", referring to the `Trust zone ceiling` bar two bullets earlier. The inserted text names its own bar explicitly (`approval_required`) rather than saying "that last bar", so the older reference is not captured by the new one.
