### PR TITLE
feat(runs): say when a run was released by the person who started it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **A self-approved run says so** (`#785`). An approval granted by the backend user who started the run is now labelled as such — on the run timeline, and in the *Recent runs* table of the Agent Runs inbox, which gains an *Approval* column. An approval granted by anybody else is labelled too, so the two are told apart at a glance instead of by comparing two uid numbers.
+
+  Derived at read time from values that were already stored, so it is right for runs recorded before this change. The readout compares the two uids in one place, `Domain\Enum\ApprovalAttribution`, and both surfaces render its answer; ADR-172's four-eyes gate keeps its own, stricter comparison in `AiActorContext::isInitiatorOf()`.
+
+  Granted approvals only: a denial carries no label, because ADR-172 lets an initiator deny their own run on purpose. Nothing reads *self* unless both uids are present and equal, and the two ways one can be missing are two labels rather than one: a run started by a service account and released by a backend user reads *Approved, but the record does not say who started the run*, while an approval whose decider was not recorded reads *Approved, but the record does not say by whom*. An empty cell is not the opposite of any of that — it means the run passed no fence, was denied, or its approvals could not be loaded or decoded.
+
+  This is a readout and refuses nothing. Whether self-approval is allowed remains the `require_second_approver` switch (ADR-172). See ADR-173.
+
 
 - **Per-call cost and real token counts on the telemetry row** (`#770`). Every
   provider call now records what it actually consumed — input tokens, output

--- a/Classes/Controller/Backend/AgentRunController.php
+++ b/Classes/Controller/Backend/AgentRunController.php
@@ -64,6 +64,14 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
  * has no grant equivalent, so the approval grant widens the list but not the
  * detail page (ADR-153).
  *
+ * The list therefore carries ONE fact the detail page would refuse to that same
+ * viewer: the ADR-173 approval attribution, derived from the approval events of
+ * runs a grant holder may list but not open. Deliberate and bounded — it is the
+ * same audit-only class as the `decidedBy` uid above — four labels and an empty
+ * cell, and it names nobody. The
+ * alternative, showing the column only on the viewer's own rows, would hide
+ * exactly the rows an approval grant exists to review.
+ *
  * The page works fully with JavaScript OFF: native `<f:form>` POST, a
  * POST-redirect-GET flush with session flash messages, and a 422 in-place
  * re-render that preserves the operator's raw input. The CSRF defence is the
@@ -286,7 +294,7 @@ final class AgentRunController extends ActionController
 
         $this->moduleTemplate->assignMultiple([
             'waiting'        => $this->viewFactory->buildWaiting($waitingRuns ?? [], $viewer instanceof BackendUserAuthentication ? $viewer : null),
-            'terminal'       => $this->viewFactory->buildTerminal($terminalRuns ?? [], $actor),
+            'terminal'       => $this->viewFactory->buildTerminal($terminalRuns ?? [], $actor, $this->approvalDeciders($terminalRuns ?? [])),
             'dataLoadError'  => $dataLoadError,
             'errorRunUuid'   => $errorRunUuid,
             'rawInput'       => $rawInput,
@@ -295,6 +303,33 @@ final class AgentRunController extends ActionController
         ]);
 
         return $this->moduleTemplate->renderResponse('Backend/AgentRun/List');
+    }
+
+    /**
+     * Who granted each listed run's approvals (ADR-173), in ONE statement for the
+     * whole table — the alternative, an event read per row, would be twenty
+     * queries for a marker.
+     *
+     * No authorisation is added or needed here: the rows are exactly the ones
+     * the list query already released to this viewer. That is not an actor-scoped
+     * set — for an admin or an `agent_approve` grant holder `$restrictTo` is null
+     * and the list is every user's run on purpose (ADR-131), which is the case
+     * this marker exists for. A `decidedBy` uid is audit metadata the inbox
+     * docblock already names as such.
+     *
+     * @param list<AgentRun> $runs
+     *
+     * @return array<int, list<int>>
+     */
+    private function approvalDeciders(array $runs): array
+    {
+        if ($runs === []) {
+            return [];
+        }
+
+        return $this->persister->findApprovalDeciders(
+            array_map(static fn(AgentRun $run): int => $run->uid, $runs),
+        );
     }
 
     /**

--- a/Classes/Domain/Enum/ApprovalAttribution.php
+++ b/Classes/Domain/Enum/ApprovalAttribution.php
@@ -1,0 +1,190 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\Enum;
+
+/**
+ * Who decided a recorded approval, relative to who started the run (ADR-173).
+ *
+ * Both halves of the answer are already stored — the run carries `beUser`, the
+ * APPROVAL event's payload carries `decidedBy` ({@see AgentEventKind::APPROVAL})
+ * — but nothing put them side by side, so a run its own initiator released read
+ * exactly like one a second person reviewed. This enum is the one place the
+ * READOUT compares the two uids; the readers ({@see \Netresearch\NrLlm\Service\Agent\Timeline\RunTimelineFactory}
+ * for the run timeline, {@see \Netresearch\NrLlm\Service\Agent\Inbox\WaitingRunViewFactory}
+ * for the inbox) render its case and never repeat the comparison.
+ *
+ * The ENFORCEMENT half compares them separately and differently, in
+ * {@see \Netresearch\NrLlm\Domain\ValueObject\AiActorContext::isInitiatorOf()}
+ * (ADR-172's four-eyes gate) — which also excludes service accounts, where this
+ * enum only has two uids to look at. Neither is a copy of the other, and the two
+ * are not interchangeable.
+ *
+ * This is a READOUT, not a control. Whether self-approval is refused is
+ * `require_second_approver` (ADR-172), a per-configuration switch that is
+ * default off — which is exactly why the readout matters: where the switch is
+ * off, an operator may believe four-eyes applies when it does not.
+ *
+ * Denials are deliberately out of scope: ADR-172 lets an initiator deny their
+ * own run on purpose, so marking a self-denial would flag the one case the
+ * design considers correct.
+ *
+ * Four cases, because two uids give four states and only one of them is a
+ * comparison. Both present is SELF or SECOND_PERSON; a missing decider is
+ * UNRESOLVED; a missing initiator with a decider present is INITIATOR_UNKNOWN,
+ * which is the ordinary shape of a service-account run a human released, not an
+ * error. Collapsing the last two into one label would put "the record does not
+ * say by whom" on a record that says exactly that.
+ */
+enum ApprovalAttribution: string
+{
+    /**
+     * The approval was granted by the backend user who started the run.
+     *
+     * Not an anomaly — for anyone who is not an administrator, not a service
+     * account and holds no `AGENT_APPROVE` grant, it is the fallback path in
+     * {@see \Netresearch\NrLlm\Domain\ValueObject\AiActorContext::mayActOnRun()};
+     * and on a single-operator install every approval is a self-approval,
+     * whichever branch of that method admits it. The point is that the record
+     * says so.
+     */
+    case SELF = 'self';
+
+    /**
+     * The approval was granted by a backend user other than the initiator —
+     * four eyes actually happened.
+     */
+    case SECOND_PERSON = 'secondPerson';
+
+    /**
+     * The record names who approved, but not who started the run: `decidedBy`
+     * is a backend user and `beUser` is 0.
+     *
+     * The normal shape of a run a service account or any non-backend caller
+     * began — `beUser` identifies a backend user, so such a run carries 0 and
+     * matches nobody ({@see \Netresearch\NrLlm\Domain\ValueObject\AiActorContext::isInitiatorOf()}).
+     * A human then approving it is an ordinary event, not a defect, and it is
+     * emphatically not {@see self::UNRESOLVED}: the record does say by whom.
+     * What it does not say is against whom to compare.
+     *
+     * Its own case rather than {@see self::SECOND_PERSON}, because nobody has
+     * established that two people were involved — only that the one who decided
+     * is not known to be the one who started.
+     */
+    case INITIATOR_UNKNOWN = 'initiatorUnknown';
+
+    /**
+     * The record does not name who approved: `decidedBy` is 0 or negative.
+     *
+     * Reachable through the readers, which coerce a `decidedBy` that is not an
+     * int — a truncated, corrupt or hand-edited payload — to 0 rather than
+     * dropping the approval.
+     *
+     * A sessionless recording is NOT a second way in, though it reads like one:
+     * both approve entry points pair
+     * {@see \Netresearch\NrLlm\Controller\Backend\BackendUserUidTrait::currentBackendUserUid()}
+     * with `currentActor()`, and an actor whose uid is 0 is
+     * {@see \Netresearch\NrLlm\Domain\ValueObject\AiActorContext::anonymous()},
+     * which {@see \Netresearch\NrLlm\Domain\ValueObject\AiActorContext::mayActOnRun()}
+     * refuses before {@see \Netresearch\NrLlm\Service\Agent\ResumeCoordinator::approve()}
+     * records anything — pinned by
+     * AiActorContextTest::anAnonymousActorMayNotActOnAnyRun(). So the case is
+     * defensive against that half, not driven by it.
+     *
+     * Its own case rather than a silent omission, because "nobody can tell"
+     * must not read as "a second person looked" — and 0 === 0 must never
+     * produce {@see self::SELF}. The initiator is not consulted here: whether
+     * or not the run names one, the fact this row states is that the decider is
+     * unrecorded.
+     */
+    case UNRESOLVED = 'unresolved';
+
+    /**
+     * The attribution of ONE recorded approval.
+     *
+     * Order matters. The decider is asked first, because an unnamed decider is
+     * the whole answer whatever the run says; only then can the initiator be
+     * absent, which is a different fact and gets a different case.
+     */
+    public static function fromDecision(int $initiatorBeUser, int $decidedByBeUser): self
+    {
+        if ($decidedByBeUser <= 0) {
+            return self::UNRESOLVED;
+        }
+
+        if ($initiatorBeUser <= 0) {
+            return self::INITIATOR_UNKNOWN;
+        }
+
+        return $initiatorBeUser === $decidedByBeUser ? self::SELF : self::SECOND_PERSON;
+    }
+
+    /**
+     * The attribution of a whole run, which may have passed several fences.
+     * Null when the run recorded no granted approval at all — the caller then
+     * shows nothing, because there is nothing to attribute.
+     *
+     * The strongest case wins, ranked SELF > UNRESOLVED > INITIATOR_UNKNOWN >
+     * SECOND_PERSON, so a collapsed row never understates: one self-released
+     * fence makes the run self-approved however many others a colleague signed,
+     * and a record that names no decider is not rounded up into a claim that a
+     * second person looked.
+     *
+     * That rank has an accepted price. A run with no initiator, one fence
+     * decided by user 5 and one whose decider was not recorded, collapses to
+     * UNRESOLVED — so the row says the decider is unrecorded while the timeline
+     * prints `decidedBy=5` for the other fence. Understating one fence is the
+     * direction this readout is allowed to be wrong in; claiming a second pair
+     * of eyes is not.
+     *
+     * Four of the six case pairings occur; two cannot. The initiator is one
+     * value for the whole run, so INITIATOR_UNKNOWN never meets SELF or
+     * SECOND_PERSON — a run either names an initiator or it does not. Both
+     * halves are enumerated by
+     * ApprovalAttributionTest::theOnlyPairingsARunCanShowAreTheFourItsInitiatorAllows().
+     *
+     * @param list<int> $decidedByBeUsers the `decidedBy` uids of the run's GRANTED approvals
+     */
+    public static function fromDecisions(int $initiatorBeUser, array $decidedByBeUsers): ?self
+    {
+        $collapsed = null;
+        foreach ($decidedByBeUsers as $decidedBy) {
+            $attribution = self::fromDecision($initiatorBeUser, $decidedBy);
+            if (!$collapsed instanceof self || $attribution->rank() > $collapsed->rank()) {
+                $collapsed = $attribution;
+            }
+        }
+
+        return $collapsed;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_map(static fn(self $case): string => $case->value, self::cases());
+    }
+
+    /**
+     * How loudly this case speaks, for {@see self::fromDecisions()}. Private and
+     * unordered by declaration on purpose: the ranking is a display rule, not a
+     * property of the case, and tying it to `cases()` order would make adding a
+     * case silently reorder the collapse.
+     */
+    private function rank(): int
+    {
+        return match ($this) {
+            self::SELF              => 4,
+            self::UNRESOLVED        => 3,
+            self::INITIATOR_UNKNOWN => 2,
+            self::SECOND_PERSON     => 1,
+        };
+    }
+}

