### PR TITLE
feat(usecase): let a pack declare the editor actions it is built for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **A use-case pack can declare the editor actions it is built for** (`#769`).
+  `UseCasePack::$recommendedEditorActions` names the editorial writes a pack was
+  designed for. The install plan reports, per declared action, whether this
+  installation has it, whether it is enabled, which record types it addresses,
+  and links to the Tools module and the Editor Action Center.
+
+  It is a declaration, not an execution contract: installing enables no action
+  and runs none, and no field connects a pack task to a tool. A pack task still
+  executes as a plain completion. See ADR-168 for why an apply path is
+  deliberately absent, and `Documentation/Administration/UseCasePacks.rst`.
+
+  The same screen now prints `recommendedToolGroups` with their live state
+  instead of raw, so a group no registered tool carries is marked *Not available
+  here* rather than looking like a real one. The constructor refuses blank and
+  duplicate entries in the NEW list only — `recommendedToolGroups` reaches the
+  frozen `@api` provider interface and keeps its contract, because every pack is
+  built inside `UseCasePackRegistry`'s constructor and a new throw there would
+  take down the backend of anyone shipping a pack with a repeated group. Unknown
+  identifiers are surfaced on the plan rather than refused, for the same reason:
+  both sets stay open for third-party packs.
+
+  The one shipped pack, Editorial Starter, declares no editor action — its tasks
+  are text transforms, and an editor action runs on the default configuration
+  rather than on the pack's.
+
 - **A refused unapproved write is now countable** (`#757`). The refusal added
   in 0.29.1 was visible only as an errored step in one run's timeline, so
   "did this ever fire" had no answer. It writes a `write_unapproved`

--- a/Classes/Controller/Backend/UseCasePackController.php
+++ b/Classes/Controller/Backend/UseCasePackController.php
@@ -39,10 +39,11 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
  *
  * - **Nothing is written before an operator confirms.** `show` computes a plan
  *   read-only; only the POSTed `install` writes, and it refuses a GET.
- * - **It recommends, it does not apply.** The governance profile and the tool
- *   groups are rendered with a link to the surface that owns them. Neither is
- *   set from here (ADR-145 for the profile, the Tools module's admin enable for
- *   the groups).
+ * - **It recommends, it does not apply.** The governance profile, the tool
+ *   groups and the editor actions are rendered with a link to the surface that
+ *   owns them. None of them is set from here (ADR-145 for the profile, the
+ *   Tools module's admin enable for the groups and the actions, ADR-168 for why
+ *   the editor-action list stays a declaration).
  * - **The technical wizard stays.** Every screen links to it, and a use case
  *   with no pack says so and links there instead of hiding itself.
  *
@@ -115,6 +116,11 @@ final class UseCasePackController extends ActionController
             'wizardUrl' => $this->wizardUrl(),
             'governanceUrl' => $this->routeUrl('nrllm_overview', 'Backend\\LlmModule', 'governance'),
             'toolsUrl' => $this->routeUrl('nrllm_tools', 'Backend\\Tool', 'list'),
+            // The Editor Action Center lives in the editor-facing module
+            // (ADR-158), not in the admin tree. Linked because the plan names
+            // editor actions and an operator wants to see them where an editor
+            // does; enabling one stays in the Tools module above.
+            'editorActionsUrl' => $this->routeUrl('nrllm_aitasks', 'Backend\\EditorAction', 'catalogue'),
             'tasksUrl' => $this->routeUrl('nrllm_tasks', 'Backend\\TaskList', 'list'),
             'snippetsUrl' => $this->routeUrl('nrllm_snippets', 'Backend\\PromptSnippet', 'list'),
             'configurationsUrl' => $this->routeUrl('nrllm_configurations', 'Backend\\Configuration', 'list'),

--- a/Classes/Service/Tool/PackToolReadiness.php
+++ b/Classes/Service/Tool/PackToolReadiness.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool;
+
+use Netresearch\NrLlm\Service\UseCase\PackEditorActionState;
+use Netresearch\NrLlm\Service\UseCase\PackToolGroupState;
+use Netresearch\NrLlm\Service\UseCase\PackToolReadinessInterface;
+
+/**
+ * The tool module's answer to what a use-case pack recommends (ADR-168).
+ *
+ * Everything here is read off {@see ToolAvailabilityServiceInterface}, which is
+ * already the one place that resolves "which tools are registered", "which
+ * declare an editor action" and "what is enabled after the group AND tool
+ * cascade". No second registry and no second enabled-check: the cascade is a
+ * five-part rule with copies already, and this would have been the next one.
+ *
+ * The per-viewer question — would THIS backend user be offered the action right
+ * now — is {@see EditorActionCatalogueInterface::groupsFor()} and is
+ * deliberately not asked here. It answers with an absence, and an absence cannot
+ * tell a typo from a disabled tool from a missing default configuration. The
+ * plan screen is an administrator's, and the three need to be distinguishable.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
+final readonly class PackToolReadiness implements PackToolReadinessInterface
+{
+    public function __construct(
+        private ToolAvailabilityServiceInterface $availability,
+    ) {}
+
+    public function editorActionStates(array $toolNames): array
+    {
+        if ($toolNames === []) {
+            return [];
+        }
+
+        $declarations = $this->availability->editorActions();
+
+        $states = [];
+        foreach ($this->availability->states() as $state) {
+            $states[$state['name']] = $state;
+        }
+
+        $result = [];
+        foreach ($toolNames as $toolName) {
+            $declaration = $declarations[$toolName] ?? null;
+            $state       = $states[$toolName] ?? null;
+
+            $result[] = new PackEditorActionState(
+                toolName: $toolName,
+                // A registered tool that declares NO editor action counts as
+                // undeclared here: the pack named it as an editor action, and
+                // as one it does not exist. A tool whose declaration throws is
+                // already absent from editorActions() for the same reason
+                // (ADR-152) — the module renders it as an undeclared tool.
+                declared: $declaration !== null,
+                enabled: $declaration !== null && ($state['enabled'] ?? false),
+                // Gated on the declaration for the same reason `enabled` is.
+                // `get_page` is registered and carries a group, but it is not
+                // an editor action — printing its group next to a "Not
+                // available here" badge would point the operator at a switch
+                // that exists and would not produce the action.
+                group: $declaration !== null ? ($state['group'] ?? '') : '',
+                declaration: $declaration,
+            );
+        }
+
+        return $result;
+    }
+
+    public function toolGroupStates(array $groups): array
+    {
+        if ($groups === []) {
+            return [];
+        }
+
+        $known = [];
+        foreach ($this->availability->groupStates() as $state) {
+            $known[$state['name']] = $state;
+        }
+
+        $result = [];
+        foreach ($groups as $group) {
+            $state = $known[$group] ?? null;
+
+            $result[] = new PackToolGroupState(
+                group: $group,
+                // groupStates() lists the groups of the currently REGISTERED
+                // tools. A group missing from it has no switch in the Tools
+                // module, so recommending it points at nothing.
+                registered: $state !== null,
+                enabled: $state['enabled'] ?? false,
+                labelKey: $state['labelKey'] ?? null,
+            );
+        }
+
+        return $result;
+    }
+}

--- a/Classes/Service/UseCase/EditorialStarterPackProvider.php
+++ b/Classes/Service/UseCase/EditorialStarterPackProvider.php
@@ -143,6 +143,15 @@ final readonly class EditorialStarterPackProvider implements UseCasePackProvider
                 // Named so an admin knows which switch would extend the pack;
                 // enabling stays a decision in the Tools module.
                 recommendedToolGroups: ['content'],
+                // No editor action, deliberately (ADR-168). The four tasks are
+                // text transforms an editor runs in the Tasks module; none of
+                // them writes a record. And an editor action runs on the
+                // DEFAULT configuration, not on the pack's, so this pack's
+                // house-style snippet would not reach one — naming an action
+                // here would claim a link its records do not have. A Media
+                // Accessibility or Translation pack is where the field earns
+                // its keep.
+                recommendedEditorActions: [],
             ),
         ];
     }

--- a/Classes/Service/UseCase/PackEditorActionState.php
+++ b/Classes/Service/UseCase/PackEditorActionState.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\UseCase;
+
+use Netresearch\NrLlm\Domain\ValueObject\EditorAction;
+
+/**
+ * One editor action a pack was designed for, as this installation currently
+ * answers for it (ADR-168).
+ *
+ * Three separate facts, kept separate because an operator acts on each one
+ * differently:
+ *
+ * - `declared` — this installation has no registered tool of that name that
+ *   declares an editor action. Either the pack names something a third-party
+ *   extension provides and it is not installed, or the pack has a typo. Both
+ *   need to be visible; a missing declaration silently rendering as "disabled"
+ *   would send the operator to a Tools module that has no such row.
+ * - `enabled` — the admin toggle in the Tools module, group AND tool cascade.
+ *   Meaningful only when `declared` is true.
+ * - `group` — the tool group the action's switch sits under in the Tools
+ *   module, which is the half that says WHERE to go. Empty when `declared` is
+ *   false, including for a registered tool that is no editor action: its group
+ *   is real and would not produce the action.
+ * - `declaration` — the human-facing {@see EditorAction}: label, description,
+ *   icon and the record types the action addresses. Null when undeclared.
+ *
+ * `enabled` is the ADMIN state, deliberately not "would the person looking at
+ * this screen be offered the action right now". The per-viewer answer is
+ * {@see \Netresearch\NrLlm\Service\Tool\EditorActionCatalogueInterface::groupsFor()},
+ * and it folds four different reasons — no default configuration, no access to
+ * it, the tool gate, the record type — into one absent row. On a plan screen
+ * that would make a typo indistinguishable from a missing default
+ * configuration. The plan answers what an admin can act on; the catalogue
+ * answers what an editor is offered.
+ */
+final readonly class PackEditorActionState
+{
+    public function __construct(
+        public string $toolName,
+        public bool $declared,
+        public bool $enabled,
+        public string $group = '',
+        public ?EditorAction $declaration = null,
+    ) {}
+
+    /**
+     * The tables whose records this action addresses, or an empty list when the
+     * action is not declared here.
+     *
+     * @return list<string>
+     */
+    public function getRecordTypes(): array
+    {
+        // `?->` would be redundant: the null-coalescing property fetch already
+        // tolerates a null left side.
+        return $this->declaration->recordTypes ?? [];
+    }
+}

