### PR TITLE
feat: four-eyes approval as a per-configuration switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Four-eyes approval, per configuration** (`#786`). A new configuration field,
+  *Require a second approver*, refuses an approval from the backend user who
+  started the run. Default off, so every existing record keeps the
+  single-operator behaviour it has today.
+
+  An approval only: the initiator can still deny their own run, because a denial
+  never runs the pending call. No exemption for administrators — being allowed
+  to act on every run does not make an admin a second pair of eyes on their own
+  request. Service accounts are unaffected: a run they start records no backend
+  user and matches nobody.
+
+  The refusal reaches the operator as a flash message, the same way every other
+  approval refusal in the module does; the run stays at the fence so a colleague
+  can decide it. See ADR-172.
+
+  Additive on the `@api` surface: `LlmConfiguration::getRequireSecondApprover()`,
+  `::requiresSecondApprover()`, `::setRequireSecondApprover()` and
+  `AiActorContext::isInitiatorOf()`.
+
 - **A use-case pack can declare the editor actions it is built for** (`#769`).
   `UseCasePack::$recommendedEditorActions` names the editorial writes a pack was
   designed for. The install plan reports, per declared action, whether this

--- a/Classes/Controller/Backend/AgentRunController.php
+++ b/Classes/Controller/Backend/AgentRunController.php
@@ -24,6 +24,7 @@ use Netresearch\NrLlm\Service\Agent\Exception\RunConfigurationGoneException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingApprovalException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingInputException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunStateUnavailableException;
+use Netresearch\NrLlm\Service\Agent\Exception\SelfApprovalDeniedException;
 use Netresearch\NrLlm\Service\Agent\Exception\StaleApprovalTurnException;
 use Netresearch\NrLlm\Service\Agent\Exception\StaleInputTurnException;
 use Netresearch\NrLlm\Service\Agent\Exception\SubmitterNotPermittedException;
@@ -177,6 +178,10 @@ final class AgentRunController extends ActionController
             // ADR-133: the run was released, not consumed — someone who may run
             // the pending write can still decide it.
             return $this->flashRedirect('runs.error.approverNotPermitted', ContextualFeedbackSeverity::ERROR);
