### PR TITLE
feat(governance): bind a run's forced sources against the trust ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **A run's forced snippets and skills now bind against the ADR-144 trust
+  ceiling** (`#731`, ADR-164). The Tool Playground injects a per-run forced set
+  that reaches the wire like a configuration's own snippet; the ceiling asked
+  `classify()`, which answers for the configuration alone, so it never saw
+  them. The gate now folds the same source list the context readout shows.
+
+  The playground is admin-only, so this was never a privilege escalation — it
+  was an administrator able to send, on one run, context the configuration's
+  trust zone would refuse. An installation that has classified nothing is
+  unaffected; one that has may see a playground run refused, naming the forced
+  snippet. Observe mode shows the decision without throwing.
+
+  Not covered: a resumed run, whose suspended state does not persist the forced
+  set (`#761`). New value object `InjectedContext`; `chatWithConfiguration()`
+  and `chatWithToolsForConfiguration()` take it as a trailing optional
+  parameter, additive on both.
+
 ## [0.29.1] - 2026-08-13
 
 ### Fixed

--- a/Classes/Domain/ValueObject/InjectedContext.php
+++ b/Classes/Domain/ValueObject/InjectedContext.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\ValueObject;
+
+use Netresearch\NrLlm\Domain\Model\PromptSnippet;
+use Netresearch\NrLlm\Domain\Model\Skill;
+
+/**
+ * The sources one run injects on top of its configuration (ADR-164).
+ *
+ * The ADR-144 ceiling reads these alongside the configuration's own snippets
+ * and skills, so a run cannot carry, per call, context the configuration's
+ * trust zone would refuse.
+ *
+ * A value object rather than {@see \Netresearch\NrLlm\Service\Tool\RunAugmentation}
+ * itself, which is where the forced set is actually assembled: the architecture
+ * rules forbid `LlmServiceManager` from depending on `Service\Tool`, and that
+ * rule is right — the manager has no business knowing the tool loop exists. The
+ * augmentation converts to this on the way in.
+ *
+ * @api
+ */
+final readonly class InjectedContext
+{
+    /**
+     * @param list<PromptSnippet> $snippets
+     * @param list<Skill>         $skills
+     */
+    public function __construct(
+        public array $snippets = [],
+        public array $skills = [],
+    ) {}
+}