--- a/Classes/Service/UseCase/PackToolGroupState.php
+++ b/Classes/Service/UseCase/PackToolGroupState.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\UseCase;
+
+/**
+ * One tool group a pack recommends, as this installation currently answers for
+ * it (ADR-168).
+ *
+ * The template used to print the raw string, so `contnet` looked exactly like
+ * `content`. `registered` is the difference: no registered tool declares this
+ * group, so nothing in the Tools module carries that name and the recommendation
+ * points at a switch that does not exist.
+ *
+ * `labelKey` is null outside the curated {@see \Netresearch\NrLlm\Domain\Enum\ToolGroup}
+ * taxonomy — a third-party group is registered and switchable, it simply has no
+ * translated name. Null therefore says "no translation", never "unknown".
+ */
+final readonly class PackToolGroupState
+{
+    public function __construct(
+        public string $group,
+        public bool $registered,
+        public bool $enabled,
+        public ?string $labelKey = null,
+    ) {}
+}

--- a/Classes/Service/UseCase/PackToolReadinessInterface.php
+++ b/Classes/Service/UseCase/PackToolReadinessInterface.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\UseCase;
+
+/**
+ * What this installation answers about the tool-module things a pack RECOMMENDS
+ * (ADR-168).
+ *
+ * The seam exists because of ADR-090, not because a second implementation is
+ * expected. `Service\UseCase` is core; the tool registry, the admin toggles and
+ * the editor-action declarations are `nr_llm_tools`, and `ModuleSeamTest`
+ * forbids core importing that namespace — a core class asking
+ * {@see \Netresearch\NrLlm\Service\Tool\ToolAvailabilityServiceInterface}
+ * directly would make the two candidate packages mutually dependent. So core
+ * declares the question and the tool module answers it
+ * ({@see \Netresearch\NrLlm\Service\Tool\PackToolReadiness}).
+ *
+ * Both methods are READ-ONLY and advisory. Nothing here enables a group, enables
+ * a tool or starts a run — a pack states what it was built for, and acting on
+ * that stays the administrator's decision in the Tools module (ADR-145,
+ * ADR-140).
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
+interface PackToolReadinessInterface
+{
+    /**
+     * The live state of each named editor action, in the order asked, one entry
+     * per name — including the names this installation does not know, because a
+     * silently dropped row is exactly the typo the plan exists to show.
+     *
+     * @param list<string> $toolNames
+     *
+     * @return list<PackEditorActionState>
+     */
+    public function editorActionStates(array $toolNames): array;
+
+    /**
+     * The live state of each named tool group, in the order asked, one entry per
+     * name — same contract, same reason.
+     *
+     * @param list<string> $groups
+     *
+     * @return list<PackToolGroupState>
+     */
+    public function toolGroupStates(array $groups): array;
+}

--- a/Classes/Service/UseCase/UseCasePack.php
+++ b/Classes/Service/UseCase/UseCasePack.php
@@ -39,6 +39,12 @@ use Netresearch\NrLlm\Service\Preset\ConfigurationPreset;
  *   enabled its own tools would hand an install button the authority of the
  *   tool gate.
  *
+ * The same holds one step further down for `$recommendedEditorActions`
+ * (ADR-168): a pack installs TASKS, and a task runs as a plain completion. The
+ * named editorial writes are TOOLS reached through the Editor Action Center.
+ * Naming them here states what the pack was designed for; it enables nothing,
+ * runs nothing, and creates no link between a task record and a tool.
+ *
  * Skills are absent by design — see ADR-163.
  */
 final readonly class UseCasePack
