### PR TITLE
feat(governance): re-gate a resumed run's forced sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,22 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and `chatWithToolsForConfiguration()` take it as a trailing optional
   parameter, additive on both.
 
+- **A resumed run re-gates its forced sources** (`#761`, ADR-165). ADR-164 made
+  a run's forced snippets and skills bind against the ADR-144 trust ceiling but
+  could not reach a resume: `SuspendedRunState` carried no forced set, so a run
+  that came back from an approval or an input pause was judged on its
+  configuration alone.
+
+  The state now carries `forcedSnippetUids` / `forcedSkillUids`, and the loop
+  re-loads them on resume — so the ceiling is re-applied against the *live*
+  trust zone, which is what can have changed while the run was suspended (the
+  configuration re-pointed at a less trusted provider, or enforcement switched
+  from observe to enforce).
+
+  A row suspended before this change has neither key and resumes exactly as it
+  did. A uid that no longer resolves — the snippet was deleted meanwhile —
+  contributes nothing rather than stranding the run.
+
 ## [0.29.1] - 2026-08-13
 
 ### Fixed

--- a/Classes/Domain/ValueObject/SuspendedRunState.php
+++ b/Classes/Domain/ValueObject/SuspendedRunState.php
@@ -38,13 +38,15 @@ namespace Netresearch\NrLlm\Domain\ValueObject;
 final readonly class SuspendedRunState
 {
     /**
-     * @param list<array<string, mixed>>                                               $messages         serialised ChatMessage transcript (ends with the assistant tool-call turn)
-     * @param list<array<string, mixed>>                                               $pendingCalls     serialised ToolCall list of the suspended turn
-     * @param list<string>|null                                                        $allowedToolNames the run's original tool allow-list, so resume re-applies the SAME per-run constraint (null = the globally-enabled set)
-     * @param array<string, mixed>                                                     $options          the run's serialised ToolOptions, so resume continues with the same temperature/max-tokens/think/etc.
-     * @param string|null                                                              $inputToolName    on an input pause (ADR-105) the tool whose typed input the user must supply; null on an approval pause
-     * @param array<string, mixed>                                                     $inputSchema      on an input pause the tool's declared input schema (a JSON-Schema subset); `[]` on an approval pause
-     * @param list<array{index: int, tool: string, lines: list<string>, failed: bool}> $callPreviews     what the pending calls WOULD do, captured at suspend in the run's actor context (ADR-136); `index` points into `$pendingCalls`. Only calls whose tool implements ToolPreviewInterface appear, so `[]` is the normal case
+     * @param list<array<string, mixed>>                                               $messages          serialised ChatMessage transcript (ends with the assistant tool-call turn)
+     * @param list<array<string, mixed>>                                               $pendingCalls      serialised ToolCall list of the suspended turn
+     * @param list<string>|null                                                        $allowedToolNames  the run's original tool allow-list, so resume re-applies the SAME per-run constraint (null = the globally-enabled set)
+     * @param array<string, mixed>                                                     $options           the run's serialised ToolOptions, so resume continues with the same temperature/max-tokens/think/etc.
+     * @param string|null                                                              $inputToolName     on an input pause (ADR-105) the tool whose typed input the user must supply; null on an approval pause
+     * @param array<string, mixed>                                                     $inputSchema       on an input pause the tool's declared input schema (a JSON-Schema subset); `[]` on an approval pause
+     * @param list<array{index: int, tool: string, lines: list<string>, failed: bool}> $callPreviews      what the pending calls WOULD do, captured at suspend in the run's actor context (ADR-136); `index` points into `$pendingCalls`. Only calls whose tool implements ToolPreviewInterface appear, so `[]` is the normal case
+     * @param list<int>                                                                $forcedSnippetUids the run's per-run forced snippets, so resume re-applies the ADR-164 ceiling to them (ADR-165); `[]` for a run that forced none
+     * @param list<int>                                                                $forcedSkillUids   the run's per-run forced skills, same reason
      */
     public function __construct(
         public array $messages,
@@ -57,10 +59,12 @@ final readonly class SuspendedRunState
         public ?string $inputToolName = null,
         public array $inputSchema = [],
         public array $callPreviews = [],
+        public array $forcedSnippetUids = [],
+        public array $forcedSkillUids = [],
     ) {}
 
     /**
-     * @return array{messages: list<array<string, mixed>>, pendingCalls: list<array<string, mixed>>, iterations: int, promptTokens: int, completionTokens: int, allowedToolNames: list<string>|null, options: array<string, mixed>, inputToolName: string|null, inputSchema: array<string, mixed>, callPreviews: list<array{index: int, tool: string, lines: list<string>, failed: bool}>}
+     * @return array{messages: list<array<string, mixed>>, pendingCalls: list<array<string, mixed>>, iterations: int, promptTokens: int, completionTokens: int, allowedToolNames: list<string>|null, options: array<string, mixed>, inputToolName: string|null, inputSchema: array<string, mixed>, callPreviews: list<array{index: int, tool: string, lines: list<string>, failed: bool}>, forcedSnippetUids: list<int>, forcedSkillUids: list<int>}
      */
     public function toArray(): array
     {
@@ -75,6 +79,8 @@ final readonly class SuspendedRunState
             'inputToolName'    => $this->inputToolName,
             'inputSchema'      => $this->inputSchema,
             'callPreviews'     => $this->callPreviews,
+            'forcedSnippetUids' => $this->forcedSnippetUids,
+            'forcedSkillUids'   => $this->forcedSkillUids,
         ];
     }
 