+        } catch (SelfApprovalDeniedException) {
+            // ADR-172: the run was released, not consumed — a colleague can
+            // still decide it, and the initiator can still deny it.
+            return $this->flashRedirect('runs.error.selfApproval', ContextualFeedbackSeverity::WARNING);
         } catch (ApprovalNotAuditableException) {
             return $this->flashRedirect('runs.error.notAuditable', ContextualFeedbackSeverity::ERROR);
         } catch (CorruptSuspendedStateException|RunStateUnavailableException) {

--- a/Classes/Controller/Backend/ToolPlaygroundController.php
+++ b/Classes/Controller/Backend/ToolPlaygroundController.php
@@ -37,6 +37,7 @@ use Netresearch\NrLlm\Service\Agent\Exception\RunConfigurationGoneException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingApprovalException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingInputException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunStateUnavailableException;
+use Netresearch\NrLlm\Service\Agent\Exception\SelfApprovalDeniedException;
 use Netresearch\NrLlm\Service\Agent\Exception\StaleApprovalTurnException;
 use Netresearch\NrLlm\Service\Agent\Exception\StaleInputTurnException;
 use Netresearch\NrLlm\Service\Agent\Exception\SubmitterNotPermittedException;
@@ -334,6 +335,19 @@ final class ToolPlaygroundController extends ActionController implements LoggerA
                 'status'  => 'awaiting_approval',
                 'runUuid' => $runUuid,
                 'error'   => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.approverNotPermitted', 'You may not approve an action that runs a tool you are not permitted to use yourself.'),
+            ], 403);
+        } catch (SelfApprovalDeniedException) {
+            // ADR-172: the caller started this run and the configuration wants a
+            // second approver. In the Playground the caller is ALWAYS the
+            // initiator, so a write-declaring turn on such a configuration can
+            // only be released from the Agent Runs inbox by somebody else. Same
+            // shape as above: nothing ran, the run is decidable again, 403
+            // because the obstacle is who is asking.
+            return $this->respondJson([
+                'success' => false,
+                'status'  => 'awaiting_approval',
+                'runUuid' => $runUuid,
+                'error'   => $this->localize('LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.tool.selfApproval', 'You started this run and its configuration requires a second approver. Someone else has to release it.'),
             ], 403);
         } catch (ApprovalNotAuditableException) {
             // Nothing was executed and the run is decidable again; 503, because

--- a/Classes/Domain/Model/LlmConfiguration.php
+++ b/Classes/Domain/Model/LlmConfiguration.php
@@ -128,6 +128,13 @@ class LlmConfiguration extends AbstractEntity
 
     protected bool $isDefault = false;
 
+    /**
+     * Whether releasing a suspended write on a run of this configuration needs
+     * somebody other than the person who started it (ADR-172). False keeps the
+     * single-operator behaviour, which is what every pre-existing record has.
+     */
+    protected bool $requireSecondApprover = false;
+
     protected int $tstamp = 0;
 
     protected int $crdate = 0;
@@ -447,6 +454,21 @@ class LlmConfiguration extends AbstractEntity
     public function isDefault(): bool
     {
         return $this->getIsDefault();
+    }
+
+    public function getRequireSecondApprover(): bool
+    {
+        return $this->requireSecondApprover;
+    }
+
+    public function requiresSecondApprover(): bool
+    {
+        return $this->getRequireSecondApprover();
+    }
+
+    public function setRequireSecondApprover(bool $requireSecondApprover): void
+    {
+        $this->requireSecondApprover = $requireSecondApprover;
     }
 
     /**

--- a/Classes/Domain/ValueObject/AiActorContext.php
+++ b/Classes/Domain/ValueObject/AiActorContext.php
@@ -234,6 +234,26 @@ final readonly class AiActorContext
     }
 
     /**
+     * Whether this actor is the backend user who started the run (ADR-172).
+     *
+     * Separate from {@see mayActOnRun()} on purpose: that answers whether the
+     * actor may act at all, this answers whether the actor would be deciding
+     * their own request. An administrator is not exempt — being allowed to act
+     * on every run does not make an admin a second pair of eyes on their own.
+     *
+     * A service account is never the initiator: `beUser` identifies a backend
+     * user, so a run a service account started carries 0 and matches nobody.
+     * Four-eyes therefore constrains humans and leaves machine callers to the
+     * scope mechanism, which is where their authorisation lives.
+     */
+    public function isInitiatorOf(AgentRun $run): bool
+    {
+        return !$this->isServiceAccount()
+            && $this->backendUserUid > 0
+            && $this->backendUserUid === $run->beUser;
+    }
+
+    /**
      * A short, log-safe description of the actor for exception messages and
      * audit entries. Never contains a session uuid or any content.
      */

--- a/Classes/Service/Agent/Exception/SelfApprovalDeniedException.php
+++ b/Classes/Service/Agent/Exception/SelfApprovalDeniedException.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Agent\Exception;
+
+use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
+
+/**
+ * The actor started this run and its configuration requires a second approver
+ * (ADR-172).
+ *
+ * Distinct from {@see RunAccessDeniedException}, which says the actor may not
+ * act on the run at all. Here the actor may act — the same person could deny
+ * the turn, or approve a run somebody else started — but must not release a
+ * write they themselves asked for. The message names the configuration so an
+ * operator who did not expect the refusal can see where the setting lives.
+ */
+final class SelfApprovalDeniedException extends AgentRuntimeException
+{
+    public static function forActor(AiActorContext $actor, string $runUuid, string $configurationIdentifier): self
+    {
+        return new self(
+            $runUuid,
+            sprintf(
+                '%s started run %s and configuration "%s" requires a second approver.',
+                ucfirst($actor->describe()),
+                $runUuid !== '' ? $runUuid : 'unknown',
+                $configurationIdentifier,
+            ),
+        );
+    }
+}

--- a/Classes/Service/Agent/ResumeCoordinator.php
+++ b/Classes/Service/Agent/ResumeCoordinator.php
@@ -32,6 +32,7 @@ use Netresearch\NrLlm\Service\Agent\Exception\RunConfigurationGoneException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingApprovalException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunNotAwaitingInputException;
 use Netresearch\NrLlm\Service\Agent\Exception\RunStateUnavailableException;
+use Netresearch\NrLlm\Service\Agent\Exception\SelfApprovalDeniedException;
 use Netresearch\NrLlm\Service\Agent\Exception\StaleApprovalTurnException;
 use Netresearch\NrLlm\Service\Agent\Exception\StaleInputTurnException;
 use Netresearch\NrLlm\Service\Agent\Exception\SubmitterNotPermittedException;
@@ -208,6 +209,21 @@ final readonly class ResumeCoordinator
         $configuration = $this->configurationRepository->findByUid($run->configurationUid);
         if ($configuration === null) {
             throw RunConfigurationGoneException::forRun($runUuid);
+        }
+
+        // Four-eyes (ADR-172). Refused here, before anything is claimed, so the
+        // run stays WAITING_FOR_APPROVAL and a colleague can still decide it.
+        //
+        // An APPROVAL only. A DENIAL by the initiator stays allowed for the same
+        // reason it passes gates 2 and 3 below: the control exists to stop a
+        // write from EXECUTING, and a denial never runs the pending call — it
+        // resumes the loop with the refusal. Refusing the denial would strand
+        // the turn while the person who wants it gone is turned away.
+        if ($decision->approved
+            && $configuration->requiresSecondApprover()
+            && $actor->isInitiatorOf($run)
+        ) {
+            throw SelfApprovalDeniedException::forActor($actor, $runUuid, $run->configurationIdentifier);
         }
 
         // Reject an already-unreadable state BEFORE the claim, and do not carry

--- a/Configuration/TCA/tx_nrllm_configuration.php
+++ b/Configuration/TCA/tx_nrllm_configuration.php
@@ -52,6 +52,7 @@ return [
                     allowed_groups,
                     allowed_tool_groups,
                     allowed_guardrails,
+                    require_second_approver,
                 --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,
                     hidden,
                     --palette--;;status
@@ -442,6 +443,15 @@ return [
                 'renderType' => 'selectCheckBox',
                 'itemsProcFunc' => GuardrailItems::class . '->addItems',
                 'default' => '',
+            ],
+        ],
+        'require_second_approver' => [
+            'label' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_configuration.require_second_approver',
+            'description' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_tca.xlf:tx_nrllm_configuration.require_second_approver.description',
+            'config' => [
+                'type' => 'check',
+                'renderType' => 'checkboxToggle',
+                'default' => 0,
             ],
         ],
         'snippet_tags' => [

--- a/Documentation/Adr/Adr172FourEyesApprovalPerConfiguration.rst
+++ b/Documentation/Adr/Adr172FourEyesApprovalPerConfiguration.rst
@@ -1,0 +1,97 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-172:
+
+============================================================================
+ADR-172: Four-eyes approval is a per-configuration switch, default off
+============================================================================
+
+:Status: Accepted
+:Date: 2026-08-14
+:Authors: Netresearch DTT GmbH
+
+.. _adr-172-context:
+
+Context
+=======
+
+:ref:`ADR-083 <adr-083>` authorises an action on an agent run as owner-or-admin,
+and :ref:`ADR-130 <adr-130>` adds the ``AGENT_APPROVE`` grant so an approver can
+decide runs that are not their own. Nothing in either excludes the actor who
+*started* the run. The person who triggers a write-tool call can therefore
+release it themselves.
+
+For a single-operator install that is the intended convenience, and it is what
+every existing record does today. It stops being convenience where several
+people share a backend login, or where the approval is the audit control rather
+than a confirmation dialog: the fence then records that somebody approved,
+without recording that anybody else looked.
+
+Found during the demo test of the write path (Jira NEXT-133). The mechanism
+worked — the write landed live and correctly paused. The question was only who
+may release it.
+
+.. _adr-172-decision:
+
+Decision
+========
+
+A per-configuration switch, ``require_second_approver``, default ``0``.
+
+When it is set, :php:`ResumeCoordinator::approve()` refuses an approval from the
+backend user the run records as its initiator. The refusal happens after the
+configuration is loaded and **before** anything is claimed, so the run stays
+``WAITING_FOR_APPROVAL`` and a colleague can still decide it.
+
+Three boundaries make the rule predictable:
+
+**An approval only, never a denial.** The initiator may still deny their own
+run. This is the same reasoning that lets a denial pass gates 2 and 3 in
+``approve()``: those controls exist to stop a *write* from executing, and a
+denial never runs the pending call — it resumes the loop with the refusal so the
+model learns of it. Refusing a denial would strand the turn while the person who
+wants it gone is turned away.
+
+**No exemption for administrators.** Being allowed to act on every run does not
+make an administrator a second pair of eyes on their own request. An
+administrator who did not start the run may approve it as before.
+
+**Service accounts are unaffected.** ``beUser`` identifies a backend user, so a
+run started by a service account records ``0`` and matches nobody. Four-eyes
+constrains humans; a machine caller's authorisation stays with the scope
+mechanism, which is where it already lives.
+
+.. _adr-172-alternatives:
+
+Why not install-wide
+====================
+
+An install-wide setting was the alternative. It was rejected because the two
+populations that need four-eyes and the population that needs single-operator
+convenience live on the same install: a configuration whose agent may write to
+``pages`` is a different risk from one that only reads. Making the choice
+per-configuration lets an operator raise the bar exactly where the writes are,
+without turning every playground run into a two-person ceremony.
+
+The switch is small enough that an install-wide default could be layered on
+later without changing this record's semantics.
+
+.. _adr-172-consequences:
+
+Consequences
+============
+
+A refused approval surfaces the way every other approval refusal in this module
+does — a typed exception caught in
+:php:`AgentRunController`, rendered as a flash message
+(``runs.error.selfApproval``). That is deliberate rather than a UI gap: the same
+pattern already carries ``StaleApprovalTurnException`` and
+``ApproverNotPermittedException``, both of which can only be known at decision
+time. Hiding the button instead would require the inbox factory to resolve every
+run's configuration on every render, and would still have to keep the
+server-side refusal.
+
+An install that turns the switch on without having a second person with either
+admin rights or the ``AGENT_APPROVE`` grant will strand its runs at the fence.
+That is the setting doing what it says; the field description states the
+requirement.

--- a/Documentation/Adr/Adr172FourEyesApprovalPerConfiguration.rst
+++ b/Documentation/Adr/Adr172FourEyesApprovalPerConfiguration.rst
@@ -95,3 +95,10 @@ An install that turns the switch on without having a second person with either
 admin rights or the ``AGENT_APPROVE`` grant will strand its runs at the fence.
 That is the setting doing what it says; the field description states the
 requirement.
+
+**The Playground cannot complete such a run.** Its caller is always the person
+who started it, so a suspended turn on a four-eyes configuration can only be
+released from the Agent Runs inbox, by somebody else. The Playground answers
+403 with that sentence rather than an unhandled error. This is the switch
+working as specified, but it is the consequence an operator is most likely to
+meet first, which is why it is written down here and not left to be discovered.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -523,3 +523,4 @@ Tools
    Adr169RecordManagementUsesTypo3Permissions
    Adr170OneDeadlinePerMcpOperation
    Adr171PersonasTheCodeAlreadyAssumes
+   Adr172FourEyesApprovalPerConfiguration

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -3930,6 +3930,10 @@
                 <source>This action runs a tool you are not permitted to use yourself, so you may not approve it. The run is still waiting for someone who is.</source>
                 <target>Diese Aktion führt ein Werkzeug aus, das Sie selbst nicht verwenden dürfen; deshalb können Sie sie nicht freigeben. Der Lauf wartet weiterhin auf eine berechtigte Person.</target>
             </trans-unit>
+            <trans-unit id="runs.error.selfApproval">
+                <source>You started this run, and its configuration requires a second approver. Someone else has to release it. You can still deny it.</source>
+                <target>Sie haben diesen Lauf gestartet, und seine Konfiguration verlangt eine zweite freigebende Person. Die Freigabe muss jemand anderes erteilen. Ablehnen können Sie ihn weiterhin.</target>
+            </trans-unit>
             <trans-unit id="runs.error.submitterNotPermitted">
                 <source>This form feeds a tool you are not permitted to use yourself, so you may not submit its input. The run is still waiting for someone who is.</source>
                 <target>Dieses Formular versorgt ein Werkzeug, das Sie selbst nicht verwenden dürfen; deshalb können Sie seine Eingabe nicht absenden. Der Lauf wartet weiterhin auf eine berechtigte Person.</target>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -3500,6 +3500,10 @@
                 <source>Unknown tool group</source>
                 <target>Unbekannte Werkzeuggruppe</target>
             </trans-unit>
+            <trans-unit id="error.tool.selfApproval">
+                <source>You started this run and its configuration requires a second approver. Someone else has to release it.</source>
+                <target>Sie haben diesen Lauf gestartet, und seine Konfiguration verlangt eine zweite freigebende Person. Die Freigabe muss jemand anderes erteilen.</target>
+            </trans-unit>
             <trans-unit id="error.mcp.unknownServer">
                 <source>Unknown MCP server</source>
                 <target>Unbekannter MCP-Server</target>

--- a/Resources/Private/Language/de.locallang_tca.xlf
+++ b/Resources/Private/Language/de.locallang_tca.xlf
@@ -311,6 +311,15 @@
                 <target>Welche optionalen Schutzmechanismen für Läufe mit dieser Konfiguration gelten. Leer = alle aktiv. Sicherheitskritische Schutzmechanismen (Schwärzung von Geheimnissen) laufen immer und werden hier nicht aufgeführt.</target>
             </trans-unit>
 
+            <trans-unit id="tx_nrllm_configuration.require_second_approver">
+                <source>Require a second approver</source>
+                <target>Zweite freigebende Person verlangen</target>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_configuration.require_second_approver.description">
+                <source>Whoever starts a run cannot approve its own suspended write; someone else has to. Turn this on where the approval is the audit control rather than a confirmation dialog — a shared backend login, or a workflow that has to record that a second person looked. The initiator can still deny the run, and an administrator is not exempt.</source>
+                <target>Wer einen Lauf startet, kann dessen angehaltenen Schreibzugriff nicht selbst freigeben; das muss jemand anderes tun. Einschalten, wo die Freigabe die Prüfinstanz ist und nicht bloß ein Bestätigungsdialog — etwa bei einem geteilten Backend-Zugang oder wenn festgehalten werden muss, dass eine zweite Person hingesehen hat. Ablehnen kann die startende Person weiterhin, und Administratoren sind nicht ausgenommen.</target>
+            </trans-unit>
+
             <trans-unit id="tx_nrllm_configuration.snippet_tags">
                 <source>Prompt snippet tags</source>
                 <target>Tags für Prompt-Bausteine</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -2640,6 +2640,9 @@
             <trans-unit id="error.tool.unknownGroup">
                 <source>Unknown tool group</source>
             </trans-unit>
+            <trans-unit id="error.tool.selfApproval">
+                <source>You started this run and its configuration requires a second approver. Someone else has to release it.</source>
+            </trans-unit>
             <trans-unit id="error.mcp.unknownServer">
                 <source>Unknown MCP server</source>
             </trans-unit>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -2963,6 +2963,9 @@
             <trans-unit id="runs.error.approverNotPermitted">
                 <source>This action runs a tool you are not permitted to use yourself, so you may not approve it. The run is still waiting for someone who is.</source>
             </trans-unit>
+            <trans-unit id="runs.error.selfApproval">
+                <source>You started this run, and its configuration requires a second approver. Someone else has to release it. You can still deny it.</source>
+            </trans-unit>
             <trans-unit id="runs.error.submitterNotPermitted">
                 <source>This form feeds a tool you are not permitted to use yourself, so you may not submit its input. The run is still waiting for someone who is.</source>
             </trans-unit>

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -241,6 +241,12 @@
             <trans-unit id="tx_nrllm_configuration.allowed_guardrails.description">
                 <source>Which optional guardrails apply to runs with this configuration. Empty = all apply. Security-critical guardrails (secret redaction) always run and are not listed here.</source>
             </trans-unit>
+            <trans-unit id="tx_nrllm_configuration.require_second_approver">
+                <source>Require a second approver</source>
+            </trans-unit>
+            <trans-unit id="tx_nrllm_configuration.require_second_approver.description">
+                <source>Whoever starts a run cannot approve its own suspended write; someone else has to. Turn this on where the approval is the audit control rather than a confirmation dialog — a shared backend login, or a workflow that has to record that a second person looked. The initiator can still deny the run, and an administrator is not exempt.</source>
+            </trans-unit>
 
             <trans-unit id="tx_nrllm_configuration.snippet_tags">
                 <source>Prompt snippet tags</source>

--- a/Tests/Functional/Service/Agent/ResumeCoordinatorFourEyesGateTest.php
+++ b/Tests/Functional/Service/Agent/ResumeCoordinatorFourEyesGateTest.php
@@ -1,0 +1,314 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Agent;
+
+use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
+use Netresearch\NrLlm\Domain\Enum\BackendUserGrant;
+use Netresearch\NrLlm\Domain\Enum\PrivacyLevel;
+use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
+use Netresearch\NrLlm\Domain\Enum\ToolEffect;
+use Netresearch\NrLlm\Domain\Enum\TrustZone;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\Provider;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
+use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
+use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
+use Netresearch\NrLlm\Domain\ValueObject\SuspendedRunState;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Domain\ValueObject\ToolLoopResult;
+use Netresearch\NrLlm\Service\Agent\AgentRunExecutor;
+use Netresearch\NrLlm\Service\Agent\ApprovalDecision;
+use Netresearch\NrLlm\Service\Agent\Exception\SelfApprovalDeniedException;
+use Netresearch\NrLlm\Service\Agent\PendingTurnDigest;
+use Netresearch\NrLlm\Service\Agent\ResumeCoordinator;
+use Netresearch\NrLlm\Service\Governance\DataClassEnforcementResolver;
+use Netresearch\NrLlm\Service\Governance\TrustZoneResolver;
+use Netresearch\NrLlm\Service\Skill\SkillComposer;
+use Netresearch\NrLlm\Service\Tool\ActingBackendUserResolver;
+use Netresearch\NrLlm\Service\Tool\AgentRunPersister;
+use Netresearch\NrLlm\Service\Tool\AgentRunRepository;
+use Netresearch\NrLlm\Service\Tool\AgentStateCodec;
+use Netresearch\NrLlm\Service\Tool\AllowedToolsResolver;
+use Netresearch\NrLlm\Service\Tool\ToolAvailabilityService;
+use Netresearch\NrLlm\Service\Tool\ToolCallPolicy;
+use Netresearch\NrLlm\Service\Tool\ToolDataClassResolver;
+use Netresearch\NrLlm\Service\Tool\ToolEffectResolver;
+use Netresearch\NrLlm\Service\Tool\ToolGroupStateRepository;
+use Netresearch\NrLlm\Service\Tool\ToolLoopServiceInterface;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Service\Tool\ToolStateRepository;
+use Netresearch\NrLlm\Tests\Fixture\FixedPrivacyPolicy;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use Netresearch\NrLlm\Tests\Unit\Service\Tool\Fixtures\FakeTool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
+use RuntimeException;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * ADR-172: with `require_second_approver` set, the backend user who started a
+ * run may not release it.
+ *
+ * The run lives in the functional database and goes through the real
+ * claim/release transitions, so "the run is still decidable" is asserted on the
+ * stored row. `touch_thing` declares a write but no admin flag, so the ADR-133
+ * gate admits both principals used here and the four-eyes gate is the only
+ * thing that can refuse.
+ */
+#[CoversClass(ResumeCoordinator::class)]
+final class ResumeCoordinatorFourEyesGateTest extends AbstractFunctionalTestCase
+{
+    private AgentRunPersister $persister;
+
+    private bool $resumed = false;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // BeUsers.csv: uid 1 = admin (the run owner), uid 2 = non-admin editor.
+        $this->importFixture('BeUsers.csv');
+        $this->persister = new AgentRunPersister(
+            new AgentRunRepository($this->connectionPool(), $this->get(AgentStateCodec::class)),
+            FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL),
+            new NullLogger(),
+        );
+    }
+
+    #[Test]
+    public function theInitiatorMayNotApproveTheirOwnRun(): void
+    {
+        $uuid = $this->suspendOn('touch_thing', 1);
+
+        try {
+            $this->coordinator(true)->approve($this->initiator(), $uuid, $this->decision(true, 1, 'touch_thing'));
+            self::fail('Expected SelfApprovalDeniedException');
+        } catch (SelfApprovalDeniedException $exception) {
+            self::assertStringContainsString('requires a second approver', $exception->getMessage());
+            $this->assertStillWaiting($uuid);
+        }
+    }
+
+    #[Test]
+    public function beingAnAdministratorIsNoExemption(): void
+    {
+        // uid 1 is an administrator. Acting on every run is not the same as
+        // being a second pair of eyes on one's own.
+        $uuid = $this->suspendOn('touch_thing', 1);
+
+        try {
+            $this->coordinator(true)->approve(
+                AiActorContext::backendUser(1, isAdmin: true),
+                $uuid,
+                $this->decision(true, 1, 'touch_thing'),
+            );
+            self::fail('Expected SelfApprovalDeniedException');
+        } catch (SelfApprovalDeniedException) {
+            $this->assertStillWaiting($uuid);
+        }
+    }
+
+    #[Test]
+    public function theInitiatorMayStillDenyTheirOwnRun(): void
+    {
+        // The control exists to stop a write from EXECUTING. A denial never runs
+        // the pending call — it resumes the loop with the refusal so the model
+        // learns of it — so refusing the denial would only strand the turn while
+        // the person who wants it gone is turned away.
+        $uuid = $this->suspendOn('touch_thing', 1);
+
+        $this->coordinator(true)->approve($this->initiator(), $uuid, $this->decision(false, 1, 'touch_thing'));
+
+        $run = $this->persister->findRun($uuid);
+        self::assertInstanceOf(AgentRun::class, $run);
+        self::assertNotSame(
+            AgentRunStatus::WAITING_FOR_APPROVAL,
+            $run->statusEnum(),
+            'the denial was accepted, so the run left the fence',
+        );
+    }
+
+    #[Test]
+    public function aColleagueReleasesTheSameRun(): void
+    {
+        $uuid = $this->suspendOn('touch_thing', 1);
+
+        $this->coordinator(true)->approve($this->colleague(), $uuid, $this->decision(true, 2, 'touch_thing'));
+
+        self::assertTrue($this->resumed, 'the second pair of eyes released the turn');
+        $this->assertSettledCompleted($uuid);
+    }
+
+    #[Test]
+    public function theInitiatorApprovesWhenTheSwitchIsOff(): void
+    {
+        // The default, and what every pre-existing record does.
+        $uuid = $this->suspendOn('touch_thing', 1);
+
+        $this->coordinator(false)->approve($this->initiator(), $uuid, $this->decision(true, 1, 'touch_thing'));
+
+        self::assertTrue($this->resumed);
+        $this->assertSettledCompleted($uuid);
+    }
+
+    #[Test]
+    public function aServiceAccountIsNeverTheInitiator(): void
+    {
+        // A run a service account started records beUser 0, which matches
+        // nobody. Four-eyes constrains humans; the scope mechanism is where a
+        // machine caller's authorisation lives.
+        $uuid = $this->suspendOn('list_pages', 0);
+
+        $this->coordinator(true)->approve($this->serviceAccount(), $uuid, $this->decision(true, 0, 'list_pages'));
+
+        self::assertTrue($this->resumed);
+        $this->assertSettledCompleted($uuid);
+    }
+
+    // --- assertions --------------------------------------------------------
+
+    private function assertStillWaiting(string $uuid): void
+    {
+        self::assertFalse($this->resumed, 'nothing was executed');
+
+        $run = $this->persister->findRun($uuid);
+        self::assertInstanceOf(AgentRun::class, $run);
+        self::assertSame(AgentRunStatus::WAITING_FOR_APPROVAL, $run->statusEnum());
+        self::assertNotNull($run->suspendedState, 'a colleague can still decide it');
+        self::assertSame(0, $run->finishedAt, 'a refused decision never settles the run');
+    }
+
+    private function assertSettledCompleted(string $uuid): void
+    {
+        $run = $this->persister->findRun($uuid);
+        self::assertInstanceOf(AgentRun::class, $run);
+        self::assertSame(AgentRunStatus::COMPLETED, $run->statusEnum());
+    }
+
+    // --- helpers -----------------------------------------------------------
+
+    private function initiator(): AiActorContext
+    {
+        return AiActorContext::backendUser(1, grants: [BackendUserGrant::AGENT_APPROVE]);
+    }
+
+    private function colleague(): AiActorContext
+    {
+        return AiActorContext::backendUser(2, grants: [BackendUserGrant::AGENT_APPROVE]);
+    }
+
+    private function serviceAccount(): AiActorContext
+    {
+        return AiActorContext::serviceAccount('nightly-approver', [ServiceAccountScope::AGENT_APPROVE]);
+    }
+
+    private function decision(bool $approved, int $decidedBy, string $tool): ApprovalDecision
+    {
+        return new ApprovalDecision($approved, $decidedBy, (new PendingTurnDigest())->forState($this->state($tool)));
+    }
+
+    /**
+     * @return string the run uuid
+     */
+    private function suspendOn(string $tool, int $beUser): string
+    {
+        $handle = $this->persister->begin(null, $beUser);
+        self::assertNotNull($handle);
+        self::assertTrue($this->persister->suspend($handle, $this->state($tool)));
+
+        return $handle->uuid;
+    }
+
+    private function state(string $tool): SuspendedRunState
+    {
+        return new SuspendedRunState([], [ToolCall::function('c1', $tool, ['uid' => 42])->toArray()], 1, 0, 0);
+    }
+
+    private function coordinator(bool $fourEyes): ResumeCoordinator
+    {
+        $registry = new ToolRegistry([
+            new FakeTool('touch_thing', effect: ToolEffect::NON_IDEMPOTENT_WRITE),
+            new FakeTool('list_pages'),
+        ]);
+
+        $policy = new ToolCallPolicy(
+            $registry,
+            new ToolAvailabilityService($registry, new ToolStateRepository($this->connectionPool()), new ToolGroupStateRepository($this->connectionPool())),
+            new AllowedToolsResolver(new SkillComposer(), $registry),
+            new ToolDataClassResolver($registry),
+            new TrustZoneResolver(),
+            new DataClassEnforcementResolver(),
+        );
+
+        $configurationRepository = self::createStub(LlmConfigurationRepository::class);
+        $configurationRepository->method('findByUid')->willReturn($this->localConfiguration($fourEyes));
+
+        $loop = $this->toolLoop();
+
+        return new ResumeCoordinator(
+            $this->persister,
+            $configurationRepository,
+            $loop,
+            new AgentRunExecutor($loop, $this->persister),
+            null,
+            new ToolEffectResolver($registry),
+            new PendingTurnDigest(),
+            $policy,
+            new ActingBackendUserResolver(),
+            new NullLogger(),
+        );
+    }
+
+    private function toolLoop(): ToolLoopServiceInterface
+    {
+        $loop = self::createStub(ToolLoopServiceInterface::class);
+        $loop->method('resume')->willReturnCallback(function (): ToolLoopResult {
+            $this->resumed = true;
+
+            return new ToolLoopResult('continued', [], 1, false, UsageStatistics::fromTokens(1, 1));
+        });
+        $loop->method('resumeWithInput')->willReturnCallback(static function (): ToolLoopResult {
+            throw new RuntimeException('resumeWithInput must not be reached', 1786800001);
+        });
+
+        return $loop;
+    }
+
+    /**
+     * A LOCAL-trust-zone configuration, so the trust-zone axis of the real gate
+     * permits the fake tools and the four-eyes switch is the variable.
+     */
+    private function localConfiguration(bool $fourEyes): LlmConfiguration
+    {
+        $provider = new Provider();
+        $provider->setTrustZoneEnum(TrustZone::LOCAL);
+
+        $model = new Model();
+        $model->setProvider($provider);
+
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('cfg-four-eyes');
+        $configuration->setLlmModel($model);
+        $configuration->setRequireSecondApprover($fourEyes);
+
+        return $configuration;
+    }
+
+    private function connectionPool(): ConnectionPool
+    {
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+
+        return $connectionPool;
+    }
+}