@@ -50,13 +56,15 @@ final readonly class UseCasePack
     private const SNIPPET_TAGS_MAX_LENGTH = 255;
 
     /**
-     * @param string            $identifier            Pack identifier, unique across all providers
-     * @param UseCase           $useCase               The question this pack answers
-     * @param string            $name                  Human-readable pack name
-     * @param string            $description           What an operator gets from installing it
-     * @param list<PackTask>    $tasks                 Task records to create
-     * @param list<PackSnippet> $snippets              Snippet records to create
-     * @param list<string>      $recommendedToolGroups Tool groups the tasks benefit from; shown, never enabled
+     * @param string            $identifier               Pack identifier, unique across all providers
+     * @param UseCase           $useCase                  The question this pack answers
+     * @param string            $name                     Human-readable pack name
+     * @param string            $description              What an operator gets from installing it
+     * @param list<PackTask>    $tasks                    Task records to create
+     * @param list<PackSnippet> $snippets                 Snippet records to create
+     * @param list<string>      $recommendedToolGroups    Tool groups the tasks benefit from; shown, never enabled
+     * @param list<string>      $recommendedEditorActions Tool names of the editor actions this pack was designed
+     *                                                    for; shown with their live state, never enabled or run
      */
     public function __construct(
         public string $identifier,
@@ -68,6 +76,7 @@ final readonly class UseCasePack
         public array $tasks = [],
         public array $snippets = [],
         public array $recommendedToolGroups = [],
+        public array $recommendedEditorActions = [],
     ) {
         if (preg_match(self::IDENTIFIER_PATTERN, $identifier) !== 1) {
             throw new InvalidArgumentException(
@@ -99,6 +108,28 @@ final readonly class UseCasePack
             'snippet',
             1791460024,
         );
+
+        // A blank entry renders as an empty badge and a repeated one renders
+        // twice, so both are refused at declaration time, where the author is.
+        //
+        // This checks `$recommendedEditorActions` ONLY, and deliberately leaves
+        // `$recommendedToolGroups` alone. The field is pre-existing and reached
+        // through the `@api` {@see UseCasePackProviderInterface}, so packs that
+        // are not in this repository may already declare a blank or repeated
+        // group; every pack is built inside {@see UseCasePackRegistry}'s
+        // constructor, which catches nothing, so a new throw on an old field
+        // would turn a cosmetic defect in one third-party pack into a fatal in
+        // every backend module that injects the registry. A new field ships
+        // with its contract; an old field does not get one retro-fitted under
+        // its callers (ADR-168).
+        //
+        // What is NOT refused for either list is an identifier this
+        // installation does not know. Both sets are OPEN — a third-party
+        // extension ships its own tools, its own group and its own pack — so
+        // "unknown here" is answered by the install plan against the live
+        // registry, where it is shown rather than fatal.
+        $this->assertNoBlankEntries($this->recommendedEditorActions, 'recommended editor action', 1791460026);
+        $this->assertUniqueIdentifiers($this->recommendedEditorActions, 'recommended editor action', 1791460027);
 
         // The derived tag list is written to `tx_nrllm_configuration.snippet_tags`,
         // a varchar(255). Extbase writes it without FormEngine's max check.
@@ -145,6 +176,27 @@ final readonly class UseCasePack
         }
 
         return array_keys($tags);
+    }
+
+    /**
+     * @param list<string> $identifiers
+     */
+    private function assertNoBlankEntries(array $identifiers, string $kind, int $code): void
+    {
+        foreach ($identifiers as $identifier) {
+            if (trim($identifier) !== '') {
+                continue;
+            }
+
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Use-case pack "%s" declares an empty %s.',
+                    $this->identifier,
+                    $kind,
+                ),
+                $code,
+            );
+        }
     }
 
     /**

--- a/Classes/Service/UseCase/UseCasePackInstaller.php
+++ b/Classes/Service/UseCase/UseCasePackInstaller.php
@@ -52,6 +52,12 @@ use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
  * snippets. Without the link the pack would install its snippets and leave them
  * composed into nothing. The addition is shown on the plan screen before it
  * happens, and tags the operator selected themselves are kept.
+ *
+ * {@see plan()} additionally reports the state of the tool groups and editor
+ * actions the pack RECOMMENDS (ADR-168). {@see install()} does not read those
+ * lists at all: there is no branch here that enables a tool group, enables an
+ * editor action or runs one, and {@see PackToolReadinessInterface} has no
+ * writing method to call.
  */
 final readonly class UseCasePackInstaller
 {
@@ -70,6 +76,7 @@ final readonly class UseCasePackInstaller
         private TaskRepository $taskRepository,
         private PromptSnippetRepository $snippetRepository,
         private PersistenceManagerInterface $persistenceManager,
+        private PackToolReadinessInterface $toolReadiness,
     ) {}
 
     /**
@@ -122,6 +129,11 @@ final readonly class UseCasePackInstaller
             missingSnippetTags: $missingSnippetTags,
             affectedConfigurations: $this->configurationsReachedBy($preset->identifier, $pendingSnippetTags),
             incomingSnippets: $this->snippetsPulledInBy($pack, $missingSnippetTags),
+            // What installing does NOT do (ADR-168). Both lists are read
+            // through the tool module's own availability service; the plan
+            // states their current state and neither can block the install.
+            editorActions: $this->toolReadiness->editorActionStates($pack->recommendedEditorActions),
+            toolGroups: $this->toolReadiness->toolGroupStates($pack->recommendedToolGroups),
         );
     }
 

--- a/Classes/Service/UseCase/UseCasePackPlan.php
+++ b/Classes/Service/UseCase/UseCasePackPlan.php
@@ -46,6 +46,15 @@ use Netresearch\NrLlm\Service\Preset\PresetPreflightResult;
  * Fluid's property access prefers `get`/`is`/`has` over the property itself, so
  * a `hasMissingSnippetTags()` would make `{plan.missingSnippetTags}` resolve to
  * a boolean and `<f:for>` over it fail at render time.
+ *
+ * `editorActions` and `toolGroups` are a fourth kind of thing again: they are
+ * what installing does NOT change (ADR-168). The pack names editor actions it
+ * was designed for and tool groups its tasks benefit from; both live behind an
+ * administrator's switch in the Tools module, and the plan states their current
+ * state so the operator can see that the pack's value depends on a switch they
+ * still have to throw. Neither is counted by {@see getPendingCount()} and
+ * neither can block {@see isInstallable()} — an advisory declaration that could
+ * stop an install would be an execution contract wearing a different name.
  */
 final readonly class UseCasePackPlan
 {
@@ -55,6 +64,8 @@ final readonly class UseCasePackPlan
      * @param list<string>                                                     $missingSnippetTags
      * @param list<array{identifier: string, name: string}>                    $affectedConfigurations
      * @param list<array{identifier: string, name: string, dataClass: string}> $incomingSnippets
+     * @param list<PackEditorActionState>                                      $editorActions
+     * @param list<PackToolGroupState>                                         $toolGroups
      */
     public function __construct(
         public UseCasePack $pack,
@@ -65,7 +76,45 @@ final readonly class UseCasePackPlan
         public array $missingSnippetTags = [],
         public array $affectedConfigurations = [],
         public array $incomingSnippets = [],
+        public array $editorActions = [],
+        public array $toolGroups = [],
     ) {}
+
+    /**
+     * The declared editor actions this installation does not know.
+     *
+     * A typo and an uninstalled provider extension look identical from here,
+     * and both need the same thing: to be named on the screen instead of
+     * rendering as a disabled row that sends the operator to a Tools module with
+     * no such entry.
+     *
+     * @return list<PackEditorActionState>
+     */
+    public function getUndeclaredEditorActions(): array
+    {
+        return array_values(array_filter(
+            $this->editorActions,
+            static fn(PackEditorActionState $state): bool => !$state->declared,
+        ));
+    }
+
+    /**
+     * The recommended tool groups no registered tool carries — same question,
+     * one level up, and read by the same kind of paragraph on the plan screen.
+     *
+     * The red badge alone says the group is missing; it does not say that
+     * installing the pack will not produce it, which is the half an operator
+     * acts on.
+     *
+     * @return list<PackToolGroupState>
+     */
+    public function getUnregisteredToolGroups(): array
+    {
+        return array_values(array_filter(
+            $this->toolGroups,
+            static fn(PackToolGroupState $state): bool => !$state->registered,
+        ));
+    }
 
     /**
      * @return list<UseCasePackPlanItem>

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -359,6 +359,13 @@ services:
   Netresearch\NrLlm\Service\Tool\EditorActionCatalogueInterface:
     alias: Netresearch\NrLlm\Service\Tool\EditorActionCatalogue
 
+  # The use-case pack plan's read-only view of the tool module (ADR-168). The
+  # interface lives in Service\UseCase (core) and the implementation in
+  # Service\Tool, because ADR-090 forbids core importing the tool namespace —
+  # so the container, not an import, is what joins the two.
+  Netresearch\NrLlm\Service\UseCase\PackToolReadinessInterface:
+    alias: Netresearch\NrLlm\Service\Tool\PackToolReadiness
+
   # Concrete BudgetService is private (autoregistered); consumers wire
   # against the public BudgetServiceInterface alias.
   Netresearch\NrLlm\Service\BudgetServiceInterface:

--- a/Documentation/Administration/Tools.rst
+++ b/Documentation/Administration/Tools.rst
@@ -465,6 +465,8 @@ The declaration is presentation only. It does not decide whether a tool writes
 — that is the tool's declared effect — and it changes nothing about how a call
 is fenced, approved or audited.
 
+.. _administration-tools-editor-actions:
+
 What editors see
 ----------------
 

--- a/Documentation/Administration/UseCasePacks.rst
+++ b/Documentation/Administration/UseCasePacks.rst
@@ -98,13 +98,68 @@ What a pack recommends but never applies
 - **Tool groups.** The pack names the groups its tasks benefit from
   (*Editorial Starter*: ``content``). Enabling a tool group stays an
   administrator decision in the :ref:`Tools module <administration-tools>`.
+- **Editor actions.** The pack names the editorial writes it was designed for —
+  see below. Installing enables none of them and runs none of them.
 - **Nothing about providers or API keys.** The pack states model
   *requirements*. When no active model satisfies them, the plan says which
   requirement is missing and links to the setup wizard.
 
+Both the tool groups and the editor actions are shown with their **current
+state** rather than as a bare list, because both are switches you may still have
+to throw:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Badge
+     - Meaning
+   * - *Enabled*
+     - Registered here and switched on. For a tool group that is all it takes.
+       An editor action additionally needs a **default configuration** the
+       acting editor has access to — a pack installs none, and without one the
+       action stays absent from the Editor Action Center even while this badge
+       reads *Enabled*.
+   * - *Disabled*
+     - Registered here and switched off. Enable it in the
+       :ref:`Tools module <administration-tools>` if you want it.
+   * - *Not available here*
+     - Not registered at all: the extension providing it is not installed, or
+       the pack names it wrongly. Installing the pack neither adds it nor
+       repairs it.
+
 A pack installs **no skills**. A skill carries provenance and a trust level
 from the source it was synced from, and a pack can produce neither; add a
 :ref:`skill source <administration-skills>` instead.
+
+.. _administration-usecase-packs-editor-actions:
+
+Editor actions a pack is designed for
+=====================================
+
+A pack installs **tasks**, and a task runs as a plain completion — it produces
+text you copy or apply yourself. The named editorial writes an editor triggers
+from a record (set a file's alternative text, create a translation draft, update
+page metadata) are **tools**, offered through the
+:ref:`Editor Action Center <administration-tools-editor-actions>`, disabled by
+default, enabled by an administrator, and paused for approval on every run.
+
+``recommendedEditorActions`` lets a pack say which of those it was built for, so
+a pack whose value depends on one — translation, alt text — can state it instead
+of implying a workflow its records cannot perform. For each declared action the
+plan screen shows the action's name and description, whether this installation
+has it, whether it is enabled, which record types it applies to and the tool
+group it sits under — that group is where its switch is in the Tools module —
+with links to the Tools module and the Editor Action Center.
+
+That is the whole feature. The plan does not enable an action, does not run one,
+and does not connect a pack task to one — a task-to-action execution contract
+would need a new execution path and is a separate decision
+(:ref:`ADR-168 <adr-168>`).
+
+*Editorial Starter* declares no editor action, deliberately: its four tasks are
+text transforms, and an editor action runs on the **default** configuration
+rather than on the pack's, so the pack's house-style snippet would not reach
+one.
 
 .. _administration-usecase-packs-reinstall:
 

--- a/Documentation/Adr/Adr168PacksDeclareEditorActions.rst
+++ b/Documentation/Adr/Adr168PacksDeclareEditorActions.rst
@@ -1,0 +1,177 @@
+.. _adr-168:
+
+========================================================================
+ADR-168: A use-case pack declares editor actions, and only declares them
+========================================================================
+
+:Status: Accepted
+:Date: 2026-08-13
+:Extends: :ref:`ADR-163 <adr-163>` (a fourth advisory field on the pack) and
+    :ref:`ADR-152 <adr-152>` / :ref:`ADR-158 <adr-158>` (the editor-action
+    declarations and the surface that offers them)
+:Authors: Netresearch DTT GmbH
+
+Context
+=======
+
+A use-case pack installs a configuration preset, tasks and snippets. A task runs
+as a plain completion: :php:`TaskExecutionService::execute()` builds a prompt,
+injects skills and dispatches it — there is no tool path in it at all. The named
+editorial writes an editor actually uses (``set_file_alternative_text``,
+``create_translation_draft``, ``update_page_metadata``,
+``move_content_element``, ``create_content_element_draft``) are **tools**,
+reached through the Editor Action Center, disabled by default and enabled by an
+administrator in the Tools module, with every run pausing for approval.
+
+Nothing on :php:`UseCasePack` connected the two. So a pack could claim "installs
+these tasks and snippets" and nothing more — which is fine for Editorial
+Starter, and useless for a Translation or Media Accessibility pack, whose whole
+point is the action. Issue `#769`.
+
+The same file carried a second, smaller defect: :php:`$recommendedToolGroups` is
+a :php:`list<string>` that the template printed raw, so ``contnet`` rendered
+exactly like ``content``.
+
+Decision
+========
+
+**A new advisory field.** :php:`UseCasePack::$recommendedEditorActions` is a
+:php:`list<string>` of tool names. It is the fourth field of the same kind as the
+governance profile and the tool groups, and it is read by exactly one thing: the
+install plan.
+
+**The plan states, it does not act.** :php:`UseCasePackInstaller::plan()` reports
+per declared action whether this installation declares it, whether it is enabled,
+which record types it addresses, and its tool group — and the plan screen links
+to the Tools module and to the Editor Action Center. :php:`install()` never reads
+the list. There is no branch that enables a tool group, enables an action or runs
+one, and the readout interface has no writing method to call.
+
+The reason is not caution, it is the same decision twice already made.
+:ref:`ADR-145 <adr-145>` established that a governance profile describes a
+posture and never applies one; :ref:`ADR-140 <adr-140>` refused an automatic
+apply engine for the same class of thing. An "apply" button here would be that
+engine arriving through the back door, holding the authority of the tool gate —
+the one control an administrator sets deliberately on top of the group gate and
+the approval pause. A pack is data. It is not allowed to be a privilege.
+
+**One registry, one enabled-check.** The states are read off
+:php:`ToolAvailabilityServiceInterface` — the service that already resolves which
+tools are registered, which declare an editor action (:ref:`ADR-152 <adr-152>`)
+and what is enabled after the group AND tool cascade. No second registry and no
+second enabled-check: :php:`EditorActionCatalogue` documents that the enabled
+rule already has copies and that a fourth is the one that ages.
+
+**The ADMIN state, not the per-viewer offer.**
+:php:`EditorActionCatalogueInterface::groupsFor()` is deliberately *not* what the
+plan asks. It answers for one viewer and folds four different reasons — no
+default configuration, no access to it, the tool gate, the record type — into a
+single absent row. On a plan screen that would make a pack's typo
+indistinguishable from a missing default configuration. The plan answers what an
+administrator can act on; the catalogue answers what an editor is offered.
+Different questions, and the plan needs the one with a remedy attached.
+
+**Core declares the question, the tool module answers it.**
+:php:`Service\UseCase` is core, and :ref:`ADR-090 <adr-090>` — enforced by
+:php:`ModuleSeamTest` — forbids core importing :php:`Service\Tool`. So
+:php:`PackToolReadinessInterface` and its two DTOs live in
+:php:`Service\UseCase`, :php:`PackToolReadiness` implements it in
+:php:`Service\Tool`, and the container joins them. The alternative was a sixth
+name on the seam test's by-name exception list; it was rejected because the
+exception list is for classes that *move with* the tool module in a split, and
+the pack plan moves with core.
+
+**The constructor validates the new field only.** It rejects a blank entry and a
+repeated one in :php:`$recommendedEditorActions`, and leaves
+:php:`$recommendedToolGroups` exactly as it was.
+
+The asymmetry is the point. A new field ships with its contract, and no pack
+outside this repository declares it yet. :php:`$recommendedToolGroups` is
+pre-existing and reached through the frozen ``@api``
+:php:`UseCasePackProviderInterface`, so a third-party pack declaring
+``['content', 'content']`` is a supported scenario that works today — and
+:php:`UseCasePackRegistry` builds every pack in its constructor and catches
+nothing, so a new throw there would take down every backend module that injects
+the registry. That is the same blast radius this ADR invokes below to keep the
+identifier sets open; it cannot be unacceptable for an unknown group and
+acceptable for a repeated one.
+
+What the untouched field costs is bounded and visible: a blank entry renders as
+an empty badge, a repeated one renders twice. Both are on the plan screen, where
+an operator reads them and the pack's author can fix them.
+
+The two rejected alternatives:
+
+* *Validate both and record it as a contract change.* Honest, and still an
+  outage for anyone who ships the defect — a backend that no longer starts is
+  not a validation message.
+* *Validate both and make the registry catch per provider.* A real robustness
+  change, and a much larger one: it would make a throwing pack silently absent
+  rather than loud, and it would remove the very argument that keeps the
+  identifier sets open. If it is wanted it is its own decision, not a side
+  effect of adding a field.
+
+**Unknown identifiers are surfaced, not refused at declaration time.** Neither
+list is checked against :php:`Domain\Enum\ToolGroup` or against a list of known
+editor actions, and this is the point issue `#769` left open:
+
+* Both sets are open. :php:`ToolGroup`'s own docblock says so, and
+  :php:`Form\Tca\ToolGroupItems` proves it — the selectable groups are the groups
+  of the currently *registered* tools, not the enum's cases. A third-party
+  extension ships its own tools, its own group and, through the same ``@api``
+  :php:`UseCasePackProviderInterface`, its own pack.
+* A throw would not be a validation error, it would be an outage.
+  :php:`UseCasePackRegistry` builds every pack in its constructor and catches
+  nothing, so one unknown group in one third-party pack would take down every
+  backend module that injects the registry.
+
+So the typo is caught where the truth lives: the plan asks the live registry and
+renders a third badge, "Not available here", distinct from "Disabled" — and both
+cards carry the same explanatory sentence when that badge appears, because the
+badge says an identifier is missing while only the sentence says that installing
+the pack will not produce it. For the
+packs *this repository ships* the check is a test —
+:php:`UseCasePackRenderTest::everyEditorActionAndToolGroupTheShippedPacksNameExistsHere`
+asserts every recommended group and action of every registered pack exists. That
+is closed for our packs and open for everyone else's, which is the split the
+extension point requires.
+
+.. _adr-168-not:
+
+What this does not do
+=====================
+
+**It does not connect a task to an action.** A pack task still executes as a
+completion, and no field here changes that. Wiring a task to perform a write
+needs a new execution path with its own fence, preview and audit story; that is a
+separate decision and explicitly out of scope.
+
+**It does not block an install.** A declared action that is disabled — or absent
+entirely — changes no count on the plan and cannot hide the confirm button. An
+advisory declaration that could stop an install would be an execution contract
+wearing a different name.
+
+**Editorial Starter declares no action, and that is the truthful answer.** Its
+four tasks are text transforms run in the Tasks module; none of them writes a
+record. And an editor action runs on the **default** configuration
+(:php:`EditorActionCatalogue::usableDefault()`), not on the pack's own, so the
+pack's house-style snippet would not reach one. Naming an action there to
+demonstrate the field would claim a link the pack's records do not have. The
+field earns its keep with the Translation and Media Accessibility packs, which is
+what issue `#769` filed it as a precondition for.
+
+Consequences
+============
+
+A pack can now state what it is for without overpromising, and an operator sees
+on one screen which switch the pack's value still depends on.
+
+:php:`UseCasePackInstaller` gains a constructor argument. It is autowired and
+absent from the frozen ``@api`` surface, so the addition breaks no caller the
+project supports. It carries no ``@internal`` annotation, which is a gap in the
+class rather than a property this record may rely on.
+
+A future ``nr_llm_tools`` extraction has one more seam to satisfy: core would
+need a null implementation of :php:`PackToolReadinessInterface` for an
+installation without the tool package. Until 1.0 there is one extension and the
+container always has the real one.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -512,3 +512,4 @@ Tools
    Adr165ResumeReGatesTheForcedSet
    Adr166DeactivationDoesNotLowerACeiling
    Adr167ConfigurationAccessIsASimulatedAxis
+   Adr168PacksDeclareEditorActions

--- a/Resources/Private/Language/de.locallang_mod_usecase.xlf
+++ b/Resources/Private/Language/de.locallang_mod_usecase.xlf
@@ -131,6 +131,42 @@
                 <source>The pack does not enable these. Enabling a tool group stays an administrator decision:</source>
                 <target>Das Paket aktiviert diese nicht. Eine Tool-Gruppe zu aktivieren bleibt eine Entscheidung der Administration:</target>
             </trans-unit>
+            <trans-unit id="show.toolGroups.unknown">
+                <source>A group marked as not available is carried by no registered tool on this installation — either the extension providing it is missing, or the pack names it wrongly. Installing the pack neither adds it nor repairs it.</source>
+                <target>Eine als nicht vorhanden markierte Gruppe wird in dieser Installation von keinem registrierten Tool geführt – entweder fehlt die Extension, die sie mitbringt, oder das Paket benennt sie falsch. Die Installation des Pakets ergänzt sie nicht und repariert sie nicht.</target>
+            </trans-unit>
+            <trans-unit id="show.toolState.enabled">
+                <source>Enabled</source>
+                <target>Aktiviert</target>
+            </trans-unit>
+            <trans-unit id="show.toolState.disabled">
+                <source>Disabled</source>
+                <target>Deaktiviert</target>
+            </trans-unit>
+            <trans-unit id="show.toolState.unknown">
+                <source>Not available here</source>
+                <target>Hier nicht vorhanden</target>
+            </trans-unit>
+            <trans-unit id="show.editorActions">
+                <source>Editor actions this pack is designed for</source>
+                <target>Redaktionsaktionen, für die dieses Paket gedacht ist</target>
+            </trans-unit>
+            <trans-unit id="show.editorActions.recordTypes">
+                <source>Applies to:</source>
+                <target>Gilt für:</target>
+            </trans-unit>
+            <trans-unit id="show.editorActions.group">
+                <source>Tool group:</source>
+                <target>Tool-Gruppe:</target>
+            </trans-unit>
+            <trans-unit id="show.editorActions.unknown">
+                <source>An action marked as not available is not registered on this installation — either the extension providing it is missing, or the pack names it wrongly. Installing the pack neither adds nor repairs it.</source>
+                <target>Eine als nicht vorhanden markierte Aktion ist in dieser Installation nicht registriert – entweder fehlt die Extension, die sie mitbringt, oder das Paket benennt sie falsch. Die Installation des Pakets ergänzt sie nicht und repariert sie nicht.</target>
+            </trans-unit>
+            <trans-unit id="show.editorActions.hint">
+                <source>The pack declares these; it does not enable them and does not run them. Enabling an action is an administrator decision in the Tools module, and every run still pauses for approval:</source>
+                <target>Das Paket nennt diese Aktionen; es aktiviert sie nicht und führt sie nicht aus. Eine Aktion zu aktivieren bleibt eine Entscheidung der Administration im Tools-Modul, und jeder Lauf hält weiterhin zur Freigabe an:</target>
+            </trans-unit>
             <trans-unit id="show.skills">
                 <source>Skills</source>
                 <target>Skills</target>

--- a/Resources/Private/Language/locallang_mod_usecase.xlf
+++ b/Resources/Private/Language/locallang_mod_usecase.xlf
@@ -99,6 +99,33 @@
             <trans-unit id="show.toolGroups.hint">
                 <source>The pack does not enable these. Enabling a tool group stays an administrator decision:</source>
             </trans-unit>
+            <trans-unit id="show.toolGroups.unknown">
+                <source>A group marked as not available is carried by no registered tool on this installation — either the extension providing it is missing, or the pack names it wrongly. Installing the pack neither adds it nor repairs it.</source>
+            </trans-unit>
+            <trans-unit id="show.toolState.enabled">
+                <source>Enabled</source>
+            </trans-unit>
+            <trans-unit id="show.toolState.disabled">
+                <source>Disabled</source>
+            </trans-unit>
+            <trans-unit id="show.toolState.unknown">
+                <source>Not available here</source>
+            </trans-unit>
+            <trans-unit id="show.editorActions">
+                <source>Editor actions this pack is designed for</source>
+            </trans-unit>
+            <trans-unit id="show.editorActions.recordTypes">
+                <source>Applies to:</source>
+            </trans-unit>
+            <trans-unit id="show.editorActions.group">
+                <source>Tool group:</source>
+            </trans-unit>
+            <trans-unit id="show.editorActions.unknown">
+                <source>An action marked as not available is not registered on this installation — either the extension providing it is missing, or the pack names it wrongly. Installing the pack neither adds nor repairs it.</source>
+            </trans-unit>
+            <trans-unit id="show.editorActions.hint">
+                <source>The pack declares these; it does not enable them and does not run them. Enabling an action is an administrator decision in the Tools module, and every run still pauses for approval:</source>
+            </trans-unit>
             <trans-unit id="show.skills">
                 <source>Skills</source>
             </trans-unit>

--- a/Resources/Private/Templates/Backend/UseCase/Show.html
+++ b/Resources/Private/Templates/Backend/UseCase/Show.html
@@ -237,22 +237,115 @@
                     </div>
                 </div>
 
-                <f:comment>Recommended tool groups — enabling stays in the Tools module.</f:comment>
-                <f:if condition="{pack.recommendedToolGroups}">
+                <f:comment>
+                    Recommended tool groups — enabling stays in the Tools module.
+                    Printed with their live state rather than raw: a group no
+                    registered tool carries is a typo or an extension that is not
+                    installed, and both used to look exactly like a real one.
+                </f:comment>
+                <f:if condition="{plan.toolGroups}">
                     <div class="card mb-4">
                         <div class="card-body">
                             <h2 class="card-title h6">
                                 <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_usecase.xlf:show.toolGroups" default="Optional tool groups" />
                             </h2>
-                            <p class="mb-2">
-                                <f:for each="{pack.recommendedToolGroups}" as="group">
-                                    <code>{group}</code>
+                            <ul class="list-unstyled mb-2">
+                                <f:for each="{plan.toolGroups}" as="group">
+                                    <li class="mb-1">
+                                        <code>{group.group}</code>
+                                        <f:if condition="{group.labelKey}">
+                                            <span class="text-body-secondary"><f:translate key="{group.labelKey}" default="" /></span>
+                                        </f:if>
+                                        <f:render section="ToolState" arguments="{known: group.registered, enabled: group.enabled}" />
+                                    </li>
                                 </f:for>
-                            </p>
+                            </ul>
+                            <f:comment>
+                                Same explanation the editor-action card carries,
+                                for the same reason: the red badge says a group
+                                is missing, not that installing the pack will
+                                not produce it.
+                            </f:comment>
+                            <f:if condition="{plan.unregisteredToolGroups}">
+                                <p class="small mb-2">
+                                    <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_usecase.xlf:show.toolGroups.unknown" default="A group marked as not available is carried by no registered tool on this installation — either the extension providing it is missing, or the pack names it wrongly. Installing the pack neither adds it nor repairs it." />
+                                </p>
+                            </f:if>
                             <p class="small mb-0">
                                 <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_usecase.xlf:show.toolGroups.hint" default="The pack does not enable these. Enabling a tool group stays an administrator decision:" />
                                 <a href="{toolsUrl}" class="text-decoration-underline">
                                     <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:manage.title" default="Tools" />
+                                </a>
+                            </p>
+                        </div>
+                    </div>
+                </f:if>
+
+                <f:comment>
+                    Editor actions the pack was DESIGNED for (ADR-168). A pack
+                    installs tasks, and a task runs as a plain completion — the
+                    named editorial writes are tools reached through the Editor
+                    Action Center. Installing enables none of them and runs none
+                    of them; the state is here so the operator can see which
+                    switch the pack's value still depends on.
+                </f:comment>
+                <f:if condition="{plan.editorActions}">
+                    <div class="card mb-4">
+                        <div class="card-body">
+                            <h2 class="card-title h6">
+                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_usecase.xlf:show.editorActions" default="Editor actions this pack is designed for" />
+                            </h2>
+                            <ul class="list-unstyled mb-2">
+                                <f:for each="{plan.editorActions}" as="action">
+                                    <li class="mb-2">
+                                        <div>
+                                            <f:if condition="{action.declaration}">
+                                                <strong><f:translate key="{action.declaration.labelKey}" default="{action.toolName}" /></strong>
+                                            </f:if>
+                                            <code>{action.toolName}</code>
+                                            <f:render section="ToolState" arguments="{known: action.declared, enabled: action.enabled}" />
+                                        </div>
+                                        <f:if condition="{action.declaration}">
+                                            <div class="small text-body-secondary">
+                                                <f:translate key="{action.declaration.descriptionKey}" default="" />
+                                            </div>
+                                        </f:if>
+                                        <f:if condition="{action.recordTypes}">
+                                            <div class="small">
+                                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_usecase.xlf:show.editorActions.recordTypes" default="Applies to:" />
+                                                <f:for each="{action.recordTypes}" as="recordType">
+                                                    <code>{recordType}</code>
+                                                </f:for>
+                                            </div>
+                                        </f:if>
+                                        <f:comment>
+                                            The group is WHERE the switch is: the
+                                            Tools module lists actions under it,
+                                            so an operator sent there needs the
+                                            name. Empty for an action this
+                                            installation does not have.
+                                        </f:comment>
+                                        <f:if condition="{action.group}">
+                                            <div class="small">
+                                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_usecase.xlf:show.editorActions.group" default="Tool group:" />
+                                                <code>{action.group}</code>
+                                            </div>
+                                        </f:if>
+                                    </li>
+                                </f:for>
+                            </ul>
+                            <f:if condition="{plan.undeclaredEditorActions}">
+                                <p class="small mb-2">
+                                    <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_usecase.xlf:show.editorActions.unknown" default="An action marked as not available is not registered on this installation — either the extension providing it is missing, or the pack names it wrongly. Installing the pack neither adds nor repairs it." />
+                                </p>
+                            </f:if>
+                            <p class="small mb-0">
+                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_usecase.xlf:show.editorActions.hint" default="The pack declares these; it does not enable them and does not run them. Enabling an action is an administrator decision in the Tools module, and every run still pauses for approval:" />
+                                <a href="{toolsUrl}" class="text-decoration-underline">
+                                    <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_tool.xlf:manage.title" default="Tools" />
+                                </a>
+                                <a href="{editorActionsUrl}" class="ms-2 text-decoration-underline">
+                                    <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:editorActions.title" default="AI actions" />
                                 </a>
                             </p>
                         </div>
@@ -292,6 +385,45 @@
             </a>
         </div>
     </div>
+</f:section>
+
+<f:comment>
+    Three states, not two: "not available" is what makes a typo or a missing
+    provider extension visible instead of rendering as a switch the operator
+    could go and flip (ADR-168).
+</f:comment>
+<f:section name="ToolState">
+    <f:if condition="{known}">
+        <f:then>
+            <f:if condition="{enabled}">
+                <f:then>
+                    <span class="badge text-bg-success">
+                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_usecase.xlf:show.toolState.enabled" default="Enabled" />
+                    </span>
+                </f:then>
+                <f:else>
+                    <span class="badge text-bg-warning">
+                        <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_usecase.xlf:show.toolState.disabled" default="Disabled" />
+                    </span>
+                </f:else>
+            </f:if>
+        </f:then>
+        <f:else>
+            <f:comment>
+                Not `text-bg-danger`: white on the backend's danger red is 4.37:1 at
+                badge size and fails WCAG AA (check-badge-contrast.php refuses it).
+                Not `text-bg-warning` either — that is already "Disabled", and the two
+                states are not the same one: an operator resolves Disabled by flipping
+                a switch, while this identifier does not exist here at all and
+                installing the pack will not produce it. Secondary reads as absent,
+                which is what it is; the label and the paragraph below carry the
+                meaning, so colour is not the only channel.
+            </f:comment>
+            <span class="badge text-bg-secondary">
+                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_usecase.xlf:show.toolState.unknown" default="Not available here" />
+            </span>
+        </f:else>
+    </f:if>
 </f:section>
 
 <f:section name="State">

--- a/Tests/Functional/Controller/Backend/UseCasePackRenderTest.php
+++ b/Tests/Functional/Controller/Backend/UseCasePackRenderTest.php
@@ -18,6 +18,7 @@ use Netresearch\NrLlm\Domain\Repository\PromptSnippetRepository;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPreset;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPresetRegistry;
 use Netresearch\NrLlm\Service\UseCase\EditorialStarterPackProvider;
+use Netresearch\NrLlm\Service\UseCase\PackToolReadinessInterface;
 use Netresearch\NrLlm\Service\UseCase\UseCase;
 use Netresearch\NrLlm\Service\UseCase\UseCasePack;
 use Netresearch\NrLlm\Service\UseCase\UseCasePackInstaller;
@@ -172,6 +173,110 @@ final class UseCasePackRenderTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function everyEditorActionAndToolGroupTheShippedPacksNameExistsHere(): void
+    {
+        // The enum check issue #769 asked for, applied where it is safe: our own
+        // packs, against the real registry. It is not a constructor throw —
+        // both sets are open for third-party packs, and throwing would fire
+        // inside UseCasePackRegistry's constructor (ADR-168).
+        $readiness = $this->getService(PackToolReadinessInterface::class);
+
+        foreach ($this->getService(UseCasePackRegistry::class)->all() as $pack) {
+            foreach ($readiness->editorActionStates($pack->recommendedEditorActions) as $state) {
+                self::assertTrue(
+                    $state->declared,
+                    sprintf('Pack "%s" names editor action "%s", which no registered tool declares.', $pack->identifier, $state->toolName),
+                );
+            }
+
+            foreach ($readiness->toolGroupStates($pack->recommendedToolGroups) as $state) {
+                self::assertTrue(
+                    $state->registered,
+                    sprintf('Pack "%s" recommends tool group "%s", which no registered tool carries.', $pack->identifier, $state->group),
+                );
+            }
+        }
+    }
+
+    #[Test]
+    public function theShippedPackDeclaresNoEditorAction(): void
+    {
+        // Deliberate, and asserted so it stays deliberate: Editorial Starter's
+        // four tasks are text transforms run in the Tasks module. An editor
+        // action runs on the DEFAULT configuration, not on the pack's, so its
+        // house-style snippet would not reach one — declaring an action here
+        // would claim a link the records do not have (ADR-168).
+        self::assertSame([], $this->pack()->recommendedEditorActions);
+    }
+
+    #[Test]
+    public function thePlanScreenShowsADeclaredEditorActionWithItsStateAndRecordTypes(): void
+    {
+        $this->importFixture('Providers.csv');
+        $this->importFixture('Models.csv');
+
+        $body = $this->renderShow($this->packDeclaring(['set_file_alternative_text']));
+
+        self::assertStringContainsString('Editor actions this pack is designed for', $body);
+        self::assertStringContainsString('set_file_alternative_text', $body);
+        // The record types are the half that says what the action is FOR.
+        self::assertStringContainsString('sys_file', $body);
+        // The group is the half that says WHERE the switch is: the Tools module
+        // lists the action under it (ADR-135 puts the writers in `editing`).
+        self::assertStringContainsString('Tool group:', $body);
+        self::assertStringContainsString('<code>editing</code>', $body);
+        // Disabled by default, and the screen has to say so rather than imply
+        // the pack turns it on.
+        self::assertStringContainsString('Disabled', $body);
+        self::assertStringContainsString('does not enable them and does not run them', $body);
+        // Nothing on this screen may offer to enable or run the action.
+        self::assertStringNotContainsString('Enable this action', $body);
+    }
+
+    #[Test]
+    public function thePlanScreenNamesADeclaredEditorActionThisInstallationDoesNotHave(): void
+    {
+        // The central regression: a typo (or an uninstalled provider extension)
+        // must be a visible row, not a silently dropped one.
+        $this->importFixture('Providers.csv');
+        $this->importFixture('Models.csv');
+
+        $body = $this->renderShow($this->packDeclaring(['set_file_alternativ_text']));
+
+        self::assertStringContainsString('set_file_alternativ_text', $body);
+        self::assertStringContainsString('Not available here', $body);
+        self::assertStringContainsString('is not registered on this installation', $body);
+    }
+
+    #[Test]
+    public function thePlanScreenMarksARecommendedToolGroupNoToolCarries(): void
+    {
+        $this->importFixture('Providers.csv');
+        $this->importFixture('Models.csv');
+
+        $body = $this->renderShow($this->packDeclaring([], ['contnet']));
+
+        self::assertStringContainsString('contnet', $body);
+        self::assertStringContainsString('Not available here', $body);
+        // The badge says the group is missing; only the paragraph says that
+        // installing the pack will not produce it. The editor-action card
+        // carries the same sentence, and the two screens have to match.
+        self::assertStringContainsString('carried by no registered tool on this installation', $body);
+    }
+
+    #[Test]
+    public function theToolGroupExplanationIsAbsentWhenEveryRecommendedGroupExists(): void
+    {
+        $this->importFixture('Providers.csv');
+        $this->importFixture('Models.csv');
+
+        $body = $this->renderShow($this->packDeclaring([], ['content']));
+
+        self::assertStringNotContainsString('carried by no registered tool on this installation', $body);
+        self::assertStringNotContainsString('Not available here', $body);
+    }
+
+    #[Test]
     public function thePlanScreenExplainsAnUnsatisfiableSetupInsteadOfOfferingTheButton(): void
     {
         // No providers or models: nothing satisfies `chat`.
@@ -197,9 +302,35 @@ final class UseCasePackRenderTest extends AbstractFunctionalTestCase
         ]);
     }
 
-    private function renderShow(): string
+    /**
+     * The shipped pack with a declaration bolted on — the shipped one declares
+     * no editor action, and inventing one there to demonstrate the feature
+     * would make the pack claim something untrue.
+     *
+     * @param list<string> $editorActions
+     * @param list<string> $toolGroups
+     */
+    private function packDeclaring(array $editorActions, array $toolGroups = ['content']): UseCasePack
     {
         $pack = $this->pack();
+
+        return new UseCasePack(
+            identifier: $pack->identifier,
+            useCase: $pack->useCase,
+            name: $pack->name,
+            description: $pack->description,
+            configurationPreset: $pack->configurationPreset,
+            recommendedGovernanceProfile: $pack->recommendedGovernanceProfile,
+            tasks: $pack->tasks,
+            snippets: $pack->snippets,
+            recommendedToolGroups: $toolGroups,
+            recommendedEditorActions: $editorActions,
+        );
+    }
+
+    private function renderShow(?UseCasePack $pack = null): string
+    {
+        $pack ??= $this->pack();
 
         return $this->render('Backend/UseCase/Show', 'show', [
             'pack' => $pack,
@@ -210,6 +341,7 @@ final class UseCasePackRenderTest extends AbstractFunctionalTestCase
             'tasksUrl' => '/typo3/module/nrllm/tasks',
             'snippetsUrl' => '/typo3/module/nrllm/snippets',
             'configurationsUrl' => '/typo3/module/nrllm/configurations',
+            'editorActionsUrl' => '/typo3/module/web/nrllm-aitasks',
         ]);
     }
 

--- a/Tests/Unit/Service/Tool/PackToolReadinessTest.php
+++ b/Tests/Unit/Service/Tool/PackToolReadinessTest.php
@@ -1,0 +1,208 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool;
+
+use Netresearch\NrLlm\Domain\ValueObject\EditorAction;
+use Netresearch\NrLlm\Service\Tool\PackToolReadiness;
+use Netresearch\NrLlm\Service\Tool\ToolAvailabilityServiceInterface;
+use Netresearch\NrLlm\Service\UseCase\PackEditorActionState;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The three questions a use-case pack's plan asks about a declared editor
+ * action (ADR-168): does it exist here, is it enabled, which records does it
+ * address.
+ */
+#[CoversClass(PackToolReadiness::class)]
+final class PackToolReadinessTest extends TestCase
+{
+    /** Public because the anonymous availability fixture below reads them. */
+    public const ALT_TEXT = 'set_file_alternative_text';
+
+    public const TRANSLATION = 'create_translation_draft';
+
+    private function availability(): ToolAvailabilityServiceInterface
+    {
+        return new class implements ToolAvailabilityServiceInterface {
+            public function enabledNames(): array
+            {
+                return [PackToolReadinessTest::ALT_TEXT];
+            }
+
+            public function states(): array
+            {
+                return [
+                    [
+                        'name' => PackToolReadinessTest::ALT_TEXT,
+                        'description' => 'Sets a file alternative text.',
+                        'group' => 'editing',
+                        'enabled' => true,
+                        'toolEnabled' => true,
+                        'groupEnabled' => true,
+                        'defaultEnabled' => false,
+                        'overridden' => true,
+                    ],
+                    [
+                        'name' => PackToolReadinessTest::TRANSLATION,
+                        'description' => 'Creates a translation draft.',
+                        'group' => 'editing',
+                        'enabled' => false,
+                        'toolEnabled' => false,
+                        'groupEnabled' => true,
+                        'defaultEnabled' => false,
+                        'overridden' => false,
+                    ],
+                    [
+                        'name' => 'get_page',
+                        'description' => 'Reads a page.',
+                        'group' => 'content',
+                        'enabled' => true,
+                        'toolEnabled' => true,
+                        'groupEnabled' => true,
+                        'defaultEnabled' => true,
+                        'overridden' => false,
+                    ],
+                ];
+            }
+
+            public function editorActions(): array
+            {
+                return [
+                    PackToolReadinessTest::ALT_TEXT => new EditorAction(
+                        'LLL:alt.label',
+                        'LLL:alt.description',
+                        'nrllm-editor-action-file-alt-text',
+                        ['sys_file'],
+                    ),
+                    PackToolReadinessTest::TRANSLATION => new EditorAction(
+                        'LLL:translate.label',
+                        'LLL:translate.description',
+                        'nrllm-editor-action-create-translation',
+                        ['pages', 'tt_content'],
+                    ),
+                ];
+            }
+
+            public function groupStates(): array
+            {
+                return [
+                    ['name' => 'editing', 'labelKey' => 'LLL:tool.group.editing', 'enabled' => true, 'overridden' => false],
+                    ['name' => 'content', 'labelKey' => 'LLL:tool.group.content', 'enabled' => false, 'overridden' => true],
+                    ['name' => 'my_ext', 'labelKey' => null, 'enabled' => true, 'overridden' => false],
+                ];
+            }
+        };
+    }
+
+    private function readiness(): PackToolReadiness
+    {
+        return new PackToolReadiness($this->availability());
+    }
+
+    #[Test]
+    public function anEnabledActionReportsItsDeclarationAndItsRecordTypes(): void
+    {
+        $states = $this->readiness()->editorActionStates([self::ALT_TEXT]);
+
+        self::assertCount(1, $states);
+        self::assertSame(self::ALT_TEXT, $states[0]->toolName);
+        self::assertTrue($states[0]->declared);
+        self::assertTrue($states[0]->enabled);
+        self::assertSame('editing', $states[0]->group);
+        self::assertSame(['sys_file'], $states[0]->getRecordTypes());
+        self::assertSame('LLL:alt.label', $states[0]->declaration?->labelKey);
+    }
+
+    #[Test]
+    public function aDisabledActionIsStillDeclaredAndStillNamesItsRecordTypes(): void
+    {
+        // The distinction the plan exists for: the operator has a switch to
+        // throw, and the screen must say which one and for what.
+        $states = $this->readiness()->editorActionStates([self::TRANSLATION]);
+
+        self::assertTrue($states[0]->declared);
+        self::assertFalse($states[0]->enabled);
+        self::assertSame(['pages', 'tt_content'], $states[0]->getRecordTypes());
+    }
+
+    #[Test]
+    public function anUnknownActionIsReportedAsUndeclaredRatherThanDroppedOrDisabled(): void
+    {
+        // The central regression: a typo must be a visible row. Dropping it
+        // would make the plan silent, and reporting it as merely "disabled"
+        // would send the operator to a Tools module with no such entry.
+        $states = $this->readiness()->editorActionStates(['set_file_alternativ_text']);
+
+        self::assertCount(1, $states);
+        self::assertSame('set_file_alternativ_text', $states[0]->toolName);
+        self::assertFalse($states[0]->declared);
+        self::assertFalse($states[0]->enabled);
+        self::assertNull($states[0]->declaration);
+        self::assertSame([], $states[0]->getRecordTypes());
+    }
+
+    #[Test]
+    public function aRegisteredToolThatDeclaresNoEditorActionCountsAsUndeclared(): void
+    {
+        // `get_page` exists and is enabled, but it is not an editor action.
+        // Reporting it as an enabled action would let a pack claim an editorial
+        // write for a read-only tool.
+        $states = $this->readiness()->editorActionStates(['get_page']);
+
+        self::assertFalse($states[0]->declared);
+        self::assertFalse($states[0]->enabled, 'the tool is enabled, but not as an editor action');
+        // `get_page` sits in `content`, and the plan screen renders the group as
+        // "where the switch for this action is". There is no such switch, so the
+        // real group must not be offered as one.
+        self::assertSame('', $states[0]->group, 'the tool has a group, but the action does not exist');
+    }
+
+    #[Test]
+    public function everyNameAskedForGetsExactlyOneRowInOrder(): void
+    {
+        $states = $this->readiness()->editorActionStates([self::TRANSLATION, 'nope', self::ALT_TEXT]);
+
+        self::assertSame(
+            [self::TRANSLATION, 'nope', self::ALT_TEXT],
+            array_map(static fn(PackEditorActionState $state): string => $state->toolName, $states),
+        );
+    }
+
+    #[Test]
+    public function anEmptyDeclarationCostsNothing(): void
+    {
+        self::assertSame([], $this->readiness()->editorActionStates([]));
+        self::assertSame([], $this->readiness()->toolGroupStates([]));
+    }
+
+    #[Test]
+    public function toolGroupsReportRegistrationEnabledStateAndTheCuratedLabel(): void
+    {
+        $states = $this->readiness()->toolGroupStates(['editing', 'content', 'my_ext', 'contnet']);
+
+        self::assertTrue($states[0]->registered);
+        self::assertTrue($states[0]->enabled);
+        self::assertSame('LLL:tool.group.editing', $states[0]->labelKey);
+
+        self::assertTrue($states[1]->registered);
+        self::assertFalse($states[1]->enabled, 'an admin override disabled the group');
+
+        // A third-party group is registered and switchable; it simply has no
+        // translated name. Null must not read as "unknown".
+        self::assertTrue($states[2]->registered);
+        self::assertNull($states[2]->labelKey);
+
+        // The typo the template used to print as if it were real.
+        self::assertFalse($states[3]->registered);
+        self::assertFalse($states[3]->enabled);
+    }
+}

--- a/Tests/Unit/Service/UseCase/UseCasePackPlanTest.php
+++ b/Tests/Unit/Service/UseCase/UseCasePackPlanTest.php
@@ -10,9 +10,12 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Unit\Service\UseCase;
 
 use Netresearch\NrLlm\Domain\DTO\ModelSelectionCriteria;
+use Netresearch\NrLlm\Domain\ValueObject\EditorAction;
 use Netresearch\NrLlm\Service\Governance\GovernanceProfile;
 use Netresearch\NrLlm\Service\Preset\ConfigurationPreset;
 use Netresearch\NrLlm\Service\Preset\PresetPreflightResult;
+use Netresearch\NrLlm\Service\UseCase\PackEditorActionState;
+use Netresearch\NrLlm\Service\UseCase\PackToolGroupState;
 use Netresearch\NrLlm\Service\UseCase\UseCase;
 use Netresearch\NrLlm\Service\UseCase\UseCasePack;
 use Netresearch\NrLlm\Service\UseCase\UseCasePackInstallResult;
@@ -25,6 +28,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(UseCasePackPlan::class)]
 #[CoversClass(UseCasePackPlanItem::class)]
 #[CoversClass(UseCasePackInstallResult::class)]