@@ -118,7 +124,40 @@ final readonly class SuspendedRunState
             // preview" — the card then shows the arguments alone, exactly as it
             // did before — and NEVER stops the run from resuming.
             self::previewsFrom($data['callPreviews'] ?? null, self::survivingIndexMap($rawPendingCalls)),
+            // Back-compat (ADR-165), the same shape as the preview field above:
+            // a row suspended before the forced set was persisted has neither
+            // key and rehydrates with none. That is the pre-ADR-165 behaviour —
+            // the resumed send is not re-gated against the forced sources — and
+            // never a reason to refuse the resume.
+            self::uidsFrom($data['forcedSnippetUids'] ?? null),
+            self::uidsFrom($data['forcedSkillUids'] ?? null),
         );
+    }
+
+    /**
+     * A persisted uid list, keeping only positive integers.
+     *
+     * A uid of 0 or below never identifies a record, so it is dropped rather
+     * than handed to a repository that would answer null for it.
+     *
+     * @return list<int>
+     */
+    private static function uidsFrom(mixed $raw): array
+    {
+        if (!is_array($raw)) {
+            return [];
+        }
+
+        $uids = [];
+        foreach ($raw as $value) {
+            if (is_int($value) && $value > 0) {
+                $uids[] = $value;
+            } elseif (is_string($value) && ctype_digit($value) && (int)$value > 0) {
+                $uids[] = (int)$value;
+            }
+        }
+
+        return $uids;
     }
 
     /**

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -13,7 +13,11 @@ use LogicException;
 use Netresearch\NrLlm\Domain\Enum\AgentRunTerminationReason;
 use Netresearch\NrLlm\Domain\Enum\GovernanceDecision;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\PromptSnippet;
+use Netresearch\NrLlm\Domain\Model\Skill;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
+use Netresearch\NrLlm\Domain\Repository\SkillRepository;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\GovernanceEvent;
 use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
@@ -115,7 +119,77 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         // in exactly the place that inspects it — the playground — and the
         // budget would be short by the snippet block on every production run.
         private ?ConfigurationSnippetResolver $snippetResolver = null,
+        // Re-load the run's forced sources on resume so the ADR-164 ceiling
+        // still sees them (ADR-165). Optional like the collaborators above: a
+        // construction without them keeps the pre-ADR-165 behaviour, where a
+        // resumed send was not re-gated against the forced set.
+        private ?PromptSnippetRepository $promptSnippetRepository = null,
+        private ?SkillRepository $skillRepository = null,
     ) {}
+
+    /**
+     * The uids of a forced source list, for the suspend state (ADR-165).
+     *
+     * A record with no uid is not persistable and is dropped: it cannot be
+     * re-loaded on resume, so writing a placeholder would only produce a
+     * lookup that answers nothing.
+     *
+     * @param list<PromptSnippet>|list<Skill> $records
+     *
+     * @return list<int>
+     */
+    private function uidsOf(array $records): array
+    {
+        $uids = [];
+        foreach ($records as $record) {
+            $uid = $record->getUid();
+            if ($uid !== null && $uid > 0) {
+                $uids[] = $uid;
+            }
+        }
+
+        return $uids;
+    }
+
+    /**
+     * The run's forced set, re-loaded from the uids the suspend persisted
+     * (ADR-165), or null when the run forced nothing.
+     *
+     * Null rather than an empty augmentation, so the send path keeps passing
+     * null exactly as an ordinary run does — the gate then takes its
+     * configuration-only path rather than folding an empty list.
+     *
+     * A uid that no longer resolves — the snippet was deleted while the run was
+     * suspended — contributes nothing. The transcript still carries its text,
+     * so this degrades to the pre-ADR-165 answer for that one source rather
+     * than refusing a resume over a record that is gone.
+     */
+    private function augmentationFrom(SuspendedRunState $state): ?RunAugmentation
+    {
+        if ($state->forcedSnippetUids === [] && $state->forcedSkillUids === []) {
+            return null;
+        }
+
+        $snippets = $state->forcedSnippetUids !== [] && $this->promptSnippetRepository instanceof PromptSnippetRepository
+            ? $this->promptSnippetRepository->findByUids($state->forcedSnippetUids)
+            : [];
+
+        $skills = [];
+        if ($state->forcedSkillUids !== [] && $this->skillRepository instanceof SkillRepository) {
+            $wanted = array_flip($state->forcedSkillUids);
+            foreach ($this->skillRepository->findAll() as $skill) {
+                if ($skill instanceof Skill && $skill->getUid() !== null && isset($wanted[$skill->getUid()])) {
+                    $skills[] = $skill;
+                }
+            }
+        }
+
+        if ($snippets === [] && $skills === []) {
+            return null;
+        }
+
+        return new RunAugmentation(forcedSkills: $skills, forcedSnippets: $snippets);
+    }
 
     /**
      * Run the bounded agent loop and return its outcome.
@@ -300,6 +374,10 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                             // approval time: this is the run's actor context, the
                             // only identity allowed to read the targets (ADR-136).
                             callPreviews: $this->previewsForTurn($resp->toolCalls ?? [], $allowedNames, $context),
+                            // The forced set travels with the suspend so resume
+                            // re-applies the ADR-164 ceiling to it (ADR-165).
+                            forcedSnippetUids: $this->uidsOf($augmentation->forcedSnippets ?? []),
+                            forcedSkillUids: $this->uidsOf($augmentation->forcedSkills ?? []),
                         ));
                     }
                 }
@@ -334,6 +412,8 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                             $options?->toArray() ?? [],
                             inputToolName: $call->name,
                             inputSchema: $schema,
+                            forcedSnippetUids: $this->uidsOf($augmentation->forcedSnippets ?? []),
+                            forcedSkillUids: $this->uidsOf($augmentation->forcedSkills ?? []),
                         ));
                     }
                 }
@@ -573,7 +653,9 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
             $options,
             $maxIterations,
             $runTrace,
-            null,
+            // Rebuilt from the persisted uids, not carried in memory: a resume
+            // runs in a different process from the suspend (ADR-165).
+            $this->augmentationFrom($state),
             true,
             $state->iterations,
             $state->promptTokens,
@@ -694,7 +776,9 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
             $options,
             $maxIterations,
             $runTrace,
-            null,
+            // Rebuilt from the persisted uids, not carried in memory: a resume
+            // runs in a different process from the suspend (ADR-165).
+            $this->augmentationFrom($state),
             true,
             $state->iterations,
             $state->promptTokens,

--- a/Documentation/Adr/Adr084HumanInTheLoopApproval.rst
+++ b/Documentation/Adr/Adr084HumanInTheLoopApproval.rst
@@ -6,9 +6,11 @@
 ADR-084: Human-in-the-loop tool approval with suspend and resume
 ============================================================================
 
-:Status: Accepted (the trigger is widened by :ref:`ADR-134 <adr-134>`)
+:Status: Accepted (the trigger is widened by :ref:`ADR-134 <adr-134>`; the
+    suspended state carries a further field — see :ref:`ADR-165 <adr-165>`)
 :Date: 2026-07-18
-:Amended: 2026-08-09 by :ref:`ADR-134 <adr-134>`
+:Amended: 2026-08-09 by :ref:`ADR-134 <adr-134>`, and 2026-08-13 by
+    :ref:`ADR-165 <adr-165>`
 :Authors: Netresearch DTT GmbH
 
 .. note::

--- a/Documentation/Adr/Adr164ForcedSourcesBindAgainstTheCeiling.rst
+++ b/Documentation/Adr/Adr164ForcedSourcesBindAgainstTheCeiling.rst
@@ -4,11 +4,12 @@
 ADR-164: A run's forced sources bind against the trust ceiling
 ===============================================================
 
-:Status: Accepted
+:Status: Accepted (the resumed-run gap is closed — see :ref:`ADR-165 <adr-165>`)
 :Date: 2026-08-13
 :Amends: :ref:`ADR-144 <adr-144>` (the ceiling now reads a run's forced set, not
     the configuration alone) and :ref:`ADR-151 <adr-151>` (its "shown and not
     gated" asymmetry is resolved in favour of gating)
+:Amended: 2026-08-13 by :ref:`ADR-165 <adr-165>`
 :Authors: Netresearch DTT GmbH
 
 Context
@@ -103,7 +104,8 @@ time, where this ADR *does* gate it, so nothing new is injected on resume. What
 a resume can miss is a ceiling that changed *while* the run was suspended — the
 configuration re-pointed at a less trusted provider, or enforcement switched
 from observe to enforce. Closing that needs the forced set persisted into the
-suspended state, which is issue `#761`.
+suspended state, which is issue `#761` — done in :ref:`ADR-165 <adr-165>`, so
+this paragraph is the reasoning, not the current behaviour.
 
 Consequences
 ============

--- a/Documentation/Adr/Adr165ResumeReGatesTheForcedSet.rst
+++ b/Documentation/Adr/Adr165ResumeReGatesTheForcedSet.rst
@@ -1,0 +1,91 @@
+.. _adr-165:
+
+============================================================
+ADR-165: A resumed run re-gates its forced sources
+============================================================
+
+:Status: Accepted
+:Date: 2026-08-13
+:Amends: :ref:`ADR-164 <adr-164>` (its "does not cover a resumed run" gap) and
+    :ref:`ADR-084 <adr-084>` (a further field on the suspended state)
+:Authors: Netresearch DTT GmbH
+
+Context
+=======
+
+:ref:`ADR-164 <adr-164>` makes a run's forced snippets and skills bind against
+the ADR-144 trust ceiling, and named the one place it did not reach:
+:php:`ToolLoopService::resume()` and :php:`resumeWithInput()` re-enter the loop
+with assembly skipped and no augmentation, because
+:php:`SuspendedRunState` did not carry one. Issue `#761`.
+
+The bound was narrow and worth restating, because it decides how much machinery
+this justifies. The forced text enters the transcript at assembly time, where
+ADR-164 gates it, so a resume injects nothing new. What a resume could miss is a
+ceiling that changed *while* the run was suspended: the configuration re-pointed
+at a less trusted provider or given a fallback that reaches one, or
+``dataClassEnforcement`` switched from ``observe`` to enforcing. Both of those
+already re-gate the configuration's *own* sources, because
+:php:`assertContextPermitted()` runs on every pipeline call against the live
+configuration. Only the forced half was frozen out.
+
+Decision
+========
+
+**The suspended state carries the forced set as uids.**
+:php:`SuspendedRunState` gains :php:`$forcedSnippetUids` and
+:php:`$forcedSkillUids`, written at both suspend sites and read on both resume
+paths. A row persisted before this ADR has neither key and rehydrates with
+none — the pre-ADR-165 behaviour, never a refusal to resume. That is the same
+back-compat shape :ref:`ADR-136 <adr-136>`'s call previews use, for the same
+reason: a running installation has such rows in its database.
+
+**Uids, and re-loaded on resume.** The alternative was to freeze the
+*classification* at suspend time and re-compare it against the live zone. That
+would also have closed the two risks above, without a repository lookup. Uids
+win because the resume then reflects the record as it is now: an operator who
+raises a snippet's class while a run is suspended means it, and a frozen copy
+would ignore them. It is the same identity-over-snapshot choice
+:php:`AgentRunRequestCodec` already makes for a queued run's entities.
+
+**The state, not the queued request.** :php:`AgentRunRequestCodec::rehydrate()`
+can already recover a queued run's forced set from ``queuedRequest``, which
+looks like it would do the job with no new field. It would not:
+``queuedRequest`` is null for a run started synchronously from the playground —
+and that is precisely the path that motivated ADR-164. The suspended state is
+written by both.
+
+**Re-loaded in the loop, not in the coordinator.** :php:`ToolLoopService` takes
+the two repositories as optional collaborators and rebuilds the augmentation
+itself. :php:`ResumeCoordinator` has two call sites into the loop and would have
+had to thread it through both; the loop has one place where a resumed run
+re-enters. Optional, like every other collaborator on that constructor: a
+construction without them keeps the pre-ADR-165 behaviour rather than failing.
+
+.. _adr-165-not:
+
+What this does not do
+=====================
+
+**It does not resurrect a deleted source.** A uid that no longer resolves —
+the snippet was deleted while the run was suspended — contributes nothing to the
+classification. The transcript still carries its text, so for that one source
+the answer degrades to the pre-ADR-165 one. Refusing the resume instead would
+strand a run over a record an operator deliberately removed, and would make
+deleting a snippet a way to break running work.
+
+**It does not re-gate anything else about a resume.** The transcript, the
+allow-list and the options are restored exactly as :ref:`ADR-084 <adr-084>`
+established. Only the forced set is added to what the ceiling can see.
+
+Consequences
+============
+
+A run suspended for approval or typed input, whose configuration is re-pointed
+at a less trusted provider before the approver answers, is now refused on resume
+rather than sending. The refusal names the forced source, as
+:ref:`ADR-164 <adr-164>` requires.
+
+An installation that has classified nothing is unaffected, and a run that forced
+nothing hands over null exactly as before — the gate keeps its
+configuration-only path rather than folding an empty list.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -509,3 +509,4 @@ Tools
    Adr162BulkEditorActionsAsOrdinaryRuns
    Adr163UseCasePacks
    Adr164ForcedSourcesBindAgainstTheCeiling
+   Adr165ResumeReGatesTheForcedSet

--- a/Tests/Unit/Api/api-surface.txt
+++ b/Tests/Unit/Api/api-surface.txt
@@ -846,7 +846,7 @@ Netresearch\NrLlm\Domain\ValueObject\RoutingSummary (class)
   property readonly rejectionReasons: array
 
 Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState (class)
-  constructor(array $messages, array $pendingCalls, int $iterations, int $promptTokens, int $completionTokens, ?array $allowedToolNames = …, array $options = …, ?string $inputToolName = …, array $inputSchema = …, array $callPreviews = …)
+  constructor(array $messages, array $pendingCalls, int $iterations, int $promptTokens, int $completionTokens, ?array $allowedToolNames = …, array $options = …, ?string $inputToolName = …, array $inputSchema = …, array $callPreviews = …, array $forcedSnippetUids = …, array $forcedSkillUids = …)
   method isInputPause(): bool
   method static fromArray(array $data): self
   method toArray(): array
@@ -854,6 +854,8 @@ Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState (class)
   property readonly allowedToolNames: ?array
   property readonly callPreviews: array
   property readonly completionTokens: int
+  property readonly forcedSkillUids: array
+  property readonly forcedSnippetUids: array
   property readonly inputSchema: array
   property readonly inputToolName: ?string
   property readonly iterations: int

--- a/Tests/Unit/Domain/ValueObject/SuspendedRunStateTest.php
+++ b/Tests/Unit/Domain/ValueObject/SuspendedRunStateTest.php
@@ -122,4 +122,50 @@ final class SuspendedRunStateTest extends TestCase
 
         self::assertSame([], $restored->callPreviews);
     }
+
+    #[Test]
+    public function theForcedSetSurvivesTheRoundTrip(): void
+    {
+        // ADR-165: a resume runs in a different process from the suspend, so
+        // the run's forced sources reach the ADR-164 ceiling only if the state
+        // carries their uids.
+        $state = new SuspendedRunState([], [], 1, 0, 0, forcedSnippetUids: [41, 7], forcedSkillUids: [77]);
+
+        // Through real JSON, because that is the round trip the AgentRun row
+        // makes: an int list survives it, and this is where it would not.
+        $decoded = json_decode(json_encode($state->toArray(), JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        /** @var array<string, mixed> $decoded */
+        $restored = SuspendedRunState::fromArray($decoded);
+
+        self::assertSame([41, 7], $restored->forcedSnippetUids);
+        self::assertSame([77], $restored->forcedSkillUids);
+    }
+
+    #[Test]
+    public function aRowWrittenBeforeTheForcedSetExistedRehydratesWithoutIt(): void
+    {
+        // Every state suspended before ADR-165 lacks both keys, and a running
+        // installation has such rows. They must resume, not fail.
+        $restored = SuspendedRunState::fromArray(['messages' => [], 'pendingCalls' => []]);
+
+        self::assertSame([], $restored->forcedSnippetUids);
+        self::assertSame([], $restored->forcedSkillUids);
+    }
+
+    #[Test]
+    public function anUnusableUidIsDroppedRatherThanHandedToARepository(): void
+    {
+        // JSON round-trips and hand-edited rows can carry anything. A uid of 0
+        // or below identifies no record, and a non-numeric entry is not a uid
+        // at all; both would only produce a lookup that answers nothing.
+        $restored = SuspendedRunState::fromArray([
+            'messages'          => [],
+            'pendingCalls'      => [],
+            'forcedSnippetUids' => [41, 0, -3, 'nine', '12', null, ['nested']],
+        ]);
+
+        self::assertSame([41, 12], $restored->forcedSnippetUids);
+    }
 }

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -22,7 +22,9 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\PromptSnippet;
 use Netresearch\NrLlm\Domain\Model\Provider;