--- a/Tests/Unit/Api/api-surface.txt
+++ b/Tests/Unit/Api/api-surface.txt
@@ -430,6 +430,7 @@ Netresearch\NrLlm\Domain\Model\LlmConfiguration (class)
   method getPresetChecksum(): string
   method getProvider(): ?Netresearch\NrLlm\Domain\Model\Provider
   method getProviderType(): string
+  method getRequireSecondApprover(): bool
   method getSkills(): TYPO3\CMS\Extbase\Persistence\ObjectStorage
   method getSnippetTagList(): array
   method getSnippetTags(): string
@@ -448,6 +449,7 @@ Netresearch\NrLlm\Domain\Model\LlmConfiguration (class)
   method isActive(): bool
   method isDefault(): bool
   method removeSkill(Netresearch\NrLlm\Domain\Model\Skill $skill): void
+  method requiresSecondApprover(): bool
   method setAllowedGuardrails(string $allowedGuardrails): void
   method setAllowedToolGroups(string $allowedToolGroups): void
   method setBeGroups(?TYPO3\CMS\Extbase\Persistence\ObjectStorage $beGroups): void
@@ -472,6 +474,7 @@ Netresearch\NrLlm\Domain\Model\LlmConfiguration (class)
   method setOptionsArray(array $options): void
   method setPresencePenalty(float $presencePenalty): void
   method setPresetChecksum(string $presetChecksum): void