+#[CoversClass(PackEditorActionState::class)]
+#[CoversClass(PackToolGroupState::class)]
 final class UseCasePackPlanTest extends TestCase
 {
     private function pack(): UseCasePack
@@ -129,6 +134,55 @@ final class UseCasePackPlanTest extends TestCase
         self::assertSame(['tone_of_voice'], $plan->missingSnippetTags);
         self::assertFalse($plan->isFullyInstalled());
         self::assertTrue($plan->isInstallable());
+    }
+
+    #[Test]
+    public function theDeclaredEditorActionsAreCarriedWithTheirStateAndChangeNoCount(): void
+    {
+        $plan = new UseCasePackPlan(
+            pack: $this->pack(),
+            configuration: new UseCasePackPlanItem('ext.fixture', 'Fixture', true),
+            tasks: [new UseCasePackPlanItem('a', 'A', true)],
+            snippets: [],
+            preflight: PresetPreflightResult::satisfiable('GPT-5'),
+            editorActions: [
+                new PackEditorActionState(
+                    'set_file_alternative_text',
+                    true,
+                    false,
+                    'editing',
+                    new EditorAction('LLL:label', 'LLL:description', 'icon', ['sys_file']),
+                ),
+                new PackEditorActionState('set_file_alternativ_text', false, false),
+            ],
+            toolGroups: [
+                new PackToolGroupState('editing', true, true, 'LLL:tool.group.editing'),
+                new PackToolGroupState('contnet', false, false),
+            ],
+        );
+
+        self::assertSame(['sys_file'], $plan->editorActions[0]->getRecordTypes());
+        self::assertSame(
+            ['set_file_alternativ_text'],
+            array_map(
+                static fn(PackEditorActionState $state): string => $state->toolName,
+                $plan->getUndeclaredEditorActions(),
+            ),
+        );
+        self::assertSame(
+            ['contnet'],
+            array_map(
+                static fn(PackToolGroupState $state): string => $state->group,
+                $plan->getUnregisteredToolGroups(),
+            ),
+        );
+
+        // A declaration is advisory (ADR-168): a disabled — or entirely
+        // unknown — editor action must not make the pack look unfinished or
+        // block the confirm button.
+        self::assertSame(0, $plan->getPendingCount());
+        self::assertTrue($plan->isFullyInstalled());
+        self::assertFalse($plan->isInstallable());
     }
 
     #[Test]