+use Netresearch\NrLlm\Domain\Model\Skill;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRunReference;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ContextBudgetBreakdown;
@@ -895,6 +897,128 @@ final class ToolLoopServiceTest extends TestCase
     }
 
     #[Test]
+    public function theSuspendCarriesTheForcedSetSoResumeCanReGateIt(): void
+    {
+        // ADR-165. Without this the uids are gone the moment the process ends,
+        // and ResumeCoordinator works from the suspended state rather than the
+        // original request — so there is nothing left to rebuild from.
+        $snippet = $this->snippetWithUid(41, 'incident-report');
+        $skill   = $this->skillWithUid(77);
+
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturn($this->response('', [new ToolCall('call_1', 'delete_thing', [])]));
+
+        $state = $this->suspend(
+            $this->service($mgr, new ToolRegistry([$this->approvalTool()])),
+            new RunAugmentation(forcedSkills: [$skill], forcedSnippets: [$snippet]),
+        );
+
+        self::assertSame([41], $state->forcedSnippetUids);
+        self::assertSame([77], $state->forcedSkillUids);
+    }
+
+    #[Test]
+    public function resumeRebuildsTheForcedSetAndHandsItToTheCeiling(): void
+    {
+        // The half that actually closes #761: the persisted uids are re-loaded
+        // and reach the manager, so the ADR-164 gate folds them against the
+        // LIVE trust zone — which is what can have changed while the run was
+        // suspended.
+        $snippet = $this->snippetWithUid(41, 'incident-report');
+
+        $repository = self::createStub(PromptSnippetRepository::class);
+        $repository->method('findByUids')->willReturn([$snippet]);
+
+        $seen = 'unset';
+        $mgr  = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturnCallback(
+            function (
+                array $messages,
+                array $tools,
+                LlmConfiguration $configuration,
+                ?ToolOptions $options = null,
+                ?AgentRunReference $run = null,
+                ?InjectedContext $injectedContext = null,
+            ) use (&$seen): CompletionResponse {
+                $seen = $injectedContext;
+
+                return $this->response('done');
+            },
+        );
+
+        $state = new SuspendedRunState(
+            [$this->userTurn('delete it')],
+            [],
+            1,
+            0,
+            0,
+            forcedSnippetUids: [41],
+        );
+
+        $this->service($mgr, new ToolRegistry([$this->approvalTool()]), null, $repository)
+            ->resume($state, true, $this->localConfiguration(), ToolExecutionContext::none(), null, new RunTrace());
+
+        self::assertInstanceOf(InjectedContext::class, $seen);
+        self::assertSame([$snippet], $seen->snippets);
+    }
+
+    #[Test]
+    public function aStateSuspendedBeforeTheForcedSetWasPersistedStillResumes(): void
+    {
+        // Back-compat: a row written before ADR-165 has neither key. It must
+        // resume exactly as it did — hand over nothing — rather than refuse
+        // over a forced set nobody recorded.
+        $seen = 'unset';
+        $mgr  = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturnCallback(
+            function (
+                array $messages,
+                array $tools,
+                LlmConfiguration $configuration,
+                ?ToolOptions $options = null,
+                ?AgentRunReference $run = null,
+                ?InjectedContext $injectedContext = null,
+            ) use (&$seen): CompletionResponse {
+                $seen = $injectedContext;
+
+                return $this->response('done');
+            },
+        );
+
+        $state = SuspendedRunState::fromArray([
+            'messages'     => [$this->userTurn('delete it')],
+            'pendingCalls' => [],
+            'iterations'   => 1,
+        ]);
+
+        self::assertSame([], $state->forcedSnippetUids);
+
+        $this->service($mgr, new ToolRegistry([$this->approvalTool()]))
+            ->resume($state, true, $this->localConfiguration(), ToolExecutionContext::none(), null, new RunTrace());
+
+        self::assertNull($seen);
+    }
+
+    private function snippetWithUid(int $uid, string $identifier): PromptSnippet
+    {
+        $snippet = new PromptSnippet();
+        $snippet->setIdentifier($identifier);
+        $snippet->setName($identifier);
+        $snippet->_setProperty('uid', $uid);
+
+        return $snippet;
+    }
+
+    private function skillWithUid(int $uid): Skill
+    {
+        $skill = new Skill();
+        $skill->_setProperty('uid', $uid);
+
+        return $skill;
+    }
+
+    #[Test]
     public function resumeDeniedInjectsARefusalThenContinues(): void
     {
         $mgr   = self::createStub(LlmServiceManagerInterface::class);
@@ -1064,10 +1188,16 @@ final class ToolLoopServiceTest extends TestCase
         self::assertSame(42, $capturedOptions->getBeUserUid());
     }
 