--- a/Classes/Service/Agent/Inbox/TerminalRunView.php
+++ b/Classes/Service/Agent/Inbox/TerminalRunView.php
@@ -18,10 +18,20 @@ namespace Netresearch\NrLlm\Service\Agent\Inbox;
 final readonly class TerminalRunView
 {
     /**
-     * @param bool $openableByViewer whether {@see \Netresearch\NrLlm\Domain\ValueObject\AiActorContext::mayActOnRun()}
-     *                               would let this viewer READ this run (ADR-153). The list is wider than the
-     *                               read: an approval-grant holder sees every user's run but may only open their
-     *                               own, so the detail link is offered only where it would resolve
+     * @param bool   $openableByViewer    whether {@see \Netresearch\NrLlm\Domain\ValueObject\AiActorContext::mayActOnRun()}
+     *                                    would let this viewer READ this run (ADR-153). The list is wider than the
+     *                                    read: an approval-grant holder sees every user's run but may only open their
+     *                                    own, so the detail link is offered only where it would resolve
+     * @param string $approvalAttribution
+     *                                    an {@see \Netresearch\NrLlm\Domain\Enum\ApprovalAttribution} value when the run
+     *                                    recorded a granted approval (ADR-173). `''` is the absence of one and covers
+     *                                    the run granted no approval, its approvals were denials
+     *                                    (a denial is never attributed), or the deciders could not be loaded or
+     *                                    decoded. Not split, because the row renders each of them identically —
+     *                                    nothing — and the fail-soft read returns the same empty map either way,
+     *                                    so a split would need a signal that does not exist.
+     *                                    A string, like the timeline entry's, because the partial switches on it
+     *                                    as a literal; it assembles no key
      */
     public function __construct(
         public string $runUuid,
@@ -31,5 +41,6 @@ final readonly class TerminalRunView
         public string $configLabel,
         public ?string $formattedCost = null,
         public bool $openableByViewer = false,
+        public string $approvalAttribution = '',
     ) {}
 }

--- a/Classes/Service/Agent/Inbox/WaitingRunViewFactory.php
+++ b/Classes/Service/Agent/Inbox/WaitingRunViewFactory.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Agent\Inbox;
 
+use Netresearch\NrLlm\Domain\Enum\ApprovalAttribution;
 use Netresearch\NrLlm\Domain\Enum\ServiceAccountScope;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Domain\ValueObject\AiActorContext;
@@ -66,16 +67,21 @@ final readonly class WaitingRunViewFactory
     }
 
     /**
-     * @param list<AgentRun>      $runs
-     * @param AiActorContext|null $actor the actor the table is rendered for, asked whether it may READ each run
-     *                                   (ADR-153). The list is deliberately wider than the read — an approval-grant
-     *                                   holder sees every user's run — so the detail link is offered only where
-     *                                   {@see AiActorContext::mayActOnRun()} would let it resolve. Null withholds
-     *                                   every link (fail-closed)
+     * @param list<AgentRun>        $runs
+     * @param AiActorContext|null   $actor            the actor the table is rendered for, asked whether it may READ each run
+     *                                                (ADR-153). The list is deliberately wider than the read — an approval-grant
+     *                                                holder sees every user's run — so the detail link is offered only where
+     *                                                {@see AiActorContext::mayActOnRun()} would let it resolve. Null withholds
+     *                                                every link (fail-closed)
+     * @param array<int, list<int>> $decidersByRunUid the `decidedBy` uids of each run's GRANTED approvals, keyed by run uid
+     *                                                (ADR-173), as {@see \Netresearch\NrLlm\Service\Tool\AgentRunPersister::findApprovalDeciders()}
+     *                                                returns them. Absent or empty means the row states no attribution — which
+     *                                                is also what a failed load degrades to, so a store hiccup costs the marker
+     *                                                and never fabricates one
      *
      * @return list<TerminalRunView>
      */
-    public function buildTerminal(array $runs, ?AiActorContext $actor = null): array
+    public function buildTerminal(array $runs, ?AiActorContext $actor = null, array $decidersByRunUid = []): array
     {
         return array_map(
             fn(AgentRun $run): TerminalRunView => new TerminalRunView(
@@ -86,9 +92,32 @@ final readonly class WaitingRunViewFactory
                 configLabel: $this->configLabel($run),
                 formattedCost: $run->estimatedCost > 0.0 ? number_format($run->estimatedCost, 4) : null,
                 openableByViewer: $actor?->mayActOnRun($run, ServiceAccountScope::AGENT_READ) ?? false,
+                // Neither surface owns the rule: both ask ApprovalAttribution
+                // (ADR-173). They can still read differently on a run with
+                // several fences — the timeline states each one, this list
+                // collapses them by rank in fromDecisions(). That is the
+                // accepted price recorded on the enum, not a disagreement
+                // about the rule.
+                approvalAttribution: $this->attribution($run, $decidersByRunUid[$run->uid] ?? []),
             ),
             $runs,
         );
+    }
+
+    /**
+     * Who released this run, as the row states it (ADR-173). `''` is the row
+     * stating nothing, and three inputs reach it: the run granted no approval,
+     * every approval was a denial (denials never enter `$deciders`), or the
+     * deciders could not be loaded or decoded and the caller passed the empty fallback.
+     * They are not told apart here — see {@see TerminalRunView} for why.
+     *
+     * @param list<int> $deciders
+     */
+    private function attribution(AgentRun $run, array $deciders): string
+    {
+        $attribution = ApprovalAttribution::fromDecisions($run->beUser, $deciders);
+
+        return $attribution instanceof ApprovalAttribution ? $attribution->value : '';
     }
 
     /**

--- a/Classes/Service/Agent/Timeline/RunTimelineEntry.php
+++ b/Classes/Service/Agent/Timeline/RunTimelineEntry.php
@@ -36,18 +36,26 @@ final readonly class RunTimelineEntry
 
     public const OUTCOME_FAILED = 'failed';
 
+    /** The row is not a granted approval, so there is nobody to attribute (ADR-173). */
+    public const ATTRIBUTION_NONE = '';
+
     /**
-     * @param string $source     one of the SOURCE_* constants; the view translates it
-     * @param string $kind       the row's own kind (step kind, operation, or decision)
-     * @param int    $occurredAt UNIX timestamp the row was written
-     * @param int    $sequence   the step sequence within the run; -1 for rows that have none,
-     *                           which also orders them after a step of the same second
-     * @param int    $round      the loop round, 0 when the row has none
-     * @param float  $durationMs 0.0 when the row has none
-     * @param string $detail     `key=value` metadata pairs, already joined for display
-     * @param string $outcome    one of the OUTCOME_* constants — a string rather than a
-     *                           nullable bool because the view has to tell "no outcome"
-     *                           apart from "failed", which a Fluid truth test cannot
+     * @param string $source              one of the SOURCE_* constants; the view translates it
+     * @param string $kind                the row's own kind (step kind, operation, or decision)
+     * @param int    $occurredAt          UNIX timestamp the row was written
+     * @param int    $sequence            the step sequence within the run; -1 for rows that have none,
+     *                                    which also orders them after a step of the same second
+     * @param int    $round               the loop round, 0 when the row has none
+     * @param float  $durationMs          0.0 when the row has none
+     * @param string $detail              `key=value` metadata pairs, already joined for display
+     * @param string $outcome             one of the OUTCOME_* constants — a string rather than a
+     *                                    nullable bool because the view has to tell "no outcome"
+     *                                    apart from "failed", which a Fluid truth test cannot
+     * @param string $approvalAttribution
+     *                                    an {@see \Netresearch\NrLlm\Domain\Enum\ApprovalAttribution}
+     *                                    value on a granted-approval row, `''` on every other row
+     *                                    (ADR-173). A string for the same reason `$outcome` is one:
+     *                                    the partial switches on it as a literal; it assembles no key
      */
     public function __construct(
         public string $source,
@@ -58,5 +66,6 @@ final readonly class RunTimelineEntry
         public float $durationMs,
         public string $detail,
         public string $outcome = self::OUTCOME_NONE,
+        public string $approvalAttribution = self::ATTRIBUTION_NONE,
     ) {}
 }

--- a/Classes/Service/Agent/Timeline/RunTimelineFactory.php
+++ b/Classes/Service/Agent/Timeline/RunTimelineFactory.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Agent\Timeline;
 
+use Netresearch\NrLlm\Domain\Enum\AgentEventKind;
+use Netresearch\NrLlm\Domain\Enum\ApprovalAttribution;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRunEvent;
 use Netresearch\NrLlm\Service\Governance\GovernanceEventRepositoryInterface;
@@ -96,6 +98,7 @@ final readonly class RunTimelineFactory
                 durationMs: $event->durationMs,
                 detail: $this->stepDetail($event->payload),
                 outcome: $this->stepOutcome($event->payload),
+                approvalAttribution: $this->approvalAttribution($run, $event),
             );
         }
 
@@ -222,6 +225,38 @@ final readonly class RunTimelineFactory
         }
 
         return $this->join($facts);