--- a/Tests/Unit/Service/UseCase/UseCasePackTest.php
+++ b/Tests/Unit/Service/UseCase/UseCasePackTest.php
@@ -61,9 +61,16 @@ final class UseCasePackTest extends TestCase
     /**
      * @param list<PackTask>    $tasks
      * @param list<PackSnippet> $snippets
+     * @param list<string>      $toolGroups
+     * @param list<string>      $editorActions
      */
-    private function pack(string $identifier = 'fixture-pack', array $tasks = [], array $snippets = []): UseCasePack
-    {
+    private function pack(
+        string $identifier = 'fixture-pack',
+        array $tasks = [],
+        array $snippets = [],
+        array $toolGroups = [],
+        array $editorActions = [],
+    ): UseCasePack {
         return new UseCasePack(
             identifier: $identifier,
             useCase: UseCase::EDITORIAL,
@@ -73,6 +80,8 @@ final class UseCasePackTest extends TestCase
             recommendedGovernanceProfile: GovernanceProfile::CONTROLLED_CLOUD,
             tasks: $tasks,
             snippets: $snippets,
+            recommendedToolGroups: $toolGroups,
+            recommendedEditorActions: $editorActions,
         );
     }
 
@@ -126,6 +135,61 @@ final class UseCasePackTest extends TestCase
         $this->expectExceptionCode(1791460024);
 
         $this->pack(snippets: [$this->snippet('same'), $this->snippet('same')]);
+    }
+
+    #[Test]
+    public function aBlankRecommendedEditorActionIsRefused(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1791460026);
+
+        $pack = $this->pack(editorActions: ['']);
+        self::fail('Expected the blank editor action to be refused, got ' . implode(',', $pack->recommendedEditorActions));
+    }
+
+    #[Test]
+    public function aDuplicateRecommendedEditorActionIsRefused(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1791460027);
+
+        $pack = $this->pack(editorActions: ['set_file_alternative_text', 'set_file_alternative_text']);
+        self::fail('Expected the duplicate editor action to be refused, got ' . implode(',', $pack->recommendedEditorActions));
+    }
+
+    #[Test]
+    public function theBlankAndDuplicateCheckStopsAtTheNewFieldAndLeavesToolGroupsAlone(): void
+    {
+        // Deliberate asymmetry, not an oversight (ADR-168).
+        // `recommendedEditorActions` is new, so it ships with its contract.
+        // `recommendedToolGroups` is pre-existing and reached through the `@api`
+        // provider interface: a third-party pack may already declare a blank or
+        // repeated group, and every pack is built inside UseCasePackRegistry's
+        // constructor, which catches nothing. Refusing it here would turn a
+        // cosmetic defect in one foreign pack into a fatal in every backend
+        // module that injects the registry. What it costs: an empty badge and a
+        // row printed twice on the plan screen.
+        $pack = $this->pack(toolGroups: ['content', '  ', 'content']);
+
+        self::assertSame(['content', '  ', 'content'], $pack->recommendedToolGroups);
+    }
+
+    #[Test]
+    public function anUnknownIdentifierIsDeliberatelyNotRefusedAtDeclarationTime(): void
+    {
+        // Both sets are OPEN: a third-party extension ships its own tools, its
+        // own tool group and — through the same `@api` provider interface — its
+        // own pack. Throwing here would fire inside UseCasePackRegistry's
+        // constructor and take down every module that injects it, so "unknown
+        // to this installation" is the install plan's answer instead, against
+        // the live registry (ADR-168).
+        //
+        // What this therefore does NOT catch: a typo in a shipped pack. That is
+        // covered by UseCasePackRenderTest, which asks the real registry.
+        $pack = $this->pack(toolGroups: ['contnet'], editorActions: ['set_file_alternativ_text']);
+
+        self::assertSame(['contnet'], $pack->recommendedToolGroups);
+        self::assertSame(['set_file_alternativ_text'], $pack->recommendedEditorActions);
     }
 
     #[Test]


