### PR TITLE
fix(mcp): spend one budget across an operation's legs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,36 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **One MCP operation now has one timeout, not one per HTTP request** (`#773`,
+  ADR-170). A tool call against an MCP server is three requests — the protocol
+  handshake, its confirmation, then `tools/call` — and each carried a full
+  15-second timeout of its own, so a server answering just inside its limit
+  three times over stalled the call for about 45 seconds. A catalogue import
+  was worse: up to 50 pages, 15 seconds each.
+
+  An operation now opens one budget and every request spends from it, which
+  bounds the operation at that budget plus under a second — no leg is ever
+  granted less than one whole second, so the last one can overrun by a
+  fraction. The default is 20 seconds, configurable as `mcpOperationTimeout`:
+  the old per-request 15 with 5 on top for the handshake in front of the work.
+  That is a composition, not a guarantee for the work request — it is granted
+  what the handshake left. A healthy server answers `initialize` out of memory
+  and the readiness notification with a 202, so the work request gets close to
+  the full 20, more than the 15 it had; a handshake that costs more than 5
+  seconds leaves it less than 15. When the budget runs out, the operation stops
+  with a message naming the budget and the server and saying the server was not
+  asked — distinct from every message about a server that answered badly.
+
+  This is stricter for a slow server than before, in two ways. A catalogue that
+  walks several pages can now be refused where it previously succeeded slowly.
+  And a server that is slow to handshake *and* slow to work can be cut off on
+  the leg where it is legitimately slow, which a fresh 15-second per-request
+  timeout would have let through. Both refusals name the number, and raising
+  `mcpOperationTimeout` is the answer. Nothing here cancels a request already in
+  flight — the stall is reduced, not removed (`#774`). `McpClient` takes a third
+  constructor argument and `McpHttpTransport::call()` / `::notify()` a fourth;
+  neither class is on the `@api` surface.
+
 - **A run's forced snippets and skills now bind against the ADR-144 trust
   ceiling** (`#731`, ADR-164). The Tool Playground injects a per-run forced set
   that reaches the wire like a configuration's own snippet; the ceiling asked

--- a/Classes/Service/Tool/Mcp/Exception/McpTransportException.php
+++ b/Classes/Service/Tool/Mcp/Exception/McpTransportException.php
@@ -15,10 +15,12 @@ use RuntimeException;
  * A call to an MCP server did not produce a usable result (ADR-116).
  *
  * One type for every way the conversation can fail — refused host, transport
- * error, non-2xx status, unparseable body, JSON-RPC error object — because
- * every caller does the same thing with it: record it against the server and
- * stop. The distinction that matters to an operator is the message, which names
- * the server, and that survives into `import_error`.
+ * error, non-2xx status, unparseable body, JSON-RPC error object, an operation
+ * budget that ran out (ADR-170) — because every caller does the same thing with
+ * it: record it against the server and stop. The distinction that matters to an
+ * operator is the message, which names the server, and that survives into
+ * `import_error`. Each factory below carries its own code, so a reader who
+ * needs the kind rather than the sentence has it without parsing prose.
  *
  * The message is built here rather than at the call site so a server's own
  * response text can never be pasted into it unbounded: a remote party writes
@@ -81,6 +83,32 @@ final class McpTransportException extends RuntimeException
                 self::clip($contentType),
             ),
             1799990215,
+        );
+    }
+
+    /**
+     * The operation spent its whole budget before this leg could be sent
+     * (ADR-170).
+     *
+     * Worded so the log tells the two apart at a glance: nothing was asked of
+     * the server here, and the number that ran out is one this installation
+     * chose and can raise. Every other factory above describes a far side that
+     * answered badly or not at all.
+     *
+     * It is NOT a cancellation, and says so. Cancelling an in-flight call
+     * remains unimplemented (issue #774, ADR-161) — this refuses a request that
+     * has not started.
+     */
+    public static function forExhaustedDeadline(string $identifier, int $totalSeconds): self
+    {
+        return new self(
+            sprintf(
+                'The %d-second operation budget for MCP server "%s" ran out before this request was sent, '
+                . 'so the server was not asked. This is the budget this installation sets, not a server that did not answer.',
+                $totalSeconds,
+                $identifier,
+            ),
+            1799990217,
         );
     }
 

--- a/Classes/Service/Tool/Mcp/McpClient.php
+++ b/Classes/Service/Tool/Mcp/McpClient.php
@@ -31,8 +31,14 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
  * matters: this class is a DI singleton on a long-lived queue worker, so a
  * retained session id would be handed to whatever server came next, and a
  * session belonging to server A is meaningless, at best, when presented to
- * server B. The price is paid per call and is bounded by the transport
- * timeout; the alternative is a cache whose invalidation nobody owns.
+ * server B. The price is paid per call and is bounded by the operation
+ * deadline; the alternative is a cache whose invalidation nobody owns.
+ *
+ * That deadline is opened here, once per public method, and every leg spends
+ * from it (ADR-170). This class is where it belongs because this class is what
+ * knows an operation: the transport sees one request at a time and would give
+ * each of them a full budget, which is how a three-leg tool call used to reach
+ * three times the timeout an operator was told about.
  *
  * It is also where liveness is recorded (ADR-154). An operation is the unit an
  * operator reasons about — "the server answered" — and it is the only level at
@@ -79,11 +85,16 @@ final readonly class McpClient
     public function __construct(
         private McpHttpTransport $transport,
         private McpHealthRecorderInterface $health,
+        private McpDeadlineFactory $deadlines,
     ) {}
 
     /**
      * Every tool the server advertises, across all pages.
      *
+     * The whole walk shares one budget, page ceiling included (ADR-170): a
+     * catalogue that takes fifty pages is still one operation somebody is
+     * waiting for, and fifty pages with a timeout each is the stall this
+     * deadline exists to end.
      *
      * @throws McpTransportException
      *
@@ -91,7 +102,8 @@ final readonly class McpClient
      */
     public function listTools(McpServerRecord $server): array
     {
-        $session = $this->openSession($server)['sessionId'];
+        $deadline = $this->deadlines->forOperation();
+        $session  = $this->openSession($server, $deadline)['sessionId'];
 
         $tools  = [];
         $cursor = null;
@@ -101,6 +113,7 @@ final readonly class McpClient
                 $server,
                 'tools/list',
                 $cursor === null ? [] : ['cursor' => $cursor],
+                $deadline,
                 $session,
             );
 
@@ -157,12 +170,13 @@ final readonly class McpClient
      */
     public function callTool(McpServerRecord $server, string $remoteName, array $arguments): McpCallOutcome
     {
-        $session = $this->openSession($server)['sessionId'];
+        $deadline = $this->deadlines->forOperation();
+        $session  = $this->openSession($server, $deadline)['sessionId'];
 
         $answer = $this->transport->call($server, 'tools/call', [
             'name'      => $remoteName,
             'arguments' => $arguments === [] ? new stdClass() : $arguments,
-        ], $session);
+        ], $deadline, $session);
 
         // The server answered, so it is alive — including when the answer is a
         // tool-level `isError` below. That is the tool failing, not the server.
@@ -213,7 +227,7 @@ final readonly class McpClient
         }
 
         try {
-            $handshake = $this->openSession($server);
+            $handshake = $this->openSession($server, $this->deadlines->forOperation());
         } catch (McpTransportException $e) {
             return McpConnectionReport::unreachable($e->getMessage());
         }
@@ -247,11 +261,14 @@ final readonly class McpClient
      * then simply means no session header on the following request, which is
      * valid.
      *
+     * Both legs spend from the operation's budget, so what the handshake costs
+     * is not available to the request it opens the way for (ADR-170).
+     *
      * @throws McpTransportException
      *
      * @return array{result: array<string, mixed>, sessionId: string|null, durationMs: int}
      */
-    private function openSession(McpServerRecord $server): array
+    private function openSession(McpServerRecord $server, McpOperationDeadline $deadline): array
     {
         $handshake = $this->transport->call($server, 'initialize', [
             'protocolVersion' => self::PROTOCOL_VERSION,
@@ -264,11 +281,11 @@ final readonly class McpClient
                 'name'    => 'nr_llm',
                 'version' => '1',
             ],
-        ]);
+        ], $deadline);
 
         // The protocol requires the client to confirm it is ready before it
         // issues requests. A server may reject everything until it arrives.
-        $this->transport->notify($server, 'notifications/initialized', [], $handshake['sessionId']);
+        $this->transport->notify($server, 'notifications/initialized', [], $deadline, $handshake['sessionId']);
 
         return $handshake;
     }

--- a/Classes/Service/Tool/Mcp/McpClockInterface.php
+++ b/Classes/Service/Tool/Mcp/McpClockInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Mcp;
+
+/**
+ * The one clock reading an MCP operation deadline is measured against
+ * (ADR-170).
+ *
+ * Monotonic, not wall clock. A deadline asks "how much of the budget is left",
+ * and a wall clock answers that wrongly whenever the system time is stepped
+ * mid-operation — an NTP correction during a slow handshake would either hand
+ * the last leg a budget nobody granted or declare it exhausted while seconds
+ * remain. That is also why {@see \Psr\Clock\ClockInterface} is not used: it
+ * returns a `DateTimeImmutable`, which is a wall-clock instant by construction.
+ *
+ * The extension's other time seam — the request-pinned `date` aspect that
+ * {@see McpHealthRecorder} stamps rows with — cannot serve either: it is
+ * constant for the whole request, so every reading inside one operation would
+ * be the same and nothing would ever expire.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
+interface McpClockInterface
+{
+    /**
+     * A monotonic reading in nanoseconds.
+     *
+     * Only differences between two readings are meaningful; the origin is
+     * arbitrary and is not a date.
+     */
+    public function monotonicNanoseconds(): int;
+}

--- a/Classes/Service/Tool/Mcp/McpDeadlineFactory.php
+++ b/Classes/Service/Tool/Mcp/McpDeadlineFactory.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Mcp;
+
+use Throwable;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+/**
+ * Turns operator configuration into one {@see McpOperationDeadline} per MCP
+ * operation (ADR-170).
+ *
+ * The budget is a product decision, not an implementation detail, so it lives
+ * in `ext_conf_template.txt` where an operator can see and raise it — rather
+ * than in a constant that only a code reader can find. That matters here
+ * because the number is a trade: too low and a slow but legitimate server is
+ * cut off mid-import, too high and an agent run keeps a backend user waiting.
+ * Only the installation knows which of its servers is which.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
+final readonly class McpDeadlineFactory
+{
+    /**
+     * The whole-operation budget, in seconds, when nothing is configured.
+     *
+     * Composed rather than inherited: 15 seconds is what a single request had
+     * before this existed, and the extra 5 pay for the two handshake legs in
+     * front of the work. That is a composition, not a floor under the payload
+     * leg — there is one budget and the legs spend it in order, so `tools/call`
+     * or a catalogue page is granted 20 minus what the handshake elapsed. On a
+     * healthy server that is close to the whole 20, more than the leg had
+     * before: `initialize` answers out of memory and the readiness notification
+     * is answered with a 202. Where the handshake costs more than 5 seconds the
+     * payload leg gets less than 15, and a server slow to handshake AND slow to
+     * work is newly cut off — accepted, visible in the refusal, and answered by
+     * raising the configured budget (ADR-170, decision 5).
+     *
+     * The worst case an operator can hit falls from about 45 seconds to this
+     * number plus the sub-second overrun
+     * {@see McpOperationDeadline::legTimeoutSeconds()} admits.
+     *
+     * It is deliberately NOT the old 15 as a total, which would put the payload
+     * leg under 15 on every multi-leg call rather than only on a slow one.
+     */
+    public const DEFAULT_TOTAL_SECONDS = 20;
+
+    /** The extension configuration key an operator raises. */
+    private const CONFIGURATION_KEY = 'mcpOperationTimeout';
+
+    public function __construct(
+        private McpClockInterface $clock,
+        private ExtensionConfiguration $extensionConfiguration,
+    ) {}
+
+    /**
+     * Open the budget for one operation. Every leg of that operation spends it.
+     */
+    public function forOperation(): McpOperationDeadline
+    {
+        return McpOperationDeadline::start($this->clock, $this->configuredTotalSeconds());
+    }
+
+    /**
+     * An empty, non-numeric or non-positive value falls back to the default.
+     *
+     * There is no upper clamp. A long budget costs the operator who set it the
+     * wait they asked for, and an MCP tool that legitimately runs for a minute
+     * is a server this extension has no business overruling. Past the
+     * installation's own PHP limit that wait is not paid gracefully — a backend
+     * tool call runs inside the AJAX request, so the request dies on
+     * `max_execution_time` or a gateway timeout instead of returning the failed
+     * tool result {@see McpTool::execute()} writes. ADR-170 decision 5 records
+     * that consequence and still refuses the clamp.
+     */
+    private function configuredTotalSeconds(): int
+    {
+        $raw = trim($this->readString(self::CONFIGURATION_KEY));
+
+        if ($raw !== '' && is_numeric($raw) && (int)$raw > 0) {
+            return (int)$raw;
+        }
+
+        return self::DEFAULT_TOTAL_SECONDS;
+    }
+
+    private function readString(string $key): string
+    {
+        try {
+            $raw = $this->extensionConfiguration->get('nr_llm', $key);
+        } catch (Throwable) {
+            return '';
+        }
+
+        // Values saved through the install tool arrive as strings, but an
+        // int-typed template field may come back as int when set
+        // programmatically.
+        if (\is_int($raw) || \is_float($raw)) {
+            return (string)$raw;
+        }
+
+        return is_string($raw) ? $raw : '';
+    }
+}