+    }
+
+    /**
+     * Who decided this row, relative to who started the run (ADR-173) — `''` for
+     * every row that is not a GRANTED approval.
+     *
+     * `decidedBy` is already in {@see self::STEP_FACTS}, so the uid was on the
+     * page; what was missing is the comparison against the run's own initiator.
+     * Among the surfaces that PRESENT it, {@see ApprovalAttribution} is the only
+     * place it is made, which is what lets the inbox state the same fact without
+     * a second definition of it. POLICY compares the same two uids again, in
+     * {@see \Netresearch\NrLlm\Domain\ValueObject\AiActorContext::isInitiatorOf()}
+     * (ADR-172's four-eyes gate) — by a stricter rule that also excludes service
+     * accounts, so it is not this comparison duplicated.
+     *
+     * A denial carries no attribution on purpose: ADR-172 allows an initiator to
+     * deny their own run, so flagging that would mark the case the design calls
+     * correct.
+     */
+    private function approvalAttribution(AgentRun $run, AgentRunEvent $event): string
+    {
+        if ($event->kind !== AgentEventKind::APPROVAL->value) {
+            return RunTimelineEntry::ATTRIBUTION_NONE;
+        }
+
+        if (($event->payload['approved'] ?? null) !== true) {
+            return RunTimelineEntry::ATTRIBUTION_NONE;
+        }
+
+        $decidedBy = $event->payload['decidedBy'] ?? null;
+
+        return ApprovalAttribution::fromDecision($run->beUser, is_int($decidedBy) ? $decidedBy : 0)->value;
     }
 
     /**

--- a/Classes/Service/Tool/AgentRunPersister.php
+++ b/Classes/Service/Tool/AgentRunPersister.php
@@ -583,6 +583,30 @@ final readonly class AgentRunPersister
     }
 
     /**
+     * The `decidedBy` uids of several runs' GRANTED approvals, keyed by run uid
+     * (ADR-173) — the read the approvals inbox turns into its self-approved
+     * marker, in one statement for the whole page.
+     *
+     * Fail-soft like {@see self::findEvents()}: an empty map on a store error, so
+     * a hiccup costs the marker and not the inbox. The marker's absence is the
+     * safe direction — it never invents a second approver.
+     *
+     * @param list<int> $runUids
+     *
+     * @return array<int, list<int>>
+     */
+    public function findApprovalDeciders(array $runUids): array
+    {
+        try {
+            return $this->repository->findApprovalDeciders($runUids);
+        } catch (Throwable $exception) {
+            $this->logger?->warning('AgentRun approval deciders could not be loaded', ['exception' => $exception]);
+
+            return [];
+        }
+    }
+
+    /**
      * Running runs whose lease has expired (ADR-104 reaper). Fail-soft: an empty
      * list on error, so a reaper tick simply does nothing that pass.
      *

--- a/Classes/Service/Tool/AgentRunRepository.php
+++ b/Classes/Service/Tool/AgentRunRepository.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Tool;
 
+use Netresearch\NrLlm\Domain\Enum\AgentEventKind;
 use Netresearch\NrLlm\Domain\Enum\AgentRunStatus;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRun;
 use Netresearch\NrLlm\Domain\ValueObject\AgentRunEvent;
@@ -611,6 +612,47 @@ final readonly class AgentRunRepository implements AgentRunRepositoryInterface, 
             ->fetchAllAssociative();
 
         return array_map($this->hydrateEvent(...), $rows);
+    }
+
+    public function findApprovalDeciders(array $runUids): array
+    {
+        if ($runUids === []) {
+            return [];
+        }
+
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_EVENT);
+        $queryBuilder->getRestrictions()->removeAll();
+
+        $rows = $queryBuilder
+            ->select('run', 'payload')
+            ->from(self::TABLE_EVENT)
+            ->where(
+                $queryBuilder->expr()->in('run', $queryBuilder->createNamedParameter($runUids, Connection::PARAM_INT_ARRAY)),
+                $queryBuilder->expr()->eq('kind', $queryBuilder->createNamedParameter(AgentEventKind::APPROVAL->value)),
+            )
+            ->orderBy('run', 'ASC')
+            ->addOrderBy('sequence', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $deciders = [];
+        foreach ($rows as $row) {
+            $raw     = $row['payload'] ?? '';
+            $payload = is_string($raw) && $raw !== '' ? json_decode($raw, true) : null;
+            // Strict true: an approval is the only decision that authorises the
+            // pending write, and a payload that cannot be decoded says nothing.
+            if (!is_array($payload) || ($payload['approved'] ?? null) !== true) {
+                continue;
+            }
+
+            $decidedBy = $payload['decidedBy'] ?? null;
+            // 0 for an unusable value rather than a skip: the approval happened,
+            // and dropping it would let the run read as never having passed a
+            // fence. ApprovalAttribution renders that as UNRESOLVED.
+            $deciders[self::toInt($row['run'] ?? null)][] = is_int($decidedBy) ? $decidedBy : 0;
+        }
+
+        return $deciders;
     }
 
     public function maxEventSequence(int $runUid): int

--- a/Classes/Service/Tool/AgentRunRepositoryInterface.php
+++ b/Classes/Service/Tool/AgentRunRepositoryInterface.php
@@ -220,6 +220,24 @@ interface AgentRunRepositoryInterface
     public function findEvents(int $runUid, int $afterSequence = -1): array;
 
     /**
+     * The `decidedBy` uids of the GRANTED approvals of several runs, keyed by run
+     * uid and ordered by sequence (ADR-173).
+     *
+     * One statement for the whole page rather than {@see findEvents()} per row:
+     * the approvals inbox lists up to twenty terminal runs, and the marker it
+     * needs must not cost a query each. Runs without a granted approval are
+     * absent from the result, not present with an empty list.
+     *
+     * Denials are excluded here, not by the caller: ADR-172 permits an initiator
+     * to deny their own run, so a self-denial is not a fact any surface flags.
+     *
+     * @param list<int> $runUids
+     *
+     * @return array<int, list<int>>
+     */
+    public function findApprovalDeciders(array $runUids): array;
+
+    /**
      * The highest event sequence recorded for a run, or -1 when the run has no
      * events yet. A resume continues the stream at max + 1 (ADR-101) —
      * MAX-based, not count-based, so gaps can never cause a duplicate sequence.

--- a/Documentation/Administration/AgentRuns.rst
+++ b/Documentation/Administration/AgentRuns.rst
@@ -31,8 +31,45 @@ The module shows two lists:
 - **Awaiting your decision** — runs paused for an approval or for input, each
   rendered as a card with the controls to resolve it.
 - **Recent runs** — a read-only table of the most recently finished runs
-  (configuration, status, created, finished, cost when non-zero, and — on the
-  runs you may open — a :guilabel:`Timeline` link to the run's detail page).
+  (configuration, status, created, finished, approval, cost when non-zero, and —
+  on the runs you may open — a :guilabel:`Timeline` link to the run's detail
+  page).
+
+The :guilabel:`Approval` column states who granted a run's approval
+(:ref:`ADR-173 <adr-173>`), so you can see it without opening each run. Four
+readings, and only *Approved by the person who started the run* is highlighted:
+
+- **Approved by the person who started the run** — the decision and the request
+  came from the same backend user. Allowed by default; whether it is refused is
+  the *Require a second approver* setting (:ref:`ADR-172 <adr-172>`).
+- **Approved by someone other than the person who started the run** — two people
+  were involved.
+- **Approved, but the record does not say who started the run** — the run was
+  started by a service account or another non-backend caller, so there is no
+  backend user to compare the approver against. The approver is still recorded.
+- **Approved, but the record does not say by whom** — the approving user was not
+  recorded, so nothing can be said about the decision either way.
+
+A run can pass several approval fences, and the column has one cell for it. It
+then shows the strongest single reading, not a summary: *Approved by the person
+who started the run* if any one fence was released by the initiator, otherwise
+*Approved, but the record does not say by whom* if any one approver went
+unrecorded. So a run whose second fence a colleague signed still reads as
+self-approved, and the run timeline is where the fences are shown one by one.
+
+An empty cell says three different things and must not be read as "no approval
+was needed": the run passed no approval fence, or it was denied, or the
+approvals could not be loaded or decoded. The run's timeline tells them apart, on the runs
+you may open.
+
+The same label appears on the approval row of the run timeline, next to the
+``decidedBy`` uid. A denial never carries one: denying your own run is
+deliberate, not an anomaly.
+
+The column shows the same label to everyone who can see the row. A user holding
+*Approve suspended AI runs* (``agent_approve``) lists other people's runs
+without being able to open them, and for those runs the label is all the column
+says — it never names a user.
 
 If the store cannot be read, the page shows a warning box rather than a
 silently empty inbox — an empty list therefore means "nothing waiting", not

--- a/Documentation/Adr/Adr173SelfApprovalIsVisibleInTheRecord.rst
+++ b/Documentation/Adr/Adr173SelfApprovalIsVisibleInTheRecord.rst
@@ -1,0 +1,221 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-173:
+
+============================================================================
+ADR-173: A self-approved run says so, wherever the approval is shown
+============================================================================
+
+:Status: Accepted
+:Date: 2026-08-14
+:Authors: Netresearch DTT GmbH
+
+.. _adr-173-context:
+
+Context
+=======
+
+An approval event records who decided, and the run records who started it.
+Until now nothing put the two side by side, so a run its own initiator released
+read exactly like one a second person reviewed. An auditor had to hold two uid
+numbers in mind and notice they matched.
+
+Self-approval is not an edge case. :php:`AiActorContext::mayActOnRun()` ends
+with ``$this->backendUserUid > 0 && $this->backendUserUid === $run->beUser``, so
+for anyone who is not an administrator, not a service account and holds no
+``AGENT_APPROVE`` grant it is the fallback path; and on a single-operator
+install every approval is a self-approval, whichever branch admits it. That is
+the right behaviour — refusing it by default would
+strand runs forever on the installs that need the extension most.
+
+:ref:`ADR-172 <adr-172>` added ``require_second_approver``, a per-configuration
+switch, default off, which refuses self-approval where an operator turns it on.
+That is the enforcement half. This record is the visibility half, and ADR-172
+makes it worth more rather than less: where the switch is off — everywhere, by
+default — an operator may believe four-eyes applies when it does not.
+
+.. _adr-173-decision:
+
+Decision
+========
+
+The READOUT compares the two uids in one place,
+:php:`Domain\\Enum\\ApprovalAttribution`, and two readers display its answer.
+
+That is a claim about the readout only. The four-eyes *gate* of
+:ref:`ADR-172 <adr-172>` compares the same two uids separately, in
+:php:`AiActorContext::isInitiatorOf()`, and the two are not equivalent:
+:php:`isInitiatorOf()` additionally excludes service accounts, where this enum
+sees two numbers and nothing else. Merging them would make a display rule part
+of an authorisation decision.
+
+Two uids give four states, and only one of them is a comparison, so the enum has
+four cases:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Case
+     - When
+     - What the label says
+   * - :php:`SELF`
+     - both uids present and equal
+     - approved by the person who started the run
+   * - :php:`SECOND_PERSON`
+     - both uids present and different
+     - approved by someone other than the person who started the run
+   * - :php:`INITIATOR_UNKNOWN`
+     - a decider, no initiator
+     - approved, but the record does not say who started the run
+   * - :php:`UNRESOLVED`
+     - no decider
+     - approved, but the record does not say by whom
+
+:php:`fromDecision()` takes the two uids; :php:`fromDecisions()` collapses a run
+that passed several fences, ranked ``SELF > UNRESOLVED > INITIATOR_UNKNOWN >
+SECOND_PERSON`` so a collapsed row never understates: one self-released fence
+makes the run self-approved however many others a colleague signed.
+
+Four of the six case pairings occur; two cannot. The initiator is one value for
+the whole run, so :php:`INITIATOR_UNKNOWN` never meets :php:`SELF` or
+:php:`SECOND_PERSON`. A run with an initiator mixes :php:`SELF`,
+:php:`SECOND_PERSON` and :php:`UNRESOLVED`; a run without one mixes
+:php:`INITIATOR_UNKNOWN` and :php:`UNRESOLVED`.
+:php:`ApprovalAttributionTest::theOnlyPairingsARunCanShowAreTheFourItsInitiatorAllows()`
+enumerates both halves, so the count is checked rather than asserted in prose.
+
+The rank has an accepted price, taken deliberately. A run with no initiator, one
+fence decided by user 5 and one whose decider was not recorded, collapses to
+:php:`UNRESOLVED` — the row says the decider is unrecorded while the timeline
+prints ``decidedBy=5`` for the other fence. Understating one fence is the
+direction this readout is allowed to be wrong in; claiming a second pair of eyes
+is not.
+
+**No new column.** Both values are already stored — ``tx_nrllm_agentrun.be_user``
+and the APPROVAL event's ``decidedBy`` (:ref:`ADR-101 <adr-101>`). The
+distinction is derived at read time, so it is also right for every run recorded
+before this change.
+
+**Why an enum and not a template conditional.** Two surfaces show it and a third
+could. A uid comparison repeated per template is three chances to write
+``===`` where the guard against ``0 === 0`` belongs, and the two pages would be
+free to disagree about who released a run. The enum is dependency-free, so both
+readers use it without either owning the rule.
+
+Three boundaries make the readout predictable:
+
+**Granted approvals only.** A denial carries no attribution. ADR-172 explicitly
+permits an initiator to deny their own run, so marking a self-denial would flag
+the one case the design calls correct.
+
+**Absent uids are their own answer, never "self".** ``0 === 0`` must not read as
+self-approval, and "nobody can tell" must not read as "a second person looked" —
+hence a named case rather than a silent omission.
+
+**And the two absences are two answers, not one.** A run a service account or
+any non-backend caller started records ``be_user = 0``
+(:php:`AiActorContext::isInitiatorOf()` says why: ``be_user`` identifies a
+backend user, so such a run matches nobody). A human approving that run is the
+normal case, not an edge case, and the record names them. Labelling it
+"approved, but the record does not say by whom" would be false on a row that
+prints ``decidedBy=5`` two columns to the left. What the record does not say is
+who started the run, so that is what :php:`INITIATOR_UNKNOWN` says.
+
+The mirror — an initiator with no decider — is reachable, and :php:`UNRESOLVED`
+covers it: the readers coerce a ``decidedBy`` that is not an int (a truncated,
+corrupt or hand-edited payload) to 0 rather than dropping the approval. So the
+decider is asked first, and an unnamed decider is the whole answer whatever the
+run says.
+
+A sessionless approval is **not** a second way in, although
+:php:`currentBackendUserUid()` returning 0 makes it look like one. Both approve
+entry points (:php:`AgentRunController::approveAction()`,
+:php:`ToolPlaygroundController::resumeAction()`) pair that uid with
+:php:`currentActor()`, which answers :php:`AiActorContext::anonymous()` for uid
+0 — no admin flag, no service account, no grants. :php:`mayActOnRun()` refuses
+that actor in :php:`ResumeCoordinator::approve()` before any approval is
+recorded, which
+:php:`AiActorContextTest::anAnonymousActorMayNotActOnAnyRun()` pins for every
+scope and for a run whose own ``be_user`` is 0. The case guards against a
+payload, not against a session.
+
+**A readout, not a control.** Nothing here refuses anything. Whether
+self-approval is allowed stays ADR-172's question.
+
+.. _adr-173-surfaces:
+
+Where it appears
+================
+
+**The run timeline** (:php:`RunTimelineFactory`, ADR-153). The approval row
+carries the derived label next to the ``decidedBy`` uid it already showed. This
+is the audit surface: one run, end to end.
+
+**The approvals inbox's recent-runs table.** A run is listed there before anyone
+opens it, and this is the answer to "should an auditor scanning a list see it
+without clicking into each run" — yes. Scanning twenty rows and opening each to
+learn which ones released themselves is how the distinction stays unnoticed,
+which is the defect this record closes. It also makes the table state something
+it never stated before: which listed runs recorded a GRANTED approval. An empty
+cell is not the complement of that — it is "no fence", "denied", and "the
+deciders could not be loaded" at once, which is why the column is not a fence
+inventory.
+
+The column is also the one datum this list carries that :php:`showAction` would
+refuse the same viewer: an ``agent_approve`` grant widens the list but not the
+detail page (:ref:`ADR-153 <adr-153>`), and the attribution is derived from
+approval events of runs a grant holder may list without opening. Deliberate and
+bounded — four labels and an empty cell, naming nobody, the same audit-only
+class as the ``decidedBy`` uid the module already treats that way. Restricting
+the column to the viewer's own rows would blank it on exactly the rows an
+approval grant exists to review.
+
+The cost is one statement per page render, not one per row:
+:php:`AgentRunRepositoryInterface::findApprovalDeciders()` reads the approval
+events of every listed run in a single ``IN`` query. A per-row
+:php:`findEvents()` would have been twenty queries for a marker, which is not a
+price a context table may charge.
+
+**The governance readout does not show it**, because it shows no approvals. That
+tab is an effective-policy and simulation surface (:ref:`ADR-140 <adr-140>`,
+:ref:`ADR-157 <adr-157>`): it answers whether approval *would* be required for a
+tool, never who decided one that happened. Adding a decision readout there would
+be a second audit surface competing with the run timeline, not a use of this
+derivation.
+
+**The waiting card does not show it either.** It is the surface where a decision
+is about to be made, not one where an approval is shown; a warning there is
+about a future act, which is ADR-172's subject and not this one's.
+
+.. _adr-173-consequences:
+
+Consequences
+============
+
+The marker is a badge (``text-bg-warning``) for :php:`SELF` and plain secondary
+text for the other three. Self-approval is a fact worth spotting, not a failure
+of the system — the same reasoning that keeps ``text-bg-danger`` out of this
+project's templates.
+
+All four labels are full sentences rather than a short badge vocabulary. A
+column of one-word chips ("Self", "Second person", "Unknown") reads faster and
+says less: the two unknowns differ in *which* half of the record is missing, and
+that is the distinction an auditor is here for. The cells are wider than the
+table's other columns and the label wraps; that is the accepted cost.
+
+Both surfaces render one partial,
+``Partials/Backend/AgentRun/ApprovalAttribution.html``, with a branch per case
+and an English ``default`` on each. A key assembled from the case value
+(``runs.attribution.{attribution}``) would carry no fallback, so a case whose
+label is missing would render an empty cell on both pages — the failure a
+reviewer cannot see in the diff that adds a case.
+
+A store error while loading the deciders costs the marker and leaves the inbox
+standing: :php:`AgentRunPersister::findApprovalDeciders()` degrades to an empty
+map, which renders no attribution
+(:php:`AgentRunPersisterTest::aDeciderReadThatThrowsDegradesToAnEmptyMap()`,
+against a repository that throws). That is the safe direction — the readout can
+fail to state that one person decided, but it can never invent a second one.
+
+Runs recorded before ADR-172 shipped will overwhelmingly show :php:`SELF`. That
+is not a regression appearing; it is the existing record finally being read.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -524,4 +524,5 @@ Tools
    Adr170OneDeadlinePerMcpOperation
    Adr171PersonasTheCodeAlreadyAssumes
    Adr172FourEyesApprovalPerConfiguration
+   Adr173SelfApprovalIsVisibleInTheRecord
    Adr174PerCallCostAndPreRoutingFacts

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -4094,6 +4094,26 @@
                 <source>Details</source>
                 <target>Details</target>
             </trans-unit>
+            <trans-unit id="runs.terminal.approval">
+                <source>Approval</source>
+                <target>Freigabe</target>
+            </trans-unit>
+            <trans-unit id="runs.attribution.self">
+                <source>Approved by the person who started the run</source>
+                <target>Freigegeben von der Person, die den Lauf gestartet hat</target>
+            </trans-unit>
+            <trans-unit id="runs.attribution.secondPerson">
+                <source>Approved by someone other than the person who started the run</source>
+                <target>Freigegeben von jemand anderem als der Person, die den Lauf gestartet hat</target>
+            </trans-unit>
+            <trans-unit id="runs.attribution.initiatorUnknown">
+                <source>Approved, but the record does not say who started the run</source>
+                <target>Freigegeben, aber der Datensatz nennt nicht, wer den Lauf gestartet hat</target>
+            </trans-unit>
+            <trans-unit id="runs.attribution.unresolved">
+                <source>Approved, but the record does not say by whom</source>
+                <target>Freigegeben, aber der Datensatz nennt nicht, von wem</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -3086,6 +3086,21 @@
             <trans-unit id="runs.detail.facts">
                 <source>Details</source>
             </trans-unit>
+            <trans-unit id="runs.terminal.approval">
+                <source>Approval</source>
+            </trans-unit>
+            <trans-unit id="runs.attribution.self">
+                <source>Approved by the person who started the run</source>
+            </trans-unit>
+            <trans-unit id="runs.attribution.secondPerson">
+                <source>Approved by someone other than the person who started the run</source>
+            </trans-unit>
+            <trans-unit id="runs.attribution.initiatorUnknown">
+                <source>Approved, but the record does not say who started the run</source>
+            </trans-unit>
+            <trans-unit id="runs.attribution.unresolved">
+                <source>Approved, but the record does not say by whom</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Partials/Backend/AgentRun/ApprovalAttribution.html
+++ b/Resources/Private/Partials/Backend/AgentRun/ApprovalAttribution.html
@@ -1,0 +1,24 @@
+<!--
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+-->
+<!--
+ * The ADR-173 label, in ONE place for both surfaces that show it: the
+ * recent-runs table and the run timeline. One case per branch rather than a key
+ * assembled from {attribution} — an assembled key has no `default`, so a
+ * catalogue that has not loaded renders an empty cell instead of English.
+ *
+ * The literals are the ApprovalAttribution case values;
+ * ApprovalAttributionTest::everyCaseIsRenderedByTheSharedPartial() pins them, so
+ * renaming a case fails a test instead of silently emptying two views.
+ *
+ * An empty {attribution} matches no case and renders nothing. It carries three
+ * meanings at once — no fence, a denial, or deciders that could not be loaded —
+ * so it deliberately gets no label of its own.
+-->
+<f:switch expression="{attribution}">
+    <f:case value="self"><span class="badge text-bg-warning"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:runs.attribution.self" default="Approved by the person who started the run" /></span></f:case>
+    <f:case value="secondPerson"><span class="text-body-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:runs.attribution.secondPerson" default="Approved by someone other than the person who started the run" /></span></f:case>
+    <f:case value="initiatorUnknown"><span class="text-body-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:runs.attribution.initiatorUnknown" default="Approved, but the record does not say who started the run" /></span></f:case>
+    <f:case value="unresolved"><span class="text-body-secondary"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:runs.attribution.unresolved" default="Approved, but the record does not say by whom" /></span></f:case>
+</f:switch>

--- a/Resources/Private/Partials/Backend/AgentRun/TerminalTable.html
+++ b/Resources/Private/Partials/Backend/AgentRun/TerminalTable.html
@@ -13,6 +13,7 @@
                         <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:runs.terminal.status" default="Status" /></th>
                         <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:runs.terminal.created" default="Created" /></th>
                         <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:runs.terminal.finished" default="Finished" /></th>
+                        <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:runs.terminal.approval" default="Approval" /></th>
                         <th scope="col" class="text-end"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:runs.terminal.cost" default="Cost" /></th>
                         <th scope="col"><f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:runs.terminal.detail" default="Detail" /></th>
                     </tr>
@@ -25,6 +26,9 @@
                             <td><f:format.date date="@{run.createdAt}" format="Y-m-d H:i" /></td>
                             <td>
                                 <f:if condition="{run.finishedAt} > 0"><f:format.date date="@{run.finishedAt}" format="Y-m-d H:i" /></f:if>
+                            </td>
+                            <td>
+                                <f:render partial="Backend/AgentRun/ApprovalAttribution" arguments="{attribution: run.approvalAttribution}" />
                             </td>
                             <td class="text-end">
                                 <f:if condition="{run.formattedCost}">{run.formattedCost}</f:if>

--- a/Resources/Private/Templates/Backend/AgentRun/Show.html
+++ b/Resources/Private/Templates/Backend/AgentRun/Show.html
@@ -107,7 +107,14 @@
                                                 <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:runs.detail.outcome.{entry.outcome}" />
                                             </f:if>
                                         </td>
-                                        <td><code>{entry.detail}</code></td>
+                                        <td>
+                                            <code>{entry.detail}</code>
+                                            <f:if condition="{entry.approvalAttribution}">
+                                                <div class="mt-1">
+                                                    <f:render partial="Backend/AgentRun/ApprovalAttribution" arguments="{attribution: entry.approvalAttribution}" />
+                                                </div>
+                                            </f:if>
+                                        </td>
                                     </tr>
                                 </f:for>
                             </tbody>

--- a/Tests/Functional/Controller/Backend/AgentRunControllerTest.php
+++ b/Tests/Functional/Controller/Backend/AgentRunControllerTest.php
@@ -394,6 +394,151 @@ final class AgentRunControllerTest extends AbstractFunctionalTestCase
         self::assertStringContainsString('id="run-timeline-heading"', $body);
     }
 
+    /**
+     * ADR-173, the central case: the same approval row reads differently
+     * depending on whether the person who granted it is the person who started
+     * the run. Both uids were already on the page as numbers; what was missing
+     * is the sentence.
+     */
+    #[Test]
+    public function theTimelineSaysWhenAnApprovalCameFromTheRunsOwnInitiator(): void
+    {
+        $body = $this->renderTimelineOfApproval(initiator: 1, decidedBy: 1, approved: true);
+
+        self::assertStringContainsString('Approved by the person who started the run', $body);
+        self::assertStringNotContainsString('Approved by someone other than', $body);
+    }
+
+    #[Test]
+    public function theTimelineSaysWhenASecondPersonApproved(): void
+    {
+        $body = $this->renderTimelineOfApproval(initiator: 1, decidedBy: 9, approved: true);
+
+        self::assertStringContainsString('Approved by someone other than the person who started the run', $body);
+        self::assertStringNotContainsString('Approved by the person who started the run</span>', $body);
+    }
+
+    /**
+     * The absent-user case must not produce a false marker: a run a service
+     * account started records beUser 0, and 0 === 0 is not a self-approval.
+     */
+    #[Test]
+    public function anApprovalWithoutResolvableUsersIsNotMarkedSelfApproved(): void
+    {
+        $body = $this->renderTimelineOfApproval(initiator: 0, decidedBy: 0, approved: true);
+
+        self::assertStringContainsString('Approved, but the record does not say by whom', $body);
+        self::assertStringNotContainsString('Approved by the person who started the run', $body);
+    }
+
+    /**
+     * The rendered half of the split: a service-account run approved by backend
+     * user 5. The page prints `decidedBy=5`, so a label saying the record does
+     * not name the decider would contradict the row it sits on.
+     */
+    #[Test]
+    public function aRunNoBackendUserStartedIsNotLabelledAsHavingNoRecordedDecider(): void
+    {
+        $body = $this->renderTimelineOfApproval(initiator: 0, decidedBy: 5, approved: true);
+
+        self::assertStringContainsString('decidedBy=5', $body);
+        self::assertStringContainsString('Approved, but the record does not say who started the run', $body);
+        self::assertStringNotContainsString('Approved, but the record does not say by whom', $body);
+        self::assertStringNotContainsString('Approved by the person who started the run', $body);
+    }
+
+    /**
+     * ADR-172 lets an initiator deny their own run on purpose, so the denial the
+     * initiator recorded is the case the readout must stay silent about.
+     */
+    #[Test]
+    public function aDenialByTheInitiatorCarriesNoAttribution(): void
+    {
+        $body = $this->renderTimelineOfApproval(initiator: 1, decidedBy: 1, approved: false);
+
+        self::assertStringContainsString('decidedBy=1', $body, 'The recorded decision is still on the page.');
+        self::assertStringNotContainsString('Approved by the person who started the run', $body);
+        self::assertStringNotContainsString('Approved by someone other than', $body);
+    }
+
+    /**
+     * The list half of ADR-173: an auditor scanning the recent-runs table sees
+     * which runs released themselves without opening each one. Unlike the
+     * timeline tests above this goes through the real
+     * AgentRunRepository::findApprovalDeciders() query.
+     */
+    #[Test]
+    public function theRecentRunsTableMarksASelfApprovedRun(): void
+    {
+        $handle = $this->persister->begin(null, 1);
+        self::assertNotNull($handle);
+        self::assertTrue($this->persister->recordApproval($handle, true, 1));
+        self::assertTrue($this->persister->settleCompleted(
+            $handle,
+            new ToolLoopResult('done', [], 1, false, UsageStatistics::fromTokens(3, 4)),
+        ));
+
+        $controller = $this->makeController(new ToolRegistry([]), self::createStub(AgentRuntimeInterface::class));
+        $this->setRequest($controller, 'list');
+
+        $body = (string)$controller->listAction()->getBody();
+
+        self::assertStringContainsString('Approved by the person who started the run', $body);
+    }
+
+    #[Test]
+    public function theRecentRunsTableMarksARunASecondPersonApproved(): void
+    {
+        $handle = $this->persister->begin(null, 1);
+        self::assertNotNull($handle);
+        self::assertTrue($this->persister->recordApproval($handle, true, 9));
+        self::assertTrue($this->persister->settleCompleted(
+            $handle,
+            new ToolLoopResult('done', [], 1, false, UsageStatistics::fromTokens(3, 4)),
+        ));
+
+        $controller = $this->makeController(new ToolRegistry([]), self::createStub(AgentRuntimeInterface::class));
+        $this->setRequest($controller, 'list');
+
+        $body = (string)$controller->listAction()->getBody();
+
+        self::assertStringContainsString('Approved by someone other than the person who started the run', $body);
+        self::assertStringNotContainsString('Approved by the person who started the run</span>', $body);
+    }
+
+    /**
+     * Render one run's timeline holding a single APPROVAL event, as
+     * AgentRunPersister::recordApproval() writes it.
+     */
+    private function renderTimelineOfApproval(int $initiator, int $decidedBy, bool $approved): string
+    {
+        $runUuid = 'c0ffee00-0000-4000-8000-000000000043';
+        $run     = $this->terminalRun($runUuid, $initiator);
+
+        $runtime = $this->createMock(AgentRuntimeInterface::class);
+        $runtime->method('status')->willReturn($run);
+        $runtime->method('events')->willReturn([
+            new AgentRunEvent(
+                uid: 1,
+                run: $run->uid,
+                sequence: 0,
+                kind: 'approval',
+                round: 0,
+                durationMs: 0.0,
+                payload: ['approved' => $approved, 'decidedBy' => $decidedBy],
+                crdate: 1_700_000_010,
+            ),
+        ]);
+
+        $controller = $this->makeController(new ToolRegistry([]), $runtime);
+        $this->setRequest($controller, 'show');
+
+        $response = $controller->showAction($runUuid);
+        self::assertSame(200, $response->getStatusCode());
+
+        return (string)$response->getBody();
+    }
+
     #[Test]
     public function showActionRedirectsWhenTheRuntimeReleasesNothing(): void
     {
@@ -408,7 +553,7 @@ final class AgentRunControllerTest extends AbstractFunctionalTestCase
         self::assertSame(303, $controller->showAction('does-not-exist')->getStatusCode());
     }
 
