### PR TITLE
feat(governance): count refused unapproved writes as their own decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **A refused unapproved write is now countable** (`#757`). The refusal added
+  in 0.29.1 was visible only as an errored step in one run's timeline, so
+  "did this ever fire" had no answer. It writes a `write_unapproved`
+  governance event, which the Governance blocks widget and the run timeline
+  pick up without further change.
+
+  Its own decision case rather than a `tool_denied` with a reason: that value
+  means "the gate did not offer this tool", and here the gate did — that is how
+  the call reached the branch. The approval *trail* stays off this table and on
+  the run, where its longer retention window is (`#754`).
+
 ## [0.29.1] - 2026-08-13
 
 ### Fixed

--- a/Classes/Domain/Enum/GovernanceDecision.php
+++ b/Classes/Domain/Enum/GovernanceDecision.php
@@ -59,6 +59,29 @@ enum GovernanceDecision: string
     case CONTEXT_BLOCKED = 'context_blocked';
 
     /**
+     * A pending write was refused on resume because no human had approved it.
+     *
+     * A separate case from {@see self::TOOL_DENIED}, which means "the gate did
+     * not offer this tool". Here the gate DID offer it — that is how the call
+     * reached the branch at all. It is refused because the turn it belongs to
+     * suspended for typed input rather than for approval, and an input
+     * submission is not an approval (see
+     * {@see \Netresearch\NrLlm\Service\Tool\ToolLoopService::resumeWithInput()}).
+     * Folding the two together would make the same value mean two things,
+     * separable only by a `reason` string.
+     *
+     * Also distinct from {@see self::APPROVAL_REQUIRED}, which is the
+     * guardrail's verdict on a provider RESPONSE. This is a tool call that was
+     * stopped, not a response routed for review.
+     *
+     * The approval TRAIL is deliberately not in this table — it lives on the
+     * run, under the longer `approval` retention window, because a run awaiting
+     * an approver carries resumable work. A refusal carries none, so it belongs
+     * with the other governance telemetry.
+     */
+    case WRITE_UNAPPROVED = 'write_unapproved';
+
+    /**
      * @return list<string>
      */
     public static function values(): array

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -654,6 +654,26 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                 // the approval scan and suspends for a real one.
                 $result = sprintf('Error: tool "%s" requires approval that was not given.', $call->name);
                 $runTrace?->recordToolExecution($state->iterations, 0.0, $call->name, $call->arguments, $result, true);
+                // Recorded, not only traced (#757). The run timeline shows this
+                // refusal for one run; the governance table is what answers
+                // "did this ever fire, and how often" — which is the question
+                // that says whether the gap this branch closes is theoretical.
+                $this->governanceEvents?->record(new GovernanceEvent(
+                    correlationId: $context->run?->correlationId() ?? '',
+                    decision: GovernanceDecision::WRITE_UNAPPROVED->value,
+                    reason: 'inputResumeWithoutApproval',
+                    provider: $configuration->getProviderType(),
+                    model: $configuration->getModelId(),
+                    configurationIdentifier: $configuration->getIdentifier(),
+                    beUser: $context->actor->backendUserUid,
+                    toolName: $call->name,
+                    agentrunUid: $context->run->uid ?? 0,
+                    guardrail: '',
+                    // The tool that DID receive the human's input, so an
+                    // operator can see which suspend the refused call rode in
+                    // on. Never the arguments: this row is metadata.
+                    detail: 'inputTool=' . $state->inputToolName,
+                ));
             } else {
                 $tt0 = hrtime(true);
                 $runTrace?->beforeToolExecution($call->name);

--- a/Classes/Widgets/DataProvider/GovernanceBlocksOverTimeDataProvider.php
+++ b/Classes/Widgets/DataProvider/GovernanceBlocksOverTimeDataProvider.php
@@ -40,6 +40,7 @@ final readonly class GovernanceBlocksOverTimeDataProvider implements ChartDataPr
         'response_blocked'  => '#D9534F',
         'approval_required' => '#E8A33D',
         'content_filter'    => '#8E2A27',
+        'write_unapproved'  => '#7B4FA8',
     ];
 
     public function __construct(

--- a/Documentation/Administration/Governance.rst
+++ b/Documentation/Administration/Governance.rst
@@ -257,6 +257,11 @@ ceiling. Two places show them:
   denials, guardrail response blocks, and the guardrail's own
   ``approval_required`` verdict on a response.
 
+  A ``write_unapproved`` bar counts writes the runtime refused because
+  nothing had approved them: a pending call that reached the input-resume
+  path after its tool was switched on mid-run. It is a refusal, not an
+  approval record, which is why it belongs in this table.
+
   The ``approval_required`` bar is **not** a count of tools held for human
   approval. A tool-approval suspend writes no row in this table,
   deliberately: the approval trail lives on the run itself, under the

--- a/Resources/Private/Language/de.locallang_dashboard.xlf
+++ b/Resources/Private/Language/de.locallang_dashboard.xlf
@@ -178,6 +178,10 @@
                 <source>Content filter</source>
                 <target>Content-Filter</target>
             </trans-unit>
+            <trans-unit id="widget.governance_blocks.decision.write_unapproved">
+                <source>Unapproved write refused</source>
+                <target>Schreibzugriff ohne Freigabe abgelehnt</target>
+            </trans-unit>
             <trans-unit id="widget.tool_denials.title">
                 <source>Tool denials by reason</source>
                 <target>Tool-Ablehnungen nach Grund</target>

--- a/Resources/Private/Language/locallang_dashboard.xlf
+++ b/Resources/Private/Language/locallang_dashboard.xlf
@@ -134,6 +134,9 @@
             <trans-unit id="widget.governance_blocks.decision.content_filter">
                 <source>Content filter</source>
             </trans-unit>
+            <trans-unit id="widget.governance_blocks.decision.write_unapproved">
+                <source>Unapproved write refused</source>
+            </trans-unit>
             <trans-unit id="widget.tool_denials.title">
                 <source>Tool denials by reason</source>
             </trans-unit>

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Domain\DTO\BudgetCheckResult;
 
 use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
 use Netresearch\NrLlm\Domain\Enum\ArtifactType;
+use Netresearch\NrLlm\Domain\Enum\GovernanceDecision;
 use Netresearch\NrLlm\Domain\Enum\ToolEffect;
 use Netresearch\NrLlm\Domain\Enum\TrustZone;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
@@ -24,6 +25,7 @@ use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ContextBudgetBreakdown;
 use Netresearch\NrLlm\Domain\ValueObject\ContextFitResult;
+use Netresearch\NrLlm\Domain\ValueObject\GovernanceEvent;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolArtifact;
@@ -55,6 +57,7 @@ use Netresearch\NrLlm\Service\Tool\ToolInterface;
 use Netresearch\NrLlm\Service\Tool\ToolLoopService;
 use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 use Netresearch\NrLlm\Service\Tool\ToolResultBounder;
+use Netresearch\NrLlm\Tests\Unit\Command\Fixture\InMemoryGovernanceEventRepository;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeInputTool;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeToolAvailability;
@@ -1500,6 +1503,60 @@ final class ToolLoopServiceTest extends TestCase
             $writes[0]->toolIsError,
             'a write nobody approved must not execute just because it became offered while the run was suspended',
         );