### PR DESCRIPTION
## Description

A use-case pack could not say which editor actions it is built for, so a pack whose value depends on one — translation, alt text — either overpromised or stayed silent about the half that matters.

Packs install **tasks**, and a task runs as a plain completion. The write capabilities editors actually use are **tools**, reached through the Editor Action Center, admin-enabled in the Tools module and approval-paused per call. Nothing on `UseCasePack` connected the two.

`UseCasePack` gains `recommendedEditorActions`. For each declared action the install plan reports whether it exists on this installation, whether it is enabled, its tool group, and the record types it supports — and links to the switch. It does **not** enable the action and does **not** execute it. An apply path here would be the automatic governance-apply engine ADR-140 and ADR-145 declined to build.

**Why this is not one class.** `Service\UseCase` is core, and ADR-090 (enforced by `ModuleSeamTest`) forbids core importing the tool module — so core declares `PackToolReadinessInterface` plus two DTOs, `Service\Tool\PackToolReadiness` implements it, and a DI alias joins them. The architecture suite is green on the final tree.

**Why not `EditorActionCatalogue::groupsFor()`.** It answers for one viewer and folds four causes into a single absent row: no default configuration, no access to it, the tool gate, and the record type. It therefore cannot distinguish "this pack has a typo" from "this installation has no default configuration" — which is exactly the distinction a plan screen has to make. The facts come from `ToolAvailabilityServiceInterface` instead, which is the catalogue's own source for all three, so this is not a second registry and not a fourth copy of the enabled check. `runRequestFor()` was never an option: it starts a run.