--- a/Classes/Service/Context/InputContextClassifier.php
+++ b/Classes/Service/Context/InputContextClassifier.php
@@ -66,10 +66,14 @@ final readonly class InputContextClassifier
      * `$forcedSnippets` / `$forcedSkills` are the per-RUN additions a caller
      * injects on top of the configuration (the playground's forced set). They
      * really do reach the wire, so a readout that omitted them would
-     * under-report the run — but the ADR-144 gate does NOT see them: it asks
-     * {@see self::classify()}, which answers for the configuration alone. A
-     * forced source is therefore listed and NOT gated, and both the panel and
-     * this docblock say so rather than implying the gate covers it.
+     * under-report the run.
+     *
+     * Since ADR-164 the gate reads THIS method with the same forced set rather
+     * than {@see self::classify()}, so the panel and the ceiling now answer for
+     * the same source list. `classify()` deliberately keeps its narrower
+     * configuration-only meaning: it is the fold a caller wants when the
+     * question really is "what does this configuration carry", independent of
+     * any one run.
      *
      * A forced source the configuration already carries is listed once: the
      * loop's own assembly drops the duplicate text, so counting it twice would

--- a/Classes/Service/Context/InputContextTrustGate.php
+++ b/Classes/Service/Context/InputContextTrustGate.php
@@ -14,6 +14,8 @@ use Netresearch\NrLlm\Domain\Enum\ToolDataClass;
 use Netresearch\NrLlm\Domain\Enum\TrustZone;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\PromptSnippet;
+use Netresearch\NrLlm\Domain\Model\Skill;
 use Netresearch\NrLlm\Domain\ValueObject\GovernanceEvent;
 use Netresearch\NrLlm\Domain\ValueObject\InputContextDecision;
 use Netresearch\NrLlm\Exception\InputContextTrustZoneException;
@@ -83,10 +85,31 @@ final readonly class InputContextTrustGate
      * A simulator that has not resolved one passes null and gets the zone the
      * configuration's own relation gives — the pre-ADR-149 answer, which for a
      * criteria-mode record is the fail-closed `EXTERNAL_GLOBAL`.
+     *
+     * `$forcedSnippets` / `$forcedSkills` are the sources a caller injects on
+     * top of the configuration for this one run (ADR-164). They bind: the
+     * ceiling is a statement about where the text may travel, and a caller
+     * choosing to attach it does not make the destination more trustworthy.
+     * Passing them folds them into the same classification the configuration's
+     * own sources produce, so the strictest declaration wins and the refusal
+     * names whichever source set it — configuration or forced.
+     *
+     * @param list<PromptSnippet> $forcedSnippets
+     * @param list<Skill>         $forcedSkills
      */
-    public function decide(LlmConfiguration $configuration, ?Model $servingModel = null): InputContextDecision
-    {
-        $classification = $this->classifier->classify($configuration);
+    public function decide(
+        LlmConfiguration $configuration,
+        ?Model $servingModel = null,
+        array $forcedSnippets = [],
+        array $forcedSkills = [],
+    ): InputContextDecision {
+        // sources() + strictest() IS classify() when nothing is forced, so a
+        // caller that injects nothing gets exactly the pre-ADR-164 answer. It
+        // is also the list the ADR-151 readout folds, which is what keeps the
+        // panel and the gate from disagreeing about what a run carries.
+        $classification = InputContextClassifier::strictest(
+            $this->classifier->sources($configuration, $forcedSnippets, $forcedSkills),
+        );
         if (!$classification->isDeclared()) {
             return InputContextDecision::undeclared();
         }
@@ -114,14 +137,22 @@ final readonly class InputContextTrustGate
      *
      * `$agentRunUid` attributes the refusal to the agent run that triggered it
      * (ADR-153); 0 for a plain provider call, which has no run.
+     *
+     * `$forcedSnippets` / `$forcedSkills` carry the run's per-call injections
+     * into the rule (ADR-164) — see {@see self::decide()}.
+     *
+     * @param list<PromptSnippet> $forcedSnippets
+     * @param list<Skill>         $forcedSkills
      */
     public function assertPermitted(
         LlmConfiguration $configuration,
         int $beUser = 0,
         ?Model $servingModel = null,
         int $agentRunUid = 0,
+        array $forcedSnippets = [],
+        array $forcedSkills = [],
     ): void {
-        $decision = $this->decide($configuration, $servingModel);
+        $decision = $this->decide($configuration, $servingModel, $forcedSnippets, $forcedSkills);
         if (!$decision->zoneRefused) {
             return;
         }

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -18,6 +18,7 @@ use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRunReference;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ContextFitResult;
+use Netresearch\NrLlm\Domain\ValueObject\InjectedContext;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
@@ -206,6 +207,10 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
      * so the model this gate judges is the model the terminal will resolve
      * (ADR-138: two resolutions of one call pass the same operation).
      *
+     * `$injectedContext` carries the sources this ONE run injects on top of the
+     * configuration (ADR-164). They bind against the same ceiling: the tool
+     * loop is the only caller that has them, and it forwards its own.
+     *
      * @param array<string, mixed> $metadata
      * @param int                  $agentRunUid the run this call belongs to (ADR-153), stamped onto the
      *                                          refusal row; 0 when the call is not part of a run
@@ -215,6 +220,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         array $metadata,
         ProviderOperation $operation,
         int $agentRunUid = 0,
+        ?InjectedContext $injectedContext = null,
     ): void {
         if (!$this->inputContextGate instanceof InputContextTrustGate) {
             return;
@@ -227,6 +233,8 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             is_int($beUser) ? $beUser : 0,
             $this->servingModelForGate($configuration, $operation),
             $agentRunUid,
+            $injectedContext->snippets ?? [],
+            $injectedContext->skills ?? [],
         );
     }
 
@@ -818,9 +826,11 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
      *
      * @param list<ChatMessage|array<string, mixed>> $messages
      * @param list<ToolSpec|array<string, mixed>>    $tools
-     * @param ?AgentRunReference                     $run      the agent run driving this round (ADR-153); null outside a run
+     * @param ?AgentRunReference                     $run             the agent run driving this round (ADR-153); null outside a run
+     * @param ?InjectedContext                       $injectedContext sources this run injects on top of the configuration (ADR-164);
+     *                                                                the ADR-144 ceiling binds against them too
      */
-    public function chatWithToolsForConfiguration(array $messages, array $tools, LlmConfiguration $configuration, ?ToolOptions $options = null, ?AgentRunReference $run = null): CompletionResponse
+    public function chatWithToolsForConfiguration(array $messages, array $tools, LlmConfiguration $configuration, ?ToolOptions $options = null, ?AgentRunReference $run = null, ?InjectedContext $injectedContext = null): CompletionResponse
     {
         $options ??= new ToolOptions();
         $optionOverrides = $options->toArray();
@@ -878,6 +888,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             },
             $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->idempotency($options->getIdempotencyKey()),
             $run,
+            $injectedContext,
         );
     }
 
@@ -1049,8 +1060,10 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
      * @param array<string, mixed>                   $metadata
      * @param array<string, mixed>                   $optionOverrides per-call options that take precedence over the configuration's stored defaults
      * @param ?AgentRunReference                     $run             the agent run driving this call (ADR-153); null outside a run
+     * @param ?InjectedContext                       $injectedContext sources this run injects on top of the configuration (ADR-164);
+     *                                                                the ADR-144 ceiling binds against them too
      */
-    public function chatWithConfiguration(array $messages, LlmConfiguration $configuration, array $metadata = [], array $optionOverrides = [], ?AgentRunReference $run = null): CompletionResponse
+    public function chatWithConfiguration(array $messages, LlmConfiguration $configuration, array $metadata = [], array $optionOverrides = [], ?AgentRunReference $run = null, ?InjectedContext $injectedContext = null): CompletionResponse
     {
         $messages           = $this->screenInput($messages);
         $normalisedMessages = $this->messageShaper->normalise($messages);
@@ -1069,6 +1082,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             },
             $metadata,
             $run,
+            $injectedContext,
         );
     }
 
@@ -1184,6 +1198,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         callable $terminal,
         array $metadata = [],
         ?AgentRunReference $run = null,