-    private function suspend(ToolLoopService $service): SuspendedRunState
+    private function suspend(ToolLoopService $service, ?RunAugmentation $augmentation = null): SuspendedRunState
     {
         try {
-            $service->runLoop([$this->userTurn('delete it')], $this->localConfiguration(), ToolExecutionContext::none(), null);
+            $service->runLoop(
+                [$this->userTurn('delete it')],
+                $this->localConfiguration(),
+                ToolExecutionContext::none(),
+                null,
+                augmentation: $augmentation,
+            );
         } catch (ToolApprovalRequiredException $e) {
             return $e->state;
         }
@@ -1997,6 +2127,7 @@ final class ToolLoopServiceTest extends TestCase
         LlmServiceManagerInterface $mgr,
         ToolRegistry $registry,
         ?LoggerInterface $logger = null,
+        ?PromptSnippetRepository $promptSnippetRepository = null,
     ): ToolLoopService {
         $availability = new FakeToolAvailability($registry->names());
 
@@ -2005,6 +2136,7 @@ final class ToolLoopServiceTest extends TestCase
             $registry,
             $this->realPolicy($registry, $availability),
             $logger,
+            promptSnippetRepository: $promptSnippetRepository,
         );
     }
 


### PR DESCRIPTION
Closes #761. The gap ADR-164 named and deferred.