--- a/Classes/Service/Tool/Mcp/McpHttpTransport.php
+++ b/Classes/Service/Tool/Mcp/McpHttpTransport.php
@@ -44,16 +44,14 @@ use Throwable;
  *   {@see \Netresearch\NrLlm\Service\SetupWizard\SecureHttpDispatchTrait},
  *   which cannot be reused here because it can neither authenticate per server
  *   nor set a timeout.
+ *
+ * The timeout it sets is not its own (ADR-170). Every call is given the
+ * operation's {@see McpOperationDeadline} and takes what is left of it, because
+ * a per-request budget multiplies by the number of legs the operation happens
+ * to need.
  */
 final class McpHttpTransport
 {
-    /**
-     * Total request duration. An agent run waits on this synchronously while a
-     * backend user watches, so an unreachable server has to fail while the
-     * answer is still worth having.
-     */
-    private const TIMEOUT_SECONDS = 15;
-
     /**
      * Bounds what a hostile or broken server can push into memory before we
      * decide the body is not a JSON-RPC response.
@@ -93,13 +91,20 @@ final class McpHttpTransport
      * per-server state. {@see McpClient} owns the operation and records once.
      *
      * @param array<string, mixed> $params
+     * @param McpOperationDeadline $deadline the operation's remaining budget,
+     *                                       which this leg spends from
      *
      * @throws McpTransportException on any outcome that is not a JSON-RPC result
      *
      * @return array{result: array<string, mixed>, sessionId: string|null, durationMs: int}
      */
-    public function call(McpServerRecord $server, string $method, array $params, ?string $sessionId = null): array
-    {
+    public function call(
+        McpServerRecord $server,
+        string $method,
+        array $params,
+        McpOperationDeadline $deadline,
+        ?string $sessionId = null,
+    ): array {
         $startedAt = hrtime(true);
 
         $response = $this->send($server, $this->encode($server, [
@@ -109,7 +114,7 @@ final class McpHttpTransport
             'id'      => 1,
             'method'  => $method,
             'params'  => $params === [] ? new stdClass() : $params,
-        ]), $sessionId);
+        ]), $deadline, $sessionId);
 
         $durationMs = (int)round((hrtime(true) - $startedAt) / 1_000_000);
 
@@ -128,16 +133,23 @@ final class McpHttpTransport
      * is no result to take from it.
      *
      * @param array<string, mixed> $params
+     * @param McpOperationDeadline $deadline the operation's remaining budget,
+     *                                       which this leg spends from
      *
      * @throws McpTransportException when the server could not be reached
      */
-    public function notify(McpServerRecord $server, string $method, array $params, ?string $sessionId = null): void
-    {
+    public function notify(
+        McpServerRecord $server,
+        string $method,
+        array $params,
+        McpOperationDeadline $deadline,
+        ?string $sessionId = null,
+    ): void {
         $this->send($server, $this->encode($server, [
             'jsonrpc' => '2.0',
             'method'  => $method,
             'params'  => $params === [] ? new stdClass() : $params,
-        ]), $sessionId);
+        ]), $deadline, $sessionId);
     }
 
     /**
@@ -159,8 +171,17 @@ final class McpHttpTransport
      *
      * @return array{status: int, body: string, contentType: string, sessionId: string|null}
      */
-    private function send(McpServerRecord $server, string $body, ?string $sessionId): array
+    private function send(McpServerRecord $server, string $body, McpOperationDeadline $deadline, ?string $sessionId): array
     {
+        // Checked before anything is built, and outside the catch below, so an
+        // exhausted budget cannot be reported as a far side that failed. It is
+        // also checked here rather than in `clientFor()` because the test seam
+        // above bypasses that builder, and a bound only the production path
+        // applies is a bound nothing asserts.
+        if ($deadline->isExhausted()) {
+            throw McpTransportException::forExhaustedDeadline($server->identifier, $deadline->totalSeconds());
+        }
+
         $request = $this->requestFactory
             ->createRequest('POST', $server->url)
             ->withHeader('Content-Type', 'application/json')
@@ -186,7 +207,7 @@ final class McpHttpTransport
                     throw McpTransportException::forRefusedHost($server->identifier, $host);
                 }
 
