### PR TITLE
fix(governance): ask configuration access in the run simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,24 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   contributes nothing, and a legacy suspended row with no uids still resumes.
   The skill half never had the filter and needed no change.
 
+- **The run simulator no longer answers `Allowed` for a configuration the actor
+  cannot use** (#767, ADR-167). The Governance tab asked four gates; configuration
+  access (ADR-070) was not one of them, while the configuration picker filters
+  nothing. A group-restricted configuration paired with a non-member therefore
+  read `Allowed` on the page and was refused at runtime — a false positive on
+  the one surface whose purpose is that an operator does not have to guess.
+
+  It is now the fifth axis, asked through `ConfigurationResolver::actorMayUse()`
+  — the same rule the runtime enforces, promoted to a public non-throwing
+  predicate with `getActiveByIdentifierForActor()` as its other caller. The
+  actor is built from the RESOLVED backend user, so an administrator and a group
+  member still read `Allowed`; an unresolvable uid fails closed like every other
+  axis. The scope column now carries two actor-scoped rows.
+
+  Budget stays outside the simulation, deliberately: `BudgetCheckResult` reports
+  usage and limit only when it refuses, so a row could not tell "near the limit"
+  from "nothing measured".
+
 ## [0.29.1] - 2026-08-13
 
 ### Fixed

--- a/Classes/Controller/Backend/LlmModuleController.php
+++ b/Classes/Controller/Backend/LlmModuleController.php
@@ -385,9 +385,10 @@ final class LlmModuleController extends ActionController
      * Answer "would this run be allowed" through the REAL gates (ADR-145,
      * ADR-157).
      *
-     * {@see GovernanceSimulator} calls the four runtime services in turn — the
-     * tool gate, the input-context gate, the routing decision and the approval
-     * predicate — and folds their answers into one verdict. None of them is
+     * {@see GovernanceSimulator} calls the five runtime services in turn — the
+     * tool gate, the input-context gate, the routing decision, the approval
+     * predicate and configuration access (ADR-167) — and folds their answers
+     * into one verdict. None of them is
      * reimplemented here: a simulator with its own copy of a policy is worse
      * than none, because the two can disagree and only one of them runs.
      *

--- a/Classes/Domain/ValueObject/GovernanceSimulation.php
+++ b/Classes/Domain/ValueObject/GovernanceSimulation.php
@@ -15,10 +15,11 @@ use Netresearch\NrLlm\Domain\Enum\SimulationVerdict;
  * What the whole run would do, axis by axis, and the one verdict that follows
  * (ADR-157).
  *
- * ADR-145's simulator answered for the tool gate alone, which is one of four
+ * ADR-145's simulator answered for the tool gate alone, which is one of five
  * things that can stop a tool-calling run. A page that says "Allowed" while the
- * input-context gate would refuse the send, or while routing resolves no model
- * at all, is not a partial answer — it is a wrong one.
+ * input-context gate would refuse the send, while routing resolves no model at
+ * all, or while the actor may not use the configuration in the first place
+ * (ADR-167), is not a partial answer — it is a wrong one.
  *
  * Every axis keeps its own answer. The verdict is a fold over them, never a
  * substitute for them: an operator needs to see WHICH axis decided, because the
@@ -30,8 +31,9 @@ use Netresearch\NrLlm\Domain\Enum\SimulationVerdict;
  * {@see \Netresearch\NrLlm\Domain\Repository\ModelRepository::findActive()}
  * ignores enable-fields and reads no user — and so does the input-context gate,
  * which compares a configuration's declared classes against the zone it can
- * reach. Only the tool gate reads the actor, through `requiresAdmin()`. A
- * simulator that silently answered identically on three axes would imply a
+ * reach. Two axes read the actor: the tool gate through `requiresAdmin()`, and
+ * configuration access through the actor's backend groups (ADR-070, ADR-167). A
+ * simulator that silently answered identically on the other two would imply a
  * dimension that is not there.
  *
  * @internal
@@ -39,18 +41,22 @@ use Netresearch\NrLlm\Domain\Enum\SimulationVerdict;
 final readonly class GovernanceSimulation
 {
     /**
-     * @param ToolPolicyDecision   $tool             the ADR-094 gate — the ONE actor-scoped axis
-     * @param InputContextDecision $context          the ADR-144 gate, per configuration
-     * @param RoutingReadout       $routing          the ADR-142 decision, per configuration
-     * @param bool                 $approvalRequired whether {@see \Netresearch\NrLlm\Service\Tool\ToolApprovalRule}
-     *                                               binds the tool to a human decision (ADR-084/134)
-     * @param SimulationActor      $actor            whose permissions the tool gate was asked with
+     * @param ToolPolicyDecision   $tool                 the ADR-094 gate — actor-scoped
+     * @param InputContextDecision $context              the ADR-144 gate, per configuration
+     * @param RoutingReadout       $routing              the ADR-142 decision, per configuration
+     * @param bool                 $approvalRequired     whether {@see \Netresearch\NrLlm\Service\Tool\ToolApprovalRule}
+     *                                                   binds the tool to a human decision (ADR-084/134)
+     * @param bool                 $configurationAllowed whether the actor may use this configuration at all —
+     *                                                   {@see \Netresearch\NrLlm\Service\ConfigurationResolver::actorMayUse()},
+     *                                                   the second actor-scoped axis (ADR-070/167)
+     * @param SimulationActor      $actor                whose permissions the actor-scoped axes were asked with
      */
     public function __construct(
         public ToolPolicyDecision $tool,
         public InputContextDecision $context,
         public RoutingReadout $routing,
         public bool $approvalRequired,
+        public bool $configurationAllowed,
         public SimulationActor $actor,
     ) {}
 
@@ -62,7 +68,11 @@ final readonly class GovernanceSimulation
      */
     public function getVerdict(): SimulationVerdict
     {
-        if (!$this->tool->allowed || !$this->context->isPermitted() || !$this->routing->hasSelection()) {
+        if (!$this->configurationAllowed
+            || !$this->tool->allowed
+            || !$this->context->isPermitted()
+            || !$this->routing->hasSelection()
+        ) {
             return SimulationVerdict::BLOCK;
         }
 

--- a/Classes/Service/ConfigurationResolver.php
+++ b/Classes/Service/ConfigurationResolver.php
@@ -187,7 +187,29 @@ final readonly class ConfigurationResolver
         return $configuration;
     }
 
-    private function actorMayUse(LlmConfiguration $configuration, AiActorContext $actor): bool
+    /**
+     * Whether this actor may use this configuration at all (ADR-070, ADR-167).
+     *
+     * The same rule {@see self::getActiveByIdentifierForActor()} enforces, as a
+     * predicate over an entity the caller already holds: an unrestricted
+     * configuration is usable by anyone, a restricted one by an administrator, by
+     * a service account carrying the
+     * {@see ServiceAccountScope::CONFIGURATION_USE} scope (ADR-110), or by a
+     * member of one of its backend groups.
+     *
+     * Public because a readout has to be able to ASK the rule without triggering
+     * it. Routing the Governance tab's simulator through the throwing entry point
+     * would have meant re-querying by identifier and catching one of three
+     * exception types to tell "refused" from "not found" — and a second copy of
+     * the group comparison in the simulator would be the copy that ages
+     * (the warning {@see \Netresearch\NrLlm\Service\Tool\EditorActionCatalogue}
+     * already carries). One implementation, two callers.
+     *
+     * An anonymous actor — the fail-closed context a uid that no longer resolves
+     * produces — is a member of no group, so a restricted configuration is
+     * refused for it and an unrestricted one is not.
+     */
+    public function actorMayUse(LlmConfiguration $configuration, AiActorContext $actor): bool
     {
         if (!$configuration->hasAccessRestrictions()) {
             return true;

--- a/Classes/Service/Tool/GovernanceSimulator.php
+++ b/Classes/Service/Tool/GovernanceSimulator.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
 use Netresearch\NrLlm\Domain\ValueObject\GovernanceSimulation;
 use Netresearch\NrLlm\Domain\ValueObject\SimulationActor;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Service\ConfigurationResolver;
 use Netresearch\NrLlm\Service\Context\InputContextTrustGate;
 use Netresearch\NrLlm\Service\ModelSelectionServiceInterface;
 use Netresearch\NrLlm\Utility\SafeCastTrait;
@@ -23,7 +24,7 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
  * Runs one tool call past every gate that could stop it, and reports what each
  * one said (ADR-157).
  *
- * Four axes, four real runtime services, no second copy of any rule:
+ * Five axes, five real runtime services, no second copy of any rule:
  *
  * - the tool gate — {@see ToolCallPolicyInterface::decide()} (ADR-094);
  * - the input-context gate — {@see InputContextTrustGate::decide()}, the
@@ -32,7 +33,10 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
  *   the same {@see \Netresearch\NrLlm\Service\Routing\RoutingDecisionService}
  *   call the runtime makes (ADR-142);
  * - the approval requirement — {@see ToolApprovalRule}, the predicate the loop
- *   itself scans with (ADR-084/134).
+ *   itself scans with (ADR-084/134);
+ * - configuration access — {@see ConfigurationResolver::actorMayUse()}, the
+ *   non-throwing half of the rule `getActiveByIdentifierForActor()` enforces
+ *   (ADR-070, ADR-167).
  *
  * **It lives in the tool module, not in `Service\Governance`.** Core may not
  * import the tool module (ADR-090, enforced by `ModuleSeamTest`), and the thing
@@ -76,6 +80,7 @@ final readonly class GovernanceSimulator
         private ModelSelectionServiceInterface $modelSelectionService,
         private ToolRegistry $toolRegistry,
         private ActingBackendUserResolverInterface $actingBackendUserResolver,
+        private ConfigurationResolver $configurationResolver,
     ) {}
 
     /**
@@ -98,8 +103,36 @@ final readonly class GovernanceSimulator
             $this->inputContextGate->decide($configuration),
             $this->modelSelectionService->explainRouting($configuration, self::OPERATION, null),
             ToolApprovalRule::requiresApproval($this->toolRegistry->get($toolName)),
+            $this->configurationResolver->actorMayUse($configuration, $this->actorContext($user)),
             $actor,
         );
+    }
+
+    /**
+     * The actor the configuration-access rule is asked with.
+     *
+     * Built from the RESOLVED backend user, never from the uid alone.
+     * `AiActorContext::backendUser($actorUid)` above carries the defaults
+     * `isAdmin=false, backendGroupIds=[]`, which is correct as an argument to
+     * {@see ActingBackendUserResolverInterface::resolve()} — that call answers
+     * with the real record — and would be a lie here: every restricted
+     * configuration would read "Refused" for every actor, administrators
+     * included. {@see ToolExecutionContext::fromBackendUser()} is the one place
+     * a live user is turned into a context, so the uid/admin/group extraction
+     * is not written a second time.
+     *
+     * No user — a uid that no longer resolves, or no ambient operator — yields
+     * the anonymous actor, which is a member of no group and holds no scope. A
+     * restricted configuration is therefore refused for it, matching how the
+     * tool gate treats the same case.
+     */
+    private function actorContext(?BackendUserAuthentication $user): AiActorContext
+    {
+        if (!$user instanceof BackendUserAuthentication) {
+            return AiActorContext::anonymous();
+        }
+
+        return ToolExecutionContext::fromBackendUser($user)->actor;
     }
 
     /**

--- a/Documentation/Administration/Governance.rst
+++ b/Documentation/Administration/Governance.rst
@@ -318,25 +318,25 @@ Would this be allowed?
 ======================
 
 Pick a configuration, a tool and — optionally — a backend user, then press
-:guilabel:`Simulate`. The tab runs that call past the four gates listed below
+:guilabel:`Simulate`. The tab runs that call past the five gates listed below
 and reports one verdict plus each gate's own answer
-(:ref:`ADR-157 <adr-157>`).
+(:ref:`ADR-157 <adr-157>`, :ref:`ADR-167 <adr-167>`).
 
 The verdict is one of three:
 
 ``Allowed``
-   All four gates permit the call and it would run unattended.
+   All five gates permit the call and it would run unattended.
 
 ``Allowed, after a human approves``
-   All four gates permit the call, and the tool is approval-bound
+   All five gates permit the call, and the tool is approval-bound
    (:ref:`ADR-134 <adr-134>`): the run suspends and waits for a decision
    before it executes. Folding this into ``Allowed`` would hide the axis at
    exactly the moment it decides, so it is its own outcome.
 
 ``Blocked``
-   At least one of the four refuses. The table says which.
+   At least one of the five refuses. The table says which.
 
-Four gates are asked, each through the service the runtime itself calls:
+Five gates are asked, each through the service the runtime itself calls:
 
 .. list-table::
    :header-rows: 1
@@ -344,6 +344,10 @@ Four gates are asked, each through the service the runtime itself calls:
    * - Gate
      - What it decides
      - Depends on the actor?
+   * - Configuration access (:ref:`ADR-070 <adr-070>`)
+     - whether this backend user may use this configuration at all, given the
+       backend groups it is restricted to
+     - **Yes** — through the user's group membership
    * - Tool gate (:ref:`ADR-094 <adr-094>`)
      - registered, enabled, permitted, within the configuration's tool groups,
        within the provider trust zone's data-class ceiling
@@ -359,27 +363,29 @@ Four gates are asked, each through the service the runtime itself calls:
      - whether the tool is bound to an operator decision
      - No
 
-**Only one axis is actor-scoped, and the table says so.** Routing reads the
-model catalogue with enable-fields ignored and no user context, the
-input-context gate compares a configuration against a trust zone, and the
-approval requirement is a property of the tool's own declaration. A picker
-that implied four per-user answers where there is one would be worse than no
+**Two axes are actor-scoped, and the table says so.** Routing reads the model
+catalogue with enable-fields ignored and no user context, the input-context
+gate compares a configuration against a trust zone, and the approval
+requirement is a property of the tool's own declaration. The two that read the
+user are the tool gate, through the tool's ``requiresAdmin()``, and
+configuration access, through the backend groups the record carries. A picker
+that implied five per-user answers where there are two would be worse than no
 picker.
 
-**Three things that can stop a real call are not asked here**, so ``Allowed``
-does not promise them.
+The configuration selector lists every active configuration and applies no
+membership filter, so a group-restricted configuration paired with a
+non-member is a pairing the picker makes easy to produce. The tab asks
+``ConfigurationResolver`` the same question the runtime asks it, so that
+pairing reads ``Blocked`` here and names the restriction as the reason
+(:ref:`ADR-167 <adr-167>`).
 
-Configuration access (:ref:`ADR-070 <adr-070>`) is the one the picker makes
-easy to miss. ``ConfigurationResolver`` refuses a configuration whose backend
-groups the acting user is not a member of. The configuration selector lists
-every active configuration and applies no such filter. So a group-restricted
-configuration paired with a non-member reads ``Allowed`` on this tab and is
-refused at runtime. It is the second axis that reads the user's groups, and it
-is the one the tab does not ask.
-
-The other two are the budget check and the guardrail pipeline. Both decide on
-the call itself — the remaining spend, the text of the prompt — and a picker
-supplies neither.
+**Two things that can stop a real call are not asked here**, so ``Allowed``
+does not promise them: the budget check and the guardrail pipeline. Both
+decide on the call itself — the remaining spend, the text of the prompt — and
+a picker supplies neither. The budget check has a second reason, stated in
+:ref:`ADR-167 <adr-167>`: it reports usage and limit numbers only when it
+refuses, so "close to the limit" and "no data" cannot be told apart from
+"plenty left", and a row saying otherwise would be a measurement nobody took.
 
 **The actor picker is not impersonation.** The selected backend user is
 resolved read-only through the same seam a queue worker uses to authorise for

--- a/Documentation/Adr/Adr157TheSimulationCoversTheRunAndAnswersForAnActor.rst
+++ b/Documentation/Adr/Adr157TheSimulationCoversTheRunAndAnswersForAnActor.rst
@@ -4,10 +4,13 @@
 ADR-157: The simulation covers the run, and answers for an actor
 =========================================================================
 
-:Status: Accepted
+:Status: Accepted (its "Revisit when" clause fired — see
+         :ref:`ADR-167 <adr-167>`, which makes configuration access a fifth,
+         actor-scoped axis)
 :Date: 2026-08-11
 :Amends: :ref:`ADR-145 <adr-145>` (the simulator gains the remaining gate, an
          actor, and an audit decision)
+:Amended: 2026-08-13 by :ref:`ADR-167 <adr-167>`
 :Authors: Netresearch DTT GmbH
 
 Context
@@ -176,6 +179,10 @@ therefore reads ``Allowed`` here and is refused at runtime. Budget and
 guardrails are outside the four as well, but neither is a pairing the picker
 can produce. The docs page states the limitation next to the picker.
 
+  **Closed by** :ref:`ADR-167 <adr-167>` (2026-08-13): configuration access is
+  a fifth axis, asked through the same resolver, and the scope column now
+  carries two actor-scoped rows. Budget and guardrails remain outside.
+
 ✕ Simulations leave no trace. See :ref:`the audit decision <adr-157-audit>`.
 
 ✕ The picker cannot answer for a usergroup, a service account, or a frontend
@@ -188,3 +195,7 @@ An axis becomes actor-scoped that is not today — a per-user model catalogue, o
 a configuration-access check folded into the verdict — or a requirement appears
 for a record of who simulated what. The first widens the scope column; the
 second is a new log, not a change to the governance stream.
+
+The configuration-access half fired on 2026-08-13 and is
+:ref:`ADR-167 <adr-167>`. It widened the scope column exactly as stated: a
+second row now answers ``Yes``.

--- a/Documentation/Adr/Adr167ConfigurationAccessIsASimulatedAxis.rst
+++ b/Documentation/Adr/Adr167ConfigurationAccessIsASimulatedAxis.rst
@@ -1,0 +1,127 @@
+.. _adr-167:
+
+============================================================
+ADR-167: Configuration access is a simulated axis
+============================================================
+
+:Status: Accepted
+:Date: 2026-08-13
+:Amends: :ref:`ADR-157 <adr-157>` (its "Revisit when" clause fired: a fifth,
+    actor-scoped axis)
+:Authors: Netresearch DTT GmbH
+
+Context
+=======
+
+:ref:`ADR-157 <adr-157>` built the Governance tab's simulator on four axes and
+named, as a consequence rather than a defect, the one it did not ask:
+configuration access. :php:`ConfigurationResolver` refuses a configuration whose
+backend groups the acting user is not a member of; the tab's configuration
+picker lists every active configuration and filters nothing. A group-restricted
+configuration paired with a non-member therefore read :guilabel:`Allowed` on a
+page whose entire purpose is that an operator does not have to guess, and was
+refused at runtime.
+
+That is a false positive, and it is the worst kind the page can produce: the
+picker makes the pairing easy to build, and the readout answered with the one
+verdict an operator would act on without checking.
+
+The rule was reachable only through
+:php:`ConfigurationResolver::getActiveByIdentifierForActor()`, which re-queries
+by identifier and throws — and throws one of three types, so "refused" would
+have had to be told apart from "not found" and "inactive" by catching. The
+predicate itself was private.
+
+Decision
+========
+
+**Configuration access is the fifth axis, and it folds into the verdict.** A
+configuration the actor may not use makes the verdict ``BLOCK``, like every
+other refusing axis. No fourth verdict value: the fold's meaning is unchanged —
+any refusal blocks — and a separate outcome would have implied a difference in
+what the operator has to do, when the row already names it.
+
+The row carries ``Yes`` in the scope column, which is the widening
+:ref:`ADR-157 <adr-157>` predicted. Two of five axes now read the actor: the
+tool gate through ``requiresAdmin()``, and this one through the user's backend
+groups.
+
+**The rule is promoted, not copied.**
+:php:`ConfigurationResolver::actorMayUse()` becomes public and stays the only
+implementation; :php:`getActiveByIdentifierForActor()` calls it and turns
+``false`` into its :php:`AccessDeniedException` exactly as before. Its eight
+existing branch tests are the characterization and are unchanged. The rule
+:ref:`ADR-070 <adr-070>` states is untouched — what changes is that it can now
+be asked as well as enforced.
+
+The simulator takes the entity it already holds straight to the predicate rather
+than routing through the throwing entry point. Re-querying by identifier to
+answer a question about an object in hand, then sorting three exception types to
+learn which of them meant "refused", is machinery in service of not adding a
+method. And a second group comparison written in the simulator would be the
+fourth copy of this rule — the copy :php:`EditorActionCatalogue` already warns
+about in the comment above its own call.
+
+**The actor is built from the RESOLVED backend user.** This is the trap the
+change had to avoid, and it is not hypothetical: the simulator already
+constructs :php:`AiActorContext::backendUser($actorUid)` one line earlier, as
+the *argument* to :php:`ActingBackendUserResolverInterface::resolve()`. That
+context carries the constructor defaults ``isAdmin=false`` and
+``backendGroupIds=[]``, which is correct there — the resolver answers with the
+real record — and would be a lie if handed to an access rule. Every restricted
+configuration would read :guilabel:`Refused` for every actor, administrators
+included: a false negative in place of a false positive, and one that a test
+suite asking only "is the non-member refused" would not notice.
+
+:php:`ToolExecutionContext::fromBackendUser()` is the existing seam that turns a
+live :php:`BackendUserAuthentication` into a context — uid, admin flag, group
+uids — so the extraction is not written a second time here either.
+
+**An unresolved actor is refused a restricted configuration.** A uid that no
+longer resolves yields :php:`AiActorContext::anonymous()`, which belongs to no
+group and holds no scope, so the rule refuses a restricted configuration and
+permits an unrestricted one. That is the same fail-closed treatment the other
+axes give the case: the gates are asked with no user, never with the operator's
+rights.
+
+.. _adr-167-not:
+
+What this does not do
+=====================
+
+**It does not add a budget row, and that is a decision rather than an
+omission.** Budget is the remaining pairing an operator might expect here, and
+it cannot be reported honestly today. :php:`BudgetCheckResult::allowed()` carries
+``currentUsage`` and ``limit`` as zero: the numbers exist only on the denial
+path. A row would therefore be unable to distinguish "well under the limit",
+"one call away from it" and "nothing measured", and printing one answer for
+three states is a fabricated measurement on a page whose value is that it does
+not guess. Whether the budget service should expose a headroom readout is a
+separate decision, taken separately.
+
+**It does not filter the configuration picker.** The picker still lists every
+active configuration. Filtering it would answer the question by hiding it, and
+an operator asking "why can this editor not use this configuration" needs the
+pairing to be selectable in order to be told.
+
+**It does not touch the guardrail pipeline**, which decides on the text of a
+prompt the picker does not supply, and it changes nothing about the audit:
+:ref:`ADR-157's audit decision <adr-157-audit>` stands, and a simulation still
+writes nothing.
+
+Consequences
+============
+
+A group-restricted configuration paired with a non-member now reads
+``Blocked`` and names the restriction as the reason. The page no longer reports
+an ``Allowed`` that the runtime refuses.
+
+The scope column is wider: an operator reading it sees that two answers change
+with the picked user, not one. A readout that answered identically for every
+actor on four of five axes without saying so would imply a dimension that is not
+there.
+
+:php:`ConfigurationResolver::actorMayUse()` is public. The class is not
+``@api``, so the frozen surface in ``Tests/Unit/Api/api-surface.txt`` is
+unchanged; the method is nevertheless a supported way to ask the rule without
+triggering it, which is what a readout needs.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -511,3 +511,4 @@ Tools
    Adr164ForcedSourcesBindAgainstTheCeiling
    Adr165ResumeReGatesTheForcedSet
    Adr166DeactivationDoesNotLowerACeiling
+   Adr167ConfigurationAccessIsASimulatedAxis

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -409,8 +409,8 @@
                 <target>Wäre das erlaubt?</target>
             </trans-unit>
             <trans-unit id="governance.simulator.lead">
-                <source>Ask the gates the runtime asks. This runs the real tool policy, the real input-context gate, the real routing decision and the real approval predicate, and folds their answers into one verdict. Pick a backend user to answer for someone other than yourself: the user is resolved read-only, nothing is executed as them, and nothing is written.</source>
-                <target>Frag die Gates, die die Runtime fragt. Hier laufen die echte Tool-Policy, das echte Eingabekontext-Gate, die echte Routing-Entscheidung und das echte Freigabe-Prädikat, und ihre Antworten werden zu einem Urteil zusammengefasst. Wähle einen Backend-Benutzer, um für jemand anderen als dich selbst zu antworten: der Benutzer wird nur lesend aufgelöst, es wird nichts in seinem Namen ausgeführt und nichts geschrieben.</target>
+                <source>Ask the gates the runtime asks. This runs the real configuration-access rule, the real tool policy, the real input-context gate, the real routing decision and the real approval predicate, and folds their answers into one verdict. Pick a backend user to answer for someone other than yourself: the user is resolved read-only, nothing is executed as them, and nothing is written.</source>
+                <target>Frag die Gates, die die Runtime fragt. Hier laufen die echte Konfigurationszugriffs-Regel, die echte Tool-Policy, das echte Eingabekontext-Gate, die echte Routing-Entscheidung und das echte Freigabe-Prädikat, und ihre Antworten werden zu einem Urteil zusammengefasst. Wähle einen Backend-Benutzer, um für jemand anderen als dich selbst zu antworten: der Benutzer wird nur lesend aufgelöst, es wird nichts in seinem Namen ausgeführt und nichts geschrieben.</target>
             </trans-unit>
             <trans-unit id="governance.simulator.configuration">
                 <source>Configuration</source>
@@ -508,6 +508,10 @@
                 <source>Depends on the actor?</source>
                 <target>Hängt vom Handelnden ab?</target>
             </trans-unit>
+            <trans-unit id="governance.simulator.axis.configuration">
+                <source>Configuration access</source>
+                <target>Konfigurationszugriff</target>
+            </trans-unit>
             <trans-unit id="governance.simulator.axis.tool">
                 <source>Tool gate</source>
                 <target>Tool-Gate</target>
@@ -523,6 +527,18 @@
             <trans-unit id="governance.simulator.axis.approval">
                 <source>Human approval</source>
                 <target>Menschliche Freigabe</target>
+            </trans-unit>
+            <trans-unit id="governance.simulator.configuration.allowedLead">
+                <source>This user may use this configuration.</source>
+                <target>Dieser Benutzer darf diese Konfiguration verwenden.</target>
+            </trans-unit>
+            <trans-unit id="governance.simulator.configuration.deniedLead">
+                <source>This configuration is restricted to backend groups this user is not a member of, so the run is refused before any gate is reached.</source>
+                <target>Diese Konfiguration ist auf Backend-Gruppen beschränkt, denen dieser Benutzer nicht angehört. Der Lauf wird abgelehnt, bevor ein Gate erreicht wird.</target>
+            </trans-unit>
+            <trans-unit id="governance.simulator.scope.configuration">
+                <source>Yes, it reads which backend groups the user is in.</source>
+                <target>Ja, sie liest die Backend-Gruppen des handelnden Benutzers.</target>
             </trans-unit>
             <trans-unit id="governance.simulator.scope.actor">
                 <source>Yes, through requiresAdmin().</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -311,7 +311,7 @@
                 <source>Would this be allowed?</source>
             </trans-unit>
             <trans-unit id="governance.simulator.lead">
-                <source>Ask the gates the runtime asks. This runs the real tool policy, the real input-context gate, the real routing decision and the real approval predicate, and folds their answers into one verdict. Pick a backend user to answer for someone other than yourself: the user is resolved read-only, nothing is executed as them, and nothing is written.</source>
+                <source>Ask the gates the runtime asks. This runs the real configuration-access rule, the real tool policy, the real input-context gate, the real routing decision and the real approval predicate, and folds their answers into one verdict. Pick a backend user to answer for someone other than yourself: the user is resolved read-only, nothing is executed as them, and nothing is written.</source>
             </trans-unit>
             <trans-unit id="governance.simulator.configuration">
                 <source>Configuration</source>
@@ -385,6 +385,9 @@
             <trans-unit id="governance.simulator.column.scope">
                 <source>Depends on the actor?</source>
             </trans-unit>
+            <trans-unit id="governance.simulator.axis.configuration">
+                <source>Configuration access</source>
+            </trans-unit>
             <trans-unit id="governance.simulator.axis.tool">
                 <source>Tool gate</source>
             </trans-unit>
@@ -396,6 +399,15 @@
             </trans-unit>
             <trans-unit id="governance.simulator.axis.approval">
                 <source>Human approval</source>
+            </trans-unit>
+            <trans-unit id="governance.simulator.configuration.allowedLead">
+                <source>This user may use this configuration.</source>
+            </trans-unit>
+            <trans-unit id="governance.simulator.configuration.deniedLead">
+                <source>This configuration is restricted to backend groups this user is not a member of, so the run is refused before any gate is reached.</source>
+            </trans-unit>
+            <trans-unit id="governance.simulator.scope.configuration">
+                <source>Yes, it reads which backend groups the user is in.</source>
             </trans-unit>
             <trans-unit id="governance.simulator.scope.actor">
                 <source>Yes, through requiresAdmin().</source>

--- a/Resources/Private/Templates/Backend/Governance.html
+++ b/Resources/Private/Templates/Backend/Governance.html
@@ -78,7 +78,7 @@
 
     <h2 class="mt-4"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:governance.simulator.heading" default="Would this be allowed?" /></h2>
     <p class="text-body-secondary">
-        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:governance.simulator.lead" default="Ask the gates the runtime asks. This runs the real tool policy, the real input-context gate, the real routing decision and the real approval predicate, and folds their answers into one verdict. Pick a backend user to answer for someone other than yourself: the user is resolved read-only, nothing is executed as them, and nothing is written." />
+        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:governance.simulator.lead" default="Ask the gates the runtime asks. This runs the real configuration-access rule, the real tool policy, the real input-context gate, the real routing decision and the real approval predicate, and folds their answers into one verdict. Pick a backend user to answer for someone other than yourself: the user is resolved read-only, nothing is executed as them, and nothing is written." />
     </p>
 
     <f:form action="governance" method="get" class="row g-2 align-items-end mb-3">
@@ -182,6 +182,22 @@
                     </tr>
                 </thead>
                 <tbody>
+                    <tr>
+                        <td><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:governance.simulator.axis.configuration" default="Configuration access" /></td>
+                        <td>
+                            <f:if condition="{simulation.configurationAllowed}">
+                                <f:then>
+                                    <span class="text-success"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:governance.simulator.allowed" default="Allowed" /></span>
+                                    <div class="small"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:governance.simulator.configuration.allowedLead" default="This user may use this configuration." /></div>
+                                </f:then>
+                                <f:else>
+                                    <span class="text-danger"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:governance.simulator.denied" default="Refused" /></span>
+                                    <div class="small"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:governance.simulator.configuration.deniedLead" default="This configuration is restricted to backend groups this user is not a member of, so the run is refused before any gate is reached." /></div>
+                                </f:else>
+                            </f:if>
+                        </td>
+                        <td class="text-body-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:governance.simulator.scope.configuration" default="Yes, it reads which backend groups the user is in." /></td>
+                    </tr>
                     <tr>
                         <td><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:governance.simulator.axis.tool" default="Tool gate" /></td>
                         <td>

--- a/Tests/Functional/Controller/Backend/GovernanceTabRenderTest.php
+++ b/Tests/Functional/Controller/Backend/GovernanceTabRenderTest.php
@@ -149,18 +149,33 @@ final class GovernanceTabRenderTest extends AbstractFunctionalTestCase
     public function everyAxisIsShownWithItsOwnAnswerAndItsScope(): void
     {
         // The verdict alone cannot say which gate decided, and the fix differs
-        // per gate. The scope column is the other half: three of the four axes
-        // answer the same for every actor, and a simulator that implied
-        // otherwise would be worse than one that says so.
+        // per gate. The scope column is the other half: three of the five axes
+        // answer the same for every actor and two do not, and a simulator that
+        // implied otherwise would be worse than one that says so.
         $body = $this->render(null, [], $this->simulation());
 
+        self::assertStringContainsString('Configuration access', $body);
         self::assertStringContainsString('Tool gate', $body);
         self::assertStringContainsString('Input-context gate', $body);
         self::assertStringContainsString('Routing', $body);
         self::assertStringContainsString('Human approval', $body);
         self::assertStringContainsString('Yes, through requiresAdmin().', $body);
+        self::assertStringContainsString('Yes, it reads which backend groups the user is in.', $body);
         self::assertStringContainsString('enable-fields ignored and no user context', $body);
         self::assertStringContainsString('constrains nothing', $body, 'the undeclared input context says so in words');
+    }
+
+    #[Test]
+    public function aConfigurationTheActorMayNotUseIsNamedAsTheAxisThatBlocked(): void
+    {
+        // ADR-167: the pairing that used to read "Allowed" here and was refused
+        // at runtime. It has to name the restriction, because the fix is a
+        // group membership rather than anything on the four gates below it.
+        $body = $this->render(null, [], $this->simulation(configurationAllowed: false));
+
+        self::assertStringContainsString('Blocked', $body);
+        self::assertStringContainsString('Configuration access', $body);
+        self::assertStringContainsString('restricted to backend groups this user is not a member of', $body);
     }
 
     #[Test]
@@ -643,6 +658,7 @@ final class GovernanceTabRenderTest extends AbstractFunctionalTestCase
         ?RoutingReadout $routing = null,
         bool $approvalRequired = false,
         ?SimulationActor $actor = null,
+        bool $configurationAllowed = true,
     ): GovernanceSimulation {
         $model = new Model();
         $model->setModelId('gpt-4o');
@@ -659,6 +675,7 @@ final class GovernanceTabRenderTest extends AbstractFunctionalTestCase
                 false,
             ),
             $approvalRequired,
+            $configurationAllowed,
             $actor ?? new SimulationActor(3, 'editor', false),
         );
     }

--- a/Tests/Unit/Domain/ValueObject/GovernanceSimulationTest.php
+++ b/Tests/Unit/Domain/ValueObject/GovernanceSimulationTest.php
@@ -27,7 +27,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
- * The fold from four axes to one verdict (ADR-157).
+ * The fold from five axes to one verdict (ADR-157, ADR-167).
  *
  * Each axis gets its own refusal here, because the whole point of the record is
  * that ANY of them decides — a fold that only consulted the tool gate would
@@ -130,11 +130,30 @@ final class GovernanceSimulationTest extends TestCase
         self::assertSame(SimulationVerdict::BLOCK, $simulation->getVerdict());
     }
 
+    #[Test]
+    public function configurationAccessRefusing(): void
+    {
+        // ADR-167: the actor may not use the configuration at all, so no gate
+        // downstream of it gets a say.
+        $simulation = $this->simulation(configurationAllowed: false);
+
+        self::assertSame(SimulationVerdict::BLOCK, $simulation->getVerdict());
+    }
+
+    #[Test]
+    public function configurationAccessRefusingIsNotRescuedByAnApprovalBoundTool(): void
+    {
+        $simulation = $this->simulation(approvalRequired: true, configurationAllowed: false);
+
+        self::assertSame(SimulationVerdict::BLOCK, $simulation->getVerdict());
+    }
+
     private function simulation(
         ?ToolPolicyDecision $tool = null,
         ?InputContextDecision $context = null,
         ?RoutingReadout $routing = null,
         bool $approvalRequired = false,
+        bool $configurationAllowed = true,
     ): GovernanceSimulation {
         $model = new Model();
         $model->setModelId('gpt-4o');
@@ -151,6 +170,7 @@ final class GovernanceSimulationTest extends TestCase
                 false,
             ),
             $approvalRequired,
+            $configurationAllowed,
             new SimulationActor(7, 'editor', false),
         );
     }

--- a/Tests/Unit/Service/ConfigurationResolverTest.php
+++ b/Tests/Unit/Service/ConfigurationResolverTest.php
@@ -388,4 +388,50 @@ class ConfigurationResolverTest extends AbstractUnitTestCase
         $this->resolverFor($configuration)
             ->getActiveByIdentifierForActor('restricted', AiActorContext::backendUser(3, backendGroupIds: [2]));
     }
+
+    // ---- actorMayUse(): the same decision, without the throw (ADR-167) ----
+    //
+    // The eight cases above are the characterization of the throwing entry
+    // point and are unchanged by the extraction. These pin that the predicate
+    // the Governance tab asks answers identically — one implementation, two
+    // callers — over an entity the caller already holds, with no identifier
+    // lookup and no exception to sort by type.
+
+    #[Test]
+    public function theAccessPredicateRefusesANonMemberWithoutThrowing(): void
+    {
+        self::assertFalse((new ConfigurationResolver())->actorMayUse(
+            $this->restrictedConfiguration([7]),
+            AiActorContext::backendUser(3, backendGroupIds: [2, 5]),
+        ));
+    }
+
+    #[Test]
+    public function theAccessPredicateAllowsAMemberAnAdminAndAnUnrestrictedConfiguration(): void
+    {
+        $subject = new ConfigurationResolver();
+
+        self::assertTrue($subject->actorMayUse(
+            $this->restrictedConfiguration([7, 9]),
+            AiActorContext::backendUser(3, backendGroupIds: [2, 9]),
+        ));
+        self::assertTrue($subject->actorMayUse(
+            $this->restrictedConfiguration([7]),
+            AiActorContext::backendUser(3, isAdmin: true),
+        ));
+        self::assertTrue($subject->actorMayUse(
+            $this->restrictedConfiguration([]),
+            AiActorContext::anonymous(),
+        ));
+    }
+
+    #[Test]
+    public function theAccessPredicateRefusesAnAnonymousActorARestrictedConfiguration(): void
+    {
+        // The fail-closed answer the simulator's unresolved-actor case relies on.
+        self::assertFalse((new ConfigurationResolver())->actorMayUse(
+            $this->restrictedConfiguration([7]),
+            AiActorContext::anonymous(),
+        ));
+    }
 }

--- a/Tests/Unit/Service/Tool/GovernanceSimulatorTest.php
+++ b/Tests/Unit/Service/Tool/GovernanceSimulatorTest.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Domain\Enum\SimulationVerdict;
 use Netresearch\NrLlm\Domain\Enum\ToolDataClass;
 use Netresearch\NrLlm\Domain\Enum\ToolEffect;
 use Netresearch\NrLlm\Domain\Enum\TrustZone;
+use Netresearch\NrLlm\Domain\Model\BackendUserGroup;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\Provider;
@@ -25,6 +26,7 @@ use Netresearch\NrLlm\Domain\ValueObject\ToolPolicyDecision;
 use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Service\ConfigurationResolver;
 use Netresearch\NrLlm\Service\Context\InputContextClassifier;
 use Netresearch\NrLlm\Service\Context\InputContextTrustGate;
 use Netresearch\NrLlm\Service\Governance\DataClassEnforcementResolver;
@@ -44,9 +46,10 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 
 /**
- * The wiring ADR-157 rests on: WHICH user the actor-scoped axis is asked with.
+ * The wiring ADR-157 rests on: WHICH user the actor-scoped axes are asked with.
  *
  * The readout's own tests render a simulation that was handed to them
  * ready-made, so they prove the template. These prove the resolution — that a
@@ -54,6 +57,13 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
  * operator, and that a uid resolving to nothing fails closed instead of
  * quietly answering with the operator's rights, which would report privilege
  * the account does not have.
+ *
+ * The configuration-access axis (ADR-167) is asked with an actor built from the
+ * SAME resolved record, and is tested from both sides: a non-member is refused,
+ * and a member and an administrator are not. The admin case is the one that
+ * catches the mirror-image defect — feeding the rule the uid-only actor the
+ * resolver is called with would refuse every restricted configuration for
+ * everyone.
  */
 #[CoversClass(GovernanceSimulator::class)]
 final class GovernanceSimulatorTest extends TestCase
@@ -156,6 +166,75 @@ final class GovernanceSimulatorTest extends TestCase
         self::assertFalse($simulation->approvalRequired);
     }
 
+    #[Test]
+    public function aGroupRestrictedConfigurationIsRefusedForANonMemberActor(): void
+    {
+        // The defect ADR-167 closes: the pairing the picker makes easy to
+        // produce read "Allowed" here and was refused by ConfigurationResolver
+        // at runtime.
+        $editor = $this->user(7, 'editor', admin: false, groups: [4]);
+
+        $simulation = $this->simulator($this->recordingPolicy(), $this->resolver($editor))
+            ->simulate('get_page_tree', $this->configuration(restrictedTo: 5), 7, $this->user(1, 'root', admin: true));
+
+        self::assertFalse($simulation->configurationAllowed);
+        self::assertSame(SimulationVerdict::BLOCK, $simulation->getVerdict());
+    }
+
+    #[Test]
+    public function aGroupRestrictedConfigurationIsAllowedForAMemberActor(): void
+    {
+        $editor = $this->user(7, 'editor', admin: false, groups: [5]);
+
+        $simulation = $this->simulator($this->recordingPolicy(), $this->resolver($editor))
+            ->simulate('get_page_tree', $this->configuration(restrictedTo: 5), 7, $this->user(1, 'root', admin: true));
+
+        self::assertTrue($simulation->configurationAllowed);
+        self::assertSame(SimulationVerdict::ALLOW, $simulation->getVerdict());
+    }
+
+    #[Test]
+    public function aGroupRestrictedConfigurationIsAllowedForAnAdministrator(): void
+    {
+        // The trap on the other side of the fix: the actor the resolver is
+        // ASKED with carries isAdmin=false and no groups by construction. Fed
+        // to the access rule, it would refuse every restricted configuration
+        // for everyone — including an administrator, who is in no group and
+        // may use all of them.
+        $admin = $this->user(9, 'root', admin: true);
+
+        $simulation = $this->simulator($this->recordingPolicy(), $this->resolver($admin))
+            ->simulate('get_page_tree', $this->configuration(restrictedTo: 5), 9, null);
+
+        self::assertTrue($simulation->configurationAllowed);
+        self::assertSame(SimulationVerdict::ALLOW, $simulation->getVerdict());
+    }
+
+    #[Test]
+    public function anUnrestrictedConfigurationIsAllowedForEveryone(): void
+    {
+        $editor = $this->user(7, 'editor', admin: false, groups: [4]);
+
+        $simulation = $this->simulator($this->recordingPolicy(), $this->resolver($editor))
+            ->simulate('get_page_tree', $this->configuration(), 7, $this->user(1, 'root', admin: true));
+
+        self::assertTrue($simulation->configurationAllowed);
+        self::assertSame(SimulationVerdict::ALLOW, $simulation->getVerdict());
+    }
+
+    #[Test]
+    public function anUnresolvedActorIsRefusedARestrictedConfiguration(): void
+    {
+        // Same fail-closed rule the other axes apply to a uid that resolves to
+        // nothing: no user, no group membership, no access.
+        $simulation = $this->simulator($this->recordingPolicy(), $this->resolver(null))
+            ->simulate('get_page_tree', $this->configuration(restrictedTo: 5), 42, $this->user(1, 'root', admin: true));
+
+        self::assertFalse($simulation->actor->resolved);
+        self::assertFalse($simulation->configurationAllowed);
+        self::assertSame(SimulationVerdict::BLOCK, $simulation->getVerdict());
+    }
+
     private function simulator(
         RecordingToolCallPolicy $policy,
         RecordingActingBackendUserResolver $resolver,
@@ -173,6 +252,9 @@ final class GovernanceSimulatorTest extends TestCase
             $modelSelection,
             new ToolRegistry([$this->tool($effect)]),
             $resolver,
+            // The REAL rule, over the entity the simulation already holds. No
+            // repository: actorMayUse() reads the passed configuration.
+            new ConfigurationResolver(),
         );
     }
 
@@ -260,15 +342,20 @@ final class GovernanceSimulatorTest extends TestCase
         };
     }
 