**One deliberate asymmetry, and the reason for it.** The constructor validates blank and duplicate entries in the **new** field only. `recommendedToolGroups` keeps its pre-existing contract: `UseCasePackRegistry` builds every pack inside its constructor with no `try`/`catch`, and `UseCasePackProviderInterface` is a frozen `@api` extension point — so retro-fitting a throw onto an existing field would turn a third-party pack's duplicate entry into a backend outage rather than a validation message. Both identifier sets also stay **open**: a tool group is derived from the registered tools, not from the enum's cases (`ToolGroupItems` proves it). Unknown identifiers surface on the plan screen instead of throwing.

That asymmetry is stated in ADR-168, together with the two rejected alternatives, so the code and the record argue the same side.

## Related Issue

Closes #769

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Tests

Guards observed failing before being restored, four of them:

- removing the tool-group explanation paragraph fails `thePlanScreenMarksARecommendedToolGroupNoToolCarries`;
- re-adding a blank-entry assert on `recommendedToolGroups` fails `theBlankAndDuplicateCheckStopsAtTheNewFieldAndLeavesToolGroupsAlone` — so the deliberate tolerance is pinned and a silent re-introduction of the throw would be caught;
- removing the tool-group row from the template fails the render test;
- un-gating `PackEditorActionState::$group` fails `aRegisteredToolThatDeclaresNoEditorActionCountsAsUndeclared`.