-                $response = $this->clientFor($server)->sendRequest($request);
+                $response = $this->clientFor($server, $deadline->legTimeoutSeconds())->sendRequest($request);
             }
         } catch (McpTransportException $e) {
             throw $e;
@@ -237,13 +258,18 @@ final class McpHttpTransport
     /**
      * A client bound to this one server's credential, built fresh every call.
      *
+     * `$timeoutSeconds` is what the operation has left, not a constant
+     * (ADR-170). It is never zero or less:
+     * {@see McpOperationDeadline::MINIMUM_LEG_SECONDS} explains why that would
+     * remove the bound rather than tighten it.
+     *
      * @throws McpTransportException when a declared credential does not resolve
      */
-    private function clientFor(McpServerRecord $server): ClientInterface
+    private function clientFor(McpServerRecord $server, int $timeoutSeconds): ClientInterface
     {
         $client = $this->vault->http()
             ->withReason(sprintf('nr-llm MCP call to "%s"', $server->identifier))
-            ->withTimeout(self::TIMEOUT_SECONDS);
+            ->withTimeout($timeoutSeconds);
 
         if ($server->authCredential === '') {
             return $client;

--- a/Classes/Service/Tool/Mcp/McpMonotonicClock.php
+++ b/Classes/Service/Tool/Mcp/McpMonotonicClock.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Mcp;
+
+/**
+ * The production clock: PHP's monotonic timer (ADR-170).
+ *
+ * The same source {@see McpHttpTransport} already measures a round trip with,
+ * so the latency an operator is shown and the budget a leg is granted cannot
+ * disagree about how long something took.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
+final readonly class McpMonotonicClock implements McpClockInterface
+{
+    public function monotonicNanoseconds(): int
+    {
+        // int on any 64-bit build; the cast is what makes the 32-bit float
+        // return a type the arithmetic below can rely on.
+        return (int)hrtime(true);
+    }
+}

--- a/Classes/Service/Tool/Mcp/McpOperationDeadline.php
+++ b/Classes/Service/Tool/Mcp/McpOperationDeadline.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Tool\Mcp;
+
+/**
+ * One budget for one MCP operation, spent across its legs (ADR-170).
+ *
+ * An MCP operation is several HTTP round trips: the handshake, its
+ * confirmation, and the request that was actually wanted. Each of those used to
+ * carry a full timeout of its own, so a server answering just inside its own
+ * limit three times over stalled a tool call for three times the number the
+ * constant named. The budget belongs to the OPERATION, so it is carried by an
+ * object the operation owns and each leg is granted what is left of it.
+ *
+ * It is a value passed down rather than state on the transport for the same
+ * reason the transport builds a fresh client per call: the transport is a DI
+ * singleton on a long-lived worker, and a remaining-budget field on it would be
+ * shared between two operations against two servers.
+ *
+ * Time is read through {@see McpClockInterface} so the arithmetic is assertable
+ * without sleeping.
+ */
+final readonly class McpOperationDeadline
+{
+    /**
+     * The smallest timeout a leg may be given.
+     *
+     * Not cosmetic. The transport hands this number to
+     * {@see \Netresearch\NrVault\Http\VaultHttpClientInterface::withTimeout()},
+     * which treats a non-positive value as "no override" and rebuilds the
+     * client from `$GLOBALS['TYPO3_CONF_VARS']['HTTP']['timeout']` — whose
+     * TYPO3 default is `0`, and Guzzle reads `0` as *wait forever*. A leg
+     * granted zero seconds would therefore be the one leg with no bound at all,
+     * which is the exact opposite of a deadline. Below this floor the operation
+     * refuses to send instead ({@see self::isExhausted()}).
+     */
+    public const MINIMUM_LEG_SECONDS = 1;
+
+    private function __construct(
+        private McpClockInterface $clock,
+        private int $totalSeconds,
+        private int $startedAtNanoseconds,
+    ) {}
+
+    /**
+     * Open a budget of `$totalSeconds` and start spending it now.
+     *
+     * A total below the leg floor would be exhausted before the first request,
+     * which is a misconfiguration rather than a policy, so it is raised to the
+     * floor. {@see McpDeadlineFactory} is what turns operator configuration
+     * into this number.
+     */
+    public static function start(McpClockInterface $clock, int $totalSeconds): self
+    {
+        return new self(
+            $clock,
+            max(self::MINIMUM_LEG_SECONDS, $totalSeconds),
+            $clock->monotonicNanoseconds(),
+        );
+    }
+
+    /**
+     * The whole budget, as granted — for the message an exhausted operation
+     * writes, which has to name the number an operator can change.
+     */
+    public function totalSeconds(): int
+    {
+        return $this->totalSeconds;
+    }
+
+    /**
+     * What is left, in seconds; negative once the budget is overspent.
+     */
+    public function remainingSeconds(): float
+    {
+        $elapsed = ($this->clock->monotonicNanoseconds() - $this->startedAtNanoseconds) / 1_000_000_000;
+
+        return $this->totalSeconds - $elapsed;
+    }
+
+    /**
+     * Whether the budget is gone and the next leg must not be sent.
+     */
+    public function isExhausted(): bool
+    {
+        return $this->remainingSeconds() <= 0.0;
+    }
+
+    /**
+     * The timeout the next leg is granted: what remains, never below the floor.
+     *
+     * Rounded UP, so a fraction of a second left is a leg that may run for one
+     * — the overrun is bounded by a second and the alternative is the unbounded
+     * request the floor exists to prevent.
+     */
+    public function legTimeoutSeconds(): int
+    {
+        return max(self::MINIMUM_LEG_SECONDS, (int)ceil($this->remainingSeconds()));
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -29,6 +29,10 @@ services:
       - '../Classes/Service/SetupWizard/Exception/*'
       - '../Classes/Service/Skill/Exception/*'
       - '../Classes/Service/Tool/Mcp/Exception/*'
+      # Opened inside a client method and passed down, never injected — the
+      # budget is per operation, and a container-held instance would bound the
+      # process. Private constructor and a scalar argument besides (ADR-170).
+      - '../Classes/Service/Tool/Mcp/McpOperationDeadline.php'
       # Built per catalogue row by McpToolProvider from a database row. Without
       # this the `nr_llm.tool` autoconfigure tag on ToolInterface would have the
       # container try to build it, and compilation fails on the scalar arguments.

--- a/Documentation/Administration/McpServers.rst
+++ b/Documentation/Administration/McpServers.rst
@@ -95,10 +95,32 @@ is the ordinary case of a missing page or a rejected argument. Both are
 recorded as failures in the run's event stream, so a server that is
 flaky is visible without reading transcripts.
 
+How long one operation may take
+===============================
+
+An operation against an MCP server — a tool call, a catalogue import, a
+connection test — is several HTTP requests: the protocol handshake, its
+confirmation, then the request that carries the work. All of them share
+**one** budget, set by the extension configuration field *MCP operation
+budget (seconds)* (``mcpOperationTimeout``, 20 seconds by default). What
+the handshake spends is no longer available to the request behind it, and
+a large catalogue walks its pages under the same budget.
+
+Raise it for a server that is legitimately slow — including one that is
+slow to *open*: a handshake costing more than five seconds leaves the work
+request less than the fifteen a single request used to have, so a server
+that is slow at both ends can be refused where it previously succeeded.
+
+When the budget runs out
+the operation stops with a message naming the number and the server, and
+saying plainly that nothing was asked of the server — that is this
+installation's budget, not a server that failed to answer.
+
 See :ref:`ADR-116 <adr-116>` for the design rationale,
 :ref:`ADR-154 <adr-154>` for what liveness is measured on and why the
-connection test writes nothing, and :ref:`ADR-161 <adr-161>` for the
-conformance suite every supported connection is held to — including the
-one thing it does **not** do: cancelling a call that is already in
-flight. Cancelling a run stops it at the next step, but an outstanding
-remote call still runs to its 15-second timeout.
+connection test writes nothing, :ref:`ADR-170 <adr-170>` for the operation
+budget, and :ref:`ADR-161 <adr-161>` for the conformance suite every
+supported connection is held to — including the one thing it does **not**
+do: cancelling a call that is already in flight. Cancelling a run stops it
+at the next step, but an outstanding remote call still runs until the
+server answers or the operation's remaining budget is gone.

--- a/Documentation/Adr/Adr154McpServerHealth.rst
+++ b/Documentation/Adr/Adr154McpServerHealth.rst
@@ -4,8 +4,10 @@
 ADR-154: An MCP server's liveness is observed, not inferred
 ============================================================
 
-:Status: Accepted
+:Status: Accepted (the bound an operation runs to is now the operation's own —
+    see :ref:`ADR-170 <adr-170>`)
 :Date: 2026-08-11
+:Amended: 2026-08-13 by :ref:`ADR-170 <adr-170>`
 
 Context
 =======
@@ -115,10 +117,12 @@ Decision
    because part of what they say was written by the far side. A refusal is
    written into the same region, and the region is cleared before the request
    goes out: without that, a probe that stops answering leaves the last
-   success standing for the fifteen seconds of the transport timeout and then
-   beside its own error toast. The corollary is that the report is gone on the
-   next page load, which is correct: it describes one moment, and what outlives
-   the moment is the contact date and its latency.
+   success standing for as long as the probe is bounded by — fifteen seconds of
+   transport timeout when this was written, the operation deadline of
+   :ref:`ADR-170 <adr-170>` since — and then beside its own error toast. The
+   corollary is that the report is gone on the next page load, which is
+   correct: it describes one moment, and what outlives the moment is the
+   contact date and its latency.
 
    **Transport is stated, not stored.** HTTP is the only transport this client
    speaks (:ref:`ADR-116 <adr-116>`, "Transports: HTTP only") and a column would
@@ -186,8 +190,9 @@ Each of these is a separate decision, and none is blocked by this one:
 - **Retry, backoff and circuit breaking.** A latency number is a measurement; a
   breaker is a policy about when to stop calling, and it needs an owner for the
   half-open state and an answer for what an agent run mid-loop should do.
-- **Cancelling an in-flight call.** The 15-second transport timeout is still the
-  only bound.
+- **Cancelling an in-flight call.** A timeout is still the only bound — the
+  15-second per-request one when this was written, the whole-operation deadline
+  of :ref:`ADR-170 <adr-170>` since. Neither aborts anything.
 - **Per-tool data class overrides.** The class stays a property of the server
   (:ref:`ADR-094 <adr-094>`).
 - **Non-HTTP transports.** :ref:`ADR-116 <adr-116>` rules stdio out on purpose

--- a/Documentation/Adr/Adr161McpClientConformance.rst
+++ b/Documentation/Adr/Adr161McpClientConformance.rst
@@ -4,8 +4,10 @@
 ADR-161: One conformance suite for every MCP connection we support
 ==================================================================
 
-:Status: Accepted
+:Status: Accepted (the timeouts row now covers the whole operation — see
+    :ref:`ADR-170 <adr-170>`)
 :Date: 2026-08-11
+:Amended: 2026-08-13 by :ref:`ADR-170 <adr-170>`
 
 Context
 =======
@@ -91,9 +93,12 @@ Decision
           failed.
       * - timeouts
         - Covered on both halves: the transport puts a finite timeout on the
-          client it builds (asserted against that client, not against the
+          client it builds (asserted against that client, not against a
           constant), and a connection that never answers becomes a failed tool
-          result rather than an escaping exception.
+          result rather than an escaping exception. Since
+          :ref:`ADR-170 <adr-170>` the row covers the OPERATION as well: one
+          budget is spent across the legs, an exhausted budget is its own
+          outcome, and no leg is ever granted a timeout that would mean none.
       * - cancellation
         - **A gap. Pinned by its absence, not by a behavioural check.** See
           decision 3.
@@ -138,8 +143,10 @@ Decision
    :php:`AgentRuntime::cancel()` flips persisted state and the loop stops at the
    next step boundary. The transport has no abort path, so a cancellation
    raised while a request is in flight changes nothing about that request: the
-   run waits the leg out, bounded only by the 15-second timeout
-   (:ref:`ADR-154 <adr-154>` already listed this under what it did not decide).
+   run waits the leg out, bounded only by a timeout — the 15-second per-request
+   one when this was written, the whole-operation deadline of
+   :ref:`ADR-170 <adr-170>` since (:ref:`ADR-154 <adr-154>` already listed this
+   under what it did not decide).
 
    The suite does not fake a passing cancellation test, and it does not pretend
    to a behavioural one either. There is no behaviour to assert: a cancellation

--- a/Documentation/Adr/Adr170OneDeadlinePerMcpOperation.rst
+++ b/Documentation/Adr/Adr170OneDeadlinePerMcpOperation.rst
@@ -1,0 +1,211 @@
+.. _adr-170:
+
+==============================================================
+ADR-170: One deadline per MCP operation, spent across its legs
+==============================================================
+
+:Status: Accepted
+:Date: 2026-08-13
+:Amends: :ref:`ADR-154 <adr-154>` (the transport timeout is no longer the bound
+    an operation is measured by) and :ref:`ADR-161 <adr-161>` (its conformance
+    table gains an operation-level timeout row)
+:Authors: Netresearch DTT GmbH
+
+Context
+=======
+
+An MCP operation is not one HTTP request. The protocol prescribes an opening
+sequence, so :php:`McpClient::callTool()` sends three:
+
+.. code-block:: text
+
+   initialize                 the handshake
+   notifications/initialized  its confirmation
+   tools/call                 the request that carries the work
+
+:php:`McpHttpTransport` put a 15-second timeout on each of them, because a
+transport sees one request at a time and has no notion of the operation around
+it. So the bound an operator was told about — "an unreachable server fails while
+the answer is still worth having" — was the bound on a *leg*, and the bound on
+the operation was that number multiplied by however many legs the protocol
+happened to need.
+
+A hard timeout on the first leg still ends early, so the failure is not the loud
+one. The expensive case is the slow one: each leg answers just inside its own
+limit and the tool call runs to roughly 45 seconds, with a backend user watching
+an agent run wait it out. The catalogue walk is worse — :php:`listTools()` walks
+up to 50 pages, each with its own 15 seconds.
+
+That window is also where a cancelled run keeps waiting, because nothing on this
+path can abort a request in flight (:ref:`ADR-161 <adr-161>`, decision 3). This
+record does not change that, and is careful not to look as though it does.
+
+Decision
+========
+
+1. **The budget belongs to the operation, and travels with the call.**
+   :php:`McpClient` opens one :php:`McpOperationDeadline` per public method and
+   passes it to every leg; :php:`McpHttpTransport` grants each request what is
+   left of it. The handshake spending six seconds is six seconds
+   :php:`tools/call` does not get.
+
+   It is a value handed down rather than state on the transport for the reason
+   the transport already builds a fresh client per call: it is a DI singleton on
+   a long-lived worker, so a remaining-budget field on it would be shared
+   between two operations against two different servers. The deadline is
+   likewise not a constructor argument of the client, because the client is a
+   singleton too and an operation is not.
+
+   Rejected: keeping the budget in the transport and passing a leg *index* or a
+   "this is the last leg" flag. That encodes the client's knowledge of the
+   protocol in the class that exists precisely not to have it, and it still
+   cannot answer the question that matters — how much time is left.
+
+2. **Time is read through a clock seam, and a monotonic one.**
+   :php:`McpClockInterface` returns a monotonic nanosecond reading;
+   :php:`McpMonotonicClock` is :php:`hrtime()`, the same source the transport
+   already measures a round trip with.
+
+   :php:`Psr\\Clock\\ClockInterface` was rejected rather than added: it returns
+   a :php:`DateTimeImmutable`, which is a wall-clock instant, and a wall clock
+   stepped by an NTP correction mid-operation would either grant a leg a budget
+   nobody authorised or declare it exhausted with seconds to spare. The
+   extension's existing time seam — the request-pinned ``date`` aspect
+   :php:`McpHealthRecorder` stamps rows with — cannot serve either: it is
+   constant for the whole request, so every reading inside one operation is the
+   same and nothing ever expires.
+
+3. **An exhausted budget is its own outcome, and is not a cancellation.**
+   :php:`McpTransportException::forExhaustedDeadline()` carries its own code and
+   a sentence that names what happened: the request was not sent, the number
+   that ran out is one this installation chose, and the server was not asked. An
+   operator reading ``import_error`` or a failed step can tell that apart from
+   every other factory on that class, all of which describe a far side that
+   answered badly or not at all.
+
+   It stays the same exception *type*. Every caller still does the same thing
+   with it — record it against the server and stop — which is the reason that
+   class has one type, and a second type would buy a distinction no catch block
+   wants to make.
+
+   The check sits at the top of :php:`send()`, before the request is built and
+   outside the ``catch`` that maps a :php:`Throwable` onto "could not be
+   reached". Putting it in the client builder instead would have left the PSR-18
+   test seam unguarded and would have reported a spent budget as a failing
+   server.
+
+4. **A leg is never granted zero seconds.**
+   The number goes to
+   :php:`VaultHttpClientInterface::withTimeout()`, which treats a non-positive
+   value as *no override* and rebuilds the client from
+   ``$GLOBALS['TYPO3_CONF_VARS']['HTTP']['timeout']`` — whose TYPO3 default is
+   ``0``, and which Guzzle reads as *wait forever*. A leg handed zero would
+   therefore be the one leg with no bound at all: the exact opposite of a
+   deadline, arriving exactly when the budget is tightest.
+
+   So a remainder is rounded **up** and floored at
+   :php:`McpOperationDeadline::MINIMUM_LEG_SECONDS` (one second), and below that
+   the operation refuses to send rather than sending unbounded. The overrun this
+   admits is under a second per operation.
+
+5. **The budget is 20 seconds, and it is a configuration field.**
+   ``mcpOperationTimeout`` in ``ext_conf_template.txt``, not a constant. The
+   number is a trade only the installation can make — too low cuts off a server
+   that is slow but legitimate, too high keeps a backend user waiting — so it
+   belongs where an operator can see and change it.
+
+   20 is composed rather than inherited: 15 seconds is what a single request
+   had before this existed, and the 5 on top pay for the two handshake legs in
+   front of the work. What that composition does **not** do is guarantee the
+   payload leg those 15. There is one budget and the legs spend it in order, so
+   ``tools/call`` is granted what the handshake left — 20 minus its elapsed
+   time. The test
+   :php:`McpClientTest::theLastLegOfAToolCallGetsOnlyWhatTheHandshakeLeft`
+   asserts precisely that: a 4-second ``initialize`` and a 2-second readiness
+   notification produce ``[20, 16, 14]``, so the payload leg runs for 14 — not
+   for 15, and not for a fresh 20.
+
+   The 5 is therefore a wager on the shape of a healthy server, not a floor
+   under the payload leg. On a healthy server the wager wins comfortably:
+   ``initialize`` answers out of memory and the readiness notification is
+   answered with a 202, both far under a second, so the work request is granted
+   about 20 — *more* than the 15 it used to have. The wager is lost when the
+   handshake alone costs more than 5 seconds. Then the payload leg gets less
+   than 15, and a server whose handshake is slow **and** whose work is slow can
+   be cut off where a fresh per-request timeout let it through. That is a real
+   regression for that one server shape, and it is accepted rather than
+   designed away: it is visible in the refusal, which names the budget, and
+   raising ``mcpOperationTimeout`` is the answer an operator has. A floor under
+   the payload leg would buy it back only by putting the operation's worst case
+   above the budget an operator was shown, which is the defect this record
+   exists to close.
+
+   Inheriting the existing 15 as a *total* was rejected as strictly worse on
+   that same axis: it would leave the payload leg under 15 on *every* multi-leg
+   call, not only against a slow-handshaking server.
+
+   An empty, non-numeric or non-positive value falls back to 20; a total below
+   the leg floor is raised to it. There is no upper clamp — a long budget costs
+   the operator who set it the wait they asked for. That wait is not paid
+   gracefully at the far end of the range, and the decision is made knowing it:
+   a backend tool call runs synchronously inside the AJAX request, so
+   ``mcpOperationTimeout = 600`` against a server that stalls does not end with
+   a budget message after 600 seconds. It blocks until a PHP or gateway limit
+   ends the request first — ``max_execution_time``, FPM's
+   ``request_terminate_timeout``, or the proxy in front — and the backend user
+   gets a 500 or a 504 with no body, not the failed tool result
+   :php:`McpTool::execute()` writes for every :php:`McpTransportException` it
+   catches. So a budget raised far past the installation's PHP limit buys a
+   broken request rather than a patient one. The clamp is still refused: the
+   ceiling that matters is that PHP limit, this extension does not know it, and
+   a number hard-coded against a guess at it would cut off the legitimately slow
+   server this field exists for.
+
+.. _adr-170-not:
+
+What this does not do
+=====================
+
+**It does not cancel anything.** No :php:`cancel()`, no cancellation token, no
+abort path. A request already on the wire runs until the server answers or its
+own timeout fires; what this decides is what the *next* leg is granted, and
+whether it is sent at all. The stall is reduced, not removed — a cancelled run
+still waits out the leg in flight, now bounded by the operation's remaining
+budget rather than by a fresh 15 seconds.
+
+Cancelling in flight is
+`#774 <https://github.com/netresearch/t3x-nr-llm/issues/774>`__ and is
+unchanged by this record: it needs a seam through the vault HTTP client
+that does not exist, which is why :ref:`ADR-161 <adr-161>` pins the gap
+structurally rather than behaviourally. That structural check still passes —
+nothing added here reads as a cancellation seam — and it must keep failing the
+day one appears.
+
+**It does not add retry, backoff or circuit breaking.** A budget says when to
+stop waiting, not when to stop calling. :ref:`ADR-154 <adr-154>` left that open
+and it stays open.
+
+**It does not change what a timed-out call looks like to a run.** A connection
+that dies still becomes a failed tool result naming the server, the model is
+told, and the loop carries on.
+
+Consequences
+============
+
+An installation that changes nothing gets a tool call bounded at 20 seconds
+instead of about 45, and a catalogue import bounded at 20 seconds instead of a
+page ceiling times a per-request timeout — in both cases plus the sub-second
+overrun decision 4 admits.
+
+The import is where a real installation can notice this. A catalogue that walks
+several pages against a slow server now spends one budget across all of them,
+and can be refused where it previously succeeded slowly. The refusal names the
+budget and the server, and raising ``mcpOperationTimeout`` is the answer; the
+alternative — a per-operation bound that a paginating server can extend
+indefinitely — is the defect this record closes.
+
+:php:`McpClient` takes a third constructor argument and
+:php:`McpHttpTransport::call()` / :php:`::notify()` a fourth. Neither class is
+part of the ``@api`` surface (:ref:`ADR-127 <adr-127>`), so no frozen signature
+moves; an integrator constructing either by hand does have to pass the new
+collaborator.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -521,3 +521,4 @@ Tools
    Adr167ConfigurationAccessIsASimulatedAxis
    Adr168PacksDeclareEditorActions
    Adr169RecordManagementUsesTypo3Permissions
+   Adr170OneDeadlinePerMcpOperation

--- a/Tests/Fixtures/Mcp/FakeMcpClock.php
+++ b/Tests/Fixtures/Mcp/FakeMcpClock.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Fixtures\Mcp;
+
+use Netresearch\NrLlm\Service\Tool\Mcp\McpClockInterface;
+
+/**
+ * A monotonic clock the test moves by hand.
+ *
+ * The deadline arithmetic is about elapsed seconds, and the only other way to
+ * assert it is to sleep — which makes the suite slow and, worse, flaky on a
+ * loaded runner exactly where the numbers are tight.
+ *
+ * The origin is deliberately not zero. A deadline that accidentally treated the
+ * reading as an absolute duration rather than as one half of a difference would
+ * pass against a clock starting at 0 and fail here.
+ */
+final class FakeMcpClock implements McpClockInterface
+{
+    private int $nanoseconds = 4_242_000_000_000;
+
+    public function monotonicNanoseconds(): int
+    {
+        return $this->nanoseconds;
+    }
+
+    /**
+     * Move the clock forward. Fractions are allowed: sub-second remainders are
+     * where the leg floor is decided.
+     */
+    public function advanceSeconds(float $seconds): void
+    {
+        $this->nanoseconds += (int)round($seconds * 1_000_000_000);
+    }
+}

--- a/Tests/Fixtures/Mcp/SlowVaultHttpClient.php
+++ b/Tests/Fixtures/Mcp/SlowVaultHttpClient.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Fixtures\Mcp;
+
+use BadMethodCallException;
+use Netresearch\NrVault\Http\OAuth\OAuthConfig;
+use Netresearch\NrVault\Http\SecretPlacement;
+use Netresearch\NrVault\Http\VaultHttpClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * A vault HTTP client that answers, records the timeout each leg was given, and
+ * costs the operation a scripted amount of time.
+ *
+ * It exists because the operation deadline can only be asserted where the
+ * timeout is actually applied. `McpHttpTransport::setHttpClient()` — the seam
+ * every other MCP test uses — bypasses the vault builder that calls
+ * `withTimeout()`, so a test driven through it cannot see what a leg was
+ * granted. This double takes the vault path instead: it accumulates every
+ * timeout in order, and advances a {@see FakeMcpClock} before it answers, which
+ * is how a leg "takes" time without the suite sleeping.
+ *
+ * It is not
+ * {@see \Netresearch\NrLlm\Tests\Fixtures\Mcp\Conformance\RecordingVaultHttpClient}
+ * widened: that one exists to prove a client is CONFIGURED and never sends, and
+ * a double that both refuses to send and sends is a double that proves neither.
+ *
+ * The `with*` methods return `$this` rather than a clone, as the production
+ * client would: the point is to accumulate what the transport asked for across
+ * a whole operation.
+ */
+final class SlowVaultHttpClient implements VaultHttpClientInterface
+{
+    /**
+     * The seconds passed to withTimeout(), one entry per leg, in order.
+     *
+     * @var list<int>
+     */
+    public array $grantedTimeouts = [];
+
+    /**
+     * @param McpTestServer $server       the scripted answers
+     * @param FakeMcpClock  $clock        the operation's clock
+     * @param list<float>   $legDurations how long each leg takes, in seconds;
+     *                                    a leg beyond the list takes no time
+     */
+    public function __construct(
+        private readonly McpTestServer $server,
+        private readonly FakeMcpClock $clock,
+        private array $legDurations = [],
+    ) {}
+
+    public function sendRequest(RequestInterface $request): ResponseInterface
+    {
+        $this->clock->advanceSeconds(array_shift($this->legDurations) ?? 0.0);
+
+        return $this->server->sendRequest($request);
+    }
+
+    public function withTimeout(int $seconds): static
+    {
+        $this->grantedTimeouts[] = $seconds;
+
+        return $this;
+    }
+
+    public function withReason(string $reason): static
+    {
+        return $this;
+    }
+
+    /**
+     * Accepted and dropped: no check here reads back how a credential was
+     * placed, and the servers these tests use declare none.
+     */
+    public function withAuthentication(
+        string $secretIdentifier,
+        SecretPlacement $placement = SecretPlacement::Bearer,
+        array $options = [],
+    ): static {
+        return $this;
+    }
+
+    public function withOAuth(OAuthConfig $config, string $reason = 'OAuth2 API call'): static
+    {
+        throw new BadMethodCallException('The MCP transport never configures OAuth', 1799990242);
+    }
+}

--- a/Tests/Functional/Service/Tool/Mcp/McpHealthTest.php
+++ b/Tests/Functional/Service/Tool/Mcp/McpHealthTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrLlm\Tests\Functional\Service\Tool\Mcp;
 
 use Netresearch\NrLlm\Domain\ValueObject\McpServerRecord;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpClient;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpDeadlineFactory;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpHealthRecorder;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpHttpTransport;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpServerRepository;
@@ -175,6 +176,7 @@ final class McpHealthTest extends AbstractFunctionalTestCase
         $client = new McpClient(
             $this->transportFor($fake),
             new McpHealthRecorder(new McpServerRepository($throwing), new Context(), new NullLogger()),
+            $this->get(McpDeadlineFactory::class),
         );
 
         self::assertSame('still answered', $client->callTool($server, 'do_it', [])->text);
@@ -189,6 +191,7 @@ final class McpHealthTest extends AbstractFunctionalTestCase
         return new McpClient(
             $this->transportFor($fake),
             new McpHealthRecorder($this->servers, new Context(), new NullLogger()),
+            $this->get(McpDeadlineFactory::class),
         );
     }
 

--- a/Tests/Functional/Service/Tool/Mcp/McpImportServiceTest.php
+++ b/Tests/Functional/Service/Tool/Mcp/McpImportServiceTest.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Domain\Enum\ToolDataClass;
 use Netresearch\NrLlm\Domain\ValueObject\McpImportReport;
 use Netresearch\NrLlm\Domain\ValueObject\McpServerRecord;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpClient;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpDeadlineFactory;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpHttpTransport;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpImportService;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpSchemaNormalizer;
@@ -112,7 +113,7 @@ final class McpImportServiceTest extends AbstractFunctionalTestCase
         $transport->setHttpClient($fake);
 
         return new McpImportService(
-            new McpClient($transport, new RecordedContacts()),
+            new McpClient($transport, new RecordedContacts(), $this->get(McpDeadlineFactory::class)),
             $this->servers,
             $this->catalogue,
             new McpToolNameMapper(),
@@ -387,7 +388,7 @@ final class McpImportServiceTest extends AbstractFunctionalTestCase
             new StreamFactory(),
         );
 
-        return new McpClient($transport, new RecordedContacts());
+        return new McpClient($transport, new RecordedContacts(), $this->get(McpDeadlineFactory::class));
     }
 
     /**

--- a/Tests/Functional/Service/Tool/Mcp/McpRunAuditTest.php
+++ b/Tests/Functional/Service/Tool/Mcp/McpRunAuditTest.php
@@ -38,6 +38,7 @@ use Netresearch\NrLlm\Service\Tool\AgentRunRepositoryInterface;
 use Netresearch\NrLlm\Service\Tool\AgentStateCodec;
 use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpClient;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpDeadlineFactory;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpHttpTransport;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpTool;
 use Netresearch\NrLlm\Service\Tool\ToolAvailabilityService;
@@ -322,7 +323,7 @@ final class McpRunAuditTest extends AbstractFunctionalTestCase
             // so the first pass executes the call instead of suspending — which
             // is the path whose audit this class is about.
             false,
-            new McpClient($transport, new RecordedContacts()),
+            new McpClient($transport, new RecordedContacts(), $this->get(McpDeadlineFactory::class)),
         );
     }
 

--- a/Tests/Functional/Service/Tool/ToolLoopServiceBuiltinTest.php
+++ b/Tests/Functional/Service/Tool/ToolLoopServiceBuiltinTest.php
@@ -36,6 +36,7 @@ use Netresearch\NrLlm\Service\Tool\Builtin\UpdatePageMetadataTool;
 use Netresearch\NrLlm\Service\Tool\Exception\ToolApprovalRequiredException;
 use Netresearch\NrLlm\Service\Tool\FalStorageGate;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpClient;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpDeadlineFactory;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpHttpTransport;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpServerRepository;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpTool;
@@ -499,7 +500,7 @@ final class ToolLoopServiceBuiltinTest extends AbstractFunctionalTestCase
             ['type' => 'object', 'properties' => []],
             ToolDataClass::PUBLIC_CONTENT,
             $server->approvalRequired(),
-            new McpClient($transport, new RecordedContacts()),
+            new McpClient($transport, new RecordedContacts(), $this->get(McpDeadlineFactory::class)),
         );
     }
 

--- a/Tests/Unit/Service/Tool/Mcp/Conformance/AbstractMcpConformanceTestCase.php
+++ b/Tests/Unit/Service/Tool/Mcp/Conformance/AbstractMcpConformanceTestCase.php
@@ -13,7 +13,9 @@ use Netresearch\NrLlm\Domain\Enum\ToolEffect;
 use Netresearch\NrLlm\Domain\ValueObject\McpToolRecord;
 use Netresearch\NrLlm\Service\Tool\Mcp\Exception\McpTransportException;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpClient;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpDeadlineFactory;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpHttpTransport;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpOperationDeadline;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpSchemaNormalizer;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpTool;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpToolNameMapper;
@@ -25,9 +27,13 @@ use Netresearch\NrLlm\Service\Tool\ToolRegistry;
 use Netresearch\NrLlm\Service\Tool\ToolResultBounder;
 use Netresearch\NrLlm\Tests\Fixtures\Mcp\Conformance\McpConnectionProfile;
 use Netresearch\NrLlm\Tests\Fixtures\Mcp\Conformance\RecordingVaultHttpClient;
+use Netresearch\NrLlm\Tests\Fixtures\Mcp\FakeMcpClock;
 use Netresearch\NrLlm\Tests\Fixtures\Mcp\McpTestServer;
 use Netresearch\NrLlm\Tests\Fixtures\Mcp\RecordedContacts;
+use Netresearch\NrLlm\Tests\Fixtures\Mcp\SlowVaultHttpClient;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrVault\Http\DnsResolverInterface;
+use Netresearch\NrVault\Http\SecureHttpClientFactory;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -37,6 +43,7 @@ use Psr\Http\Message\ResponseInterface;
 use ReflectionClass;
 use ReflectionMethod;
 use RuntimeException;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Http\Client\GuzzleClientFactory;
 use TYPO3\CMS\Core\Http\RequestFactory;
 use TYPO3\CMS\Core\Http\StreamFactory;
@@ -387,11 +394,11 @@ abstract class AbstractMcpConformanceTestCase extends AbstractUnitTestCase
      * user watches, so an unreachable server has to give up while the answer is
      * still worth having.
      *
-     * Asserted against the client the transport actually builds, not against
-     * the constant: the PSR-18 test seam every other check here uses bypasses
-     * that construction by design, so this one reaches the private builder
-     * directly. Reading the constant would prove it exists, not that it is put
-     * on the client.
+     * Asserted against the client the transport actually builds, not against a
+     * constant: the PSR-18 test seam every other check here uses bypasses that
+     * construction by design, so this one reaches the private builder directly.
+     * Reading a constant would prove it exists, not that it is put on the
+     * client.
      */
     #[Test]
     public function putsAFiniteTimeoutOnTheClientItBuilds(): void
@@ -408,13 +415,105 @@ abstract class AbstractMcpConformanceTestCase extends AbstractUnitTestCase
         );
 
         (new ReflectionMethod(McpHttpTransport::class, 'clientFor'))
-            ->invoke($transport, $this->connection()->server());
+            ->invoke(
+                $transport,
+                $this->connection()->server(),
+                McpOperationDeadline::start(new FakeMcpClock(), 20)->legTimeoutSeconds(),
+            );
 
         self::assertIsInt($recording->timeoutSeconds);
         self::assertGreaterThan(0, $recording->timeoutSeconds, 'an unbounded call would hang the run');
         self::assertLessThanOrEqual(30, $recording->timeoutSeconds, 'and one nobody waits out is no bound');
         self::assertIsString($recording->reason);
         self::assertStringContainsString($this->connection()->identifier, $recording->reason);
+    }
+
+    /**
+     * TIMEOUTS, per OPERATION rather than per request (ADR-170).
+     *
+     * An operation over this connection is several round trips — the handshake,
+     * its confirmation, then the request that carries the work — and a bound
+     * that applied to each of them separately multiplied by however many legs
+     * the protocol happened to need. One budget is opened per operation, and
+     * each leg is granted what the earlier ones left.
+     *
+     * Driven through the vault path on purpose: the PSR-18 seam bypasses the
+     * one place a timeout is applied, so a check on the seam could not see what
+     * a leg was granted.
+     */
+    #[Test]
+    public function spendsOneBudgetAcrossTheLegsOfAnOperation(): void
+    {
+        $clock = new FakeMcpClock();
+        $vault = new SlowVaultHttpClient(
+            $this->connection()->scriptedServer()->willReturn(['content' => [['type' => 'text', 'text' => 'ok']]]),
+            $clock,
+            [5.0, 1.0, 2.0],
+        );
+
+        $this->vaultBackedClientFor($vault, $clock)->callTool($this->connection()->server(), 'read_page', []);
+
+        self::assertSame(
+            [20, 15, 14],
+            $vault->grantedTimeouts,
+            'the handshake spent six seconds, so the tool call gets fourteen — not a fresh budget',
+        );
+    }
+
+    /**
+     * TIMEOUTS, exhausted. A budget that runs out is its own outcome and says
+     * so: nothing was sent, so this is not a far side that failed to answer,
+     * and nothing was aborted, so it is not a cancellation either (`#774`).
+     */
+    #[Test]
+    public function anExhaustedBudgetIsItsOwnOutcomeAndNotAServerFailure(): void
+    {
+        $clock  = new FakeMcpClock();
+        $server = $this->connection()->scriptedServer()->willReturn(['content' => []]);
+        $vault  = new SlowVaultHttpClient($server, $clock, [11.0, 10.0]);
+
+        try {
+            $this->vaultBackedClientFor($vault, $clock)->callTool($this->connection()->server(), 'read_page', []);
+            self::fail('a spent budget should have refused the tool call');
+        } catch (McpTransportException $e) {
+            self::assertSame(1799990217, $e->getCode(), 'not the generic transport-failure code');
+            self::assertStringContainsString('operation budget', $e->getMessage());
+            self::assertStringContainsString('"' . $this->connection()->identifier . '"', $e->getMessage());
+            self::assertStringContainsString('not a server that did not answer', $e->getMessage());
+            self::assertStringNotContainsString('cancel', strtolower($e->getMessage()));
+        }
+
+        self::assertSame(
+            ['initialize', 'notifications/initialized'],
+            $server->methods(),
+            'the refused leg never went on the wire',
+        );
+        self::assertSame([], $this->health->contacts);
+    }
+
+    /**
+     * TIMEOUTS, floored. `withTimeout()` treats a non-positive value as "no
+     * override" and falls back to TYPO3's `HTTP.timeout`, whose default is `0`
+     * — which Guzzle reads as *wait forever*. So the leg with the least budget
+     * left is exactly the leg that must never be handed zero.
+     */
+    #[Test]
+    public function neverGrantsALegATimeoutThatWouldMeanNoTimeout(): void
+    {
+        $clock = new FakeMcpClock();
+        $vault = new SlowVaultHttpClient(
+            $this->connection()->scriptedServer()->willReturn(['content' => []]),
+            $clock,
+            [18.5, 1.2],
+        );
+
+        $this->vaultBackedClientFor($vault, $clock)->callTool($this->connection()->server(), 'read_page', []);
+
+        self::assertSame([20, 2, 1], $vault->grantedTimeouts);
+
+        foreach ($vault->grantedTimeouts as $granted) {
+            self::assertGreaterThan(0, $granted, 'a zero here is an unbounded request, not a tight one');
+        }
     }
 
     /**
@@ -678,7 +777,41 @@ abstract class AbstractMcpConformanceTestCase extends AbstractUnitTestCase
         );
         $transport->setHttpClient($http);
 
-        return new McpClient($transport, $this->health);
+        return new McpClient($transport, $this->health, $this->deadlineFactory(new FakeMcpClock()));
+    }
+
+    /**
+     * A client that reaches its server through the VAULT path, which is the
+     * only path on which the per-leg timeout is applied (ADR-170).
+     */
+    protected function vaultBackedClientFor(SlowVaultHttpClient $vault, FakeMcpClock $clock): McpClient
+    {
+        $vaultService = self::createStub(VaultServiceInterface::class);
+        $vaultService->method('http')->willReturn($vault);
+
+        $transport = new McpHttpTransport(
+            $vaultService,
+            // No DNS, so the SSRF host gate answers without a network call.
+            new SecureHttpClientFactory(new class implements DnsResolverInterface {
+                public function resolve(string $host): array
+                {
+                    return [];
+                }
+            }),
+            new RequestFactory(new GuzzleClientFactory()),
+            new StreamFactory(),
+        );
+
+        return new McpClient($transport, $this->health, $this->deadlineFactory($clock));
+    }
+
+    /**
+     * Nothing configured, so every check runs against the budget a fresh
+     * installation actually gets.
+     */
+    private function deadlineFactory(FakeMcpClock $clock): McpDeadlineFactory
+    {
+        return new McpDeadlineFactory($clock, self::createStub(ExtensionConfiguration::class));
     }
 
     protected function toolFor(ClientInterface $http, string $remoteAnnotations = ''): McpTool

--- a/Tests/Unit/Service/Tool/Mcp/McpClientTest.php
+++ b/Tests/Unit/Service/Tool/Mcp/McpClientTest.php
@@ -12,13 +12,19 @@ namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Mcp;
 use Netresearch\NrLlm\Domain\ValueObject\McpServerRecord;
 use Netresearch\NrLlm\Service\Tool\Mcp\Exception\McpTransportException;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpClient;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpDeadlineFactory;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpHttpTransport;
+use Netresearch\NrLlm\Tests\Fixtures\Mcp\FakeMcpClock;
 use Netresearch\NrLlm\Tests\Fixtures\Mcp\McpTestServer;
 use Netresearch\NrLlm\Tests\Fixtures\Mcp\RecordedContacts;
+use Netresearch\NrLlm\Tests\Fixtures\Mcp\SlowVaultHttpClient;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use Netresearch\NrVault\Http\DnsResolverInterface;
+use Netresearch\NrVault\Http\SecureHttpClientFactory;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Http\Client\GuzzleClientFactory;
 use TYPO3\CMS\Core\Http\RequestFactory;
 use TYPO3\CMS\Core\Http\StreamFactory;
@@ -45,7 +51,43 @@ final class McpClientTest extends AbstractUnitTestCase
         );
         $transport->setHttpClient($fake);
 
-        return new McpClient($transport, $this->health);
+        return new McpClient($transport, $this->health, $this->deadlineFactory(new FakeMcpClock()));
+    }
+
+    /**
+     * A client that reaches its server through the VAULT path, so what each leg
+     * of an operation was granted is observable.
+     *
+     * The PSR-18 seam `clientFor()` above uses bypasses
+     * {@see McpHttpTransport::clientFor()} — the one place a timeout is applied
+     * — by design, so no test driven through it can see the budget being spent.
+     */
+    private function budgetedClientFor(SlowVaultHttpClient $vault, FakeMcpClock $clock): McpClient
+    {
+        $vaultService = self::createStub(VaultServiceInterface::class);
+        $vaultService->method('http')->willReturn($vault);
+
+        $transport = new McpHttpTransport(
+            $vaultService,
+            // No DNS, so the SSRF host gate answers without a network call.
+            new SecureHttpClientFactory(new class implements DnsResolverInterface {
+                public function resolve(string $host): array
+                {
+                    return [];
+                }
+            }),
+            new RequestFactory(new GuzzleClientFactory()),
+            new StreamFactory(),
+        );
+
+        return new McpClient($transport, $this->health, $this->deadlineFactory($clock));
+    }
+
+    private function deadlineFactory(FakeMcpClock $clock): McpDeadlineFactory
+    {
+        // Nothing configured, so the shipped default applies — which is the
+        // number an installation that changes nothing actually runs with.
+        return new McpDeadlineFactory($clock, self::createStub(ExtensionConfiguration::class));
     }
 
     #[Test]