-    private function terminalRun(string $uuid): AgentRun
+    private function terminalRun(string $uuid, int $beUser = 1): AgentRun
     {
         return new AgentRun(
             uid: 4711,
@@ -416,7 +561,7 @@ final class AgentRunControllerTest extends AbstractFunctionalTestCase
             status: 'completed',
             configurationUid: 0,
             configurationIdentifier: 'agent',
-            beUser: 1,
+            beUser: $beUser,
             iterations: 1,
             truncated: false,
             totalPromptTokens: 120,

--- a/Tests/Functional/Service/Fixtures/ApprovalEventFailingRunRepository.php
+++ b/Tests/Functional/Service/Fixtures/ApprovalEventFailingRunRepository.php
@@ -16,19 +16,26 @@ use RuntimeException;
 
 /**
  * The real, database-backed repository with ONE fault injected: the event of a
- * chosen kind cannot be written.
+ * chosen kind cannot be written, or — with `$failsApprovalDeciderRead` — the
+ * approval deciders of the inbox's listed runs cannot be read.
  *
  * Models the store hiccup that hits a single audit record rather than the whole
  * connection, which is what {@see \Netresearch\NrLlm\Service\Tool\AgentRunPersister::recordApproval()}'s
  * boolean is about (ADR-132). Everything else — the claim, the suspend, the
  * status transitions the assertions read back — stays real, so the test asserts
  * the row the operator would actually see.
+ *
+ * The read fault is the mirror for ADR-173: it enters
+ * {@see \Netresearch\NrLlm\Service\Tool\AgentRunPersister::findApprovalDeciders()}'s
+ * catch, which a delegating fixture never does — and against a delegating
+ * fixture, swallow-and-return-`[]` and a rethrow are the same test.
  */
 final readonly class ApprovalEventFailingRunRepository implements AgentRunRepositoryInterface
 {
     public function __construct(
         private AgentRunRepositoryInterface $inner,
         private string $failingKind,
+        private bool $failsApprovalDeciderRead = false,
     ) {}
 
     public function recordEvent(int $runUid, int $sequence, string $kind, int $round, float $durationMs, string $payloadJson): void
@@ -154,6 +161,15 @@ final readonly class ApprovalEventFailingRunRepository implements AgentRunReposi
     public function findEvents(int $runUid, int $afterSequence = -1): array
     {
         return $this->inner->findEvents($runUid, $afterSequence);
+    }
+
+    public function findApprovalDeciders(array $runUids): array
+    {
+        if ($this->failsApprovalDeciderRead) {
+            throw new RuntimeException('findApprovalDeciders() failed', 1786500001);
+        }
+
+        return $this->inner->findApprovalDeciders($runUids);
     }
 
     public function maxEventSequence(int $runUid): int

--- a/Tests/Functional/Service/Fixtures/FenceRecordingRunRepository.php
+++ b/Tests/Functional/Service/Fixtures/FenceRecordingRunRepository.php
@@ -173,6 +173,11 @@ final class FenceRecordingRunRepository implements AgentRunRepositoryInterface
         return $this->inner->findEvents($runUid, $afterSequence);
     }
 
+    public function findApprovalDeciders(array $runUids): array
+    {
+        return $this->inner->findApprovalDeciders($runUids);
+    }
+
     public function maxEventSequence(int $runUid): int
     {
         return $this->inner->maxEventSequence($runUid);

--- a/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
+++ b/Tests/Functional/Service/Tool/AgentRunPersisterTest.php
@@ -24,6 +24,7 @@ use Netresearch\NrLlm\Service\Tool\AgentRunRepository;
 use Netresearch\NrLlm\Service\Tool\AgentStateCodec;
 use Netresearch\NrLlm\Tests\Fixture\FixedPrivacyPolicy;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use Netresearch\NrLlm\Tests\Functional\Service\Fixtures\ApprovalEventFailingRunRepository;
 use Netresearch\NrVault\Crypto\EnvelopeCodecInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -56,6 +57,62 @@ final class AgentRunPersisterTest extends AbstractFunctionalTestCase
 
         $this->repository = new AgentRunRepository($connectionPool, $this->get(AgentStateCodec::class));
         $this->persister  = new AgentRunPersister($this->repository, FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL), new NullLogger());
+    }
+
+    /**
+     * ADR-173: one statement answers for every listed run. Granted approvals
+     * only — a denial is a legitimate self-decision (ADR-172) and must not reach
+     * the readout — and runs that passed no fence stay out of the map rather
+     * than appearing with an empty list.
+     */
+    #[Test]
+    public function approvalDecidersAreReadForSeveralRunsAtOnceAndExcludeDenials(): void
+    {
+        $approved = $this->persister->begin(null, 4);
+        self::assertNotNull($approved);
+        self::assertTrue($this->persister->recordApproval($approved, true, 4));
+        self::assertTrue($this->persister->recordApproval($approved, true, 9));
+
+        $denied = $this->persister->begin(null, 4);
+        self::assertNotNull($denied);
+        self::assertTrue($this->persister->recordApproval($denied, false, 4));
+
+        $untouched = $this->persister->begin(null, 4);
+        self::assertNotNull($untouched);
+
+        $deciders = $this->persister->findApprovalDeciders([$approved->runUid, $denied->runUid, $untouched->runUid]);
+
+        self::assertSame([$approved->runUid => [4, 9]], $deciders);
+    }
+
+    #[Test]
+    public function approvalDecidersOfNoRunsAsksNothing(): void
+    {
+        self::assertSame([], $this->persister->findApprovalDeciders([]));
+    }
+
+    /**
+     * The fail-soft branch ADR-173 promises: a store error while loading the
+     * deciders costs the marker, not the inbox. Reachable only with a repository
+     * that throws — against a delegating fixture, swallowing the error and
+     * rethrowing it look identical. The healthy read first, so the empty map is
+     * the fault's doing and not an empty fixture.
+     */
+    #[Test]
+    public function aDeciderReadThatThrowsDegradesToAnEmptyMap(): void
+    {
+        $handle = $this->persister->begin(null, 4);
+        self::assertNotNull($handle);
+        self::assertTrue($this->persister->recordApproval($handle, true, 4));
+        self::assertSame([$handle->runUid => [4]], $this->persister->findApprovalDeciders([$handle->runUid]));
+
+        $failing = new AgentRunPersister(
+            new ApprovalEventFailingRunRepository($this->repository, failingKind: '', failsApprovalDeciderRead: true),
+            FixedPrivacyPolicy::filterAt(PrivacyLevel::FULL),
+            new NullLogger(),
+        );
+
+        self::assertSame([], $failing->findApprovalDeciders([$handle->runUid]));
     }
 
     #[Test]

--- a/Tests/Unit/Command/Fixture/InMemoryAgentRunRepository.php
+++ b/Tests/Unit/Command/Fixture/InMemoryAgentRunRepository.php
@@ -175,6 +175,11 @@ final class InMemoryAgentRunRepository implements AgentRunRepositoryInterface
         return [];
     }
 