-    private function user(int $uid, string $username, bool $admin): BackendUserAuthentication
+    /**
+     * @param list<int> $groups the backend group uids the account belongs to,
+     *                          as the live record carries them
+     */
+    private function user(int $uid, string $username, bool $admin, array $groups = []): BackendUserAuthentication
     {
-        $user       = new BackendUserAuthentication();
-        $user->user = ['uid' => $uid, 'username' => $username, 'admin' => $admin ? 1 : 0];
+        $user                 = new BackendUserAuthentication();
+        $user->user           = ['uid' => $uid, 'username' => $username, 'admin' => $admin ? 1 : 0];
+        $user->userGroupsUID  = $groups;
 
         return $user;
     }
 
-    private function configuration(): LlmConfiguration
+    private function configuration(?int $restrictedTo = null): LlmConfiguration
     {
         $provider = new Provider();
         $provider->setIdentifier('some-provider');
@@ -281,6 +368,16 @@ final class GovernanceSimulatorTest extends TestCase
         $configuration = new LlmConfiguration();
         $configuration->setIdentifier('simulated');
         $configuration->setLlmModel($model);
+
+        if ($restrictedTo !== null) {
+            $group = new BackendUserGroup();
+            $group->_setProperty('uid', $restrictedTo);
+
+            /** @var ObjectStorage<BackendUserGroup> $groups */
+            $groups = new ObjectStorage();
+            $groups->attach($group);
+            $configuration->setBeGroups($groups);
+        }
 
         return $configuration;
     }


