### PR TITLE
fix(dashboard): give context_blocked a colour and a label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,19 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and `chatWithToolsForConfiguration()` take it as a trailing optional
   parameter, additive on both.
 
+### Fixed
+
+- **The Governance blocks widget names every decision it can show** (`#763`).
+  `context_blocked` (ADR-144, the input-context ceiling) had neither a colour
+  nor a label, so its bar rendered grey and was captioned with the raw
+  `LLL:EXT:nr_llm/…` path — what an operator saw the first time that gate
+  fired. It now has both.
+
+  Two guards so the next case cannot slip through the same way: one asserts
+  every `GovernanceDecision` gets its own colour rather than the grey fallback,
+  the other that each has an English and a German label. The widget
+  description no longer enumerates the kinds — that prose had drifted twice.
+
 ## [0.29.1] - 2026-08-13
 
 ### Fixed

--- a/Classes/Widgets/DataProvider/GovernanceBlocksOverTimeDataProvider.php
+++ b/Classes/Widgets/DataProvider/GovernanceBlocksOverTimeDataProvider.php
@@ -18,11 +18,12 @@ use TYPO3\CMS\Dashboard\Widgets\ChartDataProviderInterface;
 /**
  * Chart.js bar-chart data provider for "governance blocks (last N days)".
  *
- * Aggregates tx_nrllm_governance_event by decision kind: tool-gate denials,
- * guardrail response blocks, approval-required routings and provider
- * content-filter blocks — the outcomes that were previously only logged or
- * reflected on a run. Bars are emitted in {@see GovernanceDecision} case order
- * so the chart is stable.
+ * Aggregates tx_nrllm_governance_event by decision kind — one bar per
+ * {@see GovernanceDecision} case, in case order so the chart is stable.
+ *
+ * The prose deliberately does not enumerate the cases. It did, and drifted
+ * twice: `write_unapproved` and `context_blocked` were both added to the enum
+ * without this text being touched (`#763`). The enum is the list.
  *
  * @internal Not part of the @api surface; may change without notice (ADR-127).
  */
@@ -34,13 +35,22 @@ final readonly class GovernanceBlocksOverTimeDataProvider implements ChartDataPr
 
     private const LLL = 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:';
 
