### PR TITLE
test(provider): wait against the clock the timeout guard reads

### DIFF
--- a/Tests/Unit/Provider/Contract/AbstractAdapterContractTestCase.php
+++ b/Tests/Unit/Provider/Contract/AbstractAdapterContractTestCase.php
@@ -430,7 +430,19 @@ abstract class AbstractAdapterContractTestCase extends AbstractUnitTestCase
         $adapter  = $this->adapterWithClient(
             $this->callbackClient(static function () use (&$attempts): ResponseInterface {
                 ++$attempts;
-                usleep(700_000);
+
+                // The guard in AbstractProvider::sendRequest() tells a timeout
+                // from a retryable connection failure by elapsed wall time, so
+                // this callback has to spend it. A bare usleep() is not enough:
+                // it returns early when a signal interrupts it, elapsed time
+                // then lands under the threshold and the adapter retries —
+                // observed once as a flake (#747, attempts was 2). Sleeping
+                // towards a deadline read from the same clock the guard reads
+                // cannot end short.
+                $deadline = microtime(true) + 0.7;
+                while (($remaining = $deadline - microtime(true)) > 0.0) {
+                    usleep((int)($remaining * 1_000_000));
+                }
 
                 throw new RuntimeException('cURL error 28: Operation timed out', 8599352423);
             }),


### PR DESCRIPTION
Closes #747.

## Diagnosis

The issue ruled out a slow runner correctly: `usleep(700_000)` against a `1 - 0.5 = 0.5s` threshold only ever moves elapsed time *away* from the failing side under load. But the observed `attempts` was **2**, not 4 — with `maxRetries: 3` the loop allows four attempts, and it stopped at two. So attempt 1 measured *below* 0.5s and attempt 2 above it. Only one of the listed hypotheses produces that: `usleep()` returning early on a signal. Execution order cannot, because nothing outside the callback influences the elapsed time of a single attempt.

## Fix

The callback sleeps towards a deadline taken from `microtime(true)` — the same clock `AbstractProvider::sendRequest()` measures against — and re-sleeps whatever is left. An early return now costs one more loop pass instead of a retry.

This keeps the test coupled to wall time, which is deliberate: wall time *is* the discriminator the production guard uses, and the comment above it says so. Replacing it entirely would need a clock seam on `AbstractProvider`, and the only consumer would be this test — the seven adapter constructors are frozen in `api-surface.txt`, so it would be new public surface for one caller. Reading the same clock the guard reads gets determinism without that.

A clock jump is also handled: both readings come from the same source, so backwards moves the loop longer (safe) and forwards is seen by the guard too.

## Tests

The contract test across all 7 adapters, three consecutive runs: `OK (7 tests, 7 assertions)` each time. That does not prove a flake gone — nothing does in three runs — but the failure mechanism is no longer reachable.

Full gate at PHP 8.2 (rector -n, cgl -n, phpstan, unit, `ci:test:repo`, `ci:test:changelog`): green. Unit 7055 tests / 21759 assertions.

No CHANGELOG entry: test-only, nothing user-facing changes.
