### PR TITLE
docs: point the PR checklist at the gate the workflow documents

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@
 ## Checklist
 
 - [ ] My code follows the project's coding standards
-- [ ] I have run `composer ci` and all checks pass
+- [ ] I have run `make gate` and all checks pass (not `composer ci` — that set omits Rector and the functional suite)
 - [ ] I have added tests that prove my fix/feature works
 - [ ] I have updated the documentation accordingly
 - [ ] I have added a `CHANGELOG.md` entry under `## [Unreleased]`


### PR DESCRIPTION
## Description

The checklist asked contributors to confirm `composer ci`, which is not the pre-push gate this project documents. The two sets differ in exactly the place that matters:

| | cgl | phpstan | unit | integration | fuzzy | rector | functional | changelog |
|---|---|---|---|---|---|---|---|---|
| `composer ci` | ✓ | ✓ | ✓ | ✓ | ✓ | — | — | — |
| `make gate` | ✓ | ✓ | ✓ | — | ✓ | ✓ (pinned 8.2) | ✓ (sqlite) | ✓ |

Rector and the functional suite are precisely the two the `Makefile` comment names as the ones that get skipped when the suites are invoked by hand, and which the CI matrix then finds a push later. So the box a contributor ticked certified a narrower set than [`AGENTS.md`](https://github.com/netresearch/t3x-nr-llm/blob/main/AGENTS.md) prescribes, and the gap was invisible at the moment of ticking it.

Both targets stay — `AGENTS.md` says they answer different questions — but the checklist now names the one that gates a push.

## Related Issue

None. Found while measuring this repo's governance for an unrelated question.

## Type of Change

- [x] Documentation update

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have run `make gate` — not run, and it does not apply: the diff is one line of Markdown in a PR template, touching no path any suite analyses. `composer ci:test:repo` passes.
- [ ] I have added tests that prove my fix/feature works — no behaviour changed; the claim in the new line was verified against the `gate` and `ci` targets in the `Makefile` and the `ci` script in `composer.json`.
- [x] I have updated the documentation accordingly
- [ ] I have added a `CHANGELOG.md` entry — docs-only, and this repo's `docs:` commits do not carry one.
- [ ] I have added an ADR — no public surface change.
- [x] My changes generate no new warnings

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_015QXXkquh2eQNBiTYA39Wss)_