-    /** Semantic colour per decision; a missing key falls back to grey. */
+    /**
+     * Semantic colour per decision.
+     *
+     * Every {@see GovernanceDecision} case must have one — asserted by
+     * {@see \Netresearch\NrLlm\Tests\Unit\Widgets\DataProvider\GovernanceBlocksOverTimeDataProviderTest}.
+     * The grey fallback below stays for a case added at runtime by another
+     * extension, not as a licence to leave one out here: `context_blocked`
+     * shipped without a colour and rendered as an unnamed grey bar (`#763`).
+     */
     private const DECISION_COLORS = [
         'tool_denied'       => '#607D8B',
         'response_blocked'  => '#D9534F',
         'approval_required' => '#E8A33D',
         'content_filter'    => '#8E2A27',
         'write_unapproved'  => '#7B4FA8',
+        'context_blocked'   => '#17877D',
     ];
 
     public function __construct(

--- a/Resources/Private/Language/de.locallang_dashboard.xlf
+++ b/Resources/Private/Language/de.locallang_dashboard.xlf
@@ -155,8 +155,8 @@
                 <target>Governance-Blockierungen</target>
             </trans-unit>
             <trans-unit id="widget.governance_blocks.description">
-                <source>Bar chart of governance decisions (tool denials, guardrail blocks, approvals required, content-filter blocks) over the last 30 days.</source>
-                <target>Balkendiagramm der Governance-Entscheidungen (Tool-Ablehnungen, Guardrail-Blockierungen, erforderliche Freigaben, Content-Filter-Blockierungen) der letzten 30 Tage.</target>
+                <source>Bar chart of governance decisions over the last 30 days, one bar per decision kind.</source>
+                <target>Balkendiagramm der Governance-Entscheidungen der letzten 30 Tage, ein Balken je Entscheidungsart.</target>
             </trans-unit>
             <trans-unit id="widget.governance_blocks.dataset">
                 <source>Events</source>
@@ -181,6 +181,10 @@
             <trans-unit id="widget.governance_blocks.decision.write_unapproved">
                 <source>Unapproved write refused</source>
                 <target>Schreibzugriff ohne Freigabe abgelehnt</target>
+            </trans-unit>
+            <trans-unit id="widget.governance_blocks.decision.context_blocked">
+                <source>Injected context above the ceiling</source>
+                <target>Injizierter Kontext über der Vertrauensgrenze</target>
             </trans-unit>
             <trans-unit id="widget.tool_denials.title">
                 <source>Tool denials by reason</source>

--- a/Resources/Private/Language/locallang_dashboard.xlf
+++ b/Resources/Private/Language/locallang_dashboard.xlf
@@ -117,7 +117,7 @@
                 <source>Governance blocks</source>
             </trans-unit>
             <trans-unit id="widget.governance_blocks.description">
-                <source>Bar chart of governance decisions (tool denials, guardrail blocks, approvals required, content-filter blocks) over the last 30 days.</source>
+                <source>Bar chart of governance decisions over the last 30 days, one bar per decision kind.</source>
             </trans-unit>
             <trans-unit id="widget.governance_blocks.dataset">
                 <source>Events</source>
@@ -136,6 +136,9 @@
             </trans-unit>
             <trans-unit id="widget.governance_blocks.decision.write_unapproved">
                 <source>Unapproved write refused</source>
+            </trans-unit>
+            <trans-unit id="widget.governance_blocks.decision.context_blocked">
+                <source>Injected context above the ceiling</source>
             </trans-unit>
             <trans-unit id="widget.tool_denials.title">
                 <source>Tool denials by reason</source>

--- a/Tests/Unit/Widgets/DataProvider/GovernanceBlocksOverTimeDataProviderTest.php
+++ b/Tests/Unit/Widgets/DataProvider/GovernanceBlocksOverTimeDataProviderTest.php
@@ -9,9 +9,12 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Widgets\DataProvider;
 
+use Netresearch\NrLlm\Domain\Enum\GovernanceDecision;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrLlm\Tests\Unit\Language\LabelCatalogue;
 use Netresearch\NrLlm\Widgets\DataProvider\GovernanceBlocksOverTimeDataProvider;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
 #[CoversClass(GovernanceBlocksOverTimeDataProvider::class)]
@@ -69,5 +72,52 @@ final class GovernanceBlocksOverTimeDataProviderTest extends AbstractUnitTestCas
 
         self::assertSame([], $shaped['labels']);
         self::assertSame([], $shaped['datasets'][0]['data']);
+    }
+
+    #[Test]
+    public function everyDecisionHasItsOwnColour(): void
+    {
+        // #763: `context_blocked` was added to the enum and the widget was not
+        // touched, so it rendered as the grey fallback — indistinguishable from
+        // any other unmapped case. Nothing failed. Asserted through the public
+        // shaping rather than by reading the private constant, so the check is
+        // about what the chart shows.
+        $everyCase = [];
+        foreach (GovernanceDecision::cases() as $case) {
+            $everyCase[$case->value] = 1;
+        }
+
+        $shaped = GovernanceBlocksOverTimeDataProvider::shapeChartData($everyCase, [], 'Events');
+        $colors = $shaped['datasets'][0]['backgroundColor'];
+
+        self::assertCount(count(GovernanceDecision::cases()), $colors);
+        self::assertNotContains('#9E9E9E', $colors, 'A decision fell through to the grey fallback — give it a colour in DECISION_COLORS.');
+        self::assertSame($colors, array_unique($colors), 'Two decisions share a colour, so the chart cannot tell them apart.');
+    }
+
+    #[Test]
+    #[DataProvider('decisionCases')]
+    public function everyDecisionHasALabelInBothCatalogues(string $value): void
+    {
+        // The other half of #763: without a trans-unit the bar is labelled with
+        // the raw LLL: path, because ResolvesLanguageLabelTrait returns its
+        // argument unchanged when the key does not resolve.
+        $key = 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.governance_blocks.decision.' . $value;
+
+        self::assertNotNull(LabelCatalogue::source($key), 'No English label for ' . $value);
+        self::assertNotNull(LabelCatalogue::target($key), 'No German label for ' . $value);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function decisionCases(): array
+    {
+        $cases = [];
+        foreach (GovernanceDecision::cases() as $case) {
+            $cases[$case->value] = [$case->value];
+        }
+
+        return $cases;
     }
 }


### PR DESCRIPTION
Closes #763.

## What was wrong

`GovernanceDecision::CONTEXT_BLOCKED` (ADR-144's input-context ceiling) reached the enum without the widget being touched. Two independent consequences, neither of which failed anything:

- **No colour.** `DECISION_COLORS` listed five of six cases, so the lookup fell through to `'#9E9E9E'` — grey, and indistinguishable from any future unmapped case.
- **No label.** `ResolvesLanguageLabelTrait::resolveLabel()` returns its argument unchanged when the key does not resolve, so the bar was captioned `LLL:EXT:nr_llm/Resources/Private/Language/locallang_dashboard.xlf:widget.governance_blocks.decision.context_blocked`. That is what an operator saw the first time the gate fired.

Teal `#17877D` — distinct from all five existing hues, and read next to `tool_denied`'s slate the two answer opposite directions of the same axis.

## Guards

The gap existed because a case was added and nothing noticed. Two tests now refuse the next one:

- `everyDecisionHasItsOwnColour` — asserted through the public `shapeChartData()` rather than by reading the private constant, so it checks what the chart shows. It also refuses two decisions sharing a colour.
- `everyDecisionHasALabelInBothCatalogues` — one case per decision, via the existing `LabelCatalogue`.

**Both verified by controlled failure**: with the colour and the trans-unit removed again, the run is `Tests: 11, Assertions: 22, Failures: 2` naming exactly `A decision fell through to the grey fallback` and `No English label for context_blocked`. Restored, `OK (11 tests, 24 assertions)`. A guard that has never been seen to fail is not a guard.

## Also in scope

The widget description enumerated the decision kinds — `(tool denials, guardrail blocks, approvals required, content-filter blocks)` — and had drifted twice, missing both `write_unapproved` and `context_blocked`. It no longer enumerates them, in EN, DE and the class docblock. Any enumeration would drift again; the enum is the list.

## Tests

Full gate at PHP 8.2 — rector -n, cgl -n, phpstan, unit (7069 tests / 21813 assertions), fuzzy, `ci:test:repo`, `ci:test:changelog`: green. Both XLIFF files checked well-formed.