@@ -443,5 +485,172 @@ final class McpClientTest extends AbstractUnitTestCase
         }
 
         self::assertSame([], $this->health->contacts);
+    }
+
+    // -- the operation deadline (ADR-170) ----------------------------------
+
+    /**
+     * The regression this exists for.
+     *
+     * A tool call is three HTTP legs, and each of them used to carry a full
+     * timeout of its own — so a server answering just inside its limit three
+     * times over stalled the call for three times the number an operator was
+     * told about. One budget is opened per operation and every leg is granted
+     * what the earlier ones left.
+     *
+     * Against the per-leg behaviour this asserted `[15, 15, 15]`: the handshake
+     * spending six seconds cost the request that carries the work nothing.
+     */
+    #[Test]
+    public function theLastLegOfAToolCallGetsOnlyWhatTheHandshakeLeft(): void
+    {
+        $clock = new FakeMcpClock();
+        $vault = new SlowVaultHttpClient(
+            (new McpTestServer())
+                ->willHandshake()
+                ->willReturn(['content' => [['type' => 'text', 'text' => 'done']]]),
+            $clock,
+            [4.0, 2.0, 1.0],
+        );
+
+        $answer = $this->budgetedClientFor($vault, $clock)->callTool(McpTestServer::server(), 'do_it', []);
+
+        self::assertSame('done', $answer->text);
+        self::assertSame(
+            [20, 16, 14],
+            $vault->grantedTimeouts,
+            'initialize took 4 s and the readiness notification 2 s, so tools/call may run for 14 — not for a fresh 20',
+        );
+    }
+
+    /**
+     * A catalogue walk is one operation however many pages it takes, so the
+     * pages share the budget too. Fifty pages with a timeout each was 50 × the
+     * bound, which is the same defect one loop further out.
+     */
+    #[Test]
+    public function thePagesOfACatalogueWalkShareTheOperationsBudget(): void
+    {
+        $clock = new FakeMcpClock();
+        $vault = new SlowVaultHttpClient(
+            (new McpTestServer())
+                ->willHandshake()
+                ->willReturn(['tools' => [['name' => 'a']], 'nextCursor' => 'p2'])
+                ->willReturn(['tools' => [['name' => 'b']]]),
+            $clock,
+            [1.0, 0.0, 5.0, 3.0],
+        );
+
+        $tools = $this->budgetedClientFor($vault, $clock)->listTools(McpTestServer::server());
+
+        self::assertSame(['a', 'b'], array_column($tools, 'name'));
+        self::assertSame([20, 19, 19, 14], $vault->grantedTimeouts);
+    }
+
+    /**
+     * Exhaustion is its own outcome, and the message says whose fault it is: no
+     * request was sent, so this is not a server that failed to answer. It is
+     * not a cancellation either — nothing was aborted, a leg simply never
+     * started (`#774`).
+     */
+    #[Test]
+    public function aSpentBudgetRefusesTheNextLegAndSaysTheBudgetWasOurs(): void
+    {
+        $clock  = new FakeMcpClock();
+        $server = (new McpTestServer())->willHandshake()->willReturn(['content' => []]);
+        $vault  = new SlowVaultHttpClient($server, $clock, [12.0, 9.0]);
+
+        try {
+            $this->budgetedClientFor($vault, $clock)->callTool(McpTestServer::server(), 'do_it', []);
+            self::fail('a spent budget should have refused the tool call');
+        } catch (McpTransportException $e) {
+            self::assertStringContainsString('20-second operation budget', $e->getMessage());
+            self::assertStringContainsString('"srv"', $e->getMessage());
+            self::assertStringContainsString('the server was not asked', $e->getMessage());
+            self::assertStringContainsString('not a server that did not answer', $e->getMessage());
+            self::assertStringNotContainsString('cancel', strtolower($e->getMessage()));
+        }
+
+        self::assertSame(
+            ['initialize', 'notifications/initialized'],
+            $server->methods(),
+            'the refused leg never went on the wire',
+        );
+        self::assertSame([], $this->health->contacts, 'and an operation that did not complete is not a contact');
+    }
+
+    /**
+     * The floor. `withTimeout()` treats a non-positive value as "no override"
+     * and falls back to TYPO3's `HTTP.timeout`, whose default is `0` — which
+     * Guzzle reads as *wait forever*. So the leg with the least budget left
+     * would have been the one leg with no bound at all.
+     */
+    #[Test]
+    public function aLegIsNeverSentWithATimeoutThatWouldMeanNoTimeout(): void
+    {
+        $clock = new FakeMcpClock();
+        $vault = new SlowVaultHttpClient(
+            (new McpTestServer())->willHandshake()->willReturn(['content' => []]),
+            $clock,
+            [19.0, 0.7],
+        );
+
+        $this->budgetedClientFor($vault, $clock)->callTool(McpTestServer::server(), 'do_it', []);
+
+        self::assertSame([20, 1, 1], $vault->grantedTimeouts);
+
+        foreach ($vault->grantedTimeouts as $granted) {
+            self::assertGreaterThan(0, $granted, 'a zero here is an unbounded request, not a tight one');
+        }
+    }
+
+    /**
+     * The ordinary case is untouched: an operation against a server that
+     * answers promptly spends nothing worth subtracting and every leg is
+     * granted the full budget.
+     */
+    #[Test]
+    public function aFastOperationIsUnaffected(): void
+    {
+        $clock = new FakeMcpClock();
+        $vault = new SlowVaultHttpClient(
+            (new McpTestServer())
+                ->willHandshake()
+                ->willReturn(['content' => [['type' => 'text', 'text' => 'quick']]]),
+            $clock,
+            [],
+        );
+
+        $answer = $this->budgetedClientFor($vault, $clock)->callTool(McpTestServer::server(), 'do_it', []);
+
+        self::assertSame('quick', $answer->text);
+        self::assertFalse($answer->isError);
+        self::assertSame([20, 20, 20], $vault->grantedTimeouts);
+        self::assertCount(1, $this->health->contacts);
+    }
+
+    /**
+     * Each operation opens its own budget. A deadline that outlived one
+     * operation would make a slow tool call refuse the next one.
+     */
+    #[Test]
+    public function aSecondOperationStartsFromAFullBudget(): void
+    {
+        $clock = new FakeMcpClock();
+        $vault = new SlowVaultHttpClient(
+            (new McpTestServer())
+                ->willHandshake()
+                ->willReturn(['content' => []])
+                ->willHandshake()
+                ->willReturn(['content' => []]),
+            $clock,
+            [8.0, 0.0, 9.0],
+        );
+
+        $client = $this->budgetedClientFor($vault, $clock);
+        $client->callTool(McpTestServer::server(), 'do_it', []);
+        $client->callTool(McpTestServer::server(), 'do_it', []);
+
+        self::assertSame([20, 12, 12, 20, 20, 20], $vault->grantedTimeouts);
     }
 }