+  method setRequireSecondApprover(bool $requireSecondApprover): void
   method setSkills(TYPO3\CMS\Extbase\Persistence\ObjectStorage $skills): void
   method setSnippetTags(string $snippetTags): void
   method setSystemPrompt(string $systemPrompt): void
@@ -725,6 +728,7 @@ Netresearch\NrLlm\Domain\ValueObject\AiActorContext (class)
   method hasGrant(Netresearch\NrLlm\Domain\Enum\BackendUserGrant $grant): bool
   method hasScope(Netresearch\NrLlm\Domain\Enum\ServiceAccountScope $scope): bool
   method isAuthenticated(): bool
+  method isInitiatorOf(Netresearch\NrLlm\Domain\ValueObject\AgentRun $run): bool
   method isServiceAccount(): bool
   method mayAccessSession(Netresearch\NrLlm\Domain\ValueObject\AiSession $session): bool
   method mayActOnRun(Netresearch\NrLlm\Domain\ValueObject\AgentRun $run, Netresearch\NrLlm\Domain\Enum\ServiceAccountScope $scope): bool

--- a/Tests/Unit/Domain/ValueObject/AiActorContextTest.php
+++ b/Tests/Unit/Domain/ValueObject/AiActorContextTest.php
@@ -214,4 +214,31 @@ final class AiActorContextTest extends TestCase
             AiActorContext::backendUser(7)->mayActOnRun($someoneElsesRun, ServiceAccountScope::AGENT_APPROVE),
         );
     }
