### PR TITLE
fix(context): re-gate a deactivated forced snippet on resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,19 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the other that each has an English and a German label. The widget
   description no longer enumerates the kinds — that prose had drifted twice.
 
+- **Deactivating a forced snippet no longer lowers a suspended run's trust
+  ceiling** (#766, ADR-166). The ADR-165 resume re-gate rebuilt a run's forced set
+  through the active-only snippet lookup, so a snippet switched off while the
+  run waited for its approver vanished from the ADR-164 ceiling — while its text
+  stayed in the persisted transcript and went out on the very next send. The
+  re-gate now uses a new `PromptSnippetRepository::findExistingByUids()`, which
+  resolves an inactive or hidden record but still not a deleted one: "inactive"
+  bars a snippet from new composition, it does not un-classify text already
+  injected. ADR-165's three decisions are unchanged — the live record still
+  wins over a frozen classification in both directions, a deleted source still
+  contributes nothing, and a legacy suspended row with no uids still resumes.
+  The skill half never had the filter and needed no change.
+
 ## [0.29.1] - 2026-08-13
 
 ### Fixed

--- a/Classes/Domain/Repository/PromptSnippetRepository.php
+++ b/Classes/Domain/Repository/PromptSnippetRepository.php
@@ -111,22 +111,68 @@ class PromptSnippetRepository extends Repository
      *
      * Unknown and inactive uids are silently skipped.
      *
+     * This is the lookup for NEW composition — a snippet an operator switched
+     * off must not enter a prompt that is being assembled now. Do not merge it
+     * with {@see self::findExistingByUids()}: the two answer different
+     * questions and the difference is deliberate (ADR-166).
+     *
      * @param list<int> $uids
      *
      * @return list<PromptSnippet>
      */
     public function findByUids(array $uids): array
     {
+        return $this->orderedByUid($uids, true);
+    }
+
+    /**
+     * Find snippets by uid regardless of their active flag, preserving the
+     * input order.
+     *
+     * Same contract as {@see self::findByUids()} — unknown uids are silently
+     * skipped, a deleted record still resolves to nothing — except that an
+     * inactive (or hidden) snippet still resolves.
+     *
+     * This is the lookup for text that is ALREADY in a transcript: a resumed
+     * agent run re-loads its forced sources to re-gate them (ADR-165), and
+     * deactivating a snippet mid-run must not silently drop the classification
+     * of text that is still on the wire (ADR-166). "Inactive" means "not for
+     * new composition", not "already-injected text loses its class".
+     *
+     * @param list<int> $uids
+     *
+     * @return list<PromptSnippet>
+     */
+    public function findExistingByUids(array $uids): array
+    {
+        return $this->orderedByUid($uids, false);
+    }
+
+    /**
+     * Resolve uids to snippets in the caller's order, optionally restricted to
+     * active ones.
+     *
+     * The repository's default query settings ignore enable fields, so `hidden`
+     * plays no part here either way; `is_active` is the only filter, and
+     * $activeOnly is what decides whether it applies. The deleted restriction
+     * is untouched in both modes — a deleted record never resolves.
+     *
+     * @param list<int> $uids
+     *
+     * @return list<PromptSnippet>
+     */
+    private function orderedByUid(array $uids, bool $activeOnly): array
+    {
         if ($uids === []) {
             return [];
         }
 
-        $query = $this->createQuery();
+        $query      = $this->createQuery();
+        $uidMatches = $query->in('uid', $uids);
         $query->matching(
-            $query->logicalAnd(
-                $query->equals('isActive', true),
-                $query->in('uid', $uids),
-            ),
+            $activeOnly
+                ? $query->logicalAnd($query->equals('isActive', true), $uidMatches)
+                : $uidMatches,
         );
 
         /** @var array<int, PromptSnippet> $snippetsByUid */

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -163,6 +163,17 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
      * suspended — contributes nothing. The transcript still carries its text,
      * so this degrades to the pre-ADR-165 answer for that one source rather
      * than refusing a resume over a record that is gone.
+     *
+     * A source merely DEACTIVATED while the run was suspended does not degrade
+     * that way (ADR-166), which is why the snippet lookup is
+     * {@see PromptSnippetRepository::findExistingByUids()} and not the
+     * active-only {@see PromptSnippetRepository::findByUids()}. Its text is
+     * already in the transcript and
+     * still goes on the wire, so dropping it here would lower the ADR-164
+     * ceiling for content that is still being sent. "Inactive" bars a snippet
+     * from new composition; it does not un-classify text already injected. The
+     * skill half needs no counterpart: {@see SkillRepository::findAll()} ignores
+     * enable fields and the filter below is by uid only.
      */
     private function augmentationFrom(SuspendedRunState $state): ?RunAugmentation
     {
@@ -171,7 +182,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         }
 
         $snippets = $state->forcedSnippetUids !== [] && $this->promptSnippetRepository instanceof PromptSnippetRepository
-            ? $this->promptSnippetRepository->findByUids($state->forcedSnippetUids)
+            ? $this->promptSnippetRepository->findExistingByUids($state->forcedSnippetUids)
             : [];
 
         $skills = [];

--- a/Documentation/Adr/Adr165ResumeReGatesTheForcedSet.rst
+++ b/Documentation/Adr/Adr165ResumeReGatesTheForcedSet.rst
@@ -4,10 +4,12 @@
 ADR-165: A resumed run re-gates its forced sources
 ============================================================
 
-:Status: Accepted
+:Status: Accepted (the re-load no longer skips a deactivated source — see
+    :ref:`ADR-166 <adr-166>`)
 :Date: 2026-08-13
 :Amends: :ref:`ADR-164 <adr-164>` (its "does not cover a resumed run" gap) and
     :ref:`ADR-084 <adr-084>` (a further field on the suspended state)
+:Amended: 2026-08-13 by :ref:`ADR-166 <adr-166>`
 :Authors: Netresearch DTT GmbH
 
 Context
@@ -73,6 +75,10 @@ classification. The transcript still carries its text, so for that one source
 the answer degrades to the pre-ADR-165 one. Refusing the resume instead would
 strand a run over a record an operator deliberately removed, and would make
 deleting a snippet a way to break running work.
+
+A source merely **deactivated** does not fall under that paragraph. The re-load
+originally used an active-only lookup and dropped one, which was a defect, not a
+decision; :ref:`ADR-166 <adr-166>` states the distinction and fixes it.
 
 **It does not re-gate anything else about a resume.** The transcript, the
 allow-list and the options are restored exactly as :ref:`ADR-084 <adr-084>`

--- a/Documentation/Adr/Adr166DeactivationDoesNotLowerACeiling.rst
+++ b/Documentation/Adr/Adr166DeactivationDoesNotLowerACeiling.rst
@@ -1,0 +1,93 @@
+.. _adr-166:
+
+============================================================
+ADR-166: Deactivating a source does not lower a ceiling
+============================================================
+
+:Status: Accepted
+:Date: 2026-08-13
+:Amends: :ref:`ADR-165 <adr-165>` (which lookup the resume re-gate uses)
+:Authors: Netresearch DTT GmbH
+
+Context
+=======
+
+:ref:`ADR-165 <adr-165>` rebuilds a resumed run's forced set from the uids the
+suspend persisted, so the :ref:`ADR-164 <adr-164>` ceiling still sees it. It did
+that through :php:`PromptSnippetRepository::findByUids()`, which filters
+``is_active = true``.
+
+That filter is the whole defect. The repository's :php:`initializeObject()`
+already sets :php:`setIgnoreEnableFields(true)`, so TYPO3's ``hidden`` field
+plays no part; the explicit ``is_active`` clause was the only thing deciding,
+and an operator who switched a snippet off while a run was suspended made it
+vanish from the re-gate. Both lists then came back empty,
+:php:`augmentationFrom()` returned null, and the send took the
+configuration-only gate path — the pre-ADR-165 answer, silently.
+
+The text was still there. It sits in the persisted transcript, it goes on the
+wire on the very next send, and its classification is what the ceiling exists to
+weigh. Nothing about deactivating a record removes it from a conversation that
+is already carrying it.
+
+Decision
+========
+
+**"Inactive" means "not for new composition". It does not mean "already-injected
+text loses its classification".** Those are two different questions, and the
+repository now answers them with two methods.
+
+:php:`findByUids()` keeps its active-only semantics unchanged: it is the lookup
+for a prompt being assembled *now*, and a snippet an operator switched off must
+not enter one. :php:`findExistingByUids()` is new and drops only the
+``is_active`` clause — same contract otherwise: input order preserved, unknown
+uids silently skipped, a **deleted** record still resolving to nothing.
+:php:`ToolLoopService::augmentationFrom()` uses the second one, because the text
+it is classifying is already in the transcript.
+
+The two are deliberately not merged, and each carries a docblock saying which
+question it answers.
+
+**The skill half was already correct.** :php:`SkillRepository` ignores enable
+fields for the same reason the snippet repository does, and
+:php:`augmentationFrom()` filters :php:`findAll()` by uid alone — no ``enabled``
+clause anywhere on that path. A skill disabled while a run was suspended
+therefore always kept its classification on resume. Only the snippet branch had
+an explicit filter to trip over, so only the snippet branch needed a change.
+
+.. _adr-166-not:
+
+What this does not do
+=====================
+
+**It does not reverse any of ADR-165's three decisions.** They stand exactly as
+written:
+
+- the **live record wins** over a frozen classification (identity over
+  snapshot), so a class raised *or lowered* while the run was suspended takes
+  effect;
+- a **deleted** source resolves to nothing and contributes nothing — the
+  deleted restriction stays on in :php:`findExistingByUids()`, so refusing a
+  resume over a record an operator removed is still not what happens;
+- a **legacy suspended row with no uids** rehydrates with none and resumes,
+  never refuses.
+
+**It does not make an inactive snippet usable again.** Nothing composes it into
+a new prompt, nothing offers it in the playground, and a fresh run that forces
+it gets it through the active-only lookup like any other. The only thing it
+regains is being *counted* by a ceiling that is judging text already sent.
+
+**It does not widen what the ceiling reads.** The forced set is the same set
+ADR-164 defined; this changes which rows resolve, not which rows are asked for.
+
+Consequences
+============
+
+A run suspended for approval or typed input, one of whose forced snippets is
+switched off before the approver answers, is re-gated against that snippet's
+class exactly as if it were still active — and is refused when the ceiling has
+meanwhile dropped below it. Before this, deactivating a snippet mid-run was a
+way to quietly lower a run's ceiling while its text kept going out.
+
+An installation that has classified nothing is unaffected, and a run that forced
+nothing still hands over null.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -510,3 +510,4 @@ Tools
    Adr163UseCasePacks
    Adr164ForcedSourcesBindAgainstTheCeiling
    Adr165ResumeReGatesTheForcedSet
+   Adr166DeactivationDoesNotLowerACeiling

--- a/Tests/Functional/Fixtures/PromptSnippetsForcedSet.csv
+++ b/Tests/Functional/Fixtures/PromptSnippetsForcedSet.csv
@@ -1,0 +1,6 @@
+"tx_nrllm_promptsnippet"
+,"uid","pid","identifier","name","description","tags","snippet","metadata","data_class","is_active","sorting","tstamp","crdate","deleted","hidden"
+,101,0,"forced-deactivated","Deactivated while suspended","Classified secretAdjacent, switched off mid-run","incident","Incident 4711 details.","","secretAdjacent",0,10,1703347200,1703347200,0,0
+,102,0,"forced-lowered","Lowered while suspended","Was secretAdjacent at suspend time, now publicContent","incident","Press statement wording.","","publicContent",1,20,1703347200,1703347200,0,0
+,103,0,"forced-raised","Raised while suspended","Was publicContent at suspend time, now secretAdjacent","incident","Internal escalation path.","","secretAdjacent",1,30,1703347200,1703347200,0,0
+,104,0,"forced-removed","Removed while suspended","Deleted by the operator mid-run","incident","This snippet is gone.","","secretAdjacent",1,40,1703347200,1703347200,1,0

--- a/Tests/Functional/Repository/PromptSnippetRepositoryTest.php
+++ b/Tests/Functional/Repository/PromptSnippetRepositoryTest.php
@@ -185,6 +185,67 @@ final class PromptSnippetRepositoryTest extends AbstractFunctionalTestCase
     }
 
     // =========================================================================
+    // findExistingByUids()
+    // =========================================================================
+
+    #[Test]
+    public function findExistingByUidsPreservesInputOrder(): void
+    {
+        $snippets = $this->repository->findExistingByUids([5, 2, 3]);
+
+        self::assertSame(
+            ['style-minimalist', 'tone-formal', 'audience-developers'],
+            $this->identifiersOf($snippets),
+        );
+    }
+
+    #[Test]
+    public function findExistingByUidsSilentlySkipsUnknownUids(): void
+    {
+        $snippets = $this->repository->findExistingByUids([999, 2, 12345]);
+
+        self::assertSame(['tone-formal'], $this->identifiersOf($snippets));
+    }
+
+    #[Test]
+    public function findExistingByUidsResolvesInactiveSnippets(): void
+    {
+        // The ADR-166 difference to findByUids(): uid 7 is inactive and still
+        // resolves. Its text can already be in a suspended run's transcript, and
+        // deactivating it must not drop the classification of text still on the
+        // wire.
+        $snippets = $this->repository->findExistingByUids([7, 1]);
+
+        self::assertSame(['tone-inactive', 'tone-casual'], $this->identifiersOf($snippets));
+    }
+
+    #[Test]
+    public function findExistingByUidsResolvesHiddenSnippets(): void
+    {
+        // uid 10 is active but hidden. The repository's default query settings
+        // ignore enable fields, so `hidden` never filtered here — asserted so a
+        // later change to initializeObject() cannot silently reintroduce it.
+        self::assertSame(['persona-hidden'], $this->identifiersOf($this->repository->findExistingByUids([10])));
+    }
+
+    #[Test]
+    public function findExistingByUidsStillSkipsDeletedSnippets(): void
+    {
+        // The one restriction ADR-166 does NOT drop: uid 8 is deleted and stays
+        // unresolvable, so ADR-165's "a deleted source contributes nothing" is
+        // untouched.
+        $snippets = $this->repository->findExistingByUids([8, 1]);
+
+        self::assertSame(['tone-casual'], $this->identifiersOf($snippets));
+    }
+
+    #[Test]
+    public function findExistingByUidsReturnsEmptyListForEmptyInput(): void
+    {
+        self::assertSame([], $this->repository->findExistingByUids([]));
+    }
+
+    // =========================================================================
     // Persisted properties
     // =========================================================================
 

--- a/Tests/Functional/Service/Tool/ResumeForcedSnippetReGateTest.php
+++ b/Tests/Functional/Service/Tool/ResumeForcedSnippetReGateTest.php
@@ -1,0 +1,252 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Tool;
+
+use Netresearch\NrLlm\Domain\Enum\ToolDataClass;
+use Netresearch\NrLlm\Domain\Enum\TrustZone;
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\PromptSnippet;
+use Netresearch\NrLlm\Domain\Model\Provider;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRunReference;
+use Netresearch\NrLlm\Domain\ValueObject\InjectedContext;
+use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
+use Netresearch\NrLlm\Service\Governance\DataClassEnforcementResolver;
+use Netresearch\NrLlm\Service\Governance\TrustZoneResolver;
+use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
+use Netresearch\NrLlm\Service\Option\ToolOptions;
+use Netresearch\NrLlm\Service\Skill\SkillComposer;
+use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
+use Netresearch\NrLlm\Service\Tool\RunTrace;
+use Netresearch\NrLlm\Service\Tool\ToolCallPolicy;
+use Netresearch\NrLlm\Service\Tool\ToolDataClassResolver;
+use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
+use Netresearch\NrLlm\Service\Tool\ToolLoopService;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeToolAvailability;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The resume re-gate against the REAL, DB-backed snippet repository (ADR-166).
+ *
+ * The unit siblings in
+ * {@see \Netresearch\NrLlm\Tests\Unit\Service\Tool\ToolLoopServiceTest} drive
+ * {@see ToolLoopService::resume()} with a stubbed repository, so they pin the
+ * wiring but cannot see the filter the defect lived in: a stub answers whatever
+ * it was told to, active flag or not. Here the loop re-loads its forced set
+ * through the production {@see PromptSnippetRepository} over real rows, which is
+ * the only place the `is_active` clause can be observed.
+ *
+ * Every case is the same shape: a run suspends carrying snippet uids, an
+ * operator changes the record while it waits, and the resumed send is asserted
+ * on what reaches {@see InjectedContext} — the ADR-164 ceiling's input.
+ */
+#[CoversClass(ToolLoopService::class)]
+#[CoversClass(PromptSnippetRepository::class)]
+final class ResumeForcedSnippetReGateTest extends AbstractFunctionalTestCase
+{
+    private PromptSnippetRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importFixture('PromptSnippetsForcedSet.csv');
+
+        $this->repository = $this->getService(PromptSnippetRepository::class);
+    }
+
+    #[Test]
+    public function aSnippetDeactivatedWhileSuspendedKeepsItsClassOnResume(): void
+    {
+        // THE regression (ADR-166). uid 101 is classified secretAdjacent and was
+        // switched off while the run waited for its approver. Its text is still
+        // in the transcript and still goes on the wire, so the ceiling must still
+        // see it. Resolving the forced set through an active-only lookup dropped
+        // it, augmentationFrom() then returned null, and the send silently took
+        // the configuration-only gate path.
+        $seen = $this->resumeWithForcedSnippets([101]);
+
+        self::assertInstanceOf(InjectedContext::class, $seen);
+        self::assertSame(['forced-deactivated'], $this->identifiersOf($seen));
+        self::assertSame(ToolDataClass::SECRET_ADJACENT, $seen->snippets[0]->getDataClassEnum());
+    }
+
+    #[Test]
+    public function aClassLoweredWhileSuspendedTakesEffectOnResume(): void
+    {
+        // ADR-165's live-record rule, unchanged by ADR-166: uid 102 was
+        // secretAdjacent when the run suspended and the operator lowered it to
+        // publicContent. Identity over snapshot — the resume reflects the record
+        // as it is now, in both directions.
+        $seen = $this->resumeWithForcedSnippets([102]);
+
+        self::assertInstanceOf(InjectedContext::class, $seen);
+        self::assertSame(ToolDataClass::PUBLIC_CONTENT, $seen->snippets[0]->getDataClassEnum());
+    }
+
+    #[Test]
+    public function aClassRaisedWhileSuspendedTakesEffectOnResume(): void
+    {
+        // The other direction of the same rule: uid 103 was publicContent and the
+        // operator raised it. An operator who raises a class while a run is
+        // suspended means it.
+        $seen = $this->resumeWithForcedSnippets([103]);
+
+        self::assertInstanceOf(InjectedContext::class, $seen);
+        self::assertSame(ToolDataClass::SECRET_ADJACENT, $seen->snippets[0]->getDataClassEnum());
+    }
+
+    #[Test]
+    public function aDeletedSnippetStillContributesNothingOnResume(): void
+    {
+        // ADR-165's "does not resurrect a deleted source", unchanged. uid 104 is
+        // deleted; the ADR-166 lookup drops the is_active clause but leaves the
+        // deleted restriction on, so the forced set resolves to nothing and the
+        // send hands over null exactly as before.
+        self::assertNull($this->resumeWithForcedSnippets([104]));
+    }
+
+    #[Test]
+    public function aLegacyStateWithoutForcedUidsStillResumes(): void
+    {
+        // ADR-165's back-compat shape, unchanged: a row written before the field
+        // existed rehydrates with no uids and must resume handing over nothing,
+        // never refuse.
+        $state = SuspendedRunState::fromArray([
+            'messages'     => [$this->userTurn('carry on')],
+            'pendingCalls' => [],
+            'iterations'   => 1,
+        ]);
+
+        self::assertSame([], $state->forcedSnippetUids);
+        self::assertNull($this->resume($state));
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    /**
+     * @param list<int> $uids
+     */
+    private function resumeWithForcedSnippets(array $uids): ?InjectedContext
+    {
+        return $this->resume(new SuspendedRunState(
+            [$this->userTurn('carry on')],
+            [],
+            1,
+            0,
+            0,
+            forcedSnippetUids: $uids,
+        ));
+    }
+
+    /**
+     * Resume the state through a loop wired to the REAL repository and the REAL
+     * composite gate, and return the {@see InjectedContext} the send carried.
+     */
+    private function resume(SuspendedRunState $state): ?InjectedContext
+    {
+        $seen  = null;
+        $sends = 0;
+        $mgr   = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturnCallback(
+            function (
+                array $messages,
+                array $tools,
+                LlmConfiguration $configuration,
+                ?ToolOptions $options = null,
+                ?AgentRunReference $run = null,
+                ?InjectedContext $injectedContext = null,
+            ) use (&$seen, &$sends): CompletionResponse {
+                ++$sends;
+                $seen = $injectedContext;
+
+                return new CompletionResponse(
+                    content: 'done',
+                    model: 'test-model',
+                    usage: UsageStatistics::fromTokens(0, 0),
+                );
+            },
+        );
+
+        $registry     = new ToolRegistry([new FakeTool('noop')]);
+        $availability = new FakeToolAvailability($registry->names());
+        $policy       = new ToolCallPolicy(
+            $registry,
+            $availability,
+            new AllowedToolsResolver(new SkillComposer(), $registry),
+            new ToolDataClassResolver($registry),
+            new TrustZoneResolver(),
+            new DataClassEnforcementResolver(),
+        );
+
+        $loop = new ToolLoopService(
+            $mgr,
+            $registry,
+            $policy,
+            promptSnippetRepository: $this->repository,
+        );
+
+        $loop->resume($state, true, $this->localConfiguration(), ToolExecutionContext::none(), null, new RunTrace());
+
+        // A null $seen must mean "the send carried no injected context", never
+        // "the send never happened" — the two would otherwise be one assertion.
+        self::assertSame(1, $sends, 'The resumed run never reached the manager.');
+
+        return $seen;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function identifiersOf(InjectedContext $context): array
+    {
+        return array_map(
+            static fn(PromptSnippet $snippet): string => $snippet->getIdentifier(),
+            $context->snippets,
+        );
+    }
+
+    /**
+     * A configuration whose provider sits in the LOCAL trust zone, whose ceiling
+     * is SECRET_ADJACENT — so the gate's trust-zone axis genuinely runs and
+     * permits, and nothing denies the run for a reason these tests are not
+     * about. Same rationale as the unit sibling's localConfiguration().
+     */
+    private function localConfiguration(): LlmConfiguration
+    {
+        $provider = new Provider();
+        $provider->setTrustZoneEnum(TrustZone::LOCAL);
+
+        $model = new Model();
+        $model->setProvider($provider);
+
+        $configuration = new LlmConfiguration();
+        $configuration->setLlmModel($model);
+
+        return $configuration;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function userTurn(string $content): array
+    {
+        return ['role' => 'user', 'content' => $content];
+    }
+}

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -25,6 +25,7 @@ use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Model\Skill;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
+use Netresearch\NrLlm\Domain\Repository\SkillRepository;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRunReference;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ContextBudgetBreakdown;
@@ -67,6 +68,7 @@ use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeInputTool;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeToolAvailability;
 use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\PreviewingApprovalTool;
+use Netresearch\NrLlm\Tests\Unit\Support\InMemoryQueryResult;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -928,7 +930,7 @@ final class ToolLoopServiceTest extends TestCase
         $snippet = $this->snippetWithUid(41, 'incident-report');
 
         $repository = self::createStub(PromptSnippetRepository::class);
-        $repository->method('findByUids')->willReturn([$snippet]);
+        $repository->method('findExistingByUids')->willReturn([$snippet]);
 
         $seen = 'unset';
         $mgr  = self::createStub(LlmServiceManagerInterface::class);
@@ -998,6 +1000,134 @@ final class ToolLoopServiceTest extends TestCase
             ->resume($state, true, $this->localConfiguration(), ToolExecutionContext::none(), null, new RunTrace());
 
         self::assertNull($seen);
+    }
+
+    #[Test]
+    public function resumeAsksTheExistenceLookupAndNeverTheActiveOnlyOne(): void
+    {
+        // ADR-166. The two lookups differ only in the `is_active` clause, so a
+        // revert to findByUids() is a one-word edit whose damage is invisible to
+        // every double that answers unconditionally. The functional sibling
+        // (ResumeForcedSnippetReGateTest) observes the filter against real rows;
+        // this pins WHICH method the loop asks, so the swap fails here too.
+        $repository = $this->createMock(PromptSnippetRepository::class);
+        $repository->expects(self::never())->method('findByUids');
+        $repository->expects(self::once())
+            ->method('findExistingByUids')
+            ->with([41])
+            ->willReturn([$this->snippetWithUid(41, 'incident-report')]);
+
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturn($this->response('done'));
+
+        $state = new SuspendedRunState(
+            [$this->userTurn('delete it')],
+            [],
+            1,
+            0,
+            0,
+            forcedSnippetUids: [41],
+        );
+
+        $this->service($mgr, new ToolRegistry([$this->approvalTool()]), null, $repository)
+            ->resume($state, true, $this->localConfiguration(), ToolExecutionContext::none(), null, new RunTrace());
+    }
+
+    #[Test]
+    public function resumeRebuildsTheForcedSkillsToo(): void
+    {
+        // The skill half of augmentationFrom(), which nothing covered. It needs
+        // no ADR-166 counterpart — SkillRepository::findAll() ignores enable
+        // fields and the loop filters by uid alone, so a skill disabled while the
+        // run was suspended still resolves. Asserted here rather than assumed:
+        // adding an `enabled` filter to that branch would reopen #761 for skills.
+        $wanted   = $this->skillWithUid(77);
+        $unwanted = $this->skillWithUid(78);
+
+        $skills = self::createStub(SkillRepository::class);
+        $skills->method('findAll')->willReturn(new InMemoryQueryResult([$wanted, $unwanted]));
+
+        $seen = 'unset';
+        $mgr  = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturnCallback(
+            function (
+                array $messages,
+                array $tools,
+                LlmConfiguration $configuration,
+                ?ToolOptions $options = null,
+                ?AgentRunReference $run = null,
+                ?InjectedContext $injectedContext = null,
+            ) use (&$seen): CompletionResponse {
+                $seen = $injectedContext;
+
+                return $this->response('done');
+            },
+        );
+
+        $state = new SuspendedRunState(
+            [$this->userTurn('delete it')],
+            [],
+            1,
+            0,
+            0,
+            forcedSkillUids: [77],
+        );
+
+        $this->service($mgr, new ToolRegistry([$this->approvalTool()]), null, null, $skills)
+            ->resume($state, true, $this->localConfiguration(), ToolExecutionContext::none(), null, new RunTrace());
+
+        self::assertInstanceOf(InjectedContext::class, $seen);
+        self::assertSame([$wanted], $seen->skills);
+        self::assertSame([], $seen->snippets);
+    }
+
+    #[Test]
+    public function resumeWithInputRebuildsTheForcedSetToo(): void
+    {
+        // The input-pause entry point (ADR-105) rebuilds the augmentation from
+        // the same helper, and nothing covered it — a dropped call there would
+        // leave approval resumes gated and input resumes not.
+        $snippet = $this->snippetWithUid(41, 'incident-report');
+
+        $repository = self::createStub(PromptSnippetRepository::class);
+        $repository->method('findExistingByUids')->willReturn([$snippet]);
+
+        $seen = 'unset';
+        $mgr  = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')->willReturnCallback(
+            function (
+                array $messages,
+                array $tools,
+                LlmConfiguration $configuration,
+                ?ToolOptions $options = null,
+                ?AgentRunReference $run = null,
+                ?InjectedContext $injectedContext = null,
+            ) use (&$seen): CompletionResponse {
+                $seen = $injectedContext;
+
+                return $this->response('done');
+            },
+        );
+
+        $call  = ['id' => 'call_1', 'type' => 'function', 'function' => ['name' => 'ask_user', 'arguments' => '{}']];
+        $state = new SuspendedRunState(
+            [$this->userTurn('weather?'), ['role' => 'assistant', 'content' => '', 'tool_calls' => [$call]]],
+            [$call],
+            1,
+            0,
+            0,
+            ['ask_user'],
+            [],
+            'ask_user',
+            ['type' => 'object', 'properties' => ['city' => ['type' => 'string']], 'required' => ['city']],
+            forcedSnippetUids: [41],
+        );
+
+        $this->service($mgr, new ToolRegistry([new FakeInputTool('ask_user')]), null, $repository)
+            ->resumeWithInput($state, ['city' => 'Berlin'], $this->localConfiguration(), ToolExecutionContext::none());
+
+        self::assertInstanceOf(InjectedContext::class, $seen);
+        self::assertSame([$snippet], $seen->snippets);
     }
 
     private function snippetWithUid(int $uid, string $identifier): PromptSnippet
@@ -2128,6 +2258,7 @@ final class ToolLoopServiceTest extends TestCase
         ToolRegistry $registry,
         ?LoggerInterface $logger = null,
         ?PromptSnippetRepository $promptSnippetRepository = null,
+        ?SkillRepository $skillRepository = null,
     ): ToolLoopService {
         $availability = new FakeToolAvailability($registry->names());
 
@@ -2137,6 +2268,7 @@ final class ToolLoopServiceTest extends TestCase
             $this->realPolicy($registry, $availability),
             $logger,
             promptSnippetRepository: $promptSnippetRepository,
+            skillRepository: $skillRepository,
         );
     }
 