That last one is a defect found **during** this work rather than before it: while wiring the group into the template, a registered tool that declares no editor action (`get_page`) would have shown its real tool group beside a "Not available here" badge — pointing an operator at a switch that exists and would not produce the action. The field is now gated on the declaration, as `enabled` already was.

## Gates

`cgl -n`, `phpstan` (level 10), `architecture`, `unit` (7100 tests) and functional scoped to `--filter UseCasePack` (31 tests) all exit 0 on the rebased tree, plus the changelog check. The PHPUnit `Configuration:` line was checked to confirm the runs came from this worktree.

**`rector -n` at the CI-pinned PHP 8.2 did not run** — `.Build` here is resolved at 8.4, so `platform_check.php` fatals before Rector starts. Not green, not red: it did not execute, and CI is the first place it will.

## Known gap, recorded rather than fixed

`UseCasePackRegistry` still builds every pack in its constructor with no `catch`, so *any* throwing third-party pack — including the pre-existing duplicate-identifier `LogicException` this change does not touch — takes down every backend module injecting the registry. Making the registry catch and log per provider is named in ADR-168 as a rejected alternative: it is a larger change that would make a throwing pack silently absent, and it would remove the argument that currently keeps both identifier sets open. It needs its own issue, test and ADR.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have added tests that prove my feature works
- [x] I have updated the documentation accordingly
- [x] I have added a `CHANGELOG.md` entry under `## [Unreleased]`
- [x] I have added an ADR (ADR-168)
- [x] My changes generate no new warnings