## Three design choices, and why

**Uids, not a frozen classification.** Persisting the strictest class at suspend time would also have closed the two risks (`zone changed`, `observe → enforce`) without any repository lookup. Uids win because a resume then reflects the record as it is *now*: an operator who raises a snippet's class while a run is suspended means it, and a frozen copy would ignore them. Same identity-over-snapshot choice `AgentRunRequestCodec` already makes for a queued run's entities.

**The suspended state, not `queuedRequest`.** `AgentRunRequestCodec::rehydrate()` can already recover a queued run's forced set from the run row, which looks like it would work with no new field. It does not: `queuedRequest` is null for a run started synchronously from the playground — precisely the path that motivated ADR-164. The suspended state is written by both.

**Re-loaded in the loop, not in `ResumeCoordinator`.** The coordinator has two call sites into the loop; the loop has one place where a resumed run re-enters. The two repositories join `ToolLoopService` as optional collaborators, like every other one on that constructor.

## Scope of what this fixes

Narrow, and worth being precise about. The forced text enters the transcript at assembly, where ADR-164 already gates it, so a resume injects nothing new. What a resume could miss is a ceiling that changed *while* the run was suspended — the configuration re-pointed at a less trusted provider or given a fallback that reaches one, or `dataClassEnforcement` switched from `observe` to enforcing. The configuration's own sources were already re-gated on resume (`assertContextPermitted()` runs per pipeline call against the live configuration); only the forced half was frozen out.