+    }
+
+    /**
+     * The refusal above is recorded, not only traced (#757).
+     *
+     * The run trace answers "what happened in this run"; the governance table
+     * answers "did this ever fire, and how often" — which is the question that
+     * says whether the gap the branch closes is theoretical or real on a given
+     * installation.
+     */
+    #[Test]
+    public function theUnapprovedWriteRefusalIsRecordedAsItsOwnGovernanceDecision(): void
+    {
+        $registry = new ToolRegistry([
+            new FakeInputTool('ask_user'),
+            new FakeTool('write_page', 'WRITTEN', effect: ToolEffect::NON_IDEMPOTENT_WRITE),
+        ]);
+
+        $state = new SuspendedRunState(
+            [$this->userTurn('go')],
+            [
+                ['id' => 'call_1', 'type' => 'function', 'function' => ['name' => 'ask_user', 'arguments' => '{}']],
+                ['id' => 'call_2', 'type' => 'function', 'function' => ['name' => 'write_page', 'arguments' => '{}']],
+            ],
+            1,
+            0,
+            0,
+            ['ask_user', 'write_page'],
+            [],
+            'ask_user',
+            ['type' => 'object', 'properties' => ['city' => ['type' => 'string']], 'required' => ['city']],
+        );
+
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturn($this->response('done'));
+        $events = new InMemoryGovernanceEventRepository();
+
+        (new ToolLoopService(
+            $mgr,
+            $registry,
+            $this->realPolicy($registry, new FakeToolAvailability(['ask_user', 'write_page'])),
+            governanceEvents: $events,
+        ))->resumeWithInput($state, ['city' => 'Berlin'], $this->localConfiguration(), ToolExecutionContext::none());
+
+        $rows = array_values(array_filter(
+            $events->recorded,
+            static fn(GovernanceEvent $e): bool => $e->decision === GovernanceDecision::WRITE_UNAPPROVED->value,
+        ));
+
+        self::assertCount(1, $rows, 'exactly one row, for the refused write');
+        self::assertSame('write_page', $rows[0]->toolName);
+        self::assertSame('inputResumeWithoutApproval', $rows[0]->reason);
+        // Which suspend the refused call rode in on — never the arguments.
+        self::assertSame('inputTool=ask_user', $rows[0]->detail);
     }
 
     #[Test]


### PR DESCRIPTION
Closes #757. Stacked on #758 — that PR rewrites the very bullet this one extends, so the doc line has no anchor without it. GitHub retargets to `main` when #758 merges.

## What

The refusal 0.29.1 added (#753) — a pending write that reaches the input-resume path after its tool was switched on mid-run — was visible only as an errored step inside one run's timeline. "Has this ever fired, and how often" had no answer. It now writes a governance event, so the Governance blocks widget and the run timeline pick it up with no further change on their side.

## Why its own decision value

`tool_denied` means "the gate did not offer this tool". Here the gate *did* offer it — that is how the call reached the refusal branch at all. Folding the two together would make one value mean two things, separable only by reading a `reason` string. `approval_required` is also taken: that is the guardrail's verdict on a provider *response*, not a tool call that was stopped.

The approval *trail* deliberately stays out of this table and on the run, under the longer `approval` retention window — settled in #754 and now stated in `Documentation/Administration/Governance.rst`.

## Changes

- `GovernanceDecision::WRITE_UNAPPROVED` with a docblock stating both distinctions
- the `record()` call in `ToolLoopService::resumeWithInput()`, carrying `toolName` and the input tool that was waiting (`detail`)
- widget colour and EN/DE labels
- a test asserting one row with the expected tool name, reason and detail

## Not in scope

`context_blocked` has neither a widget colour nor a label — it renders the raw `LLL:` path. Pre-existing, filed separately rather than fixed in passing.

## Tests

Full gate at PHP 8.2 (`composerUpdate`, rector -n, cgl -n, phpstan, unit, `ci:test:repo`): green. Unit 7056 tests / 21763 assertions. Functional filtered to `Governance|InputPause|WritePath`: 44 tests green. `@api` surface unchanged.