### PR DESCRIPTION
## Description

The run simulator on the Governance tab answered **ALLOW** for a configuration the picked actor cannot use. A group-restricted configuration paired with a non-member read "Allowed" in the readout and was refused at runtime — a false positive on a page whose stated purpose (ADR-157) is that an operator does not have to guess.

Both ADR-157 and the admin documentation already recorded this as a *wrong answer* rather than a missing feature, and ADR-157's "Revisit when" clause pre-authorised the fix and named its consequence: a second axis becomes actor-scoped.

`ConfigurationResolver::actorMayUse()` becomes public, so a readout can **ask** the rule without triggering it. The throwing entry point now calls the same method, so there is exactly one implementation — not the fourth copy of a group comparison that `EditorActionCatalogue` already warns about ("a fourth copy of it is the copy that ages"). Routing the simulator through `getActiveByIdentifierForActor()` instead would have meant re-querying by identifier for an entity the simulator already holds, and catching one of three exception types to tell "refused" from "not found".

**The trap this change had to avoid.** `GovernanceSimulator` builds `AiActorContext::backendUser($actorUid)` with defaults — `isAdmin=false`, no groups. That is correct where it stands, because it is only an argument to the resolver that answers with the real record. Feeding it into the access rule would refuse every restricted configuration for every actor, administrators included: a false negative replacing a false positive, with the obvious tests still passing. The actor now comes from the resolved `BackendUserAuthentication` through `ToolExecutionContext::fromBackendUser()`, the one place a live user is already turned into a context.