+
+    /**
+     * ADR-172: "may act on this run" and "started this run" are different
+     * questions, and four-eyes rests on the second one.
+     */
+    #[Test]
+    public function isInitiatorOfAnswersOnlyForTheBackendUserWhoStartedTheRun(): void
+    {
+        $run = new AgentRun(1, 'uuid', 'waiting_for_approval', 0, '', 42, 0, false, 0, 0, 0, 0.0, '', '', 0, 0, 0, '{}');
+
+        self::assertTrue(AiActorContext::backendUser(42)->isInitiatorOf($run));
+        self::assertFalse(AiActorContext::backendUser(7)->isInitiatorOf($run));
+
+        // An administrator who started it is still the initiator: acting on
+        // every run does not make one a second pair of eyes on one's own.
+        self::assertTrue(AiActorContext::backendUser(42, isAdmin: true)->isInitiatorOf($run));
+
+        // A service account is never the initiator, and neither is "no user".
+        self::assertFalse(
+            AiActorContext::serviceAccount('nightly', [ServiceAccountScope::AGENT_APPROVE])->isInitiatorOf($run),
+        );
+        self::assertFalse(AiActorContext::anonymous()->isInitiatorOf($run));
+
+        // A run with no backend user matches nobody, uid 0 included.
+        $machineRun = new AgentRun(2, 'uuid2', 'waiting_for_approval', 0, '', 0, 0, false, 0, 0, 0, 0.0, '', '', 0, 0, 0, '{}');
+        self::assertFalse(AiActorContext::backendUser(0)->isInitiatorOf($machineRun));
+    }
 }

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -167,6 +167,11 @@ CREATE TABLE tx_nrllm_configuration (
     -- Access control (MM relation to be_groups)
     allowed_groups int(11) DEFAULT '0' NOT NULL,
 
+    -- Four-eyes approval (ADR-172): 1 refuses an approval from the backend user
+    -- who started the run, so releasing a write needs a second person. 0 keeps
+    -- the single-operator behaviour every existing row has.
+    require_second_approver tinyint(1) DEFAULT '0' NOT NULL,
+
     -- Comma list of permitted tool groups (empty = all groups allowed)
     allowed_tool_groups varchar(255) DEFAULT '' NOT NULL,
     allowed_guardrails varchar(255) DEFAULT '' NOT NULL,


### PR DESCRIPTION
`AiActorContext::mayActOnRun()` authorises an approval as owner-or-admin plus the `AGENT_APPROVE` grant (ADR-083 / ADR-130). Nothing in either excludes the actor who *started* the run, so the person who triggers a write-tool call can release it themselves. For a single-operator install that is the intended convenience; where several people share a backend login, or the approval is the audit control rather than a confirmation dialog, the fence records that somebody approved without recording that anybody else looked.

## The decision the issue asked for

A **per-configuration** switch, `require_second_approver`, **default off**.

Install-wide was the alternative and was rejected: the configurations that need four-eyes and the ones that need single-operator convenience live on the same install — a configuration whose agent may write to `pages` is a different risk from one that only reads. Per-configuration lets an operator raise the bar exactly where the writes are. An install-wide default could be layered on later without changing these semantics. Recorded as ADR-172.

## Three boundaries

**An approval only, never a denial.** The initiator can still deny their own run. Same reasoning that lets a denial pass gates 2 and 3 in `approve()`: those controls stop a *write* from executing, and a denial never runs the pending call — it resumes the loop with the refusal so the model learns of it. Refusing the denial would strand the turn while the person who wants it gone is turned away.

**No exemption for administrators.** Being allowed to act on every run does not make an admin a second pair of eyes on their own request. An admin who did not start the run approves as before.

**Service accounts are unaffected.** `beUser` identifies a backend user, so a run a service account started records `0` and matches nobody. Four-eyes constrains humans; a machine caller's authorisation stays with the scope mechanism.

The refusal is thrown after the configuration is loaded and before anything is claimed, so the run stays `WAITING_FOR_APPROVAL` with its state intact.

## Why the button is not hidden

`SelfApprovalDeniedException` is caught in `AgentRunController` and rendered as a flash message — the same path `StaleApprovalTurnException` and `ApproverNotPermittedException` already take, both of which can only be known at decision time. Hiding the button would require the inbox factory to resolve every run's configuration on every render and would still need the server-side refusal.

## Verification

```
runTests.sh -s functional -d sqlite -p 8.4 …ResumeCoordinatorFourEyesGateTest.php  → Tests: 6, Assertions: 52, no failures
runTests.sh -s unit    -p 8.4   → OK (7132 tests, 22084 assertions)
runTests.sh -s fuzzy   -p 8.4   → OK (86 tests, 16332 assertions)
runTests.sh -s cgl     -p 8.4   → SUCCESS
runTests.sh -s phpstan -p 8.4   → [OK] No errors
composer ci:test:changelog      → SUCCESS
```

The guard was seen to fail. With the four-eyes block removed from `approve()` and nothing else changed, two cases fail:

```
1) …ResumeCoordinatorFourEyesGateTest::theInitiatorMayNotApproveTheirOwnRun
   Expected SelfApprovalDeniedException
2) …ResumeCoordinatorFourEyesGateTest::beingAnAdministratorIsNoExemption
   Expected SelfApprovalDeniedException
```

`rector -n` was **not** run locally: this worktree's `.Build` is resolved at 8.4 and the gate is pinned to 8.2, where `platform_check.php` fatals before the suite starts. CI runs it.

The api-surface snapshot was regenerated — additive, 4 added, 0 removed, 0 changed.

Closes #786