### PR DESCRIPTION
## Description

A forced prompt snippet set **inactive** while an agent run was suspended silently dropped out of the ADR-164 trust ceiling on resume, while its text stayed in the persisted transcript and went out on the very next send.

The ADR-165 re-gate rebuilt the forced set through `PromptSnippetRepository::findByUids()`, whose `is_active` clause is the decisive filter — the repository's `initializeObject()` already sets `setIgnoreEnableFields(true)`, so `hidden` plays no part and `is_active` is the only thing that filters. With the snippet dropped, `augmentationFrom()` returned `null` and the send took the configuration-only gate path.

"Inactive" bars a snippet from **new composition**. It does not un-classify text that is **already injected**. Those are two different questions, so they now have two lookups: `findByUids()` keeps its active-only semantics for composition (its two other production callers — `AgentRunRequestCodec::rehydrate()` starting a queued run, and the tool playground picker — are both new composition and stay on it), and a new `findExistingByUids()` resolves an inactive or hidden record for the re-gate. A **deleted** record still resolves to nothing in both.

**ADR-165's three decisions are untouched**, and each has a test pinning it: the live record still wins over a frozen classification in both directions, a deleted source still contributes nothing, and a legacy suspended row with no uids still resumes rather than refusing. The skill half never had the filter — `SkillRepository` ignores enable fields and the loop filters by uid alone — so it needed no counterpart, and ADR-166 records why.