+        ?InjectedContext $injectedContext = null,
     ): mixed {
         // The run's own uid is authoritative and goes on the LEFT: `$metadata`
         // is caller-supplied on the public entry points, and `+` keeps the left
@@ -1198,7 +1213,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         // rather than in each terminal because it is a property of the
         // configuration, not of the payload, and every configuration-driven
         // operation runs through this pipeline.
-        $this->assertContextPermitted($configuration, $metadata, $operation, $run->uid ?? 0);
+        $this->assertContextPermitted($configuration, $metadata, $operation, $run->uid ?? 0, $injectedContext);
 
         return $this->pipeline->run(
             ProviderCallContext::forConfiguration($operation, $configuration, $metadata, $run?->correlationId()),

--- a/Classes/Service/LlmServiceManagerInterface.php
+++ b/Classes/Service/LlmServiceManagerInterface.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRunReference;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\InjectedContext;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
@@ -105,7 +106,7 @@ interface LlmServiceManagerInterface
      *                                                                row carries the run's correlation id and a governance row its
      *                                                                uid. Null (every caller outside a run) is unchanged behaviour.
      */
-    public function chatWithConfiguration(array $messages, LlmConfiguration $configuration, array $metadata = [], array $optionOverrides = [], ?AgentRunReference $run = null): CompletionResponse;
+    public function chatWithConfiguration(array $messages, LlmConfiguration $configuration, array $metadata = [], array $optionOverrides = [], ?AgentRunReference $run = null, ?InjectedContext $injectedContext = null): CompletionResponse;
 
     /**
      * Chat against a specific configuration from a ChatOptions object.
@@ -203,11 +204,13 @@ interface LlmServiceManagerInterface
      *
      * @param list<ChatMessage|array<string, mixed>> $messages
      * @param list<ToolSpec|array<string, mixed>>    $tools
-     * @param ?AgentRunReference                     $run      as in {@see self::chatWithConfiguration()} — the agent loop
-     *                                                         passes the run it is executing, so every round of one run
-     *                                                         shares a correlation id instead of minting N unrelated ones
+     * @param ?AgentRunReference                     $run             as in {@see self::chatWithConfiguration()} — the agent loop
+     *                                                                passes the run it is executing, so every round of one run
+     *                                                                shares a correlation id instead of minting N unrelated ones
+     * @param ?InjectedContext                       $injectedContext sources this run injects on top of the configuration
+     *                                                                (ADR-164); the ADR-144 ceiling binds against them too
      */
-    public function chatWithToolsForConfiguration(array $messages, array $tools, LlmConfiguration $configuration, ?ToolOptions $options = null, ?AgentRunReference $run = null): CompletionResponse;
+    public function chatWithToolsForConfiguration(array $messages, array $tools, LlmConfiguration $configuration, ?ToolOptions $options = null, ?AgentRunReference $run = null, ?InjectedContext $injectedContext = null): CompletionResponse;
 
     public function supportsFeature(string $feature, ?string $provider = null): bool;
 

--- a/Classes/Service/Tool/RunAugmentation.php
+++ b/Classes/Service/Tool/RunAugmentation.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Service\Tool;
 
 use Netresearch\NrLlm\Domain\Model\PromptSnippet;
 use Netresearch\NrLlm\Domain\Model\Skill;
+use Netresearch\NrLlm\Domain\ValueObject\InjectedContext;
 
 /**
  * Per-run prompt augmentation for an inspectable {@see ToolLoopService} run,
@@ -38,4 +39,16 @@ final readonly class RunAugmentation
         public array $forcedSnippets = [],
         public bool $dryRun = false,
     ) {}
+
+    /**
+     * The forced set in the shape the ADR-144 ceiling reads (ADR-164).
+     *
+     * The dry-run flag is deliberately not carried: a dry run assembles the
+     * messages and returns without calling a provider, so nothing leaves the
+     * installation and there is no send for the ceiling to judge.
+     */
+    public function injectedContext(): InjectedContext
+    {
+        return new InjectedContext($this->forcedSnippets, $this->forcedSkills);
+    }
 }

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -195,7 +195,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
 
             $runTrace?->recordRequest(1, $messages, []);
             $t0   = hrtime(true);
-            $resp = $this->mgr->chatWithConfiguration($messages, $configuration, $this->budgetMetadata($options), run: $context->run);
+            $resp = $this->mgr->chatWithConfiguration($messages, $configuration, $this->budgetMetadata($options), run: $context->run, injectedContext: $augmentation?->injectedContext());
             $runTrace?->recordLlmCall(1, $this->elapsedMs($t0), $resp);
 
             // Fold in any carried-over counters (a resume whose continuation has
@@ -247,7 +247,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                 // The run travels with the call (ADR-153): every round of one run
                 // lands on the run's correlation id instead of minting its own,
                 // so its telemetry rows are attributable to the run afterwards.
-                $resp = $this->mgr->chatWithToolsForConfiguration($messages, $specs, $configuration, $options, $context->run);
+                $resp = $this->mgr->chatWithToolsForConfiguration($messages, $specs, $configuration, $options, $context->run, $augmentation?->injectedContext());
                 $runTrace?->recordLlmCall($iterations, $this->elapsedMs($t0), $resp);
                 $lastUsage         = $resp->usage;
                 $promptTokens     += $resp->usage->promptTokens;
@@ -371,6 +371,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                 $configuration,
                 $this->budgetMetadata($options),
                 run: $context->run,
+                injectedContext: $augmentation?->injectedContext(),
             );
             $runTrace?->recordLlmCall($iterations + 1, $this->elapsedMs($t0), $final);
             $promptTokens     += $final->usage->promptTokens;

--- a/Documentation/Administration/Tools.rst
+++ b/Documentation/Administration/Tools.rst
@@ -703,8 +703,10 @@ loop, while the Tools module governs *which* tools exist and are enabled.
      class it declared (:ref:`ADR-144 <adr-144>`) or *not classified*, and the
      strictest class across all of them. The list covers the snippets and
      skills you force-injected for this one run as well as the
-     configuration's own — the input-context gate itself still answers for the
-     configuration alone, so a forced source is shown here and is not gated.
+     configuration's own, and the input-context gate reads the same list
+     (:ref:`ADR-164 <adr-164>`): a source shown here is a source that is
+     gated. Forcing a snippet the configuration's trust zone would refuse
+     therefore refuses the run, naming that snippet.
 
 .. figure:: /Images/ToolPlaygroundRun.png
    :alt: A completed tool run — the summary strip, the ordered step list and