An unresolved actor — a uid that no longer resolves, or no ambient operator — yields the anonymous context, which is a member of no group, so it fails closed the way the tool gate does.

**Budget is deliberately not part of this.** `BudgetCheckResult` exposes usage and limit numbers only on the denial path, so "near limit" and "unknown" are indistinguishable from "available"; a four-state budget row would be a fabricated measurement. ADR-167 records that as a decision rather than an omission.

`GovernanceSimulator`, `GovernanceSimulation` and `ConfigurationResolver` are all off the `@api` surface — verified against `Tests/Unit/Api/api-surface.txt`, which the unit suite checks untouched — so there is no surface change. `SimulationVerdict` needed none either: a denied configuration folds to the existing `BLOCK`, and its `match` is over the three verdict cases, not over the axes.

The documentation was rewritten rather than patched. The whole "only one axis is actor-scoped" block in `Governance.rst` was false after this change — the heading, the paragraph, three "four gates" counts and the verdict list — not just the one sentence that named it.

## Related Issue

Closes #767

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Tests

**The guard was seen to fail, from both sides of the defect.**

Reverting the axis to a literal `true` — the unfixed simulator — fails `aGroupRestrictedConfigurationIsRefusedForANonMemberActor` and `anUnresolvedActorIsRefusedARestrictedConfiguration` with `Failed asserting that true is false`. That is the central regression test failing on the unfixed code.