## Back-compat

A row suspended before this change has neither key and rehydrates with none — the pre-change behaviour, never a refusal to resume. Same shape ADR-136's call previews use, for the same reason: a running installation has such rows in its database. `SuspendedRunState::fromArray()` also drops a uid of 0 or below and any non-numeric entry, so a hand-edited or half-decoded row cannot produce a lookup that answers nothing.

A uid that no longer resolves — the snippet was deleted meanwhile — contributes nothing. Refusing the resume instead would strand a run over a record an operator deliberately removed, and make deleting a snippet a way to break running work.

## Tests

Six, and the two load-bearing ones were **verified by controlled failure**:

- `resumeRebuildsTheForcedSetAndHandsItToTheCeiling` — with the resume wiring reverted to `null`, it fails with `Failed asserting that null is an instance of … InjectedContext`; restored, green.
- `theSuspendCarriesTheForcedSetSoResumeCanReGateIt`, `aStateSuspendedBeforeTheForcedSetWasPersistedStillResumes`, plus three on the state: real-JSON round trip, a pre-change row, and the unusable-uid filter.

Full gate at PHP 8.2 — rector -n, cgl -n, phpstan, unit (7068 tests / 21837 assertions), fuzzy, `ci:test:repo`, `ci:test:changelog`: green. Functional filtered to `Resume|Agent|Suspend|Governance|Context`: 143 tests green.

Two findings from the gate itself, both fixed before pushing: Rector wanted `uidsOf()` non-static (only called locally), and PHPStan refused `json_decode()`'s `mixed` into `fromArray()` in the round-trip test.

ADR-165, amending ADR-164 (its deferred gap) and ADR-084 (a further field on the suspended state); `api-surface.txt` regenerated — additive, two properties and two trailing optional constructor parameters.