`PromptSnippetRepository` is `@internal`, so there is no api-surface change.

## Related Issue

Closes #766

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Tests

The central regression test drives `ToolLoopService::resume()` through the **real** DB-backed repository and the real composite tool policy. That placement is the point: a doubled repository cannot observe an `is_active` clause at all, which is exactly why the existing unit coverage did not catch this.

**The guard was seen to fail.** Reverting only the production line — `findExistingByUids(...)` back to `findByUids(...)` — makes it fail with `Failed asserting that null is an instance of class InjectedContext`, and that `null` *is* the defect: the active-only lookup drops the uid, the augmentation is null, and the ceiling never sees the snippet. Exactly one of the five cases failed under the revert; the lowered, raised, deleted and legacy cases stayed green, which confirms they pin ADR-165 behaviour rather than re-asserting the same thing.

Also added, both genuinely absent before: a test for the skill branch of `augmentationFrom()`, and one for the `resumeWithInput()` entry point.

## Gates

`cgl`, `phpstan` (level 10, 1383 files), `unit` (7078 tests) all green. Functional scoped to `Tests/Functional/Repository`, `Tests/Functional/Service/Agent` and `Tests/Functional/Service/Tool` — 496 tests, green. The full functional suite was not run locally; it makes ~34 real outbound HTTPS calls and takes ~35 minutes, per the repo's own note.

**`rector -n` at the CI-pinned PHP 8.2 did not run in this worktree** — `.Build` is resolved at 8.4, so `platform_check.php` fatals before Rector starts. Not a failure and not green: it did not execute, and CI is the first place it will. An informational 8.4 run surfaced one genuine finding in a new test, which is applied; the other was a PHPUnit-13-only attribute that does not exist under the `phpunit ^11` the 8.2 leg installs, and was deliberately not applied.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix works
- [x] I have updated the documentation accordingly
- [x] I have added a `CHANGELOG.md` entry under `## [Unreleased]`
- [x] I have added an ADR (ADR-166), with the `:Amended:` pointer into ADR-165
- [x] My changes generate no new warnings