Asking the axis with the uid-only actor instead — the trap above — fails `aGroupRestrictedConfigurationIsAllowedForAMemberActor` and `aGroupRestrictedConfigurationIsAllowedForAnAdministrator` with `Failed asserting that false is true`. So the member and admin tests genuinely catch the false-negative, rather than passing for the wrong reason.

Also covered: the verdict fold in `GovernanceSimulationTest`, the new row rendering in `GovernanceTabRenderTest`, and a characterization test that `getActiveByIdentifierForActor()` still throws exactly as before after the extraction.

## Gates

`cgl`, `phpstan` (level 10) and the full `unit` suite green on the final tree, re-run after the last edit.

**`rector -n` at the CI-pinned PHP 8.2 did not run** — `.Build` in this worktree is resolved at 8.4, so `platform_check.php` fatals before Rector starts. Reported as not run, not as green; CI is the first place it executes.

One observation worth recording, unrelated to this change: the unit suite's test **count** oscillates between runs (7085 vs 7078, no failures either way, `--list-tests` stable at 7085 across five runs). A data provider yields a different number of rows at suite-build time in some runs. Nothing here touches a data provider, but it means a count-based assertion would be flaky.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix works
- [x] I have updated the documentation accordingly
- [x] I have added a `CHANGELOG.md` entry under `## [Unreleased]`
- [x] I have added an ADR (ADR-167) and amended ADR-157
- [x] My changes generate no new warnings