+    public function findApprovalDeciders(array $runUids): array
+    {
+        return [];
+    }
+
     public function maxEventSequence(int $runUid): int
     {
         return -1;

--- a/Tests/Unit/Domain/Enum/ApprovalAttributionTest.php
+++ b/Tests/Unit/Domain/Enum/ApprovalAttributionTest.php
@@ -178,7 +178,7 @@ final class ApprovalAttributionTest extends TestCase
     #[Test]
     public function everyCaseIsRenderedByTheSharedPartial(): void
     {
-        $partial = self::read('Resources/Private/Partials/Backend/AgentRun/ApprovalAttribution.html');
+        $partial = $this->read('Resources/Private/Partials/Backend/AgentRun/ApprovalAttribution.html');
 
         foreach (ApprovalAttribution::values() as $value) {
             $key     = 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:runs.attribution.' . $value;
@@ -200,7 +200,7 @@ final class ApprovalAttributionTest extends TestCase
         ];
 
         foreach ($views as $view) {
-            $markup = self::read($view);
+            $markup = $this->read($view);
 
             self::assertStringContainsString('partial="Backend/AgentRun/ApprovalAttribution"', $markup, $view);
             self::assertStringNotContainsString('runs.attribution.{', $markup, $view);
@@ -225,7 +225,7 @@ final class ApprovalAttributionTest extends TestCase
         }
     }
 
-    private static function read(string $relativePath): string
+    private function read(string $relativePath): string
     {
         $path     = __DIR__ . '/../../../../' . $relativePath;
         $contents = file_get_contents($path);

--- a/Tests/Unit/Domain/Enum/ApprovalAttributionTest.php
+++ b/Tests/Unit/Domain/Enum/ApprovalAttributionTest.php
@@ -1,0 +1,236 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Domain\Enum;
+
+use Netresearch\NrLlm\Domain\Enum\ApprovalAttribution;
+use Netresearch\NrLlm\Tests\Unit\Language\LabelCatalogue;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The one comparison of ADR-173. Everything that displays a self-approval reads
+ * its answer, so the guards live here rather than in each reader.
+ */
+#[CoversNothing]
+final class ApprovalAttributionTest extends TestCase
+{
+    #[Test]
+    public function theInitiatorDecidingTheirOwnRunIsSelfApproval(): void
+    {
+        self::assertSame(ApprovalAttribution::SELF, ApprovalAttribution::fromDecision(4, 4));
+    }
+
+    #[Test]
+    public function anotherBackendUserDecidingIsASecondPerson(): void
+    {
+        self::assertSame(ApprovalAttribution::SECOND_PERSON, ApprovalAttribution::fromDecision(4, 9));
+    }
+
+    /**
+     * The absent-user trap: `beUser` is 0 for a run a service account started and
+     * `decidedBy` is 0 for a decision whose actor could not be resolved. A plain
+     * `===` would answer SELF to 0 === 0 and put a marker on a run nobody
+     * self-approved.
+     */
+    #[Test]
+    public function anAbsentUserOnEitherSideIsNeverSelf(): void
+    {
+        self::assertNotSame(ApprovalAttribution::SELF, ApprovalAttribution::fromDecision(0, 0));
+        self::assertNotSame(ApprovalAttribution::SELF, ApprovalAttribution::fromDecision(0, 4));
+        self::assertNotSame(ApprovalAttribution::SELF, ApprovalAttribution::fromDecision(4, 0));
+        self::assertNotSame(ApprovalAttribution::SELF, ApprovalAttribution::fromDecision(-1, -1));
+    }
+
+    /**
+     * The two absences are DIFFERENT facts and must not share a label. A run a
+     * service account started carries `beUser = 0`; a backend user approving it
+     * is recorded by uid, so "the record does not say by whom" would be false —
+     * what it does not say is who started the run.
+     */
+    #[Test]
+    public function aKnownDeciderOnARunWithNoInitiatorIsItsOwnCase(): void
+    {
+        self::assertSame(ApprovalAttribution::INITIATOR_UNKNOWN, ApprovalAttribution::fromDecision(0, 5));
+        self::assertSame(ApprovalAttribution::INITIATOR_UNKNOWN, ApprovalAttribution::fromDecision(-1, 5));
+    }
+
+    /**
+     * The mirror: the decider decides the answer first, so an unrecorded decider
+     * reads the same whether or not the run names an initiator.
+     */
+    #[Test]
+    public function anUnrecordedDeciderIsUnresolvedWhateverTheRunSays(): void
+    {
+        self::assertSame(ApprovalAttribution::UNRESOLVED, ApprovalAttribution::fromDecision(4, 0));
+        self::assertSame(ApprovalAttribution::UNRESOLVED, ApprovalAttribution::fromDecision(0, 0));
+        self::assertSame(ApprovalAttribution::UNRESOLVED, ApprovalAttribution::fromDecision(4, -1));
+    }
+
+    #[Test]
+    public function aRunWithNoRecordedApprovalHasNoAttribution(): void
+    {
+        self::assertNull(ApprovalAttribution::fromDecisions(4, []));
+    }
+
+    /**
+     * A run can pass several fences. One self-released fence is the fact the row
+     * has to state, however many others a colleague signed.
+     */
+    #[Test]
+    public function oneSelfApprovalAmongSeveralDecidesTheWholeRun(): void
+    {
+        self::assertSame(ApprovalAttribution::SELF, ApprovalAttribution::fromDecisions(4, [9, 4]));
+        self::assertSame(ApprovalAttribution::SELF, ApprovalAttribution::fromDecisions(4, [4, 9]));
+        self::assertSame(ApprovalAttribution::SELF, ApprovalAttribution::fromDecisions(4, [0, 4]));
+    }
+
+    #[Test]
+    public function anUnresolvedDecisionIsNotRoundedUpIntoASecondPerson(): void
+    {
+        self::assertSame(ApprovalAttribution::UNRESOLVED, ApprovalAttribution::fromDecisions(4, [9, 0]));
+        self::assertSame(ApprovalAttribution::UNRESOLVED, ApprovalAttribution::fromDecisions(4, [0, 9]));
+    }
+
+    #[Test]
+    public function severalDecisionsByOthersStayASecondPerson(): void
+    {
+        self::assertSame(ApprovalAttribution::SECOND_PERSON, ApprovalAttribution::fromDecisions(4, [9, 11]));
+    }
+
+    /**
+     * A run with no initiator can only mix INITIATOR_UNKNOWN with UNRESOLVED —
+     * SELF and SECOND_PERSON are unreachable for it. The unrecorded decider
+     * still wins, so the collapsed row never claims a decider it does not have.
+     */
+    #[Test]
+    public function aRunWithoutAnInitiatorCollapsesToUnresolvedOnlyWhenADeciderIsMissing(): void
+    {
+        self::assertSame(ApprovalAttribution::INITIATOR_UNKNOWN, ApprovalAttribution::fromDecisions(0, [5]));
+        self::assertSame(ApprovalAttribution::INITIATOR_UNKNOWN, ApprovalAttribution::fromDecisions(0, [5, 9]));
+        self::assertSame(ApprovalAttribution::UNRESOLVED, ApprovalAttribution::fromDecisions(0, [5, 0]));
+        self::assertSame(ApprovalAttribution::UNRESOLVED, ApprovalAttribution::fromDecisions(0, [0, 5]));
+    }
+
+    /**
+     * {@see ApprovalAttribution::fromDecisions()} claims four of the six case
+     * pairings occur and two cannot. Enumerated rather than argued: every
+     * initiator × two-decider combination the uid domain allows, reduced to the
+     * pairs one run can show. Both halves are asserted, because the count in the
+     * docblock was written backwards once already.
+     */
+    #[Test]
+    public function theOnlyPairingsARunCanShowAreTheFourItsInitiatorAllows(): void
+    {
+        $uids = [-1, 0, 4, 9];
+        $seen = [];
+
+        foreach ($uids as $initiator) {
+            foreach ($uids as $firstDecider) {
+                foreach ($uids as $secondDecider) {
+                    $first  = ApprovalAttribution::fromDecision($initiator, $firstDecider);
+                    $second = ApprovalAttribution::fromDecision($initiator, $secondDecider);
+                    if ($first === $second) {
+                        continue;
+                    }
+
+                    $pair = [$first->name, $second->name];
+                    sort($pair);
+                    $seen[implode('+', $pair)] = true;
+                }
+            }
+        }
+
+        $pairs = array_keys($seen);
+        sort($pairs);
+
+        self::assertSame([
+            'INITIATOR_UNKNOWN+UNRESOLVED',
+            'SECOND_PERSON+SELF',
+            'SECOND_PERSON+UNRESOLVED',
+            'SELF+UNRESOLVED',
+        ], $pairs);
+
+        // The two the initiator being one value for the whole run rules out.
+        self::assertNotContains('INITIATOR_UNKNOWN+SELF', $pairs);
+        self::assertNotContains('INITIATOR_UNKNOWN+SECOND_PERSON', $pairs);
+    }
+
+    #[Test]
+    public function theCaseValuesAreTheTranslationKeySuffixesThePartialSwitchesOn(): void
+    {
+        self::assertSame(['self', 'secondPerson', 'initiatorUnknown', 'unresolved'], ApprovalAttribution::values());
+    }
+
+    /**
+     * Both surfaces delegate to ONE partial, which carries a branch per case and
+     * an English `default` on each. The alternative — a key assembled from the
+     * case value — has no `default` at all: renaming a case, or adding one,
+     * would empty the cell on both surfaces with every other test still green.
+     */
+    #[Test]
+    public function everyCaseIsRenderedByTheSharedPartial(): void
+    {
+        $partial = self::read('Resources/Private/Partials/Backend/AgentRun/ApprovalAttribution.html');
+
+        foreach (ApprovalAttribution::values() as $value) {
+            $key     = 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:runs.attribution.' . $value;
+            $english = LabelCatalogue::source($key);
+            self::assertNotNull($english, 'No English text for ' . $key);
+
+            self::assertStringContainsString('<f:case value="' . $value . '">', $partial, 'No branch for ' . $value);
+            self::assertStringContainsString('key="' . $key . '"', $partial, 'No translation key for ' . $value);
+            self::assertStringContainsString('default="' . $english . '"', $partial, 'No English fallback for ' . $value);
+        }
+    }
+
+    #[Test]
+    public function neitherSurfaceAssemblesTheTranslationKeyItself(): void
+    {
+        $views = [
+            'Resources/Private/Partials/Backend/AgentRun/TerminalTable.html',
+            'Resources/Private/Templates/Backend/AgentRun/Show.html',
+        ];
+
+        foreach ($views as $view) {
+            $markup = self::read($view);
+
+            self::assertStringContainsString('partial="Backend/AgentRun/ApprovalAttribution"', $markup, $view);
+            self::assertStringNotContainsString('runs.attribution.{', $markup, $view);
+        }
+    }
+
+    /**
+     * Every case has to be renderable. The shared partial resolves
+     * `runs.attribution.<value>` per branch, and a case whose catalogue entry is
+     * missing falls back to the branch's English `default` — in German it then
+     * silently shows English, which is the failure a reviewer cannot see in the
+     * diff that adds the case.
+     */
+    #[Test]
+    public function everyCaseHasAnEnglishAndAGermanLabel(): void
+    {
+        foreach (ApprovalAttribution::values() as $value) {
+            $key = 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:runs.attribution.' . $value;
+
+            self::assertNotNull(LabelCatalogue::source($key), 'No English text for ' . $key);
+            self::assertNotNull(LabelCatalogue::target($key), 'No German text for ' . $key);
+        }
+    }
+
+    private static function read(string $relativePath): string
+    {
+        $path     = __DIR__ . '/../../../../' . $relativePath;
+        $contents = file_get_contents($path);
+        self::assertIsString($contents, 'Unreadable: ' . $path);
+
+        return $contents;
+    }
+}

--- a/Tests/Unit/Domain/ValueObject/AiActorContextTest.php
+++ b/Tests/Unit/Domain/ValueObject/AiActorContextTest.php
@@ -216,6 +216,31 @@ final class AiActorContextTest extends TestCase
     }
 
     /**
+     * ADR-173 rests on this. A request with no backend session produces
+     * {@see AiActorContext::anonymous()}, and an anonymous actor is refused
+     * every operation on every run — the approval it would record with
+     * `decidedBy = 0` included, and on a run whose own `beUser` is 0 too, where
+     * a plain `===` would have matched. So the enum's UNRESOLVED case guards a
+     * corrupt payload, not a sessionless approval, and this is the link that
+     * would have to move for that to change.
+     */
+    #[Test]
+    public function anAnonymousActorMayNotActOnAnyRun(): void
+    {
+        $humanRun   = new AgentRun(1, 'uuid', 'waiting_for_approval', 0, '', 42, 0, false, 0, 0, 0, 0.0, '', '', 0, 0, 0, '{}');
+        $machineRun = new AgentRun(2, 'uuid2', 'waiting_for_approval', 0, '', 0, 0, false, 0, 0, 0, 0.0, '', '', 0, 0, 0, '{}');
+
+        foreach ([$humanRun, $machineRun] as $run) {
+            foreach (ServiceAccountScope::cases() as $scope) {
+                self::assertFalse(
+                    AiActorContext::anonymous()->mayActOnRun($run, $scope),
+                    sprintf('Anonymous was admitted to %s on run %d', $scope->value, $run->uid),
+                );
+            }
+        }
+    }
+
+    /**
      * ADR-172: "may act on this run" and "started this run" are different
      * questions, and four-eyes rests on the second one.
      */

--- a/Tests/Unit/Service/Agent/Inbox/WaitingRunViewFactoryTest.php
+++ b/Tests/Unit/Service/Agent/Inbox/WaitingRunViewFactoryTest.php
@@ -301,6 +301,58 @@ final class WaitingRunViewFactoryTest extends TestCase
     }
 
     /**
+     * ADR-173: the recent-runs table states the same distinction the run
+     * timeline does, so an auditor scanning the list does not have to open each
+     * run to find the ones that released themselves.
+     */
+    #[Test]
+    public function aTerminalRowSaysWhetherItsApprovalCameFromItsOwnInitiator(): void
+    {
+        $run = $this->makeRun('a', null, status: 'completed', beUser: 7);
+
+        // makeRun() gives every run uid 1, which is the key of the deciders map.
+        self::assertSame('self', $this->factory()->buildTerminal([$run], null, [1 => [7]])[0]->approvalAttribution);
+        self::assertSame('secondPerson', $this->factory()->buildTerminal([$run], null, [1 => [9]])[0]->approvalAttribution);
+        self::assertSame('self', $this->factory()->buildTerminal([$run], null, [1 => [9, 7]])[0]->approvalAttribution);
+    }
+
+    #[Test]
+    public function aTerminalRowThatPassedNoFenceStatesNoAttribution(): void
+    {
+        $run = $this->makeRun('a', null, status: 'completed', beUser: 7);
+
+        // No entry for this run, and the degraded empty map a failed load yields.
+        self::assertSame('', $this->factory()->buildTerminal([$run], null, [2 => [7]])[0]->approvalAttribution);
+        self::assertSame('', $this->factory()->buildTerminal([$run])[0]->approvalAttribution);
+    }
+
+    /**
+     * A run a service account started records beUser 0; 0 === 0 must not put a
+     * self-approved marker on a row nobody self-approved.
+     */
+    #[Test]
+    public function aTerminalRowWithoutResolvableUsersIsUnresolvedNotSelf(): void
+    {
+        $run = $this->makeRun('a', null, status: 'completed', beUser: 0);
+
+        self::assertSame('unresolved', $this->factory()->buildTerminal([$run], null, [1 => [0]])[0]->approvalAttribution);
+    }
+
+    /**
+     * A service-account run a backend user released: the row must not claim the
+     * decider is unrecorded, because it is. What is missing is the initiator to
+     * compare against.
+     */
+    #[Test]
+    public function aTerminalRowOfARunNoBackendUserStartedSeparatesTheTwoAbsences(): void
+    {
+        $run = $this->makeRun('a', null, status: 'completed', beUser: 0);
+
+        self::assertSame('initiatorUnknown', $this->factory()->buildTerminal([$run], null, [1 => [5]])[0]->approvalAttribution);
+        self::assertSame('unresolved', $this->factory()->buildTerminal([$run], null, [1 => [5, 0]])[0]->approvalAttribution);
+    }
+
+    /**
      * ADR-136: the card shows what the call WOULD do, not only its arguments.
      */
     #[Test]