--- a/Documentation/Adr/Adr144InjectedContextCarriesADataClass.rst
+++ b/Documentation/Adr/Adr144InjectedContextCarriesADataClass.rst
@@ -6,12 +6,13 @@ ADR-144: Injected context carries a declared data class
 
 :Status: Accepted (the criteria-mode zone now comes from the resolved model —
     see :ref:`ADR-149 <adr-149>`; the system prompt is classified after all —
-    see :ref:`ADR-155 <adr-155>`)
+    see :ref:`ADR-155 <adr-155>`; a run's forced sources bind too — see
+    :ref:`ADR-164 <adr-164>`)
 :Date: 2026-08-10
 :Amends: :ref:`ADR-094 <adr-094>` (the axis now binds in both directions)
          and :ref:`ADR-139 <adr-139>` (its "no trust-zone ceiling" gap)
-:Amended: 2026-08-11 by :ref:`ADR-149 <adr-149>`, and 2026-08-11 by
-    :ref:`ADR-155 <adr-155>`
+:Amended: 2026-08-11 by :ref:`ADR-149 <adr-149>`, 2026-08-11 by
+    :ref:`ADR-155 <adr-155>`, and 2026-08-13 by :ref:`ADR-164 <adr-164>`
 :Authors: Netresearch DTT GmbH
 
 Context

--- a/Documentation/Adr/Adr151ContextBudgetReadout.rst
+++ b/Documentation/Adr/Adr151ContextBudgetReadout.rst
@@ -6,10 +6,12 @@
 ADR-151: The context budget is a breakdown, not a number
 ============================================================================
 
-:Status: Accepted
+:Status: Accepted (the forced set is gated after all — see
+   :ref:`ADR-164 <adr-164>`)
 :Date: 2026-08-11
 :Amends: :ref:`ADR-081 <adr-081>` (a fifth ``RunStep`` kind, and therefore a
    fifth persisted event kind)
+:Amended: 2026-08-13 by :ref:`ADR-164 <adr-164>`
 :Authors: Netresearch DTT GmbH
 
 .. _adr-151-context:
@@ -101,11 +103,12 @@ classification exists because the text is sensitive.
 *The run, not the configuration.* A playground run also injects the forced
 snippets and skills the operator ticked, and those reach the wire exactly like
 the configuration's own, so :php:`sources()` takes them as arguments and the
-panel lists them. The gate does not see them: it asks :php:`classify()`, which
-answers for the configuration alone. A forced source is therefore **shown and
-not gated**, and the panel is a superset of what ADR-144 enforces rather than a
-mirror of it. Widening the gate to the forced set is a decision about
-enforcement and belongs to ADR-144, not to a readout.
+panel lists them. The gate did not see them at the time of writing: it asked
+:php:`classify()`, which answers for the configuration alone, so a forced source
+was **shown and not gated** and the panel was a superset of what ADR-144
+enforced rather than a mirror of it. Widening the gate was a decision about
+enforcement and belonged to ADR-144, not to a readout; it was taken in
+:ref:`ADR-164 <adr-164>`, and the panel and the ceiling now fold the same list.
 
 .. _adr-151-not:
 