--- a/Tests/Unit/Service/Tool/Mcp/McpDeadlineFactoryTest.php
+++ b/Tests/Unit/Service/Tool/Mcp/McpDeadlineFactoryTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Mcp;
+
+use Netresearch\NrLlm\Service\Tool\Mcp\McpDeadlineFactory;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpOperationDeadline;
+use Netresearch\NrLlm\Tests\Fixtures\Mcp\FakeMcpClock;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+#[CoversClass(McpDeadlineFactory::class)]
+final class McpDeadlineFactoryTest extends AbstractUnitTestCase
+{
+    /**
+     * The number is a product decision and is stated, not inherited: 15 seconds
+     * was one request's timeout before this existed and the 5 on top pay for
+     * the handshake in front of the work. It buys the payload leg no floor —
+     * {@see McpClientTest::theLastLegOfAToolCallGetsOnlyWhatTheHandshakeLeft}
+     * is where what that leg actually gets is asserted.
+     */
+    #[Test]
+    public function anUnconfiguredInstallationGetsTheStatedDefault(): void
+    {
+        self::assertSame(20, McpDeadlineFactory::DEFAULT_TOTAL_SECONDS);
+        self::assertSame(20, $this->factoryFor(null)->forOperation()->totalSeconds());
+    }
+
+    /**
+     * An operator with a legitimately slow server raises it, which is the whole
+     * reason it is a configuration field rather than a constant.
+     */
+    #[Test]
+    public function aConfiguredBudgetIsWhatTheOperationGets(): void
+    {
+        self::assertSame(90, $this->factoryFor('90')->forOperation()->totalSeconds());
+        self::assertSame(45, $this->factoryFor(45)->forOperation()->totalSeconds());
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function unusableValues(): array
+    {
+        return [
+            'never written'      => [''],
+            'whitespace'         => ['   '],
+            'not a number'       => ['soon'],
+            'switched off'       => ['0'],
+            'negative'           => ['-5'],
+            'not even a scalar'  => [['20']],
+        ];
+    }
+
+    /**
+     * The budget cannot be switched off. A zero or negative total would exhaust
+     * before the first leg, which is an MCP client that never calls anything.
+     */
+    #[Test]
+    #[DataProvider('unusableValues')]
+    public function anUnusableValueFallsBackToTheDefault(mixed $configured): void
+    {
+        self::assertSame(20, $this->factoryFor($configured)->forOperation()->totalSeconds());
+    }
+
+    /**
+     * An installation whose extension configuration cannot be read still has to
+     * be able to call an MCP server.
+     */
+    #[Test]
+    public function unreadableConfigurationFallsBackToTheDefault(): void
+    {
+        $extensionConfiguration = self::createStub(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willThrowException(
+            new ExtensionConfigurationExtensionNotConfiguredException('not configured', 1799990243),
+        );
+
+        $factory = new McpDeadlineFactory(new FakeMcpClock(), $extensionConfiguration);
+
+        self::assertSame(20, $factory->forOperation()->totalSeconds());
+    }
+
+    /**
+     * Each operation gets its OWN budget. A factory that handed the same object
+     * out twice would let one slow tool call exhaust the next one.
+     */
+    #[Test]
+    public function eachOperationOpensItsOwnBudget(): void
+    {
+        $clock   = new FakeMcpClock();
+        $factory = new McpDeadlineFactory($clock, $this->configurationReturning(null));
+
+        $first = $factory->forOperation();
+        $clock->advanceSeconds(18.0);
+        $second = $factory->forOperation();
+
+        self::assertSame(2, $first->legTimeoutSeconds());
+        self::assertSame(20, $second->legTimeoutSeconds());
+    }
+
+    #[Test]
+    public function theBudgetIsMeasuredOnTheInjectedClock(): void
+    {
+        $clock    = new FakeMcpClock();
+        $deadline = (new McpDeadlineFactory($clock, $this->configurationReturning(null)))->forOperation();
+
+        $clock->advanceSeconds(20.0);
+
+        self::assertTrue($deadline->isExhausted());
+        self::assertInstanceOf(McpOperationDeadline::class, $deadline);
+    }
+
+    private function factoryFor(mixed $configured): McpDeadlineFactory
+    {
+        return new McpDeadlineFactory(new FakeMcpClock(), $this->configurationReturning($configured));
+    }
+
+    private function configurationReturning(mixed $configured): ExtensionConfiguration
+    {
+        $extensionConfiguration = self::createStub(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturnMap([
+            ['nr_llm', 'mcpOperationTimeout', $configured],
+        ]);
+
+        return $extensionConfiguration;
+    }
+}

--- a/Tests/Unit/Service/Tool/Mcp/McpHttpTransportTest.php
+++ b/Tests/Unit/Service/Tool/Mcp/McpHttpTransportTest.php
@@ -11,6 +11,8 @@ namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Mcp;
 
 use Netresearch\NrLlm\Service\Tool\Mcp\Exception\McpTransportException;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpHttpTransport;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpOperationDeadline;
+use Netresearch\NrLlm\Tests\Fixtures\Mcp\FakeMcpClock;
 use Netresearch\NrLlm\Tests\Fixtures\Mcp\McpTestServer;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrVault\Service\VaultServiceInterface;
@@ -41,12 +43,21 @@ final class McpHttpTransportTest extends AbstractUnitTestCase
         return $transport;
     }
 
+    /**
+     * A budget with room in it, so the checks below are about the wire rather
+     * than about the deadline (ADR-170).
+     */
+    private function deadline(int $totalSeconds = 20): McpOperationDeadline
+    {
+        return McpOperationDeadline::start(new FakeMcpClock(), $totalSeconds);
+    }
+
     #[Test]
     public function sendsJsonRpcAndReturnsTheResultObject(): void
     {
         $fake = (new McpTestServer())->willReturn(['tools' => []]);
 
-        $answer = $this->transportFor($fake)->call(McpTestServer::server(), 'tools/list', ['cursor' => 'abc']);
+        $answer = $this->transportFor($fake)->call(McpTestServer::server(), 'tools/list', ['cursor' => 'abc'], $this->deadline());
 
         self::assertSame(['tools' => []], $answer['result']);
         self::assertSame('tools/list', $fake->received[0]['method']);
@@ -64,7 +75,7 @@ final class McpHttpTransportTest extends AbstractUnitTestCase
     {
         $fake = (new McpTestServer())->willReturn([]);
 
-        $this->transportFor($fake)->call(McpTestServer::server(), 'ping', []);
+        $this->transportFor($fake)->call(McpTestServer::server(), 'ping', [], $this->deadline());
 
         self::assertStringContainsString('"params":{}', $fake->received[0]['raw']);
     }
@@ -74,7 +85,7 @@ final class McpHttpTransportTest extends AbstractUnitTestCase
     {
         $fake = (new McpTestServer())->willReturn([]);
 
-        $this->transportFor($fake)->call(McpTestServer::server(), 'ping', [], 'sess-1');
+        $this->transportFor($fake)->call(McpTestServer::server(), 'ping', [], $this->deadline(), 'sess-1');
 
         self::assertSame('sess-1', $fake->received[0]['session']);
     }
@@ -84,7 +95,7 @@ final class McpHttpTransportTest extends AbstractUnitTestCase
     {
         $fake = (new McpTestServer())->willReturn([], 'sess-9');
 
-        $answer = $this->transportFor($fake)->call(McpTestServer::server(), 'initialize', []);
+        $answer = $this->transportFor($fake)->call(McpTestServer::server(), 'initialize', [], $this->deadline());
 
         self::assertSame('sess-9', $answer['sessionId']);
     }
@@ -115,7 +126,7 @@ final class McpHttpTransportTest extends AbstractUnitTestCase
         $this->expectException(McpTransportException::class);
         $this->expectExceptionCode(1799990212);
 
-        $this->transportFor($fake)->call(McpTestServer::server(), 'ping', []);
+        $this->transportFor($fake)->call(McpTestServer::server(), 'ping', [], $this->deadline());
     }
 
     #[Test]
@@ -127,7 +138,7 @@ final class McpHttpTransportTest extends AbstractUnitTestCase
         $this->expectExceptionCode(1799990214);
         $this->expectExceptionMessage('Method not found');
 
-        $this->transportFor($fake)->call(McpTestServer::server(), 'nope', []);
+        $this->transportFor($fake)->call(McpTestServer::server(), 'nope', [], $this->deadline());
     }
 
     #[Test]
@@ -138,7 +149,7 @@ final class McpHttpTransportTest extends AbstractUnitTestCase
         $this->expectException(McpTransportException::class);
         $this->expectExceptionCode(1799990215);
 
-        $this->transportFor($fake)->call(McpTestServer::server(), 'ping', []);
+        $this->transportFor($fake)->call(McpTestServer::server(), 'ping', [], $this->deadline());
     }
 
     #[Test]