--- a/Tests/Unit/Service/Agent/Timeline/RunTimelineFactoryTest.php
+++ b/Tests/Unit/Service/Agent/Timeline/RunTimelineFactoryTest.php
@@ -168,7 +168,104 @@ final class RunTimelineFactoryTest extends TestCase
         self::assertStringContainsString('fallbackAttempts=1', $timeline[1]->detail);
     }
 
-    private function agentRun(): AgentRun
+    /**
+     * ADR-173: the approval row states who decided relative to who started the
+     * run. The run fixture's initiator is beUser 1.
+     */
+    #[Test]
+    public function anApprovalGrantedByTheRunsOwnInitiatorIsMarkedSelf(): void
+    {
+        $factory = new RunTimelineFactory(new InMemoryTelemetryRepository(), new InMemoryGovernanceEventRepository());
+
+        $timeline = $factory->build($this->agentRun(), [$this->approvalEvent(0, true, 1, 1_700_000_010)]);
+
+        self::assertSame('self', $timeline[0]->approvalAttribution);
+    }
+
+    #[Test]
+    public function anApprovalGrantedByAnotherUserIsMarkedSecondPerson(): void
+    {
+        $factory = new RunTimelineFactory(new InMemoryTelemetryRepository(), new InMemoryGovernanceEventRepository());
+
+        $timeline = $factory->build($this->agentRun(), [$this->approvalEvent(0, true, 9, 1_700_000_010)]);
+
+        self::assertSame('secondPerson', $timeline[0]->approvalAttribution);
+    }
+
+    /**
+     * A denial is a legitimate self-decision (ADR-172) and an ordinary step is
+     * not a decision at all — neither may carry a marker.
+     */
+    #[Test]
+    public function neitherADenialNorAnOrdinaryStepCarriesAnAttribution(): void
+    {
+        $factory = new RunTimelineFactory(new InMemoryTelemetryRepository(), new InMemoryGovernanceEventRepository());
+
+        $timeline = $factory->build($this->agentRun(), [
+            $this->approvalEvent(0, false, 1, 1_700_000_010),
+            $this->event(1, 'llm', 1_700_000_011),
+        ]);
+
+        self::assertSame(RunTimelineEntry::ATTRIBUTION_NONE, $timeline[0]->approvalAttribution);
+        self::assertSame(RunTimelineEntry::ATTRIBUTION_NONE, $timeline[1]->approvalAttribution);
+    }
+
+    /**
+     * An approval whose decider was not recorded must not compare equal to a run
+     * a service account started — 0 === 0 is not four eyes and not self either.
+     */
+    #[Test]
+    public function anApprovalWithoutResolvableUsersIsUnresolvedNotSelf(): void
+    {
+        $factory = new RunTimelineFactory(new InMemoryTelemetryRepository(), new InMemoryGovernanceEventRepository());
+
+        $timeline = $factory->build($this->agentRun(beUser: 0), [$this->approvalEvent(0, true, 0, 1_700_000_010)]);
+
+        self::assertSame('unresolved', $timeline[0]->approvalAttribution);
+    }
+
+    /**
+     * The ordinary shape of a service-account run: `beUser` 0, released by a
+     * backend user whose uid IS on the row. "The record does not say by whom"
+     * would be a false statement about it.
+     */
+    #[Test]
+    public function anApprovalOnARunNoBackendUserStartedNamesItsDeciderStill(): void
+    {
+        $factory = new RunTimelineFactory(new InMemoryTelemetryRepository(), new InMemoryGovernanceEventRepository());
+
+        $timeline = $factory->build($this->agentRun(beUser: 0), [$this->approvalEvent(0, true, 5, 1_700_000_010)]);
+
+        self::assertSame('initiatorUnknown', $timeline[0]->approvalAttribution);
+        self::assertStringContainsString('decidedBy=5', $timeline[0]->detail);
+    }
+
+    /**
+     * A payload whose `decidedBy` is not an int (a corrupt or hand-edited row)
+     * degrades to unresolved rather than coercing into a uid comparison.
+     */
+    #[Test]
+    public function aNonIntegerDecidedByDegradesToUnresolved(): void
+    {
+        $factory = new RunTimelineFactory(new InMemoryTelemetryRepository(), new InMemoryGovernanceEventRepository());
+
+        $timeline = $factory->build($this->agentRun(), [
+            new AgentRunEvent(
+                uid: 300,
+                run: 7,
+                sequence: 0,
+                kind: 'approval',
+                round: 0,
+                durationMs: 0.0,
+                payload: ['approved' => true, 'decidedBy' => '1'],
+                crdate: 1_700_000_010,
+            ),
+        ]);
+
+        self::assertSame('unresolved', $timeline[0]->approvalAttribution);
+    }
+
+    private function agentRun(int $beUser = 1): AgentRun
     {
         return new AgentRun(
             uid: 7,
@@ -176,7 +273,7 @@ final class RunTimelineFactoryTest extends TestCase
             status: 'completed',
             configurationUid: 3,
             configurationIdentifier: 'editorial',
-            beUser: 1,
+            beUser: $beUser,
             iterations: 2,
             truncated: false,
             totalPromptTokens: 120,
@@ -215,6 +312,23 @@ final class RunTimelineFactoryTest extends TestCase
             round: 1,
             durationMs: 4.0,
             payload: ['kind' => 'tool', 'toolName' => 'get_page', 'toolIsError' => $isError],
+            crdate: $crdate,
+        );
+    }
+
+    /**
+     * An APPROVAL event exactly as AgentRunPersister::recordApproval() writes it.
+     */
+    private function approvalEvent(int $sequence, bool $approved, int $decidedBy, int $crdate): AgentRunEvent
+    {
+        return new AgentRunEvent(
+            uid: 300 + $sequence,
+            run: 7,
+            sequence: $sequence,
+            kind: 'approval',
+            round: 0,
+            durationMs: 0.0,
+            payload: ['approved' => $approved, 'decidedBy' => $decidedBy],
             crdate: $crdate,
         );
     }