--- a/Documentation/Adr/Adr164ForcedSourcesBindAgainstTheCeiling.rst
+++ b/Documentation/Adr/Adr164ForcedSourcesBindAgainstTheCeiling.rst
@@ -1,0 +1,118 @@
+.. _adr-164:
+
+===============================================================
+ADR-164: A run's forced sources bind against the trust ceiling
+===============================================================
+
+:Status: Accepted
+:Date: 2026-08-13
+:Amends: :ref:`ADR-144 <adr-144>` (the ceiling now reads a run's forced set, not
+    the configuration alone) and :ref:`ADR-151 <adr-151>` (its "shown and not
+    gated" asymmetry is resolved in favour of gating)
+:Authors: Netresearch DTT GmbH
+
+Context
+=======
+
+:ref:`ADR-144 <adr-144>` refuses a call whose injected context is classified
+above the trust zone the run can reach. It asks
+:php:`InputContextClassifier::classify()`, which answers for the configuration's
+own snippets, skills and system prompt.
+
+A run can inject *more* than that. The Tool Playground builds a forced set from
+the request body and :php:`ToolLoopService` adds each entry as a leading system
+message, so it reaches the wire exactly like a configuration's own snippet. The
+ceiling never saw it. :ref:`ADR-151 <adr-151>` documented that gap rather than
+closing it, because widening enforcement is not a readout's decision — issue
+`#731` is the decision it deferred.
+
+The gap's severity was small and stating it precisely matters. The playground is
+admin-only, so this was never a privilege escalation: it was an administrator
+able to send, for one run, context the configuration's trust zone would refuse.
+Every forced source still passed the mandatory input guardrail and secret
+redaction (:ref:`ADR-087 <adr-087>`).
+
+Decision
+========
+
+**A forced source binds against the same ceiling as a configuration's own.**
+
+The ceiling is a statement about where text may travel, not about who may ask.
+A caller choosing to attach a snippet does not make the destination more
+trustworthy, and the class was declared on the snippet record as standing
+policy. Treating an ad-hoc tick as a waiver of that policy would make the
+declaration advisory — and an advisory ceiling is the "declaration nothing
+reads" this codebase removes elsewhere.
+
+"The playground is admin-only" is an argument about *authority*, and the ceiling
+is not an authority control. The tool gate (:ref:`ADR-094 <adr-094>`) already
+applies to administrators for the same reason: it answers where data may go, and
+that answer does not change with the seniority of the person asking.
+
+**The gate folds one source list.** :php:`decide()` now folds
+:php:`InputContextClassifier::sources($configuration, $forcedSnippets,
+$forcedSkills)` instead of calling :php:`classify()`. With an empty forced set
+the two are the same fold, so a caller that injects nothing gets exactly the
+pre-ADR-164 answer. It is also the list the :ref:`ADR-151 <adr-151>` readout
+folds, so the panel and the ceiling can no longer disagree about what a run
+carries — the asymmetry ADR-151 documented is gone rather than merely explained.
+
+:php:`classify()` keeps its narrower meaning: what this *configuration* carries,
+independent of any one run. That is a real question with real callers, and
+folding a run into it would leave no way to ask it.
+
+**The refusal names whichever source set the class.** The strictest declaration
+wins and carries its own source name, so a refusal reads
+``snippet "incident-report"`` when the forced source is the reason and the
+configuration's identifier when it is not. Without that an operator cannot tell
+which of the two halves to edit — they live in different places.
+
+**The forced set travels as a domain value object.** :php:`InjectedContext`
+carries the two lists;
+:php:`\\Netresearch\\NrLlm\\Service\\Tool\\RunAugmentation::injectedContext()`
+converts. The architecture rules forbid :php:`LlmServiceManager` from depending
+on :php:`Service\\Tool`, and that rule is right — the manager has no business
+knowing the tool loop exists. The value object is what both may name.
+
+The two configuration-driven entry points that a run's assembled messages pass
+through, :php:`chatWithConfiguration()` and
+:php:`chatWithToolsForConfiguration()`, take it as a trailing optional
+parameter. Both are :php:`@api`; the addition is additive and the frozen
+surface records it.
+
+.. _adr-164-not:
+
+What this does not do
+=====================
+
+**It does not gate a dry run.** A dry run assembles the messages and returns
+without calling a provider, so nothing leaves the installation and there is no
+send to judge. :php:`RunAugmentation::injectedContext()` deliberately drops the
+flag rather than carrying it into a decision it has no part in.
+
+**It does not classify the task input.** ADR-144's second argument is untouched:
+the accepted input is whatever the caller passed this second, with no per-record
+home a declaration could live in.
+
+**It does not cover a resumed run.** :php:`ToolLoopService::resume()` and
+:php:`resumeWithInput()` re-enter the loop with assembly skipped, and the
+suspended-run state does not persist the forced set — so the resumed send
+carries the forced text in its transcript with no forced set for the gate to
+read. The bound is narrow: the forced text entered that transcript at assembly
+time, where this ADR *does* gate it, so nothing new is injected on resume. What
+a resume can miss is a ceiling that changed *while* the run was suspended — the
+configuration re-pointed at a less trusted provider, or enforcement switched
+from observe to enforce. Closing that needs the forced set persisted into the
+suspended state, which is issue `#761`.
+
+Consequences
+============
+
+An installation that has classified nothing is unaffected: an undeclared source
+still places no constraint, in the forced set exactly as everywhere else.
+
+An installation that has classified snippets may see a playground run refused
+that previously went through. That is the intended change, and the refusal names
+the forced snippet so the operator can see which tick caused it. Observe mode
+(``dataClassEnforcement``) shows the same decision without throwing, which is
+the way to measure the effect before switching enforcement on.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -508,3 +508,4 @@ Tools
    Adr161McpClientConformance
    Adr162BulkEditorActionsAsOrdinaryRuns
    Adr163UseCasePacks
+   Adr164ForcedSourcesBindAgainstTheCeiling

--- a/Tests/Unit/Api/api-surface.txt
+++ b/Tests/Unit/Api/api-surface.txt
@@ -822,6 +822,11 @@ Netresearch\NrLlm\Domain\ValueObject\GuardrailResult (class)
   property readonly redactedThinking: ?string
   property readonly verdict: Netresearch\NrLlm\Domain\Enum\GuardrailVerdict
 
+Netresearch\NrLlm\Domain\ValueObject\InjectedContext (class)
+  constructor(array $snippets = …, array $skills = …)
+  property readonly skills: array
+  property readonly snippets: array
+
 Netresearch\NrLlm\Domain\ValueObject\RequestComplexity (class)
   constructor(int $score, int $payloadBytes, ?int $tokenEstimate, int $toolCount, ?int $contextPercent, string $shape)
   property readonly contextPercent: ?int
@@ -1322,9 +1327,9 @@ Netresearch\NrLlm\Service\LlmServiceManager (class)
   constructor(Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface $adapterRegistry, Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline $pipeline, Netresearch\NrLlm\Service\KeyedProviderRegistry $providerRegistry, Netresearch\NrLlm\Service\ConfigurationResolver $configurationResolver, Netresearch\NrLlm\Service\MessageShaper $messageShaper, Netresearch\NrLlm\Service\EmbedCacheKeyBuilder $embedCacheKeyBuilder, ?Netresearch\NrLlm\Service\Skill\SkillInjectionService $skillInjection = …, ?Netresearch\NrLlm\Service\ModelSelectionServiceInterface $modelSelectionService = …, ?Netresearch\NrLlm\Service\Streaming\StreamingDispatcher $streaming = …, Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener $inputScreener = …, ?Netresearch\NrLlm\Service\Prompt\ConfigurationSnippetResolver $snippetResolver = …, ?Netresearch\NrLlm\Service\Context\ContextWindowManagerInterface $contextWindow = …, ?Psr\Log\LoggerInterface $logger = …, ?Netresearch\NrLlm\Service\Context\InputContextTrustGate $inputContextGate = …)
   method chat(array $messages, ?Netresearch\NrLlm\Service\Option\ChatOptions $options = …): Netresearch\NrLlm\Domain\Model\CompletionResponse
   method chatForConfiguration(array $messages, Netresearch\NrLlm\Domain\Model\LlmConfiguration $configuration, ?Netresearch\NrLlm\Service\Option\ChatOptions $options = …): Netresearch\NrLlm\Domain\Model\CompletionResponse
-  method chatWithConfiguration(array $messages, Netresearch\NrLlm\Domain\Model\LlmConfiguration $configuration, array $metadata = …, array $optionOverrides = …, ?Netresearch\NrLlm\Domain\ValueObject\AgentRunReference $run = …): Netresearch\NrLlm\Domain\Model\CompletionResponse
+  method chatWithConfiguration(array $messages, Netresearch\NrLlm\Domain\Model\LlmConfiguration $configuration, array $metadata = …, array $optionOverrides = …, ?Netresearch\NrLlm\Domain\ValueObject\AgentRunReference $run = …, ?Netresearch\NrLlm\Domain\ValueObject\InjectedContext $injectedContext = …): Netresearch\NrLlm\Domain\Model\CompletionResponse
   method chatWithTools(array $messages, array $tools, ?Netresearch\NrLlm\Service\Option\ToolOptions $options = …): Netresearch\NrLlm\Domain\Model\CompletionResponse
-  method chatWithToolsForConfiguration(array $messages, array $tools, Netresearch\NrLlm\Domain\Model\LlmConfiguration $configuration, ?Netresearch\NrLlm\Service\Option\ToolOptions $options = …, ?Netresearch\NrLlm\Domain\ValueObject\AgentRunReference $run = …): Netresearch\NrLlm\Domain\Model\CompletionResponse
+  method chatWithToolsForConfiguration(array $messages, array $tools, Netresearch\NrLlm\Domain\Model\LlmConfiguration $configuration, ?Netresearch\NrLlm\Service\Option\ToolOptions $options = …, ?Netresearch\NrLlm\Domain\ValueObject\AgentRunReference $run = …, ?Netresearch\NrLlm\Domain\ValueObject\InjectedContext $injectedContext = …): Netresearch\NrLlm\Domain\Model\CompletionResponse
   method complete(string $prompt, ?Netresearch\NrLlm\Service\Option\ChatOptions $options = …): Netresearch\NrLlm\Domain\Model\CompletionResponse
   method completeForConfiguration(string $prompt, Netresearch\NrLlm\Domain\Model\LlmConfiguration $configuration, ?Netresearch\NrLlm\Service\Option\ChatOptions $options = …): Netresearch\NrLlm\Domain\Model\CompletionResponse
   method completeWithConfiguration(string $prompt, Netresearch\NrLlm\Domain\Model\LlmConfiguration $configuration, array $metadata = …, array $optionOverrides = …): Netresearch\NrLlm\Domain\Model\CompletionResponse
@@ -1349,9 +1354,9 @@ Netresearch\NrLlm\Service\LlmServiceManager (class)
 Netresearch\NrLlm\Service\LlmServiceManagerInterface (interface)
   method chat(array $messages, ?Netresearch\NrLlm\Service\Option\ChatOptions $options = …): Netresearch\NrLlm\Domain\Model\CompletionResponse
   method chatForConfiguration(array $messages, Netresearch\NrLlm\Domain\Model\LlmConfiguration $configuration, ?Netresearch\NrLlm\Service\Option\ChatOptions $options = …): Netresearch\NrLlm\Domain\Model\CompletionResponse
-  method chatWithConfiguration(array $messages, Netresearch\NrLlm\Domain\Model\LlmConfiguration $configuration, array $metadata = …, array $optionOverrides = …, ?Netresearch\NrLlm\Domain\ValueObject\AgentRunReference $run = …): Netresearch\NrLlm\Domain\Model\CompletionResponse
+  method chatWithConfiguration(array $messages, Netresearch\NrLlm\Domain\Model\LlmConfiguration $configuration, array $metadata = …, array $optionOverrides = …, ?Netresearch\NrLlm\Domain\ValueObject\AgentRunReference $run = …, ?Netresearch\NrLlm\Domain\ValueObject\InjectedContext $injectedContext = …): Netresearch\NrLlm\Domain\Model\CompletionResponse
   method chatWithTools(array $messages, array $tools, ?Netresearch\NrLlm\Service\Option\ToolOptions $options = …): Netresearch\NrLlm\Domain\Model\CompletionResponse
-  method chatWithToolsForConfiguration(array $messages, array $tools, Netresearch\NrLlm\Domain\Model\LlmConfiguration $configuration, ?Netresearch\NrLlm\Service\Option\ToolOptions $options = …, ?Netresearch\NrLlm\Domain\ValueObject\AgentRunReference $run = …): Netresearch\NrLlm\Domain\Model\CompletionResponse
+  method chatWithToolsForConfiguration(array $messages, array $tools, Netresearch\NrLlm\Domain\Model\LlmConfiguration $configuration, ?Netresearch\NrLlm\Service\Option\ToolOptions $options = …, ?Netresearch\NrLlm\Domain\ValueObject\AgentRunReference $run = …, ?Netresearch\NrLlm\Domain\ValueObject\InjectedContext $injectedContext = …): Netresearch\NrLlm\Domain\Model\CompletionResponse
   method complete(string $prompt, ?Netresearch\NrLlm\Service\Option\ChatOptions $options = …): Netresearch\NrLlm\Domain\Model\CompletionResponse
   method completeForConfiguration(string $prompt, Netresearch\NrLlm\Domain\Model\LlmConfiguration $configuration, ?Netresearch\NrLlm\Service\Option\ChatOptions $options = …): Netresearch\NrLlm\Domain\Model\CompletionResponse
   method completeWithConfiguration(string $prompt, Netresearch\NrLlm\Domain\Model\LlmConfiguration $configuration, array $metadata = …, array $optionOverrides = …): Netresearch\NrLlm\Domain\Model\CompletionResponse
@@ -1577,6 +1582,7 @@ Netresearch\NrLlm\Service\Retrieval\SourceReference (class)
 
 Netresearch\NrLlm\Service\Tool\RunAugmentation (class)
   constructor(array $forcedSkills = …, array $forcedSnippets = …, bool $dryRun = …)
+  method injectedContext(): Netresearch\NrLlm\Domain\ValueObject\InjectedContext
   property readonly dryRun: bool
   property readonly forcedSkills: array
   property readonly forcedSnippets: array

--- a/Tests/Unit/Service/Context/InputContextClassifierTest.php
+++ b/Tests/Unit/Service/Context/InputContextClassifierTest.php
@@ -146,9 +146,11 @@ final class InputContextClassifierTest extends TestCase
     #[Test]
     public function theGateStillAnswersForTheConfigurationAlone(): void
     {
-        // classify() is what InputContextTrustGate asks. It must NOT pick up a
-        // run's forced set: the panel is deliberately a superset of what the
-        // gate enforces, and widening the gate is an ADR-144 decision.
+        // classify() keeps its configuration-only meaning. Since ADR-164 the
+        // gate no longer asks it — it folds sources() with the run's forced set
+        // — but classify() is still the answer to "what does this configuration
+        // carry", independent of any one run, and must not start folding a
+        // forced set into that.
         $classifier    = $this->classifier([]);
         $configuration = new LlmConfiguration();
 

--- a/Tests/Unit/Service/Context/InputContextTrustGateTest.php
+++ b/Tests/Unit/Service/Context/InputContextTrustGateTest.php
@@ -442,6 +442,75 @@ final class InputContextTrustGateTest extends TestCase
         return $configuration;
     }
 
+    #[Test]
+    public function aForcedSnippetBindsAgainstTheSameCeiling(): void
+    {
+        // ADR-164: the configuration itself declares nothing, so before this the
+        // gate permitted the send. The run injects a SECRET_ADJACENT snippet the
+        // configuration never carried, and it reaches an external provider.
+        $gate = $this->gate([$this->snippet('legal-policy', '')]);
+
+        $this->expectException(InputContextTrustZoneException::class);
+        $gate->assertPermitted(
+            $this->configuration(TrustZone::EXTERNAL_GLOBAL),
+            0,
+            null,
+            0,
+            [$this->snippet('incident-report', ToolDataClass::SECRET_ADJACENT->value)],
+        );
+    }
+
+    #[Test]
+    public function theRefusalNamesTheForcedSourceNotTheConfiguration(): void
+    {
+        // An operator seeing "blocked" has to be able to tell which of the two
+        // halves refused, or the refusal is unactionable: the configuration's
+        // own sources are edited in one place and the run's forced set in
+        // another.
+        $gate = $this->gate([$this->snippet('legal-policy', '')]);
+
+        try {
+            $gate->assertPermitted(
+                $this->configuration(TrustZone::EXTERNAL_GLOBAL),
+                0,
+                null,
+                0,
+                [$this->snippet('incident-report', ToolDataClass::SECRET_ADJACENT->value)],
+            );
+            self::fail('The forced snippet must be refused.');
+        } catch (InputContextTrustZoneException $e) {
+            self::assertStringContainsString('incident-report', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function aForcedSnippetBelowTheCeilingIsPermitted(): void
+    {
+        // The forced set must not be treated as suspicious per se — only its
+        // declaration counts, exactly as for a configuration's own snippet.
+        $this->gate([$this->snippet('legal-policy', '')])->assertPermitted(
+            $this->configuration(TrustZone::EXTERNAL_GLOBAL),
+            0,
+            null,
+            0,
+            [$this->snippet('house-style', ToolDataClass::PUBLIC_CONTENT->value)],
+        );
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function theConfigurationsOwnClassStillRefusesWhenNothingIsForced(): void
+    {
+        // The regression guard for the rewrite: decide() now folds sources()
+        // instead of calling classify(). With an empty forced set the two are
+        // the same fold, and this pins that they stay the same.
+        $gate = $this->gate([$this->snippet('legal-policy', ToolDataClass::SECRET_ADJACENT->value)]);
+
+        $this->expectException(InputContextTrustZoneException::class);
+        $gate->assertPermitted($this->configuration(TrustZone::EXTERNAL_GLOBAL), 0, null, 0, [], []);
+    }
+
     /**
      * A criteria-mode configuration: model_uid = 0, so no model relation and no
      * provider — the record whose zone only the resolved model can supply.

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -19,11 +19,14 @@ use Netresearch\NrLlm\Domain\Enum\TrustZone;
 use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\PromptSnippet;
 use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRunReference;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ContextBudgetBreakdown;
 use Netresearch\NrLlm\Domain\ValueObject\ContextFitResult;
+use Netresearch\NrLlm\Domain\ValueObject\InjectedContext;
 use Netresearch\NrLlm\Domain\ValueObject\RunStep;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
 use Netresearch\NrLlm\Domain\ValueObject\ToolArtifact;
@@ -91,6 +94,78 @@ final class ToolLoopServiceTest extends TestCase
         self::assertSame(1, $result->iterations);
         self::assertFalse($result->truncated);
         self::assertSame(AgentRunTerminationReason::COMPLETED, $result->terminationReason);
+    }
+
+    #[Test]
+    public function theForcedSetReachesTheManagerSoTheCeilingCanSeeIt(): void
+    {
+        // ADR-164's wiring half. The rule itself lives in InputContextTrustGate
+        // and is tested there; what this pins is that the loop actually HANDS
+        // the forced set over. A dropped `?->injectedContext()` would reopen
+        // #731 with every gate test still green.
+        $snippet = new PromptSnippet();
+        $snippet->setIdentifier('incident-report');
+        $snippet->setName('incident-report');
+
+        $seen = null;
+        $mgr  = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturnCallback(
+            function (
+                array $messages,
+                array $tools,
+                LlmConfiguration $configuration,
+                ?ToolOptions $options = null,
+                ?AgentRunReference $run = null,
+                ?InjectedContext $injectedContext = null,
+            ) use (&$seen): CompletionResponse {
+                $seen = $injectedContext;
+
+                return $this->response('done');
+            },
+        );
+
+        $this->service($mgr, new ToolRegistry([new FakeTool('noop')]))->runLoop(
+            [$this->userTurn('hi')],
+            $this->localConfiguration(),
+            ToolExecutionContext::none(),
+            null,
+            augmentation: new RunAugmentation(forcedSnippets: [$snippet]),
+        );
+
+        self::assertInstanceOf(InjectedContext::class, $seen);
+        self::assertSame([$snippet], $seen->snippets);
+    }
+
+    #[Test]
+    public function aRunWithoutAForcedSetHandsOverNothing(): void
+    {
+        // The other half: the parameter stays null rather than becoming an empty
+        // object, so the gate keeps its pre-ADR-164 path for every ordinary run.
+        $seen = 'unset';
+        $mgr  = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturnCallback(
+            function (
+                array $messages,
+                array $tools,
+                LlmConfiguration $configuration,
+                ?ToolOptions $options = null,
+                ?AgentRunReference $run = null,
+                ?InjectedContext $injectedContext = null,
+            ) use (&$seen): CompletionResponse {
+                $seen = $injectedContext;
+
+                return $this->response('done');
+            },
+        );
+
+        $this->service($mgr, new ToolRegistry([new FakeTool('noop')]))->runLoop(
+            [$this->userTurn('hi')],
+            $this->localConfiguration(),
+            ToolExecutionContext::none(),
+            null,
+        );
+
+        self::assertNull($seen);
     }
 
     #[Test]


### PR DESCRIPTION
Closes #731. The decision the issue asked for, taken and implemented.

## The three questions, answered

**Does a per-call injected source bind at all?** Yes. The ceiling states where text may travel, not who may ask. A caller choosing to attach a snippet does not make the destination more trustworthy, and the class on the snippet record is standing policy — treating an ad-hoc tick as a waiver makes the declaration advisory. "The playground is admin-only" is an argument about authority, and the ceiling is not an authority control: the ADR-094 tool gate already applies to administrators for the same reason.

**How the forced set reaches the gate.** `decide()` folds `InputContextClassifier::sources($configuration, $forcedSnippets, $forcedSkills)` instead of calling `classify()`. With an empty forced set the two are the same fold, so every caller that injects nothing gets the previous answer unchanged. It is also the list the ADR-151 readout folds, so the asymmetry that ADR documented is gone rather than explained.

`classify()` keeps its configuration-only meaning — a real question with real callers — so `theGateStillAnswersForTheConfigurationAlone` keeps its assertions; only its comment changes.

**The refusal names the forced source.** The strictest declaration wins and carries its own source name, so the message reads `snippet "incident-report"` when the forced source is the reason. Pinned by a test, because the two halves are edited in different places.

## Transport

PHPat rejected the first attempt: `LlmServiceManager` may not depend on `Service\Tool`, so it cannot take a `RunAugmentation`. That rule is right — the manager has no business knowing the tool loop exists. The forced set travels as `Domain\ValueObject\InjectedContext`; `RunAugmentation::injectedContext()` converts.

Three send boundaries carry a run's assembled messages, all inside `runLoop()`: the no-tools completion, the tool round, and the cap-reached synthesis. All three forward it. `streamChatWithConfiguration()` deliberately does not — no caller passes a forced set into a streaming send, verified by grep over every caller.

## Not covered

A **resumed** run. `resume()` / `resumeWithInput()` re-enter with assembly skipped and pass no augmentation, because `SuspendedRunState` does not persist the forced set and `ResumeCoordinator` works from that state rather than the original request. The bound is narrow — the forced text entered the transcript at assembly time, where this PR does gate it, so nothing new is injected on resume; what a resume can miss is a ceiling that changed *while* the run was suspended. Filed as #761 with what closing it would need.

A **dry run** is not gated, deliberately: it assembles the messages and returns without calling a provider, so there is no send to judge. `injectedContext()` drops the flag rather than carrying it into a decision it has no part in.

## Surfaces

ADR-164 (amends ADR-144 and ADR-151, both `:Amended:` back). `api-surface.txt` regenerated — additive on both `@api` methods plus the new value object. `Documentation/Administration/Tools.rst` no longer tells operators a forced source is shown and not gated.

## Tests

Four gate tests (forced snippet refused above the ceiling; the refusal names it; a forced source below the ceiling passes; the configuration's own class still refuses with an empty forced set — the regression guard for the `classify()` → `sources()` rewrite) and two wiring tests on the loop, because the rule being right does not prove the loop hands the set over: a dropped `?->injectedContext()` would reopen this with every gate test still green.

Full gate at PHP 8.2 — rector -n, cgl -n, phpstan, unit (7061 tests / 21794 assertions), fuzzy, `ci:test:repo`, `ci:test:changelog`: green. Functional filtered to `Context|Governance|Playground|ToolLoop`: 85 tests green.

One note on that gate: PHPStan caught a missing `AgentRunReference` import in a new test that the unit run passed anyway — PHP never resolves the type hint while only `null` is passed. Fixed before this push.