@@ -149,7 +160,7 @@ final class McpHttpTransportTest extends AbstractUnitTestCase
         $this->expectException(McpTransportException::class);
         $this->expectExceptionCode(1799990213);
 
-        $this->transportFor($fake)->call(McpTestServer::server(), 'ping', []);
+        $this->transportFor($fake)->call(McpTestServer::server(), 'ping', [], $this->deadline());
     }
 
     #[Test]
@@ -160,7 +171,7 @@ final class McpHttpTransportTest extends AbstractUnitTestCase
         $this->expectException(McpTransportException::class);
         $this->expectExceptionCode(1799990213);
 
-        $this->transportFor($fake)->call(McpTestServer::server(), 'ping', []);
+        $this->transportFor($fake)->call(McpTestServer::server(), 'ping', [], $this->deadline());
     }
 
     /**
@@ -173,7 +184,7 @@ final class McpHttpTransportTest extends AbstractUnitTestCase
         $fake = (new McpTestServer())->willReturnRpcError(-1, "first line\nsecond line");
 
         try {
-            $this->transportFor($fake)->call(McpTestServer::server(), 'ping', []);
+            $this->transportFor($fake)->call(McpTestServer::server(), 'ping', [], $this->deadline());
             self::fail('expected the call to be refused');
         } catch (McpTransportException $e) {
             self::assertStringNotContainsString("\n", $e->getMessage());
@@ -187,7 +198,7 @@ final class McpHttpTransportTest extends AbstractUnitTestCase
         $fake = (new McpTestServer())->willReturnRpcError(-1, str_repeat('x', 5000));
 
         try {
-            $this->transportFor($fake)->call(McpTestServer::server(), 'ping', []);
+            $this->transportFor($fake)->call(McpTestServer::server(), 'ping', [], $this->deadline());
             self::fail('expected the call to be refused');
         } catch (McpTransportException $e) {
             self::assertLessThan(500, mb_strlen($e->getMessage()));
@@ -216,7 +227,7 @@ final class McpHttpTransportTest extends AbstractUnitTestCase
         $this->expectExceptionCode(1799990211);
         $this->expectExceptionMessage('"srv"');
 
-        $transport->call(McpTestServer::server(), 'ping', []);
+        $transport->call(McpTestServer::server(), 'ping', [], $this->deadline());
     }
 
     /**
@@ -228,9 +239,44 @@ final class McpHttpTransportTest extends AbstractUnitTestCase
     {
         $fake = new McpTestServer();
 
-        $this->transportFor($fake)->notify(McpTestServer::server(), 'notifications/initialized', []);
+        $this->transportFor($fake)->notify(McpTestServer::server(), 'notifications/initialized', [], $this->deadline());
 
         self::assertSame('notifications/initialized', $fake->received[0]['method']);
         self::assertArrayNotHasKey('id', $fake->received[0]['body']);
+    }
+
+    /**
+     * A spent budget stops the request before it is built, on BOTH transport
+     * entry points (ADR-170). Checking it inside the client builder instead
+     * would leave the seam these tests run through unguarded — and would put
+     * the throw inside the catch that reports a failing far side, so an
+     * exhausted budget would come out as "the server could not be reached".
+     */
+    #[Test]
+    public function refusesToSendAnythingOnceTheBudgetIsSpent(): void
+    {
+        $clock    = new FakeMcpClock();
+        $deadline = McpOperationDeadline::start($clock, 20);
+        $clock->advanceSeconds(20.0);
+
+        $fake      = (new McpTestServer())->willReturn(['tools' => []]);
+        $transport = $this->transportFor($fake);
+
+        try {
+            $transport->call(McpTestServer::server(), 'tools/list', [], $deadline);
+            self::fail('call() should have refused a spent budget');
+        } catch (McpTransportException $e) {
+            self::assertStringContainsString('20-second operation budget', $e->getMessage());
+            self::assertSame(1799990217, $e->getCode(), 'a kind of its own, not a generic transport failure');
+        }
+
+        try {
+            $transport->notify(McpTestServer::server(), 'notifications/initialized', [], $deadline);
+            self::fail('notify() should have refused a spent budget');
+        } catch (McpTransportException $e) {
+            self::assertSame(1799990217, $e->getCode(), 'the notification leg is bounded by the same budget');
+        }
+
+        self::assertSame([], $fake->received, 'nothing went on the wire');
     }
 }