--- a/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
+++ b/Tests/Unit/Service/Tool/Fixtures/RecordingAgentRunRepository.php
@@ -308,6 +308,11 @@ final class RecordingAgentRunRepository implements AgentRunRepositoryInterface
      */
     public array $maxSequenceReturns = [];
 
+    public function findApprovalDeciders(array $runUids): array
+    {
+        return [];
+    }
+
     public function maxEventSequence(int $runUid): int
     {
         if ($this->throwOnMaxSequence) {


### PR DESCRIPTION
## Description

An approval event records who decided. The run records who started it. Nothing put the two side by side, so a run released by its own initiator read exactly like one a second person reviewed.

**Self-approval is not an edge case.** `AiActorContext::mayActOnRun()` ends with `$this->backendUserUid > 0 && $this->backendUserUid === $run->beUser`, so it is the *fallback* path for anyone who is not an administrator, not a service account and holds no `agent_approve` grant — and on a single-user installation it is the only path there is.

ADR-172 (#789) shipped `require_second_approver`, a per-configuration switch that refuses it. That is the enforcement half and it is done. **This is the visibility half, and #789 makes it more valuable rather than less:** the switch is off by default, so an operator can believe four eyes applied to a configuration where the same person did both jobs.

## Two ways of not knowing are two labels

A first draft collapsed them into one, and it was false for half the cases. `AgentRun::$beUser` is `0` for every run a service account or non-BE caller started. Approve such a run as backend user 5 and the record stores `decidedBy=5` — the timeline even prints it. "Approved, but the record does not say by whom" is then simply wrong: the record does say. It does not say who *started* it.

So there are four states, not three:

| | |
| --- | --- |
| **Self-approved** | both uids present and equal |
| **Approved by someone else** | both present, different |
| **Starter unrecorded** | a service-account run released by a backend user |
| **Decider unrecorded** | an approval whose decider was not stored |

Only granted approvals carry a label. A denial carries none, because ADR-172 lets an initiator deny their own run on purpose.

## Where the two surfaces can differ, stated rather than papered over

The comparison is derived once, in `ApprovalAttribution`, and read by the approvals inbox, the run timeline and the terminal-run list. The timeline states **each** fence; the list **collapses** several by rank. On a multi-fence run they can therefore read differently — a run with fences by user 5 and by an unrecorded decider shows "the record does not say by whom" in the list while the timeline prints `decidedBy=5` beside it.

That is recorded on the enum as an accepted price, and the docblock that claimed the two surfaces "cannot disagree" is corrected. Neither surface owns the rule; the list additionally collapses.

## What this does not do

**No policy changes.** Refusing a self-approval is ADR-172's job and it exists. This makes what happened legible, nothing more.

## Related Issue

Closes #785

## Type of Change

- [x] New feature (non-breaking)
- [x] Documentation update

## Corrections made during review, worth naming

- The `string` type on two view DTOs was justified with "the view appends it to a translation key". Neither view does — the partial is an `f:switch` over four literal keys, and a named test in this branch asserts that no surface assembles a key. Three places said the opposite of a green test; all three now describe the design that shipped rather than the one that was rejected.
- The empty-cell explanation enumerated three inputs and a fourth reaches it: a granted approval whose payload JSON does not decode is dropped by the fail-soft read. Widened to "loaded or decoded" in all four places it appears.

## Gates

`cgl -n`, `phpstan` level 10, `unit` (7158 tests) and functional scoped to `--filter 'Approval|AgentRun'` (68 tests) all exit 0, plus all three repo checks.

**`rector -n` at the CI-pinned PHP 8.2 did not run** — `.Build` here is resolved at 8.4 and `platform_check.php` fatals before it starts.

**Not checked in a browser.** The new Approval column carries four full-sentence labels in a seven-column table. Nobody has looked at it at 1440px. The judgement to prefer sentences over one-word chips was taken for legibility and is worth overturning if it wraps badly — that is a review call, and it is stated here rather than left to be discovered.

## Note on ADR numbering

This record is ADR-173. A sibling branch (routing instrumentation) independently claimed 173 and has been renumbered to 174 — both were told to "confirm the next free number" rather than being given disjoint ranges, which is the parallel-agent collision that rule exists to prevent.

## Checklist

- [x] My code follows the project's coding standards
- [x] Tests prove the feature works, and the central one was seen to fail without it
- [x] Documentation updated
- [x] `CHANGELOG.md` entry under an existing heading
- [x] ADR-173 added and listed in `Documentation/Adr/Index.rst`
- [x] EN and DE labels for every new string
