### PR TITLE
docs: point the four dead path references at the files that exist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ The full `./Build/Scripts/runTests.sh -s functional` run includes ~34 provider-c
 <!-- AGENTS-GENERATED:START directory-structure -->
 ## Architecture
 
-Three-tier model: **Provider → Model → Configuration**. See `Documentation/Adr/Adr001ThreeTierProviderArchitecture.rst` for the design rationale and `Classes/Provider/AGENTS.md` for adapter contracts.
+Three-tier model: **Provider → Model → Configuration**. See `Documentation/Adr/Adr013ThreeLevelConfigurationArchitecture.rst` for the design rationale and `Classes/AGENTS.md` for adapter contracts.
 
 ### Directory Structure
 ```
@@ -158,7 +158,7 @@ nr_llm/
 - **NEVER commit `composer.lock`** — TYPO3 extensions are libraries; the lock file would conflict with project-level resolution.
 - **NEVER hardcode a cache backend in `Configuration/Caching.php`** — let the host instance configure Redis/Valkey/Memcached transparently. Specify only `frontend`, `options`, and `groups`.
 - **NEVER take TYPO3 backend screenshots below 1440px viewport** — sidebar and table columns get cut off.
-- **API keys MUST be stored as nr-vault UUID identifiers**, never as plaintext in TCA / yaml / env. See `Documentation/Adr/Adr012ApiKeyStorageVault.rst`.
+- **API keys MUST be stored as nr-vault UUID identifiers**, never as plaintext in TCA / yaml / env. `Documentation/Adr/Adr012ApiKeyEncryption.rst` records the application-level encryption this replaced and is `Superseded`; the nr-vault integration itself was decided by no ADR, which `Documentation/Adr/Index.rst` states explicitly.
 - **No email addresses in public docs** — use the GitHub issues / discussions / security-advisories links only.
 <!-- AGENTS-GENERATED:END critical -->
 

--- a/landingpage/build/data/project.json
+++ b/landingpage/build/data/project.json
@@ -65,7 +65,7 @@
       "label": "API keys stored as vault identifiers",
       "detail": "Envelope encryption via nr-vault; nr-llm never stores or logs a raw key.",
       "state": "implemented",
-      "evidence": "https://github.com/netresearch/t3x-nr-llm/blob/main/Documentation/Adr/Adr012ApiKeyStorageVault.rst"
+      "evidence": "https://github.com/netresearch/t3x-nr-llm/blob/main/Documentation/Adr/Adr012ApiKeyEncryption.rst"
     },
     {
       "id": "guardrails",


### PR DESCRIPTION
## Description

`AGENTS.md` named three paths that do not resolve, and the landing page's security-controls data named a fourth. An agent that follows them reads nothing, and in the two ADR cases it silently skips the rationale it was sent to find — the failure mode that leaves no trace, because nothing errors when a documentation pointer is dead.

Each replacement was verified by reading the target, not by fixing the filename to the nearest match. Two of the four were wrong in a way a spelling correction would have got wrong as well:

| Reference in | Named | Actually | Why |
|---|---|---|---|
| `AGENTS.md:119` | `Adr/Adr001ThreeTierProviderArchitecture.rst` | `Adr/Adr013ThreeLevelConfigurationArchitecture.rst` | ADR-001 is *Provider Abstraction Layer*. The record that decides Provider → Model → Configuration is ADR-013, so the number was wrong, not the spelling. |
| `AGENTS.md:119` | `Classes/Provider/AGENTS.md` | `Classes/AGENTS.md` | No `AGENTS.md` exists below `Classes/`. `Provider/Contract/` is covered by `Classes/AGENTS.md`. |
| `AGENTS.md:161` | `Adr/Adr012ApiKeyStorageVault.rst` | `Adr/Adr012ApiKeyEncryption.rst` | The file exists under a different name **and** its status is `Superseded`. [`Adr/Index.rst`](https://github.com/netresearch/t3x-nr-llm/blob/main/Documentation/Adr/Index.rst) states that the nr-vault integration replacing it "no record decided", so the bullet now says that rather than implying a live ADR stands behind the rule. |
| `landingpage/build/data/project.json:68` | same dead ADR filename, as the `evidence` URL of the `vault-keys` security control | `Adr012ApiKeyEncryption.rst` | This one renders as a public 404 on the landing page. Every other `evidence` path in that file resolves — checked all nine. |

## Related Issue

None. Found while measuring this repo's governance for an unrelated question.

## Type of Change

- [x] Documentation update

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have run `make gate` — not run, and it would not cover this: the diff is two Markdown lines and one JSON string, touching no path PHPStan, Rector or any PHPUnit suite analyses. `composer ci:test:repo` (badges, changelog, workflow ownership) passes.
- [ ] I have added tests that prove my fix/feature works — no behaviour changed. The four references were each verified against the file on disk.
- [x] I have updated the documentation accordingly
- [ ] I have added a `CHANGELOG.md` entry — docs-only commits in this repo do not carry one (checked the last eight `docs:` commits).
- [ ] I have added an ADR — no public surface change.
- [x] My changes generate no new warnings

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_015QXXkquh2eQNBiTYA39Wss)_