--- a/Tests/Unit/Service/Tool/Mcp/McpOperationDeadlineTest.php
+++ b/Tests/Unit/Service/Tool/Mcp/McpOperationDeadlineTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Tool\Mcp;
+
+use Netresearch\NrLlm\Service\Tool\Mcp\McpOperationDeadline;
+use Netresearch\NrLlm\Tests\Fixtures\Mcp\FakeMcpClock;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(McpOperationDeadline::class)]
+final class McpOperationDeadlineTest extends AbstractUnitTestCase
+{
+    #[Test]
+    public function theFirstLegIsGrantedTheWholeBudget(): void
+    {
+        $deadline = McpOperationDeadline::start(new FakeMcpClock(), 20);
+
+        self::assertSame(20, $deadline->totalSeconds());
+        self::assertSame(20, $deadline->legTimeoutSeconds());
+        self::assertFalse($deadline->isExhausted());
+    }
+
+    /**
+     * The whole point: what an earlier leg spent is gone. A budget that answered
+     * the same number twice would be a per-request timeout wearing a new name.
+     */
+    #[Test]
+    public function everyLegIsGrantedOnlyWhatTheEarlierOnesLeft(): void
+    {
+        $clock    = new FakeMcpClock();
+        $deadline = McpOperationDeadline::start($clock, 20);
+
+        $clock->advanceSeconds(4.0);
+        self::assertSame(16, $deadline->legTimeoutSeconds());
+
+        $clock->advanceSeconds(2.0);
+        self::assertSame(14, $deadline->legTimeoutSeconds());
+    }
+
+    #[Test]
+    public function theBudgetIsSpentOnceTheClockHasRunPastIt(): void
+    {
+        $clock    = new FakeMcpClock();
+        $deadline = McpOperationDeadline::start($clock, 20);
+
+        $clock->advanceSeconds(19.9);
+        self::assertFalse($deadline->isExhausted(), 'a tenth of a second is still a budget');
+
+        $clock->advanceSeconds(0.1);
+        self::assertTrue($deadline->isExhausted(), 'spending exactly the budget leaves nothing');
+
+        $clock->advanceSeconds(5.0);
+        self::assertTrue($deadline->isExhausted());
+        self::assertLessThan(0.0, $deadline->remainingSeconds());
+    }
+
+    /**
+     * The floor, and why it is not cosmetic.
+     *
+     * The number goes to `VaultHttpClientInterface::withTimeout()`, which treats
+     * anything non-positive as "no override" and falls back to
+     * `$GLOBALS['TYPO3_CONF_VARS']['HTTP']['timeout']` — TYPO3's default for
+     * which is `0`, and Guzzle reads `0` as *wait forever*. A leg granted zero
+     * would be the one leg with no bound at all.
+     */
+    #[Test]
+    public function aLegIsNeverGrantedZeroSecondsHoweverLittleIsLeft(): void
+    {
+        $clock    = new FakeMcpClock();
+        $deadline = McpOperationDeadline::start($clock, 20);
+
+        $clock->advanceSeconds(19.999);
+
+        self::assertFalse($deadline->isExhausted());
+        self::assertSame(
+            McpOperationDeadline::MINIMUM_LEG_SECONDS,
+            $deadline->legTimeoutSeconds(),
+            'a millisecond of budget is rounded up to the floor, never down to no bound',
+        );
+        self::assertGreaterThan(0, $deadline->legTimeoutSeconds());
+    }
+
+    /**
+     * Rounding up rather than down is the same guard one step earlier: 0.4
+     * seconds truncates to 0, and 0 is unbounded.
+     */
+    #[Test]
+    public function aPartSecondRemainderIsRoundedUpNotTruncated(): void
+    {
+        $clock    = new FakeMcpClock();
+        $deadline = McpOperationDeadline::start($clock, 10);
+
+        $clock->advanceSeconds(7.4);
+
+        self::assertSame(3, $deadline->legTimeoutSeconds());
+    }
+
+    /**
+     * A budget below the floor cannot be honoured: its first leg would already
+     * be refused. That is a misconfiguration, and the operation still has to
+     * run.
+     */
+    #[Test]
+    public function aBudgetBelowTheFloorIsRaisedToIt(): void
+    {
+        $deadline = McpOperationDeadline::start(new FakeMcpClock(), 0);
+
+        self::assertSame(McpOperationDeadline::MINIMUM_LEG_SECONDS, $deadline->totalSeconds());
+        self::assertFalse($deadline->isExhausted());
+        self::assertGreaterThan(0, $deadline->legTimeoutSeconds());
+    }
+
+    /**
+     * The clock is a monotonic source, so a reading is only meaningful against
+     * another reading. A deadline that read one as an absolute duration would
+     * pass against a clock starting at zero and fail here.
+     */
+    #[Test]
+    public function theBudgetIsMeasuredAsADifferenceNotAsAnAbsoluteReading(): void
+    {
+        $clock    = new FakeMcpClock();
+        $deadline = McpOperationDeadline::start($clock, 30);
+
+        self::assertEqualsWithDelta(30.0, $deadline->remainingSeconds(), 0.001);
+    }
+}

--- a/Tests/Unit/Service/Tool/Mcp/McpToolTest.php
+++ b/Tests/Unit/Service/Tool/Mcp/McpToolTest.php
@@ -13,11 +13,13 @@ use Netresearch\NrLlm\Domain\Enum\ToolDataClass;
 use Netresearch\NrLlm\Domain\Enum\ToolEffect;
 use Netresearch\NrLlm\Domain\ValueObject\McpToolRecord;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpClient;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpDeadlineFactory;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpHttpTransport;
 use Netresearch\NrLlm\Service\Tool\Mcp\McpTool;
 use Netresearch\NrLlm\Service\Tool\RemoteApprovalInterface;
 use Netresearch\NrLlm\Service\Tool\RemoteToolInterface;
 use Netresearch\NrLlm\Service\Tool\ToolExecutionContext;
+use Netresearch\NrLlm\Tests\Fixtures\Mcp\FakeMcpClock;
 use Netresearch\NrLlm\Tests\Fixtures\Mcp\McpTestServer;
 use Netresearch\NrLlm\Tests\Fixtures\Mcp\RecordedContacts;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
@@ -25,6 +27,7 @@ use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use ReflectionClass;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Http\Client\GuzzleClientFactory;
 use TYPO3\CMS\Core\Http\RequestFactory;
 use TYPO3\CMS\Core\Http\StreamFactory;
@@ -65,7 +68,11 @@ final class McpToolTest extends AbstractUnitTestCase
             ['type' => 'object', 'properties' => ['id' => ['type' => 'integer']]],
             $dataClass,
             $requiresApproval,
-            new McpClient($transport, new RecordedContacts()),
+            new McpClient(
+                $transport,
+                new RecordedContacts(),
+                new McpDeadlineFactory(new FakeMcpClock(), self::createStub(ExtensionConfiguration::class)),
+            ),
         );
     }
 

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -125,6 +125,13 @@ telemetry.enabled = 1
 tools.dataClassEnforcement = enforce
 
 # =============================================================================
+# MCP servers (ADR-170)
+# =============================================================================
+
+# cat=tools; type=int+; label=MCP operation budget (seconds): How long ONE operation against an MCP server may take in total — a tool call, a catalogue import, a connection test. It is a budget for the whole operation, not for each HTTP request in it: an operation opens with the protocol handshake and its confirmation, and whatever those two spend is no longer available to the request that carries the work. The default of 20 is the 15 seconds a single request had before this was introduced, with 5 on top for the handshake in front of it — but the work request is granted what the handshake actually left, not a guaranteed 15. A healthy server handshakes in well under a second, so the work request gets close to the full 20, more than it had. A handshake costing more than 5 seconds can leave it under 15 — a leg is granted the whole seconds remaining, rounded up, so a 6-second handshake grants 14 — and a server that is slow to handshake AND slow to work can be cut off here where it was not before. That is what raising this value is for. The worst case an agent run can wait falls from about 45 seconds to the budget plus under a second, because no leg is granted less than one whole second and the last one may overrun by a fraction. Raise it for a server that is legitimately slow — a large catalogue walks several pages under this one budget, and a remote tool that thinks for half a minute needs to be allowed to. An empty, non-numeric or zero value falls back to 20. There is no upper limit, because the wait is the operator's to choose. Note that this does not abort a request already in flight: it decides what the NEXT leg of the operation is granted, and refuses to start one once the budget is gone.
+mcpOperationTimeout = 20
+
+# =============================================================================
 # Model routing (ADR-138, ADR-142)
 # =============================================================================
 


### PR DESCRIPTION
## Description

A tool call against an MCP server opens with the protocol handshake and its confirmation before the request that carries the work. Each of the three legs carried its own `TIMEOUT_SECONDS = 15`, so one tool step could stall for about **45 seconds** — and a catalogue walk of 50 pages could take twelve minutes. That is also the window a cancelled agent run keeps waiting in.

An operation now opens one deadline and every leg is granted what is left of it.

```
callTool, budget 20s
  initialize                 4s spent  -> granted 20
  notifications/initialized  2s spent  -> granted 16
  tools/call                           -> granted 14
```

Default 20 seconds, configurable as `mcpOperationTimeout`.

## The default is a composition, not a floor — and the reasoning says so everywhere

An earlier draft of this change claimed on five surfaces that 20 "leaves the work request the 15 seconds a single request had". **That was false, and the change's own test said so** (`[20, 16, 14]`). It is corrected; the honest arithmetic is:

- healthy server, handshake under a second → the payload leg is granted about **20**, *more* than the 15 it had;
- handshake over five seconds → the payload leg gets **under 15**, and a server slow to handshake **and** slow to work is newly cut off where it was not before.

That trade is accepted rather than hidden: the refusal names the budget as ours, and raising the field answers it. If a maintainer disagrees with the trade, ADR-170 decision 5 is where to argue it.

## Two details that decide correctness rather than policy

**A leg is never granted zero.** `VaultHttpClient::withTimeout()` passes a zero through to `SecureHttpClientFactory::create()`, which falls back to `$GLOBALS['TYPO3_CONF_VARS']['HTTP']['timeout']` — whose TYPO3 default is `0` (`DefaultConfiguration.php:1866`) — and Guzzle reads `0` as *wait forever*. Without a floor, the one leg with no bound at all would be the last one, which is the opposite of this change's purpose. The floor is one whole second, and it is why the operation can overrun its budget by under a second (stated in ADR-170 decision 4 and on both operator-facing surfaces).

**The clock is injected.** The codebase has no clock abstraction, and the two existing `now()` seams read TYPO3's request-pinned `date` aspect, which is constant for a whole request and therefore cannot measure elapsed budget. A monotonic seam was added, which is also what makes the tests deterministic rather than sleep-based.

## This is not cancellation

It does not abort a request already in flight, and nothing here is named as though it did — ADR-161's structural check (public methods and parameters matching `/cancel|abort/i` must be empty) still passes. It decides what the *next* leg is granted and refuses to start one once the budget is gone. Real cancellation needs a cancellable primitive in nr-vault first: netresearch/t3x-nr-vault#302, tracked here as #774.

## Related Issue

Closes #773

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Tests

**The guard was seen to fail.** A literal revert is impossible because the production signatures changed, so the old behaviour was reproduced through the new seam — `isExhausted()` forced to `false` and `legTimeoutSeconds()` to return the full budget, which is exactly what a per-request timeout does. Result: **18 failures across 9 tests**, with the central one failing on precisely its own defect:

```
McpClientTest::theLastLegOfAToolCallGetsOnlyWhatTheHandshakeLeft
  -   1 => 16,            +   1 => 20,
  -   2 => 14,            +   2 => 20,
```

Also failing under the reverted behaviour: the exhaustion outcome, the zero-timeout floor (`[20,20,20]` instead of `[20,1,1]`), the catalogue-walk budget sharing, and both conformance cases.

## Gates

`cgl -n`, `phpstan` level 10, `unit` (7131 tests), functional `--filter Mcp` (50 tests) and all three repo checks exit 0 on the rebased tree. The PHPUnit `Configuration:` line was checked to confirm the runs came from this worktree.

**`rector -n` at the CI-pinned PHP 8.2 did not run** — `.Build` here is resolved at 8.4 and `platform_check.php` fatals before Rector starts. Not green, not red: it did not execute. Four new production files and four new test files reach CI without that gate having been exercised locally.

## One decision left open on purpose

The configuration key has **no upper clamp**, by ADR-170 decision 5. The consequence is now named in the record rather than worked around: a backend tool call runs synchronously in the AJAX request, so a 600-second budget against a stalling server blocks until a PHP or gateway limit ends it — a 500 or a 504 with no body, rather than the failed tool result `McpTool::execute()` writes for a caught `McpTransportException`. Which limit fires is installation-dependent (`max_execution_time`, FPM's `request_terminate_timeout`, a fronting proxy), so the ADR enumerates them instead of asserting one.

The clamp is refused because the ceiling that matters is that PHP limit, this extension does not know it, and a number hard-coded against a guess would cut off the legitimately slow server the field exists for. **If you want a clamp anyway, this is the place to say so.**

## Checklist

- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix works
- [x] I have updated the documentation accordingly
- [x] I have added a `CHANGELOG.md` entry under `## [Unreleased]`
- [x] I have added an ADR (ADR-170) and amended ADR-154 and ADR-161
- [x] My changes generate no new warnings
