### PR TITLE
feat(telemetry): record what a call cost and what it looked like before routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,52 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Per-call cost and real token counts on the telemetry row** (`#770`). Every
+  provider call now records what it actually consumed — input tokens, output
+  tokens, the model the provider named on the response, the cost derived from
+  its pricing, and how many HTTP attempts had to be repeated — under the
+  correlation id the call already carries.
+
+  `tx_nrllm_service_usage` holds the same figures as a daily aggregate with no
+  per-call key, so nothing there can be joined to a call, a request shape or a
+  complexity bucket. That made ADR-156's third activation criterion, "real cost
+  drops", not computable rather than merely awkward.
+
+  `NULL`, never `0`, where nothing was measured. A model priced at zero —
+  Ollama, Groq, anything local — used to record a cost of `0`, which is also
+  what an unpriced model records; it now records real tokens and no cost. Token
+  counts are `NULL` where the provider reported no usage block, and a recorded
+  `0` is a measured zero. Streamed runs record no token counts at all: they
+  carry an estimate, and an estimate does not belong in a column named
+  `actual`. See ADR-174.
+
+  Additive on the `@api` surface: `ProviderCallUsage`,
+  `TelemetrySignals::recordCallUsage()`, and an optional trailing
+  `ProviderRetryCounter` argument on `ProviderAdapterRegistry`'s constructor.
+
+- **Request facts, measured before the model is chosen** (`#771`). Message
+  count, turn count, tool count, payload bytes, a provider-independent token
+  estimate and the request shape are now recorded for every
+  configuration-driven send, formed before the pipeline runs — which is before
+  any model resolution.
+
+  The counts describe the transcript the caller sent. The configuration's system
+  prompt is prepended later, from options built out of the resolved model, so it
+  is in none of them — the same line the complexity record draws, which is what
+  keeps the two comparable.
+
+  The existing complexity record is measured *after* the model is chosen and
+  partly *from* it: its size term is estimated tokens against the budget of the
+  model already selected. It stays as it is and answers a different question;
+  the new set is model-independent by construction and deliberately excludes
+  context utilisation, the chosen model, its window and its price.
+
+  Nothing routes on either set. ADR-156 keeps its observer-only status and its
+  three activation criteria unchanged. See ADR-174.
+
+  Additive on the `@api` surface: `RequestFacts` and
+  `TelemetrySignals::recordRequestFacts()`.
+
 - **Four-eyes approval, per configuration** (`#786`). A new configuration field,
   *Require a second approver*, refuses an approval from the backend user who
   started the run. Default off, so every existing record keeps the

--- a/Classes/Domain/ValueObject/ProviderCallUsage.php
+++ b/Classes/Domain/ValueObject/ProviderCallUsage.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\ValueObject;
+
+/**
+ * What one provider call actually consumed, and what that cost (ADR-174).
+ *
+ * The counterpart of {@see RequestComplexity}: that one estimates a request
+ * before it is answered, this one reports what came back. Both hang off the
+ * same telemetry row, so a shape, a decision and a price share one
+ * ``correlation_id`` — which is what ``tx_nrllm_service_usage`` cannot give,
+ * being a daily aggregate with no per-call key.
+ *
+ * **Null is a measurement that did not happen, and never a zero.** A provider
+ * that reports no usage block leaves the token fields null; a model with no
+ * pricing leaves the cost null. Both cases previously surfaced as ``0`` — the
+ * cost of a free local model and the cost of an unpriced one were the same
+ * number, which is precisely the arm a cheap-model experiment is about.
+ *
+ * Prompt-free like the row it is written to: two counts, a price and a model
+ * name.
+ *
+ * @api
+ */
+final readonly class ProviderCallUsage
+{
+    /**
+     * @param ?int   $inputTokens   prompt tokens as the PROVIDER reported them, or null where it
+     *                              reported no usage at all. Not an estimate — {@see RequestFacts}
+     *                              and {@see RequestComplexity} hold those.
+     * @param ?int   $outputTokens  completion tokens as reported, null under the same condition.
+     *                              A response that genuinely produced nothing still reports a
+     *                              prompt count, so `0` here is a measured zero.
+     * @param ?float $cost          the money the tokens above cost, derived from the serving
+     *                              model's pricing. NULL where no price is known — an unpriced
+     *                              or free model yields real tokens and no cost, rather than a
+     *                              zero that reads as "this was free" for both cases.
+     * @param string $responseModel the model id the PROVIDER named on the response. Distinct from
+     *                              the configuration's model: a provider may resolve an alias to a
+     *                              dated snapshot, and which one answered is the joinable fact.
+     *                              '' where the response named none.
+     */
+    public function __construct(
+        public ?int $inputTokens,
+        public ?int $outputTokens,
+        public ?float $cost,
+        public string $responseModel,
+    ) {}
+}

--- a/Classes/Domain/ValueObject/RequestFacts.php
+++ b/Classes/Domain/ValueObject/RequestFacts.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\ValueObject;
+
+/**
+ * What the request is, measured BEFORE a model is chosen (ADR-174).
+ *
+ * {@see RequestComplexity} is measured after the model is chosen and partly
+ * FROM it — its size term is estimated tokens against the budget of the model
+ * that was already selected, so it can describe a decision but never inform
+ * one. This fact set is model-independent by construction and is formed before
+ * the pipeline runs, which is before any resolution happens.
+ *
+ * Explicitly NOT here, and deliberately: context utilisation, the chosen model,
+ * its window, its price. Every one of those is a property of a decision that
+ * has not been taken yet, and admitting one would recreate the circularity this
+ * exists to break.
+ *
+ * The operation is not repeated either — ``tx_nrllm_telemetry.operation``
+ * already names it on the same row.
+ *
+ * WHAT IS COUNTED is the transcript the caller handed over, which is not quite
+ * what goes on the wire: the configuration's stored system prompt is prepended
+ * later, by
+ * {@see \Netresearch\NrLlm\Service\MessageShaper::applySystemPrompt()}, and is
+ * in none of these figures. That is a consequence of the measurement point, not
+ * an oversight — the effective prompt comes from the call options, which are
+ * built from the resolved model, so counting it would mean measuring after the
+ * decision this record exists to precede. A system message the CALLER supplied
+ * is counted (as a message and as bytes, never as a turn), and
+ * {@see RequestComplexity} draws the same line, so the two records on one row
+ * stay comparable.
+ *
+ * OBSERVATION ONLY. Nothing routes on this; :ref:`ADR-156 <adr-156>` keeps its
+ * observer-only status and names what must be true before anything may.
+ *
+ * Prompt-free: four counts, a size and a shape.
+ *
+ * @api
+ */
+final readonly class RequestFacts
+{
+    /**
+     * @param int    $messageCount  messages the caller handed over, a system message among them
+     *                              if the caller supplied one — see the note above on the
+     *                              configuration's system prompt, which is not one of them
+     * @param int    $turnCount     conversation turns — the message count minus system messages.
+     *                              The same rule {@see RequestComplexity} counts by, so the two
+     *                              records stay comparable on the one row they share.
+     * @param int    $toolCount     tool schemas the send carries
+     * @param int    $payloadBytes  total byte length of those message contents. BYTES, like
+     *                              {@see RequestComplexity::$payloadBytes} and for the same reason
+     *                              (:ref:`ADR-121 <adr-121>`): bytes per token stay roughly
+     *                              comparable across scripts, characters do not.
+     * @param int    $tokenEstimate a provider- and model-independent token estimate for this
+     *                              payload, from the same estimator the context fit uses but with
+     *                              no calibration and no budget — so it can be compared against the
+     *                              post-fit figure without being derived from a model.
+     * @param string $shape         the {@see \Netresearch\NrLlm\Domain\Enum\RequestShape} value
+     */
+    public function __construct(
+        public int $messageCount,
+        public int $turnCount,
+        public int $toolCount,
+        public int $payloadBytes,
+        public int $tokenEstimate,
+        public string $shape,
+    ) {}
+}

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -19,6 +19,7 @@ use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConnectionException;
 use Netresearch\NrLlm\Provider\Exception\ProviderRateLimitException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
+use Netresearch\NrLlm\Service\Telemetry\ProviderRetryCounter;
 use Netresearch\NrLlm\Utility\ErrorMessageSanitizerTrait;
 use Netresearch\NrVault\Http\SecretPlacement;
 use Netresearch\NrVault\Http\SecureHttpClientFactory;
@@ -90,12 +91,23 @@ abstract class AbstractProvider implements ProviderInterface
 
     private ?ClientInterface $configuredHttpClient = null;
 
+    /**
+     * @param ?ProviderRetryCounter $retryCounter the process-wide retry tally the telemetry write
+     *                                            sites take a difference of (ADR-174). Optional and
+     *                                            nullable because adapters are also constructed by
+     *                                            hand — in tests and in
+     *                                            {@see ProviderAdapterRegistry::instantiateAdapter()} —
+     *                                            and an adapter without one simply reports no
+     *                                            retries rather than failing to build. The container
+     *                                            supplies it for every autowired adapter.
+     */
     public function __construct(
         protected readonly RequestFactoryInterface $requestFactory,
         protected readonly StreamFactoryInterface $streamFactory,
         protected readonly LoggerInterface $logger,
         protected readonly VaultServiceInterface $vault,
         protected readonly SecureHttpClientFactory $httpClientFactory,
+        protected readonly ?ProviderRetryCounter $retryCounter = null,
     ) {}
 
     abstract public function getName(): string;
@@ -374,6 +386,13 @@ abstract class AbstractProvider implements ProviderInterface
                 }
 
                 if ($attempt < $maxAttempts) {
+                    // Counted here rather than at the `$attempt++` above: this
+                    // branch is the one that repeats the request. The final
+                    // failed attempt increments $attempt and then falls out of
+                    // the loop, and calling that a retry would report one more
+                    // than were ever sent (ADR-174).
+                    $this->retryCounter?->recordRetry();
+
                     // Exponential backoff capped at 30s. Short-circuit at
                     // attempt >= 9 (100000 * 2**9 = 51.2s already exceeds the
                     // cap) so the 2 ** $attempt term cannot overflow the float→int

--- a/Classes/Provider/Middleware/TelemetryMiddleware.php
+++ b/Classes/Provider/Middleware/TelemetryMiddleware.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Provider\Middleware;
 
 use Netresearch\NrLlm\Exception\GuardrailPolicyException;
+use Netresearch\NrLlm\Service\Telemetry\ProviderRetryCounter;
 use Netresearch\NrLlm\Service\Telemetry\TelemetryRecord;
 use Netresearch\NrLlm\Service\Telemetry\TelemetryRepositoryInterface;
 use Psr\Log\LoggerInterface;
@@ -94,6 +95,7 @@ final readonly class TelemetryMiddleware implements ProviderMiddlewareInterface
         private Context $context,
         private ExtensionConfiguration $extensionConfiguration,
         private LoggerInterface $logger,
+        private ProviderRetryCounter $retryCounter = new ProviderRetryCounter(),
     ) {}
 
     /**
@@ -110,6 +112,17 @@ final readonly class TelemetryMiddleware implements ProviderMiddlewareInterface
         $start      = hrtime(true);
         $success    = false;
         $errorClass = '';
+        // Snapshot difference rather than a reset (ADR-174): a tool loop nests
+        // pipeline runs, and a reset by an inner run would make this row report
+        // only the retries that happened after it finished. Taken here, on the
+        // outermost layer, so the count covers the fallback re-sends too.
+        //
+        // ONE difference is exact here because the run below is synchronous:
+        // the pipeline holds the stack from this line to the finally, so no
+        // caller code runs in between. The streaming path does not go through
+        // the pipeline and is a generator, which is why StreamingDispatcher
+        // accumulates per resumption segment instead.
+        $retriesBefore = $this->retryCounter->total();
 
         try {
             $result  = $next($context);
@@ -130,7 +143,13 @@ final readonly class TelemetryMiddleware implements ProviderMiddlewareInterface
 
             throw $e;
         } finally {
-            $this->safeRecord($context, $success, $errorClass, $this->elapsedMs($start));
+            $this->safeRecord(
+                $context,
+                $success,
+                $errorClass,
+                $this->elapsedMs($start),
+                $this->retryCounter->total() - $retriesBefore,
+            );
         }
     }
 
@@ -148,6 +167,7 @@ final readonly class TelemetryMiddleware implements ProviderMiddlewareInterface
         bool $success,
         string $errorClass,
         int $latencyMs,
+        int $providerRetries,
     ): void {
         try {
             $signals = $context->telemetrySignals;
@@ -180,6 +200,14 @@ final readonly class TelemetryMiddleware implements ProviderMiddlewareInterface
                 // inner layers found.
                 routingSummary: $signals->routingSummary,
                 complexity: $signals->complexity,
+                // The two halves of ADR-174, from the same scratchpad: the
+                // facts were recorded on the way in, before anything resolved a
+                // model, and the usage on the way out, by UsageMiddleware. Null
+                // stays null on both — a cache hit and a failed run reach here
+                // with no usage, and neither spent a token.
+                requestFacts: $signals->requestFacts,
+                callUsage: $signals->callUsage,
+                providerRetries: $providerRetries,
             ));
         } catch (Throwable $e) {
             // Observability must not break the call it observes. safeRecord()

--- a/Classes/Provider/Middleware/TelemetrySignals.php
+++ b/Classes/Provider/Middleware/TelemetrySignals.php
@@ -10,7 +10,9 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Provider\Middleware;
 
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\ValueObject\ProviderCallUsage;
 use Netresearch\NrLlm\Domain\ValueObject\RequestComplexity;
+use Netresearch\NrLlm\Domain\ValueObject\RequestFacts;
 use Netresearch\NrLlm\Domain\ValueObject\RoutingSummary;
 
 /**
@@ -85,6 +87,34 @@ final class TelemetrySignals
     public ?RequestComplexity $complexity = null;
 
     /**
+     * What the request WAS, before anything chose a model for it (ADR-174).
+     *
+     * Recorded by {@see \Netresearch\NrLlm\Service\LlmServiceManager} on the way
+     * IN — before the pipeline runs, therefore before any resolution — which is
+     * the whole point: {@see RequestComplexity} is measured after the model is
+     * chosen and partly from it, so it cannot describe a request independently
+     * of the answer it got.
+     *
+     * Only the four configuration-driven sends form a fact set — chat,
+     * completion, tools and stream — so this stays null everywhere else: the
+     * provider-pinned entry points, embeddings, and every specialized service
+     * (image, speech and translation alike, all of which run their own
+     * operations through the pipeline and so reach the telemetry row).
+     */
+    public ?RequestFacts $requestFacts = null;
+
+    /**
+     * What the provider reported and what it cost (ADR-174).
+     *
+     * Recorded by {@see UsageMiddleware} from the response that came back, so
+     * it is null wherever no provider call happened or nothing token-shaped
+     * came out of it: a cache hit (CacheMiddleware short-circuits above Usage),
+     * a failed run, and the specialized operations that record through a tagged
+     * extractor instead.
+     */
+    public ?ProviderCallUsage $callUsage = null;
+
+    /**
      * CacheMiddleware calls this when it serves a stored response instead of
      * invoking the terminal.
      */
@@ -150,5 +180,36 @@ final class TelemetrySignals
     public function recordComplexity(RequestComplexity $complexity): void
     {
         $this->complexity = $complexity;
+    }
+
+    /**
+     * {@see \Netresearch\NrLlm\Service\LlmServiceManager} calls this once per
+     * call, before the pipeline starts.
+     *
+     * FIRST writer wins, unlike the complexity: the facts describe the request
+     * the caller made, and a fallback re-send is the same request against a
+     * different configuration. Re-measuring would produce the identical numbers
+     * at best; letting a later write through would only create a way for them
+     * to disagree.
+     */
+    public function recordRequestFacts(RequestFacts $facts): void
+    {
+        if ($this->requestFacts instanceof RequestFacts) {
+            return;
+        }
+
+        $this->requestFacts = $facts;
+    }
+
+    /**
+     * {@see UsageMiddleware} calls this with what the provider reported for the
+     * call that answered.
+     *
+     * Last writer wins: on a fallback swap the sibling's response is the one
+     * that was served, and its tokens are the ones that were spent.
+     */
+    public function recordCallUsage(ProviderCallUsage $usage): void
+    {
+        $this->callUsage = $usage;
     }
 }

--- a/Classes/Provider/Middleware/UsageMiddleware.php
+++ b/Classes/Provider/Middleware/UsageMiddleware.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ProviderCallUsage;
 use Netresearch\NrLlm\Provider\Middleware\Usage\UsageMetricsExtractorInterface;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
 use Psr\Log\LoggerInterface;
@@ -62,6 +63,13 @@ use Throwable;
  * tracked here. Failure-rate telemetry is handled by the dedicated
  * TelemetryMiddleware (ADR-058), which wraps the whole pipeline and records
  * one row regardless of outcome.
+ *
+ * It writes the same three facts twice, to two different shapes (ADR-174): the
+ * daily aggregate in tx_nrllm_service_usage, which is what a budget needs, and
+ * a per-call copy on {@see TelemetrySignals} that TelemetryMiddleware puts on
+ * the telemetry row under this call's correlation id. The aggregate has no
+ * per-call key, so without the second write no cost can be joined to a request
+ * shape, a routing decision or a complexity bucket.
  *
  * Recording is fail-soft: a failure while writing to tx_nrllm_service_usage is
  * logged and swallowed, never re-thrown, so this post-flight bookkeeping cannot
@@ -187,6 +195,21 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
             $cost = $model->estimateCost($usage->promptTokens, $usage->completionTokens);
         }
 
+        // The same three facts, per call and joinable by correlation id
+        // (ADR-174). tx_nrllm_service_usage aggregates them per day, which is
+        // the right shape for a budget and the wrong one for "what did THIS
+        // request cost". Recorded before the tracker call so a tracker failure
+        // (swallowed by handle()) still leaves the telemetry row measured.
+        $context->telemetrySignals->recordCallUsage(new ProviderCallUsage(
+            inputTokens: $this->reportedTokens($usage, $usage->promptTokens),
+            outputTokens: $this->reportedTokens($usage, $usage->completionTokens),
+            // NULL, not 0, where no price is known: a model with no pricing and
+            // a model that is genuinely free are different claims, and only one
+            // of them is "this call cost nothing".
+            cost: $cost,
+            responseModel: $responseModel,
+        ));
+
         /** @var array{tokens: int, promptTokens: int, completionTokens: int, cost?: float} $metrics */
         $metrics = [
             'tokens'           => $usage->totalTokens,
@@ -229,6 +252,27 @@ final readonly class UsageMiddleware implements ProviderMiddlewareInterface
             beUserUid: $beUserUid,
             countsAsRequest: $countsAsRequest,
         );
+    }
+
+    /**
+     * One token figure as the PROVIDER reported it, or null where it reported
+     * nothing (ADR-174).
+     *
+     * {@see UsageStatistics} types its three counts as plain ints, so an
+     * adapter that finds no `usage` block in the response builds the same
+     * object as one that was told zero. The only signal separating them is that
+     * all three are zero at once: a call that reached a provider consumed
+     * prompt tokens, so an all-zero triple is an absent measurement rather than
+     * a measured one. A response that produced no output still reports its
+     * prompt count, so a `0` that survives this check is genuine.
+     */
+    private function reportedTokens(UsageStatistics $usage, int $value): ?int
+    {
+        if ($usage->promptTokens === 0 && $usage->completionTokens === 0 && $usage->totalTokens === 0) {
+            return null;
+        }
+
+        return $value;
     }
 
     /**

--- a/Classes/Provider/ProviderAdapterRegistry.php
+++ b/Classes/Provider/ProviderAdapterRegistry.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
 use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
+use Netresearch\NrLlm\Service\Telemetry\ProviderRetryCounter;
 use Netresearch\NrVault\Http\SecureHttpClientFactory;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Psr\Http\Message\RequestFactoryInterface;
@@ -90,6 +91,11 @@ final class ProviderAdapterRegistry implements ProviderAdapterRegistryInterface,
      *                                                                        production container passes an empty array (the default);
      *                                                                        tests use this seam to exercise override / custom-type /
      *                                                                        invalid-class handling without runtime mutation.
+     * @param ?ProviderRetryCounter                         $retryCounter     passed on to every adapter this registry builds, so
+     *                                                                        the retries an adapter consumes reach the telemetry
+     *                                                                        row (ADR-174). Trailing and nullable: adapters built
+     *                                                                        without one report no retries, which is what a
+     *                                                                        hand-constructed registry in a test wants.
      *
      * @throws ProviderConfigurationException when an override class does not extend AbstractProvider
      */
@@ -100,6 +106,7 @@ final class ProviderAdapterRegistry implements ProviderAdapterRegistryInterface,
         private readonly VaultServiceInterface $vault,
         private readonly SecureHttpClientFactory $httpClientFactory,
         array $adapterOverrides = [],
+        private readonly ?ProviderRetryCounter $retryCounter = null,
     ) {
         foreach ($adapterOverrides as $adapterType => $adapterClass) {
             // Defensive: callers may pass untyped arrays; validate keys
@@ -297,6 +304,7 @@ final class ProviderAdapterRegistry implements ProviderAdapterRegistryInterface,
             $this->logger,
             $this->vault,
             $this->httpClientFactory,
+            $this->retryCounter,
         );
     }
 

--- a/Classes/Service/Complexity/MessageInspector.php
+++ b/Classes/Service/Complexity/MessageInspector.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Complexity;
+
+use Netresearch\NrLlm\Domain\Enum\MessageRole;
+use Netresearch\NrLlm\Domain\Enum\RequestShape;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+
+/**
+ * Reads a transcript the way both measurements read it (ADR-174).
+ *
+ * {@see RequestComplexityEstimator} (post-fit) and {@see RequestFactsCollector}
+ * (pre-routing) describe the same send at two different moments, and the point
+ * of writing both to one row is that they can be compared. A second definition
+ * of "a turn" or "tool traffic" would quietly break that comparison, so there
+ * is one definition and both callers use it.
+ *
+ * Accepts either shape a send can carry: a {@see ChatMessage} or the legacy
+ * array form the manager still normalises from.
+ *
+ * @internal
+ */
+final readonly class MessageInspector
+{
+    /**
+     * A conversation turn is any message that is not a system message: the
+     * system prompt is configuration, not conversation.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     */
+    public function turnCount(array $messages): int
+    {
+        $turns = 0;
+        foreach ($messages as $message) {
+            if ($this->roleOf($message) !== MessageRole::SYSTEM->value) {
+                ++$turns;
+            }
+        }
+
+        return $turns;
+    }
+
+    /**
+     * Total byte length of the message contents — {@see strlen}, not
+     * {@see mb_strlen} (:ref:`ADR-121 <adr-121>`).
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     */
+    public function payloadBytes(array $messages): int
+    {
+        $bytes = 0;
+        foreach ($messages as $message) {
+            $bytes += strlen($this->contentOf($message));
+        }
+
+        return $bytes;
+    }
+
+    /**
+     * Whether the transcript carries either half of a tool exchange: an
+     * assistant message that requested calls, or the result that answered one.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     */
+    public function carriesToolTraffic(array $messages): bool
+    {
+        foreach ($messages as $message) {
+            if ($this->isToolTraffic($message, $this->roleOf($message))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function shape(int $conversationTurns, bool $carriesTools): RequestShape
+    {
+        if ($carriesTools) {
+            return RequestShape::TOOL_ASSISTED;
+        }
+
+        return $conversationTurns > 1 ? RequestShape::MULTI_TURN : RequestShape::SINGLE_TURN;
+    }
+
+    /**
+     * @param ChatMessage|array<string, mixed> $message
+     */
+    public function roleOf(ChatMessage|array $message): string
+    {
+        if ($message instanceof ChatMessage) {
+            return $message->getRole()->value;
+        }
+
+        $role = $message['role'] ?? null;
+
+        return is_string($role) ? $role : '';
+    }
+
+    /**
+     * @param ChatMessage|array<string, mixed> $message
+     */
+    public function contentOf(ChatMessage|array $message): string
+    {
+        if ($message instanceof ChatMessage) {
+            return $message->content;
+        }
+
+        $content = $message['content'] ?? null;
+
+        return is_string($content) ? $content : '';
+    }
+
+    /**
+     * @param ChatMessage|array<string, mixed> $message
+     */
+    public function isToolTraffic(ChatMessage|array $message, string $role): bool
+    {
+        if ($role === MessageRole::TOOL->value) {
+            return true;
+        }
+
+        if ($message instanceof ChatMessage) {
+            return $message->toolCalls !== null;
+        }
+
+        $toolCalls = $message['tool_calls'] ?? $message['toolCalls'] ?? null;
+
+        return is_array($toolCalls) && $toolCalls !== [];
+    }
+}

--- a/Classes/Service/Complexity/RequestComplexityEstimator.php
+++ b/Classes/Service/Complexity/RequestComplexityEstimator.php
@@ -9,8 +9,6 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Complexity;
 
-use Netresearch\NrLlm\Domain\Enum\MessageRole;
-use Netresearch\NrLlm\Domain\Enum\RequestShape;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ContextFitResult;
 use Netresearch\NrLlm\Domain\ValueObject\RequestComplexity;
@@ -44,8 +42,27 @@ final readonly class RequestComplexityEstimator
     private const SIZE_TERM_MAX = 30;
 
     /**
-     * @param list<ChatMessage|array<string, mixed>> $messages  the transcript as it goes on the wire
-     * @param int                                    $toolCount tool schemas on the wire for this send
+     * The transcript reader is shared with {@see RequestFactsCollector} so that
+     * "a turn", "tool traffic" and the byte count mean the same thing in both
+     * records — the two sit on one row precisely to be compared (ADR-174).
+     *
+     * Defaulted rather than injected: this class is constructed inline by
+     * {@see \Netresearch\NrLlm\Service\LlmServiceManager}, whose constructor is
+     * pinned by the shared test factory.
+     */
+    public function __construct(
+        private MessageInspector $inspector = new MessageInspector(),
+    ) {}
+
+    /**
+     * @param list<ChatMessage|array<string, mixed>> $messages  the bounded transcript, post-pruning — NOT the
+     *                                                          bytes on the wire: the configuration's system
+     *                                                          prompt is prepended after the fit, so it is in
+     *                                                          neither this list nor the byte count. The same
+     *                                                          line {@see RequestFactsCollector} draws, which
+     *                                                          is what keeps the two records on one row
+     *                                                          comparable (ADR-174)
+     * @param int                                    $toolCount tool schemas this send carries
      * @param ?ContextFitResult                      $fit       the context fit for this send (ADR-107/143),
      *                                                          or null where none ran — the token and
      *                                                          utilisation figures come from it, and stay
@@ -55,21 +72,9 @@ final readonly class RequestComplexityEstimator
     {
         $toolCount = max(0, $toolCount);
 
-        $bytes         = 0;
-        $conversation  = 0;
-        $carriesTools  = $toolCount > 0;
-        foreach ($messages as $message) {
-            $role = $this->roleOf($message);
-            $bytes += strlen($this->contentOf($message));
-
-            if ($this->isToolTraffic($message, $role)) {
-                $carriesTools = true;
-            }
-
-            if ($role !== MessageRole::SYSTEM->value) {
-                ++$conversation;
-            }
-        }
+        $bytes        = $this->inspector->payloadBytes($messages);
+        $conversation = $this->inspector->turnCount($messages);
+        $carriesTools = $toolCount > 0 || $this->inspector->carriesToolTraffic($messages);
 
         $percent = $this->contextPercent($fit);
 
@@ -79,7 +84,7 @@ final readonly class RequestComplexityEstimator
             tokenEstimate: $fit?->estimatedTokens,
             toolCount: $toolCount,
             contextPercent: $percent,
-            shape: $this->shape($conversation, $carriesTools)->value,
+            shape: $this->inspector->shape($conversation, $carriesTools)->value,
         );
     }
 
@@ -124,63 +129,5 @@ final readonly class RequestComplexityEstimator
         $sizeTerm = (int)round(self::SIZE_TERM_MAX * min($contextPercent ?? 0, 100) / 100);
 
         return $turnTerm + $toolTerm + $sizeTerm;
-    }
-
-    private function shape(int $conversationTurns, bool $carriesTools): RequestShape
-    {
-        if ($carriesTools) {
-            return RequestShape::TOOL_ASSISTED;
-        }
-
-        return $conversationTurns > 1 ? RequestShape::MULTI_TURN : RequestShape::SINGLE_TURN;
-    }
-
-    /**
-     * Tool traffic is either half of a tool exchange: an assistant message that
-     * requested calls, or the result that answered one.
-     *
-     * @param ChatMessage|array<string, mixed> $message
-     */
-    private function isToolTraffic(ChatMessage|array $message, string $role): bool
-    {
-        if ($role === MessageRole::TOOL->value) {
-            return true;
-        }
-
-        if ($message instanceof ChatMessage) {
-            return $message->toolCalls !== null;
-        }
-
-        $toolCalls = $message['tool_calls'] ?? $message['toolCalls'] ?? null;
-
-        return is_array($toolCalls) && $toolCalls !== [];
-    }
-
-    /**
-     * @param ChatMessage|array<string, mixed> $message
-     */
-    private function roleOf(ChatMessage|array $message): string
-    {
-        if ($message instanceof ChatMessage) {
-            return $message->getRole()->value;
-        }
-
-        $role = $message['role'] ?? null;
-
-        return is_string($role) ? $role : '';
-    }
-
-    /**
-     * @param ChatMessage|array<string, mixed> $message
-     */
-    private function contentOf(ChatMessage|array $message): string
-    {
-        if ($message instanceof ChatMessage) {
-            return $message->content;
-        }
-
-        $content = $message['content'] ?? null;
-
-        return is_string($content) ? $content : '';
     }
 }

--- a/Classes/Service/Complexity/RequestFactsCollector.php
+++ b/Classes/Service/Complexity/RequestFactsCollector.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Complexity;
+
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\RequestFacts;
+use Netresearch\NrLlm\Service\Context\TranscriptEstimator;
+
+/**
+ * Describes a request before a model exists to describe it against (ADR-174).
+ *
+ * The one property that matters here is what this class CANNOT see: no
+ * configuration, no {@see \Netresearch\NrLlm\Domain\Model\Model}, no context
+ * budget, no price. {@see RequestComplexityEstimator} takes a
+ * {@see \Netresearch\NrLlm\Domain\ValueObject\ContextFitResult} and is therefore
+ * downstream of a selection; this takes messages and tool schemas and nothing
+ * else, which is what lets its caller run it before the pipeline does anything.
+ *
+ * Decides nothing. Its only consumer is a telemetry column group, exactly as
+ * :ref:`ADR-156 <adr-156>` requires of the complexity estimator, and ADR-174
+ * repeats that requirement rather than relaxing it. Grep for a consumer in
+ * {@see \Netresearch\NrLlm\Service\Routing\CandidateRanker} or
+ * {@see \Netresearch\NrLlm\Service\Routing\EligibilityEvaluator} before adding
+ * one.
+ *
+ * @internal
+ */
+final readonly class RequestFactsCollector
+{
+    /**
+     * @param MessageInspector    $inspector shared with {@see RequestComplexityEstimator} so both
+     *                                       records count a turn the same way
+     * @param TranscriptEstimator $estimator the same estimator the context fit uses
+     *                                       (:ref:`ADR-107 <adr-107>`), called with a calibration of
+     *                                       1.0 — the calibration is grown from a model's real
+     *                                       prompt-token counts, and a model is exactly what this
+     *                                       measurement is not allowed to know
+     */
+    public function __construct(
+        private MessageInspector $inspector = new MessageInspector(),
+        private TranscriptEstimator $estimator = new TranscriptEstimator(),
+    ) {}
+
+    /**
+     * @param list<ChatMessage|array<string, mixed>> $messages  the send as the caller handed it over
+     * @param list<array<string, mixed>>             $toolSpecs the tool schemas this send carries, empty for a plain chat
+     */
+    public function collect(array $messages, array $toolSpecs): RequestFacts
+    {
+        $turns = $this->inspector->turnCount($messages);
+
+        return new RequestFacts(
+            messageCount: count($messages),
+            turnCount: $turns,
+            toolCount: count($toolSpecs),
+            payloadBytes: $this->inspector->payloadBytes($messages),
+            tokenEstimate: $this->estimator->estimate($messages, $toolSpecs, 1.0),
+            shape: $this->inspector->shape(
+                $turns,
+                $toolSpecs !== [] || $this->inspector->carriesToolTraffic($messages),
+            )->value,
+        );
+    }
+}

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -19,6 +19,7 @@ use Netresearch\NrLlm\Domain\ValueObject\AgentRunReference;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
 use Netresearch\NrLlm\Domain\ValueObject\ContextFitResult;
 use Netresearch\NrLlm\Domain\ValueObject\InjectedContext;
+use Netresearch\NrLlm\Domain\ValueObject\RequestFacts;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Domain\ValueObject\VisionContent;
 use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
@@ -33,6 +34,7 @@ use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Provider\Middleware\TelemetrySignals;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\Complexity\RequestComplexityEstimator;
+use Netresearch\NrLlm\Service\Complexity\RequestFactsCollector;
 use Netresearch\NrLlm\Service\Context\ContextWindowManagerInterface;
 use Netresearch\NrLlm\Service\Context\InputContextTrustGate;
 use Netresearch\NrLlm\Service\Guardrail\InputGuardrailScreener;
@@ -454,6 +456,41 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             $signals->recordComplexity((new RequestComplexityEstimator())->estimate($messages, $toolCount, $fit));
         } catch (Throwable $e) {
             $this->logger?->warning('Failed to measure request complexity; the call is unaffected', ['exception' => $e]);
+        }
+    }
+
+    /**
+     * Describe the request before anything chooses a model for it (ADR-174).
+     *
+     * The counterpart of {@see self::measureComplexity()}, and deliberately not
+     * the same measurement. That one hangs off the context fit, which needs the
+     * resolved model's budget; this one runs on the caller's own thread before
+     * {@see self::runThroughPipeline()} builds a context, so no resolution can
+     * have happened yet. Both records land on one row, which is what lets a
+     * later analysis ask whether the model-independent half predicts anything
+     * about the decision the other half describes.
+     *
+     * OBSERVATION. Nothing reads it inside the decision path; :ref:`ADR-156
+     * <adr-156>` keeps its observer-only status and states what must hold first.
+     *
+     * Fail-soft like every other observation here: a measurement error must not
+     * turn a working call into a failed one.
+     *
+     * @param list<ChatMessage|array<string, mixed>> $messages
+     * @param list<array<string, mixed>>             $toolSpecs
+     */
+    private function collectRequestFacts(array $messages, array $toolSpecs = []): ?RequestFacts
+    {
+        try {
+            // Constructed here rather than injected, like the complexity
+            // estimator above and for the same reason: it is a stateless pure
+            // function object, and this manager's constructor is pinned by the
+            // shared test factory.
+            return (new RequestFactsCollector())->collect($messages, $toolSpecs);
+        } catch (Throwable $e) {
+            $this->logger?->warning('Failed to collect request facts; the call is unaffected', ['exception' => $e]);
+
+            return null;
         }
     }
 
@@ -889,6 +926,10 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->idempotency($options->getIdempotencyKey()),
             $run,
             $injectedContext,
+            $this->collectRequestFacts(
+                $normalisedMessages,
+                array_map(static fn(ToolSpec $spec): array => $spec->toArray(), $normalisedTools),
+            ),
         );
     }
 
@@ -1083,6 +1124,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             $metadata,
             $run,
             $injectedContext,
+            $this->collectRequestFacts($normalisedMessages),
         );
     }
 
@@ -1111,6 +1153,12 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
                 return $adapter->complete($prompt, $options);
             },
             $metadata,
+            null,
+            null,
+            // A raw prompt is one user turn — the same list
+            // reportPromptOverflow() measures on the way through, so the two
+            // records describe the same send.
+            $this->collectRequestFacts([ChatMessage::user($prompt)]),
         );
     }
 
@@ -1199,6 +1247,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         array $metadata = [],
         ?AgentRunReference $run = null,
         ?InjectedContext $injectedContext = null,
+        ?RequestFacts $facts = null,
     ): mixed {
         // The run's own uid is authoritative and goes on the LEFT: `$metadata`
         // is caller-supplied on the public entry points, and `+` keeps the left
@@ -1215,10 +1264,17 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         // operation runs through this pipeline.
         $this->assertContextPermitted($configuration, $metadata, $operation, $run->uid ?? 0, $injectedContext);
 
-        return $this->pipeline->run(
-            ProviderCallContext::forConfiguration($operation, $configuration, $metadata, $run?->correlationId()),
-            $terminal,
-        );
+        $context = ProviderCallContext::forConfiguration($operation, $configuration, $metadata, $run?->correlationId());
+
+        // Recorded here rather than inside the terminal, and that placement is
+        // the entire point (ADR-174): the terminal is where resolveModel() runs,
+        // so anything measured in there is measured after a model was chosen.
+        // This is the last moment that is still unambiguously before it.
+        if ($facts instanceof RequestFacts) {
+            $context->telemetrySignals->recordRequestFacts($facts);
+        }
+
+        return $this->pipeline->run($context, $terminal);
     }
 
     /**
@@ -1369,6 +1425,14 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         // complete at this point — the context copies it, so a later write
         // would not reach the context anyway.
         $streamContext = ProviderCallContext::for(ProviderOperation::Stream, $metadata);
+
+        // Before the opener, which is where the model gets resolved (ADR-174).
+        // Measured on the normalised list because that is what the opener sends;
+        // the collector reads either shape, but the byte count would differ.
+        $facts = $this->collectRequestFacts($this->messageShaper->normalise($messages));
+        if ($facts instanceof RequestFacts) {
+            $streamContext->telemetrySignals->recordRequestFacts($facts);
+        }
 
         $open = function (LlmConfiguration $config) use ($messages, $optionOverrides, $streamContext): Generator {
             $signals  = $streamContext->telemetrySignals;

--- a/Classes/Service/Streaming/StreamingDispatcher.php
+++ b/Classes/Service/Streaming/StreamingDispatcher.php
@@ -27,6 +27,7 @@ use Netresearch\NrLlm\Service\Guardrail\GuardrailInterface;
 use Netresearch\NrLlm\Service\Guardrail\GuardrailPolicyResolver;
 use Netresearch\NrLlm\Service\Guardrail\GuardrailRegistry;
 use Netresearch\NrLlm\Service\Guardrail\StreamRedactableInterface;
+use Netresearch\NrLlm\Service\Telemetry\ProviderRetryCounter;
 use Netresearch\NrLlm\Service\Telemetry\TelemetryRecord;
 use Netresearch\NrLlm\Service\Telemetry\TelemetryRepositoryInterface;
 use Netresearch\NrLlm\Service\UsageTrackerServiceInterface;
@@ -133,6 +134,11 @@ final readonly class StreamingDispatcher
         private GuardrailPolicyResolver $policyResolver = new GuardrailPolicyResolver(new GuardrailRegistry([], [])),
         #[AutowireIterator(GuardrailInterface::TAG_NAME)]
         iterable $guardrails = [],
+        // Autowired to the shared singleton in production. The private default
+        // is an isolated counter, which is the honest answer for a hand-wired
+        // dispatcher: no adapter increments it, so it reports no retries rather
+        // than another call's (ADR-174).
+        private ProviderRetryCounter $retryCounter = new ProviderRetryCounter(),
     ) {
         // Materialise the unfiltered baseline once; drain() derives the per-call
         // live-redactor and audit lists from it via the policy resolver (ADR-106).
@@ -200,6 +206,18 @@ final readonly class StreamingDispatcher
         $served          = $configuration;
         $success         = false;
         $errorClass      = '';
+        // Retries are summed per RESUMPTION SEGMENT, not as one difference
+        // around the whole drain (ADR-174). This is a generator: between two
+        // yields the CONSUMER runs, and a provider call it makes there
+        // increments the same process-wide counter. A single before/after
+        // difference would put those retries on this stream's row. $retryMark
+        // is the counter reading at the start of the segment currently on the
+        // stack, and null while the generator is suspended — so what happens in
+        // the consumer cannot be counted here. What is counted stays complete:
+        // the opener's retries, a fallback candidate's before one primed, and
+        // every retry the inner stream consumes while it is being pulled.
+        $retriesDrained  = 0;
+        $retryMark       = $this->retryCounter->total();
 
         try {
             [$inner, $served] = $this->openWithFallback($context, $configuration, $open);
@@ -219,13 +237,17 @@ final readonly class StreamingDispatcher
 
                 if (!$window instanceof StreamRedactionWindow) {
                     // No redaction-capable guardrail: verbatim pass-through.
+                    $this->closeRetrySegment($retriesDrained, $retryMark);
                     yield $chunk;
+                    $retryMark = $this->retryCounter->total();
                     $inner->next();
                     continue;
                 }
 
                 foreach ($window->push($chunk) as $delta) {
+                    $this->closeRetrySegment($retriesDrained, $retryMark);
                     yield $delta;
+                    $retryMark = $this->retryCounter->total();
                 }
 
                 $inner->next();
@@ -234,7 +256,9 @@ final readonly class StreamingDispatcher
             // Flush the redacted remainder once the stream is complete.
             if ($window instanceof StreamRedactionWindow) {
                 foreach ($window->flush() as $delta) {
+                    $this->closeRetrySegment($retriesDrained, $retryMark);
                     yield $delta;
+                    $retryMark = $this->retryCounter->total();
                 }
             }
 
@@ -249,6 +273,13 @@ final readonly class StreamingDispatcher
 
             throw $e;
         } finally {
+            // Closes the segment that was running when the drain ended, whether
+            // it ended by completing or by throwing. A generator the consumer
+            // ABANDONS reaches here from its destructor while still suspended —
+            // the mark is null then, and the retries some later, unrelated call
+            // recorded in the meantime are correctly left out.
+            $this->closeRetrySegment($retriesDrained, $retryMark);
+
             $this->settle(
                 $context,
                 $configuration,
@@ -258,8 +289,34 @@ final readonly class StreamingDispatcher
                 $firstTokenNs,
                 $success,
                 $errorClass,
+                $retriesDrained,
             );
         }
+    }
+
+    /**
+     * Close the retry segment currently on the stack, and open no new one
+     * (ADR-174).
+     *
+     * Everything the counter recorded since the mark was taken was consumed
+     * while this drain held the stack: the opener, the inner stream's own
+     * resumptions, and anything either of them nests. A null mark means the
+     * generator is suspended in the consumer's code, where the counter belongs
+     * to whatever the consumer is doing.
+     *
+     * @param int  $drained running total of retries this drain consumed
+     * @param ?int $mark    counter reading the open segment started from, or null when suspended
+     *
+     * @param-out null $mark the segment is closed and none is opened; the next one starts at the yield
+     */
+    private function closeRetrySegment(int &$drained, ?int &$mark): void
+    {
+        if ($mark === null) {
+            return;
+        }
+
+        $drained += $this->retryCounter->total() - $mark;
+        $mark = null;
     }
 
     /**
@@ -405,6 +462,7 @@ final readonly class StreamingDispatcher
         int|float|null $firstTokenNs,
         bool $success,
         string $errorClass,
+        int $providerRetries,
     ): void {
         try {
             if (!$success && $errorClass === '') {
@@ -435,6 +493,7 @@ final readonly class StreamingDispatcher
                 $errorClass,
                 $this->elapsedMs($startNs),
                 $firstTokenNs !== null ? $this->elapsedMs($startNs, $firstTokenNs) : null,
+                $providerRetries,
             );
         } catch (Throwable $e) {
             try {
@@ -593,6 +652,7 @@ final readonly class StreamingDispatcher
         string $errorClass,
         int $latencyMs,
         ?int $timeToFirstTokenMs,
+        int $providerRetries,
     ): void {
         if (!$this->telemetryEnabled()) {
             return;
@@ -627,6 +687,16 @@ final readonly class StreamingDispatcher
             // write sites have to move together.
             routingSummary: $context->telemetrySignals->routingSummary,
             complexity: $context->telemetrySignals->complexity,
+            // Recorded on the same scratchpad before the stream opened (ADR-174).
+            requestFacts: $context->telemetrySignals->requestFacts,
+            // Deliberately NOT filled: a streamed response carries no usage
+            // block, so this path has no provider-reported token counts to
+            // record. What it does have is a char-based estimate, and writing
+            // that into a column named "actual" would be the exact confusion
+            // between an estimate and a measurement that ADR-174 exists to end.
+            // The estimate stays where it already is — the usage aggregate.
+            callUsage: null,
+            providerRetries: $providerRetries,
         ));
     }
 

--- a/Classes/Service/Streaming/StreamingDispatcher.php
+++ b/Classes/Service/Streaming/StreamingDispatcher.php
@@ -689,13 +689,12 @@ final readonly class StreamingDispatcher
             complexity: $context->telemetrySignals->complexity,
             // Recorded on the same scratchpad before the stream opened (ADR-174).
             requestFacts: $context->telemetrySignals->requestFacts,
-            // Deliberately NOT filled: a streamed response carries no usage
-            // block, so this path has no provider-reported token counts to
-            // record. What it does have is a char-based estimate, and writing
-            // that into a column named "actual" would be the exact confusion
-            // between an estimate and a measurement that ADR-174 exists to end.
-            // The estimate stays where it already is — the usage aggregate.
-            callUsage: null,
+            // callUsage is left at its null default, deliberately: a streamed
+            // response carries no usage block, so this path has no
+            // provider-reported token counts. What it does have is a char-based
+            // estimate, and writing that into a column named "actual" would be
+            // the exact confusion between an estimate and a measurement that
+            // ADR-174 exists to end. The estimate stays in the usage aggregate.
             providerRetries: $providerRetries,
         ));
     }

--- a/Classes/Service/Telemetry/ProviderRetryCounter.php
+++ b/Classes/Service/Telemetry/ProviderRetryCounter.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Telemetry;
+
+use TYPO3\CMS\Core\SingletonInterface;
+
+/**
+ * Counts the HTTP attempts a provider adapter had to repeat (ADR-174).
+ *
+ * The retry loop lives in {@see \Netresearch\NrLlm\Provider\AbstractProvider::sendRequest()},
+ * which is reached from the pipeline TERMINAL and never sees the call context —
+ * so the scratchpad on {@see \Netresearch\NrLlm\Provider\Middleware\TelemetrySignals}
+ * is out of reach from where the number is produced. A process-wide counter is
+ * the one channel both ends can hold: the adapters increment it, and the two
+ * telemetry write sites difference it around the run they record — one snapshot
+ * difference where that run is synchronous, a sum of per-segment differences
+ * where it suspends. See below; the distinction is not cosmetic.
+ *
+ * MONOTONIC, never reset. A reset would be wrong under nesting — a tool loop
+ * runs pipeline runs inside a pipeline run, and the inner one resetting would
+ * make the outer row report only the retries that happened after it. Taking a
+ * difference makes nesting count correctly at both levels: retries consumed
+ * DURING this run, inner runs included.
+ *
+ * A difference is only sound around a run that holds the stack from start to
+ * finish. PHP executes one provider call at a time, so around a SYNCHRONOUS run
+ * — the middleware pipeline {@see \Netresearch\NrLlm\Provider\Middleware\TelemetryMiddleware}
+ * wraps, which streaming does not go through — one before/after difference
+ * cannot pick up another call's retries.
+ *
+ * A GENERATOR can, and the streaming path is one:
+ * {@see \Netresearch\NrLlm\Service\Streaming\StreamingDispatcher::drain()}
+ * suspends at every yield and the consumer runs there, free to make provider
+ * calls of its own. It therefore sums a difference per resumption segment
+ * instead of taking one across the whole drain. Any future write site that
+ * suspends has to do the same; a single difference around a suspending run
+ * attributes the consumer's retries to it.
+ *
+ * @internal
+ */
+final class ProviderRetryCounter implements SingletonInterface
+{
+    private int $retries = 0;
+
+    /**
+     * Called once per attempt that is about to be REPEATED — not once per
+     * attempt. A single-attempt call that fails outright consumed no retry.
+     */
+    public function recordRetry(): void
+    {
+        ++$this->retries;
+    }
+
+    /**
+     * Retries recorded since this process started. Only differences of this
+     * value mean anything; the absolute figure is an implementation detail.
+     */
+    public function total(): int
+    {
+        return $this->retries;
+    }
+}

--- a/Classes/Service/Telemetry/TelemetryRecord.php
+++ b/Classes/Service/Telemetry/TelemetryRecord.php
@@ -9,7 +9,9 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Telemetry;
 
+use Netresearch\NrLlm\Domain\ValueObject\ProviderCallUsage;
 use Netresearch\NrLlm\Domain\ValueObject\RequestComplexity;
+use Netresearch\NrLlm\Domain\ValueObject\RequestFacts;
 use Netresearch\NrLlm\Domain\ValueObject\RoutingSummary;
 
 /**
@@ -47,6 +49,25 @@ final readonly class TelemetryRecord
      *                                                          Observation only; nothing routes on it. Null
      *                                                          on the paths that carry no measurable
      *                                                          payload.
+     * @param ?RequestFacts      $requestFacts                  what the request was BEFORE a model was
+     *                                                          chosen (ADR-174). Model-independent by
+     *                                                          construction, which is what separates it
+     *                                                          from the complexity record above. Null on
+     *                                                          the paths that form no fact set.
+     * @param ?ProviderCallUsage $callUsage                     what the provider actually reported and what
+     *                                                          it cost (ADR-174). Null wherever no provider
+     *                                                          call produced a token-shaped response: a
+     *                                                          cache hit, a failed run, a streamed run, a
+     *                                                          specialized operation.
+     * @param ?int               $providerRetries               HTTP attempts an adapter had to repeat during
+     *                                                          this run (ADR-174). Both write sites hold the
+     *                                                          counter and always pass a count, so every row
+     *                                                          this version writes carries one and a recorded
+     *                                                          0 is a measured "no retry". Nullable only so
+     *                                                          the parameter can be omitted — which no
+     *                                                          production caller does; the column is
+     *                                                          nullable because rows written before it
+     *                                                          existed have no value for it.
      */
     public function __construct(
         public string $correlationId,
@@ -66,5 +87,8 @@ final readonly class TelemetryRecord
         public ?int $timeToFirstTokenMs = null,
         public ?RoutingSummary $routingSummary = null,
         public ?RequestComplexity $complexity = null,
+        public ?RequestFacts $requestFacts = null,
+        public ?ProviderCallUsage $callUsage = null,
+        public ?int $providerRetries = null,
     ) {}
 }

--- a/Classes/Service/Telemetry/TelemetryRepository.php
+++ b/Classes/Service/Telemetry/TelemetryRepository.php
@@ -9,7 +9,9 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Service\Telemetry;
 
+use Netresearch\NrLlm\Domain\ValueObject\ProviderCallUsage;
 use Netresearch\NrLlm\Domain\ValueObject\RequestComplexity;
+use Netresearch\NrLlm\Domain\ValueObject\RequestFacts;
 use Netresearch\NrLlm\Domain\ValueObject\RoutingSummary;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -35,6 +37,9 @@ final readonly class TelemetryRepository implements TelemetryRepositoryInterface
         $this->connectionPool->getConnectionForTable(self::TABLE)->insert(self::TABLE, [
             ...$this->routingColumns($record->routingSummary),
             ...$this->complexityColumns($record->complexity),
+            ...$this->requestFactColumns($record->requestFacts),
+            ...$this->callUsageColumns($record->callUsage),
+            'provider_retries'         => $record->providerRetries,
             'pid'                      => 0,
             'correlation_id'           => $record->correlationId,
             'operation'                => $record->operation,
@@ -116,6 +121,70 @@ final readonly class TelemetryRepository implements TelemetryRepositoryInterface
             'complexity_tools'           => $complexity->toolCount,
             'complexity_context_percent' => $complexity->contextPercent,
             'complexity_shape'           => $complexity->shape,
+        ];
+    }
+
+    /**
+     * The pre-routing fact group (ADR-174). Everything here is measured in one
+     * pass or not at all, so a run that formed no fact set writes NULL across
+     * the numbers and an empty shape — the same "nothing was measured" flag the
+     * complexity group uses, and never a zero somebody could average.
+     *
+     * The operation is not among them: `operation` on the same row already
+     * names it.
+     *
+     * @return array<string, int|string|null>
+     */
+    private function requestFactColumns(?RequestFacts $facts): array
+    {
+        if (!$facts instanceof RequestFacts) {
+            return [
+                'facts_messages'       => null,
+                'facts_turns'          => null,
+                'facts_tools'          => null,
+                'facts_payload_bytes'  => null,
+                'facts_token_estimate' => null,
+                'facts_shape'          => '',
+            ];
+        }
+
+        return [
+            'facts_messages'       => $facts->messageCount,
+            'facts_turns'          => $facts->turnCount,
+            'facts_tools'          => $facts->toolCount,
+            'facts_payload_bytes'  => $facts->payloadBytes,
+            'facts_token_estimate' => $facts->tokenEstimate,
+            'facts_shape'          => $facts->shape,
+        ];
+    }
+
+    /**
+     * What the provider reported, and what it cost (ADR-174).
+     *
+     * Every figure here is nullable and stays NULL when it was not measured.
+     * That is the defect this group exists to fix: a zero-priced model used to
+     * be indistinguishable from an unpriced one, both reporting a cost of 0,
+     * and the zero-priced arm is exactly what a cheap-model experiment is
+     * about.
+     *
+     * @return array<string, float|int|string|null>
+     */
+    private function callUsageColumns(?ProviderCallUsage $usage): array
+    {
+        if (!$usage instanceof ProviderCallUsage) {
+            return [
+                'actual_input_tokens'  => null,
+                'actual_output_tokens' => null,
+                'actual_cost'          => null,
+                'response_model'       => '',
+            ];
+        }
+
+        return [
+            'actual_input_tokens'  => $usage->inputTokens,
+            'actual_output_tokens' => $usage->outputTokens,
+            'actual_cost'          => $usage->cost,
+            'response_model'       => $usage->responseModel,
         ];
     }
 

--- a/Documentation/Administration/Governance.rst
+++ b/Documentation/Administration/Governance.rst
@@ -506,9 +506,9 @@ The complexity columns are observed, not applied
 
 The same rows carry a measurement of how involved each request was: a 0-100
 structural score, the request shape (a single question, a conversation, or a
-tool-assisted transcript), the number of tool schemas on the wire, the payload
-size in bytes, the token estimate and how much of the model's context window it
-filled.
+tool-assisted transcript), the number of tool schemas the send carries, the
+payload size in bytes, the token estimate and how much of the model's context
+window it filled.
 
 **You see them for routed calls only.** The measurement is taken on every
 configuration-driven send, fixed-mode ones included, but it is stored on the
@@ -548,6 +548,92 @@ sending a measurable payload through the context fit — an embeddings
 configuration in criteria mode is the usual one. Its row has a decision to show
 and nothing to measure, so the score, the shape, the tool count and the byte
 count are absent rather than shown as zeros.
+
+.. _administration-governance-call-cost:
+
+What a call cost, and what it was before a model was chosen
+===========================================================
+
+The same rows carry two further groups that the page does not show. They are
+queried directly against ``tx_nrllm_telemetry`` (:ref:`ADR-174 <adr-174>`),
+which is why they are described here rather than pointed at on screen.
+
+**What the call consumed.** ``actual_input_tokens``, ``actual_output_tokens``,
+``actual_cost``, ``response_model`` and ``provider_retries``. The cost table
+``tx_nrllm_service_usage`` holds the same figures as a daily aggregate with no
+per-call key, so a cost there cannot be attributed to one request; these columns
+can, because they sit on the row the correlation id identifies.
+
+**What the request was, before anything chose a model.** ``facts_messages``,
+``facts_turns``, ``facts_tools``, ``facts_payload_bytes``,
+``facts_token_estimate`` and ``facts_shape``. The complexity group above is
+measured after the model is chosen and partly from it — its utilisation is a
+property of the chosen window — so it describes a decision and cannot inform
+one. This group is model-independent: no window, no price, no chosen model.
+
+The counts describe the transcript the caller sent, not the bytes that left the
+server: the configuration's system prompt is added afterwards, from options that
+only exist once a model is resolved. A system message the caller wrote is
+counted. ``complexity_payload_bytes`` and the complexity shape are measured the
+same way, before that prompt is applied — but on the *pruned* list, so on a row
+where the fit dropped turns the pre-routing byte count is the larger of the two.
+
+The two token estimates are not. ``facts_token_estimate`` is the raw estimate of
+the caller's transcript and its tool schemas. ``complexity_tokens`` is the
+context fit's figure. Three things separate them, and only the first is on every
+row:
+
+* **The calibration factor.** The fit scales its estimate by a factor that starts
+  at 1.15 and only grows toward the prompt-token counts providers report; the
+  fact group is estimated with the same estimator at 1.0. Two identical lists
+  still differ by at least fifteen percent, and ``complexity_tokens`` is the
+  larger one.
+* **Pruning**, on the rows where the fit dropped turns: ``complexity_tokens``
+  describes the bounded list, ``facts_token_estimate`` the one the caller sent.
+* **The configuration's system prompt**, on the rows whose transcript does not
+  already open with a system message. The fit charges it on top of the
+  transcript; the fact group never sees it.
+
+An injected skill block is *not* a fourth difference. On every path that writes
+both columns it is already inside the transcript by the time the fact group is
+measured, so both figures carry it. Subtract the three above before reading
+anything into the gap.
+
+**NULL means nobody measured, and is never a zero.** A model priced at zero
+records real tokens and no cost, which is what separates "this arm was free"
+from "nobody priced this arm" — the distinction any cheap-model comparison rests
+on. Token counts are NULL where the provider reported no usage block. The fact
+group is NULL across the board with ``facts_shape = ''`` on the paths that
+measure nothing, exactly as ``complexity_shape`` flags the complexity group.
+``provider_retries`` is the one column that is always written — ``0`` there is a
+measured "no retry", and rows that report NULL are the ones written before the
+column existed.
+
+A streamed run records no token counts. It carries a character-based estimate
+rather than a provider usage block, and the columns are named ``actual``.
+
+Cost per request shape over the last thirty days, for example:
+
+.. code-block:: sql
+
+   SELECT facts_shape,
+          COUNT(*)                AS calls,
+          AVG(actual_cost)        AS mean_cost,
+          SUM(actual_cost)        AS total_cost,
+          AVG(actual_input_tokens)  AS mean_in,
+          AVG(actual_output_tokens) AS mean_out
+     FROM tx_nrllm_telemetry
+    WHERE crdate >= UNIX_TIMESTAMP() - 30*86400
+      AND facts_shape <> ''
+    GROUP BY facts_shape;
+
+``AVG`` skips NULLs, so an installation running free local models reports a NULL
+mean cost for those rows instead of pulling the average toward zero. Filter on
+``actual_cost IS NOT NULL`` when you want the priced population only.
+
+**Nothing routes on any of it**, exactly as for the complexity group above. The
+criteria in :ref:`ADR-156 <adr-156>` still decide, and these columns exist so
+they can be evaluated.
 
 .. _administration-governance-no-apply:
 

--- a/Documentation/Adr/Adr156PersistTheRoutingDecisionObserveComplexity.rst
+++ b/Documentation/Adr/Adr156PersistTheRoutingDecisionObserveComplexity.rst
@@ -7,6 +7,7 @@ ADR-156: Persist the routing decision, and observe complexity without routing
 :Status: Accepted
 :Date: 2026-08-11
 :Amends: :ref:`ADR-142 <adr-142>` (both of its deferrals are lifted, one of them only halfway)
+:Amended: 2026-08-14 by :ref:`ADR-174 <adr-174>`
 :Authors: Netresearch DTT GmbH
 
 Context
@@ -141,6 +142,12 @@ over a sample of real traffic, not argued:
 
 Fail any one of them and the correct outcome is to delete the idea, not to
 weaken the criterion.
+
+The third criterion was not computable when this record was written: cost lived
+only in a daily aggregate with no per-call key. :ref:`ADR-174 <adr-174>` records
+the per-call cost and real token counts on this same row, and adds a
+model-independent fact set measured before the model is chosen. Both are
+observation only; nothing here is relaxed, and the criteria above still decide.
 
 **The score's weights are judgement, not calibration** — the same admission
 ADR-142 makes about the ranking weights. Three capped terms (conversation

--- a/Documentation/Adr/Adr174PerCallCostAndPreRoutingFacts.rst
+++ b/Documentation/Adr/Adr174PerCallCostAndPreRoutingFacts.rst
@@ -1,0 +1,304 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-174:
+
+=============================================================================
+ADR-174: Per-call cost, and request facts measured before the model is chosen
+=============================================================================
+
+:Status: Accepted
+:Date: 2026-08-14
+:Amends: :ref:`ADR-156 <adr-156>` (adds two column groups to the same row; its observer-only rule is unchanged)
+:Authors: Netresearch DTT GmbH
+
+.. _adr-174-context:
+
+Context
+=======
+
+:ref:`ADR-156 <adr-156>` wrote down three conditions that must hold before
+anything is allowed to route on complexity, and the third of them is *"real cost
+drops"*. Neither instrument that criterion needs exists.
+
+**No cost can be joined to a call.** ``tx_nrllm_telemetry`` records routing,
+success, latency and a complexity estimate per provider call.
+``routing_signal_cost`` is a ranking signal, not money, and ``complexity_tokens``
+is explicitly an estimate. The money lives in ``tx_nrllm_service_usage``, which
+is a **daily aggregate** with no ``correlation_id`` — so "median cost per
+complexity bucket" is not hard to compute, it is not computable.
+
+A second defect sits underneath. ``UsageStatistics::$estimatedCost`` is never set
+by any adapter, so cost is derived solely from the model row's pricing, and
+``Model::hasPricing()`` is false when both prices are zero. A model priced at
+zero — Ollama, Groq, anything local — therefore records a cost of ``0``, which is
+the same number an unpriced model records. That is precisely the arm any
+cheap-model experiment is about, and it is the arm the data cannot describe.
+
+**The complexity score is measured after the model is chosen, and partly from
+it.** ``resolveModel()`` runs before ``fitToContextWindow()`` on every path, and
+``measureComplexity()`` hangs off the fit. The size term of the score is
+estimated tokens against the budget of the model that was **already selected**;
+context utilisation is by definition a property of the chosen window. The
+decision path never sees the payload at all — ``decide(array $criteria,
+?RoutingPolicyMode)`` takes criteria. So the record is sound post-decision
+observability and cannot become an input to the same decision, and any adaptive
+step that would bucket requests *before* the decision rests on a data flow that
+does not exist.
+
+Decision
+========
+
+Two more column groups on the one row ADR-156 already writes, and nothing reads
+either of them inside the decision path.
+
+What the call actually consumed
+-------------------------------
+
+``UsageMiddleware`` already extracts the tokens and derives the cost for the
+daily aggregate. It now records the same three facts a second time, onto the
+:php:`TelemetrySignals` scratchpad, and ``TelemetryMiddleware`` writes them to
+the row under the correlation id the call already carries. Two writes, two
+shapes, one derivation: the aggregate is what a budget needs, the per-call copy
+is what an experiment needs, and neither is recomputed from the other.
+
+**NULL is a measurement that did not happen, and is never a zero.** This is the
+whole point of the group and the reason it is stated before the columns:
+
+- ``actual_cost`` is NULL where the serving model carries no pricing. An unpriced
+  model and a free one are different claims, and only one of them is "this call
+  cost nothing".
+- ``actual_input_tokens`` / ``actual_output_tokens`` are NULL where the provider
+  reported no usage block.
+- ``provider_retries`` is the exception and is always written: both write sites
+  hold the counter, so a recorded ``0`` is a measured "no retry" and no row from
+  this version reports NULL. The column is nullable because rows that existed
+  before it did have no value for it, and that is the only population
+  ``provider_retries IS NULL`` selects.
+
+**Telling "no usage" from "zero usage" needs a rule, because the type cannot.**
+:php:`UsageStatistics` types its three counts as plain ints, so an adapter that
+finds no ``usage`` block builds the same object as one that was told zero. The
+rule is: all three counts zero at once means nothing was reported. A call that
+reached a provider consumed prompt tokens, and a response that produced no
+output still reports its prompt count — so a ``0`` that survives the rule is a
+measurement. Widening :php:`UsageStatistics` to nullable ints would say it in the
+type instead; that is a breaking change to an ``@api`` class used on every
+response, and the rule buys the same distinction for this row without it.
+
+**The model that answered is recorded separately from the model that was
+asked for.** ``served_model`` is the configuration's model. ``response_model`` is
+what the provider named on the response, which can be a dated snapshot of the
+alias that was requested. Which one answered is the joinable fact.
+
+**A streamed run records no token counts.** It has a char-based estimate and no
+usage block, and putting an estimate in a column named ``actual`` would recreate
+the exact confusion this record exists to end. Its retries and its facts are
+recorded; its usage stays NULL.
+
+**Retries are counted through a process-wide counter, not the scratchpad.** The
+retry loop lives in ``AbstractProvider::sendRequest()``, which is reached from
+the pipeline terminal and never sees the call context. :php:`ProviderRetryCounter`
+is monotonic and is never reset: both write sites take a snapshot difference
+around the run they record. A reset would be wrong under nesting — a tool loop
+runs pipeline runs inside a pipeline run — while a difference counts correctly at
+both levels. A repeat is counted when the loop is about to send again, not at the
+attempt counter: the final failed attempt increments that and is never repeated.
+
+**A difference is only sound around a run that holds the stack throughout, and
+the streaming path does not.** :php:`TelemetryMiddleware` wraps a synchronous
+pipeline run, so one before/after difference is exact there.
+:php:`StreamingDispatcher::drain` is a generator: it suspends at every yield, the
+consumer runs in that gap, and a provider call the consumer makes there
+increments the same counter. One difference around the whole drain would put
+those retries on the stream's row. The dispatcher therefore sums a difference per
+resumption segment — opener, each pull of the inner stream, the flush — and
+counts nothing while suspended. A drain the consumer abandons closes no final
+segment, so a later unrelated call cannot be attributed to it either. The
+constraint generalises: a write site that suspends cannot use a single
+difference.
+
+What the request was, before anything chose a model
+---------------------------------------------------
+
+:php:`RequestFacts` is formed by the manager on the caller's own thread, before
+:php:`runThroughPipeline` builds a context — which is before ``resolveModel()``,
+because that runs inside the terminal. Message count, turn count, tool count,
+payload bytes, a provider-independent token estimate, request shape.
+
+**The operation is not part of the group.** ``operation`` already names it on the
+same row, and a second copy would only be a way for the two to disagree.
+
+**What is counted is the caller's transcript, not the wire.** The
+configuration's stored system prompt is prepended by ``applySystemPrompt()``
+inside the terminal, from call options built out of the resolved model — so it
+is in none of these figures, and it cannot be without moving the measurement
+past the decision the measurement exists to precede. A system message the caller
+supplied is counted. The post-fit complexity record draws the same line for its
+counts: ``complexity_payload_bytes``, ``complexity_shape`` and the turn term
+inside ``complexity_score`` are measured on ``ContextFitResult::$messages``, the
+bounded list, which the configuration's prompt has not been prepended to either
+— so the system prompt is never the difference between them. Pruning is: where
+the fit dropped turns, the post-fit record measured fewer messages than the
+pre-routing one, and every count below inherits that gap.
+
+``complexity_tokens`` is the one figure not measured that way, and comparing it
+with ``facts_token_estimate`` needs to account for it. It is
+``ContextFitResult::$estimatedTokens``: the fit's own estimate, taken over the
+list the fit settled on, with the configuration's system prompt charged on top
+(``missingSystemPromptTokens()``) and the whole sum scaled by the fit's
+calibration factor. **Three things separate the two figures, and only one of them
+is on every row.**
+
+*Calibration, always.* :php:`TranscriptEstimator` scales its result by
+``max(1.0, $calibration)``. The collector passes ``1.0``; the fit passes a factor
+that starts at ``ContextWindowManager::CALIBRATION_SEED`` — 1.15 — and only ever
+grows from there. Two identical lists therefore still differ by at least fifteen
+percent, with the fit's figure the larger one.
+
+*Pruning, when the fit dropped turns.* ``complexity_tokens`` describes the
+bounded list, ``facts_token_estimate`` the list the caller handed over.
+
+*The configuration's system prompt, when the transcript does not already open
+with one.* ``missingSystemPromptTokens()`` returns 0 when ``$messages[0]`` is a
+system message, and 0 again when the effective prompt is empty
+(``ContextWindowManager.php:231``); otherwise it charges that prompt — per-call
+override and composed snippets included. On a configuration without a system
+prompt this difference is therefore absent. Neither figure holds that prompt as text; it is a
+charge the fit adds beside its transcript estimate, which is why it moves this
+one figure and none of the counts.
+
+**The skill block is not a fourth difference, and it is named here because the
+code reads as though it were.** ``injectedTokens()`` does charge it, but the two
+fits whose results become ``complexity_tokens`` — the ones in
+:php:`LlmServiceManager::fitToContextWindow()` and
+:php:`LlmServiceManager::reportPromptOverflow()`, between them the only callers
+of ``recordComplexity()`` — both pass ``$injectedText`` as ``''``. The one caller
+that passes a real block, :php:`ConversationService`, records no complexity from
+its fit. And where a block is injected at all, :php:`SkillInjectionService`
+prepends it into the transcript at the public entry point, before
+``collectRequestFacts()`` runs — so both figures carry it as text already.
+:ref:`ADR-151 <adr-151>` records the same emptiness from the readout side, for
+the agent loop.
+
+The counts beside the two token figures are the closest pair, with the same
+pruning caveat: on a row where the fit dropped turns,
+``facts_payload_bytes`` exceeds ``complexity_payload_bytes``.
+
+**What is deliberately excluded is the load-bearing half of the design**:
+context utilisation, the chosen model, its window, its price. Every one of them
+is a property of a decision that has not been taken, and admitting any one would
+recreate the circularity. :php:`RequestFactsCollector` is built so that this is
+structural rather than a promise — it takes messages and tool schemas, and its
+only two collaborators are a transcript reader and a token estimator, neither of
+which can name a model. A test asserts that constructor rather than the numbers,
+because a later collaborator would leave every recorded figure looking correct.
+
+**The token estimate is the same estimator the context fit uses, uncalibrated.**
+:php:`TranscriptEstimator` needs no model and no budget. The calibration factor
+is grown from a model's real prompt-token counts, so it is exactly the part that
+would make the figure model-dependent, and it is passed as ``1.0``. Using the
+same estimator is what makes ``facts_token_estimate`` comparable with
+``complexity_tokens`` at all; the three things that separate the two figures are
+named above, calibration among them.
+
+**One reader of a transcript, not two.** "A turn", "tool traffic" and the byte
+count are defined once, in :php:`MessageInspector`, and both the pre-routing and
+the post-fit measurement read through it. The two records sit on one row in order
+to be compared; a second, subtly different definition would break the comparison
+without breaking either caller's own tests.
+
+**The post-fit complexity record stays exactly as it is.** It answers a different
+question — how full the chosen window was — and both are worth having.
+
+The paths that form no fact set
+-------------------------------
+
+The four configuration-driven sends form one: chat, completion, tools, stream.
+Nothing else does — the provider-pinned entry points, embeddings, and every
+specialized service, image, speech and translation alike. Translation belongs in
+that list and is easy to leave out of it: ``DeepLTranslator`` extends
+``AbstractSpecializedService``, whose ``dispatch()`` runs
+``ProviderOperation::Translation`` through the same pipeline, so a DeepL call
+writes a telemetry row like any other and that row's fact group is empty. The
+boundary is the one the complexity measurement already has, for the same reason:
+these paths carry no transcript the collector can read, or they are not on a path
+that measures one. ``facts_shape`` is ``''`` there and the five numbers are NULL,
+which is the flag a reader checks before averaging anything.
+
+What this does NOT do
+=====================
+
+**Nothing routes on any of it.** There is no new signal in
+:php:`CandidateRanker`, no weight in :php:`RoutingPolicyMode`, no predicate in
+:php:`EligibilityEvaluator`, and no opt-in that would add one. ADR-156 keeps its
+observer-only status and its three activation criteria unchanged; this record
+supplies the evidence those criteria need rather than pre-empting them. The
+criteria are what decides, and they have not been evaluated yet.
+
+**No new reader in the backend.** The Governance tab shows the routing and
+complexity groups; these two are queried in SQL, like the rest of a table that
+has no TCA and no UI by design. The consumer named in ADR-156 is the evaluation
+of its own activation criteria, and that evaluation is a query, not a page. A
+readout can be added when there is a result worth showing; adding one before
+there is any data would be a page that renders NULLs.
+
+**No new index.** The analyses these columns exist for filter by ``crdate``,
+which is indexed, and group in memory afterwards. An index chosen before a query
+exists is a guess.
+
+**No estimate in a column named "actual".** See the streaming case above.
+
+**No retention change.** The new columns live inside the existing row and are
+purged with it by ``nrllm:telemetry:purge``.
+
+**No prompt, no response.** Everything added is a count, a size, a price, an enum
+name or a model id. The row's prompt-freedom stays structural: neither new DTO
+has a field that could hold content.
+
+Consequences
+============
+
+✓ "What did this request cost, and what shape was it" is one row and one join
+key. Cost per complexity bucket, per shape, per policy mode and per served model
+are all ``GROUP BY`` over ``tx_nrllm_telemetry``.
+
+✓ ADR-156's third activation criterion becomes computable, which is the only
+thing standing between the complexity question and an answer.
+
+✓ A zero-priced model now reports real tokens and no cost. The cheap-model arm
+is describable for the first time.
+
+✓ A request can be characterised without reference to the model that answered
+it, which is the prerequisite for bucketing requests before a decision — should
+the criteria ever be met.
+
+◐ Eleven more columns on a high-volume table, all scalars, most of them NULL on
+any given row. The row was already the widest thing this extension writes per
+request.
+
+◐ Two writes of the same tokens, to the aggregate and to the row. They are
+derived once and written twice, so they cannot disagree, but the aggregate stays
+the billing ledger and this stays observability — merging them would make one
+table answer two questions badly.
+
+✕ "All three counts zero means nothing was reported" is a rule, not a type. A
+provider that genuinely reports a zero-prompt call would be recorded as
+unmeasured. No provider does; if one appears, the fix is the nullable
+:php:`UsageStatistics`, with the deprecation that implies.
+
+✕ Streamed runs stay a hole in the cost data. They have no usage block to read,
+and the honest column is empty rather than approximate.
+
+✕ The figures are recorded and nobody has looked at them yet. Whether the
+pre-routing facts predict anything about the decision is exactly the open
+question; this record only makes it askable.
+
+Revisit when
+============
+
+ADR-156's three activation criteria have been evaluated against a real sample —
+whichever way they come out. That evaluation is now a query rather than a
+project, and its result belongs in ADR-156, not here.
+
+Also revisit if a provider is found that reports a genuine zero-token call, or if
+streamed responses start carrying a usage block.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -524,3 +524,4 @@ Tools
    Adr170OneDeadlinePerMcpOperation
    Adr171PersonasTheCodeAlreadyAssumes
    Adr172FourEyesApprovalPerConfiguration
+   Adr174PerCallCostAndPreRoutingFacts

--- a/Tests/Functional/DependencyInjection/RetryCounterWiringTest.php
+++ b/Tests/Functional/DependencyInjection/RetryCounterWiringTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\DependencyInjection;
+
+use Netresearch\NrLlm\Provider\Middleware\TelemetryMiddleware;
+use Netresearch\NrLlm\Provider\ProviderAdapterRegistry;
+use Netresearch\NrLlm\Service\Streaming\StreamingDispatcher;
+use Netresearch\NrLlm\Service\Telemetry\ProviderRetryCounter;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionProperty;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Pins the production wiring of the retry counter (ADR-174).
+ *
+ * ``provider_retries`` is a difference of a shared tally: the adapters
+ * increment it and the two telemetry write sites difference it. That only
+ * measures anything if all three constructors receive the SAME instance, and
+ * every one of the three arguments is optional with a private fallback —
+ * {@see ProviderAdapterRegistry} takes ``?ProviderRetryCounter $retryCounter =
+ * null`` behind a non-autowirable ``array $adapterOverrides = []``, while the
+ * two write sites default to a fresh ``new ProviderRetryCounter()``. Those
+ * defaults are deliberate (a hand-constructed object reports no retries rather
+ * than failing to build), and they are also what makes the failure silent: any
+ * ``arguments:`` entry in Services.yaml or a constructor reorder would leave
+ * the registry's counter null and the middleware's isolated, and every
+ * non-streamed row would then report a measured ``0`` with no test failing.
+ *
+ * Reflection rather than behaviour, because the identity IS the contract: two
+ * counters give the same answer as one for every call that never retries, so
+ * an end-to-end assertion would pass on the broken wiring.
+ *
+ * Extends {@see FunctionalTestCase} directly rather than the project base,
+ * whose setUp() turns a container-compile failure into a skipped test — same
+ * rationale and the same scoped HashService suppression as
+ * {@see ToolLoopGateWiringTest}.
+ */
+final class RetryCounterWiringTest extends FunctionalTestCase
+{
+    /** @var non-empty-string[] */
+    protected array $testExtensionsToLoad = [
+        'netresearch/nr-vault',
+        'netresearch/nr-llm',
+    ];
+
+    /** @var non-empty-string[] */
+    protected array $coreExtensionsToLoad = [
+        'extbase',
+        'fluid',
+    ];
+
+    protected function setUp(): void
+    {
+        set_error_handler(
+            static fn(int $errno, string $errstr, string $errfile): bool => str_contains($errfile, 'Crypto/HashService.php')
+                && (str_contains($errstr, 'TYPO3_CONF_VARS') || str_contains($errstr, 'array offset')),
+            \E_WARNING,
+        );
+
+        try {
+            parent::setUp();
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    #[Test]
+    public function theCounterIsASingletonInTheContainer(): void
+    {
+        self::assertSame(
+            $this->get(ProviderRetryCounter::class),
+            $this->get(ProviderRetryCounter::class),
+        );
+    }
+
+    /**
+     * The producer and both consumers hold one tally. Named individually so a
+     * failure says WHICH of the three drifted.
+     */
+    #[Test]
+    public function theAdapterRegistryReceivesTheSharedCounter(): void
+    {
+        self::assertSame($this->sharedCounter(), $this->counterOf($this->get(ProviderAdapterRegistry::class)));
+    }
+
+    #[Test]
+    public function theTelemetryMiddlewareReceivesTheSharedCounter(): void
+    {
+        self::assertSame($this->sharedCounter(), $this->counterOf($this->get(TelemetryMiddleware::class)));
+    }
+
+    #[Test]
+    public function theStreamingDispatcherReceivesTheSharedCounter(): void
+    {
+        self::assertSame($this->sharedCounter(), $this->counterOf($this->get(StreamingDispatcher::class)));
+    }
+
+    private function sharedCounter(): ProviderRetryCounter
+    {
+        $counter = $this->get(ProviderRetryCounter::class);
+        self::assertInstanceOf(ProviderRetryCounter::class, $counter);
+
+        return $counter;
+    }
+
+    /**
+     * The `retryCounter` a wired service actually holds. A null there is the
+     * failure this test exists for — the registry's argument is nullable, so a
+     * wiring that never supplied one compiles and then measures nothing; the
+     * assertion below is what turns that into a red test, which is why this
+     * returns a non-nullable type.
+     */
+    private function counterOf(object $service): ProviderRetryCounter
+    {
+        $property = new ReflectionProperty($service, 'retryCounter');
+        $value    = $property->getValue($service);
+
+        self::assertInstanceOf(
+            ProviderRetryCounter::class,
+            $value,
+            sprintf('%s was built without a retry counter; its rows would report a measured 0.', $service::class),
+        );
+
+        return $value;
+    }
+}

--- a/Tests/Functional/Service/Telemetry/CallCostTelemetryTest.php
+++ b/Tests/Functional/Service/Telemetry/CallCostTelemetryTest.php
@@ -1,0 +1,266 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Telemetry;
+
+use Netresearch\NrLlm\Domain\Enum\RequestShape;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\ProviderCallUsage;
+use Netresearch\NrLlm\Domain\ValueObject\RequestFacts;
+use Netresearch\NrLlm\Service\Complexity\RequestFactsCollector;
+use Netresearch\NrLlm\Service\Telemetry\TelemetryRecord;
+use Netresearch\NrLlm\Service\Telemetry\TelemetryRepository;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * The per-call cost and the pre-routing fact set, written and read back
+ * (ADR-174; issues #770 and #771).
+ *
+ * The assertions that matter are the NULL ones. Every figure here has a zero
+ * that means something else — 0 tokens, a cost of 0, 0 messages — and the whole
+ * value of the columns depends on those zeros never being written where nothing
+ * was measured. A round trip through the real schema is the only place that can
+ * be proven: the column defaults, not the PHP, are what would turn a null into
+ * a zero.
+ */
+#[CoversClass(TelemetryRepository::class)]
+final class CallCostTelemetryTest extends AbstractFunctionalTestCase
+{
+    private const TABLE = 'tx_nrllm_telemetry';
+
+    private TelemetryRepository $repository;
+
+    private ConnectionPool $connectionPool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $this->connectionPool = $connectionPool;
+
+        // Private in the container by design; instantiate it directly with the
+        // real ConnectionPool, as the sibling telemetry tests do.
+        $this->repository = new TelemetryRepository($this->connectionPool);
+    }
+
+    #[Test]
+    public function aPricedCallStoresItsRealTokensCostAndServingModel(): void
+    {
+        $this->repository->record($this->record(
+            'corr-priced',
+            new ProviderCallUsage(1000, 500, 0.00750000, 'gpt-4o-2024-08-06'),
+            2,
+        ));
+
+        $row = $this->row('corr-priced');
+
+        self::assertSame(1000, (int)$row['actual_input_tokens']);
+        self::assertSame(500, (int)$row['actual_output_tokens']);
+        self::assertIsNumeric($row['actual_cost']);
+        self::assertSame(0.0075, (float)$row['actual_cost']);
+        self::assertSame('gpt-4o-2024-08-06', $row['response_model']);
+        self::assertSame(2, (int)$row['provider_retries']);
+    }
+
+    /**
+     * The defect issue #770 names. A model priced at zero produces real tokens
+     * and NO cost — and the row has to keep those apart, because "this arm was
+     * free" and "nobody priced this arm" are the two readings a cheap-model
+     * experiment has to distinguish.
+     */
+    #[Test]
+    public function anUnpricedModelStoresRealTokensAndANullCost(): void
+    {
+        $this->repository->record($this->record(
+            'corr-unpriced',
+            new ProviderCallUsage(1200, 340, null, 'qwen3:4b'),
+            0,
+        ));
+
+        $row = $this->row('corr-unpriced');
+
+        self::assertSame(1200, (int)$row['actual_input_tokens']);
+        self::assertSame(340, (int)$row['actual_output_tokens']);
+        self::assertNull($row['actual_cost'], 'A model with no pricing has no cost; 0 would read as free.');
+        self::assertSame(0, (int)$row['provider_retries'], 'Zero retries is a measurement, not an absence.');
+    }
+
+    #[Test]
+    public function aProviderThatReportedNoUsageStoresNullTokens(): void
+    {
+        $this->repository->record($this->record(
+            'corr-no-usage',
+            new ProviderCallUsage(null, null, null, ''),
+            0,
+        ));
+
+        $row = $this->row('corr-no-usage');
+
+        self::assertNull($row['actual_input_tokens']);
+        self::assertNull($row['actual_output_tokens']);
+        self::assertNull($row['actual_cost']);
+        self::assertSame('', $row['response_model']);
+    }
+
+    /**
+     * A cache hit, a failed run and a streamed run all reach the writer with no
+     * usage at all. None of them spent a token, and none of them measured zero.
+     *
+     * The `provider_retries` assertion below is about the COLUMN, not about any
+     * writer: no production caller omits the count, so the NULL asserted here is
+     * the state rows written before the column existed carry. That both write
+     * sites really do always pass one is asserted where it can be —
+     * {@see \Netresearch\NrLlm\Tests\Unit\Provider\Middleware\TelemetryMiddlewareTest::everyRowCarriesAMeasuredRetryCountAndNeverNull()}
+     * for the pipeline and the retry tests in
+     * {@see \Netresearch\NrLlm\Tests\Unit\Service\Streaming\StreamingDispatcherTest}
+     * for the stream.
+     */
+    #[Test]
+    public function aRunWithNoProviderCallStoresNullsAcrossTheCostGroup(): void
+    {
+        $this->repository->record($this->record('corr-nothing', null, null));
+
+        $row = $this->row('corr-nothing');
+
+        self::assertNull($row['actual_input_tokens']);
+        self::assertNull($row['actual_output_tokens']);
+        self::assertNull($row['actual_cost']);
+        self::assertSame('', $row['response_model']);
+        self::assertNull($row['provider_retries'], 'A record built without a count writes NULL, as rows older than the column carry.');
+    }
+
+    #[Test]
+    public function theRequestFactsRoundTripAsMeasured(): void
+    {
+        $this->repository->record($this->record(
+            'corr-facts',
+            null,
+            null,
+            new RequestFacts(4, 3, 2, 4096, 1180, RequestShape::TOOL_ASSISTED->value),
+        ));
+
+        $row = $this->row('corr-facts');
+
+        self::assertSame(4, (int)$row['facts_messages']);
+        self::assertSame(3, (int)$row['facts_turns']);
+        self::assertSame(2, (int)$row['facts_tools']);
+        self::assertSame(4096, (int)$row['facts_payload_bytes']);
+        self::assertSame(1180, (int)$row['facts_token_estimate']);
+        self::assertSame('toolAssisted', $row['facts_shape']);
+    }
+
+    /**
+     * The empty shape is the "nothing was measured" flag, exactly as
+     * complexity_shape is (ADR-156) — and the numbers beside it are NULL rather
+     * than 0, so a reader that averages them cannot silently include the runs
+     * that measured nothing.
+     */
+    #[Test]
+    public function anUnmeasuredRequestStoresNullsAndAnEmptyShape(): void
+    {
+        $this->repository->record($this->record('corr-no-facts', null, null));
+
+        $row = $this->row('corr-no-facts');
+
+        self::assertNull($row['facts_messages']);
+        self::assertNull($row['facts_turns']);
+        self::assertNull($row['facts_tools']);
+        self::assertNull($row['facts_payload_bytes']);
+        self::assertNull($row['facts_token_estimate']);
+        self::assertSame('', $row['facts_shape']);
+    }
+
+    /**
+     * The row stays prompt-free: everything written is a count, a size, a price
+     * or a model id.
+     *
+     * The fact set here is built by the PRODUCTION collector from a transcript
+     * whose words would be recognisable if any of them survived, so a field
+     * that started carrying content would carry it into the row. And every
+     * column of the written row is checked rather than a list of names, so a
+     * column added later is covered by the same assertion.
+     */
+    #[Test]
+    public function noColumnOfTheWrittenRowCarriesAFragmentOfTheRequest(): void
+    {
+        $facts = (new RequestFactsCollector())->collect(
+            [
+                ChatMessage::system('You are Wilkins, and you answer tersely.'),
+                ChatMessage::user('Ask Wilkins about the quarterly figures for Sandhurst.'),
+            ],
+            [['type' => 'function', 'function' => ['name' => 'read_sandhurst_ledger', 'parameters' => []]]],
+        );
+
+        $this->repository->record($this->record(
+            'corr-privacy',
+            new ProviderCallUsage(10, 5, 0.1, 'gpt-4o'),
+            0,
+            $facts,
+        ));
+
+        $row = $this->row('corr-privacy');
+
+        foreach ($row as $column => $value) {
+            foreach (['Wilkins', 'quarterly', 'Sandhurst', 'read_sandhurst_ledger', 'tersely'] as $fragment) {
+                self::assertStringNotContainsString(
+                    $fragment,
+                    is_scalar($value) ? (string)$value : '',
+                    sprintf('Column %s must never carry request content (%s).', $column, $fragment),
+                );
+            }
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function row(string $correlationId): array
+    {
+        $row = $this->connectionPool
+            ->getConnectionForTable(self::TABLE)
+            ->select(['*'], self::TABLE, ['correlation_id' => $correlationId])
+            ->fetchAssociative();
+
+        self::assertIsArray($row);
+
+        return $row;
+    }
+
+    private function record(
+        string $correlationId,
+        ?ProviderCallUsage $usage,
+        ?int $retries,
+        ?RequestFacts $facts = null,
+    ): TelemetryRecord {
+        return new TelemetryRecord(
+            correlationId: $correlationId,
+            operation: 'chat',
+            provider: 'openai',
+            model: 'gpt-4o',
+            configurationIdentifier: 'primary',
+            beUser: 1,
+            success: true,
+            errorClass: '',
+            latencyMs: 100,
+            cacheHit: false,
+            fallbackAttempts: 0,
+            servedConfigurationIdentifier: 'primary',
+            servedProvider: 'openai',
+            servedModel: 'gpt-4o',
+            requestFacts: $facts,
+            callUsage: $usage,
+            providerRetries: $retries,
+        );
+    }
+}

--- a/Tests/Unit/Api/api-surface.txt
+++ b/Tests/Unit/Api/api-surface.txt
@@ -831,6 +831,13 @@ Netresearch\NrLlm\Domain\ValueObject\InjectedContext (class)
   property readonly skills: array
   property readonly snippets: array
 
+Netresearch\NrLlm\Domain\ValueObject\ProviderCallUsage (class)
+  constructor(?int $inputTokens, ?int $outputTokens, ?float $cost, string $responseModel)
+  property readonly cost: ?float
+  property readonly inputTokens: ?int
+  property readonly outputTokens: ?int
+  property readonly responseModel: string
+
 Netresearch\NrLlm\Domain\ValueObject\RequestComplexity (class)
   constructor(int $score, int $payloadBytes, ?int $tokenEstimate, int $toolCount, ?int $contextPercent, string $shape)
   property readonly contextPercent: ?int
@@ -839,6 +846,15 @@ Netresearch\NrLlm\Domain\ValueObject\RequestComplexity (class)
   property readonly shape: string
   property readonly tokenEstimate: ?int
   property readonly toolCount: int
+
+Netresearch\NrLlm\Domain\ValueObject\RequestFacts (class)
+  constructor(int $messageCount, int $turnCount, int $toolCount, int $payloadBytes, int $tokenEstimate, string $shape)
+  property readonly messageCount: int
+  property readonly payloadBytes: int
+  property readonly shape: string
+  property readonly tokenEstimate: int
+  property readonly toolCount: int
+  property readonly turnCount: int
 
 Netresearch\NrLlm\Domain\ValueObject\RoutingSummary (class)
   constructor(string $policyMode, int $candidateCount, array $rejectionReasons, bool $qualitySignalUsed, bool $healthSignalUsed, bool $costSignalUsed)
@@ -1063,13 +1079,17 @@ Netresearch\NrLlm\Provider\Middleware\ProviderOperation (enum)
 
 Netresearch\NrLlm\Provider\Middleware\TelemetrySignals (class)
   method recordCacheHit(): void
+  method recordCallUsage(Netresearch\NrLlm\Domain\ValueObject\ProviderCallUsage $usage): void
   method recordComplexity(Netresearch\NrLlm\Domain\ValueObject\RequestComplexity $complexity): void
   method recordFallbackAttempt(): void
+  method recordRequestFacts(Netresearch\NrLlm\Domain\ValueObject\RequestFacts $facts): void
   method recordRoutingSummary(?Netresearch\NrLlm\Domain\ValueObject\RoutingSummary $summary): void
   method recordServedBy(Netresearch\NrLlm\Domain\Model\LlmConfiguration $configuration): void
   property cacheHit: bool
+  property callUsage: ?Netresearch\NrLlm\Domain\ValueObject\ProviderCallUsage
   property complexity: ?Netresearch\NrLlm\Domain\ValueObject\RequestComplexity
   property fallbackAttempts: int
+  property requestFacts: ?Netresearch\NrLlm\Domain\ValueObject\RequestFacts
   property routingSummary: ?Netresearch\NrLlm\Domain\ValueObject\RoutingSummary
   property servedConfigurationIdentifier: ?string
   property servedModel: ?string
@@ -1093,7 +1113,7 @@ Netresearch\NrLlm\Provider\Middleware\Usage\UsageMetricsExtractorInterface (inte
   method supports(Netresearch\NrLlm\Provider\Middleware\ProviderCallContext $context): bool
 
 Netresearch\NrLlm\Provider\ProviderAdapterRegistry (class)
-  constructor(Psr\Http\Message\RequestFactoryInterface $requestFactory, Psr\Http\Message\StreamFactoryInterface $streamFactory, Psr\Log\LoggerInterface $logger, Netresearch\NrVault\Service\VaultServiceInterface $vault, Netresearch\NrVault\Http\SecureHttpClientFactory $httpClientFactory, array $adapterOverrides = …)
+  constructor(Psr\Http\Message\RequestFactoryInterface $requestFactory, Psr\Http\Message\StreamFactoryInterface $streamFactory, Psr\Log\LoggerInterface $logger, Netresearch\NrVault\Service\VaultServiceInterface $vault, Netresearch\NrVault\Http\SecureHttpClientFactory $httpClientFactory, array $adapterOverrides = …, ?Netresearch\NrLlm\Service\Telemetry\ProviderRetryCounter $retryCounter = …)
   method clearCache(?int $providerUid = …): void
   method createAdapterFromModel(Netresearch\NrLlm\Domain\Model\Model $model, bool $useCache = …): Netresearch\NrLlm\Provider\Contract\ProviderInterface
   method createAdapterFromProvider(Netresearch\NrLlm\Domain\Model\Provider $provider, bool $useCache = …): Netresearch\NrLlm\Provider\Contract\ProviderInterface

--- a/Tests/Unit/Provider/AbstractProviderTest.php
+++ b/Tests/Unit/Provider/AbstractProviderTest.php
@@ -24,6 +24,7 @@ use Netresearch\NrLlm\Provider\GeminiProvider;
 use Netresearch\NrLlm\Provider\GroqProvider;
 use Netresearch\NrLlm\Provider\MistralProvider;
 use Netresearch\NrLlm\Provider\OpenAiProvider;
+use Netresearch\NrLlm\Service\Telemetry\ProviderRetryCounter;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrVault\Http\SecretPlacement;
 use Netresearch\NrVault\Http\VaultHttpClientInterface;
@@ -984,6 +985,89 @@ class AbstractProviderTest extends AbstractUnitTestCase
             self::assertStringNotContainsString('Unknown error', $e->getMessage());
             self::assertSame($underlying, $e->getPrevious());
         }
+    }
+
+    /**
+     * The retry counter records REPEATS, not attempts (ADR-174).
+     *
+     * `maxRetries = 2` sends three requests; two of them are repeats. Counting
+     * per attempt would report three, and counting at the `$attempt++` inside
+     * the catch would report three as well — the last increment happens on the
+     * attempt that then falls out of the loop and is never repeated. The
+     * difference matters because the figure lands in a telemetry column an
+     * operator reads as "how often did we have to try again".
+     */
+    #[Test]
+    public function theRetryCounterCountsRepeatedAttemptsAndNotTheFinalFailedOne(): void
+    {
+        $counter  = new ProviderRetryCounter();
+        $provider = new MistralProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+            $counter,
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel'     => 'mistral-large-latest',
+            'maxRetries'       => 2,
+            // The send loop treats an attempt that consumed the timeout as a
+            // client-side timeout and refuses to retry it. A generous timeout
+            // keeps this test on the retry path.
+            'timeout'          => 3600,
+        ]);
+
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects(self::exactly(3))
+            ->method('sendRequest')
+            ->willThrowException(new RuntimeException('socket reset'));
+        $provider->setHttpClient($client);
+
+        try {
+            $provider->complete('hi');
+            self::fail('Expected ProviderConnectionException was not thrown');
+        } catch (ProviderConnectionException) {
+            // The row this test is about is written from the counter, not from
+            // the exception.
+        }
+
+        self::assertSame(2, $counter->total(), 'Three attempts, two of them repeats.');
+    }
+
+    /**
+     * A call that succeeds first time consumed no retry — and 0 has to be a
+     * measured zero, because the telemetry column distinguishes it from "not
+     * observed" (NULL).
+     */
+    #[Test]
+    public function aCallThatNeverRepeatsLeavesTheRetryCounterAtZero(): void
+    {
+        $counter  = new ProviderRetryCounter();
+        $provider = new MistralProvider(
+            $this->createRequestFactoryMock(),
+            $this->createStreamFactoryMock(),
+            $this->createLoggerMock(),
+            $this->createVaultServiceMock(),
+            $this->createSecureHttpClientFactoryMock(),
+            $counter,
+        );
+        $provider->configure([
+            'apiKeyIdentifier' => $this->randomApiKey(),
+            'defaultModel'     => 'mistral-large-latest',
+        ]);
+        $client = $this->createHttpClientMock();
+        $client->method('sendRequest')->willReturn($this->createJsonResponseMock([
+            'choices' => [['message' => ['content' => 'hi'], 'finish_reason' => 'stop']],
+            'model'   => 'mistral-large-latest',
+            'usage'   => ['prompt_tokens' => 3, 'completion_tokens' => 1, 'total_tokens' => 4],
+        ]));
+        $provider->setHttpClient($client);
+
+        $provider->complete('hi');
+
+        self::assertSame(0, $counter->total());
     }
 
     /**

--- a/Tests/Unit/Provider/Middleware/TelemetryMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/TelemetryMiddlewareTest.php
@@ -17,6 +17,7 @@ use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
 use Netresearch\NrLlm\Provider\Middleware\TelemetryMiddleware;
+use Netresearch\NrLlm\Service\Telemetry\ProviderRetryCounter;
 use Netresearch\NrLlm\Service\Telemetry\TelemetryRecord;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrLlm\Tests\Unit\Fixture\InMemoryTelemetryRepository;
@@ -349,6 +350,139 @@ final class TelemetryMiddlewareTest extends AbstractUnitTestCase
         self::assertSame(0, $repository->records[0]->beUser);
     }
 
+    /**
+     * ADR-174 states that ``provider_retries`` is ALWAYS written, that a stored
+     * ``0`` is therefore a measured "no retry", and that the only rows reporting
+     * NULL are the ones written before the column existed. The streaming write
+     * site had tests for its half; this one had none, so the claim rested on
+     * reading the code — and a middleware that stopped passing the count would
+     * write NULL on every non-streamed call with nothing failing.
+     */
+    #[Test]
+    public function everyRowCarriesAMeasuredRetryCountAndNeverNull(): void
+    {
+        $repository = $this->recordingRepository();
+        $counter    = new ProviderRetryCounter();
+
+        $this->pipeline($repository, retryCounter: $counter)->run(
+            (new ProviderCallContext(ProviderOperation::Chat, 'corr-no-retry'))
+                ->withConfiguration($this->configuration('primary')),
+            static fn(): string => 'answer',
+        );
+
+        self::assertCount(1, $repository->records);
+        self::assertNotNull($repository->records[0]->providerRetries, 'NULL here would read as "rows older than the column".');
+        self::assertSame(0, $repository->records[0]->providerRetries);
+    }
+
+    /**
+     * The row counts what THIS run consumed, which is why the write site takes
+     * a difference rather than reading the total: the counter is process-wide
+     * and monotonic, so whatever an earlier call left on it belongs to that
+     * call's row.
+     */
+    #[Test]
+    public function theRowCountsOnlyTheRetriesConsumedDuringItsOwnRun(): void
+    {
+        $repository = $this->recordingRepository();
+        $counter    = new ProviderRetryCounter();
+
+        // An earlier, unrelated call in the same process.
+        $counter->recordRetry();
+        $counter->recordRetry();
+        $counter->recordRetry();
+
+        $this->pipeline($repository, retryCounter: $counter)->run(
+            (new ProviderCallContext(ProviderOperation::Chat, 'corr-retries'))
+                ->withConfiguration($this->configuration('primary')),
+            static function () use ($counter): string {
+                $counter->recordRetry();
+                $counter->recordRetry();
+
+                return 'answer';
+            },
+        );
+
+        self::assertSame(2, $repository->records[0]->providerRetries);
+        self::assertSame(5, $counter->total(), 'The counter itself is monotonic and never reset.');
+    }
+
+    /**
+     * The nesting case the monotonic counter exists for: a tool loop runs
+     * pipeline runs inside a pipeline run. A reset by the inner one would make
+     * the outer row report only what happened after it finished; a difference
+     * counts correctly at both levels, and the outer row deliberately INCLUDES
+     * the inner one's retries because they were consumed during it.
+     */
+    #[Test]
+    public function anInnerRunCountsItsOwnRetriesAndTheOuterRunCountsThemToo(): void
+    {
+        $repository    = $this->recordingRepository();
+        $counter       = new ProviderRetryCounter();
+        $pipeline      = $this->pipeline($repository, retryCounter: $counter);
+        $configuration = $this->configuration('primary');
+
+        $pipeline->run(
+            (new ProviderCallContext(ProviderOperation::Chat, 'corr-outer'))
+                ->withConfiguration($configuration),
+            static function () use ($counter, $pipeline, $configuration): string {
+                $counter->recordRetry();
+
+                $pipeline->run(
+                    (new ProviderCallContext(ProviderOperation::Chat, 'corr-inner'))
+                        ->withConfiguration($configuration),
+                    static function () use ($counter): string {
+                        $counter->recordRetry();
+                        $counter->recordRetry();
+
+                        return 'inner';
+                    },
+                );
+
+                return 'outer';
+            },
+        );
+
+        $byCorrelation = [];
+        foreach ($repository->records as $record) {
+            $byCorrelation[$record->correlationId] = $record->providerRetries;
+        }
+
+        self::assertSame(2, $byCorrelation['corr-inner']);
+        self::assertSame(3, $byCorrelation['corr-outer'], 'The inner run happened DURING the outer one.');
+    }
+
+    /**
+     * A failed run is still a measured run: the count is taken in the finally,
+     * so the retries that were consumed before the exception are on the row
+     * rather than lost with it.
+     */
+    #[Test]
+    public function aFailedRunStillRecordsTheRetriesItConsumed(): void
+    {
+        $repository = $this->recordingRepository();
+        $counter    = new ProviderRetryCounter();
+
+        try {
+            $this->pipeline($repository, retryCounter: $counter)->run(
+                (new ProviderCallContext(ProviderOperation::Chat, 'corr-failed'))
+                    ->withConfiguration($this->configuration('primary')),
+                static function () use ($counter): string {
+                    $counter->recordRetry();
+                    $counter->recordRetry();
+
+                    throw new RuntimeException('exhausted', 1755100000);
+                },
+            );
+        } catch (RuntimeException) {
+            // The row is what this test is about; the exception propagating is
+            // asserted elsewhere.
+        }
+
+        self::assertFalse($repository->records[0]->success);
+        self::assertSame(2, $repository->records[0]->providerRetries);
+    }
+
     // -----------------------------------------------------------------------
     // Test helpers
     // -----------------------------------------------------------------------
@@ -362,13 +496,17 @@ final class TelemetryMiddlewareTest extends AbstractUnitTestCase
         return new InMemoryTelemetryRepository();
     }
 
-    private function pipeline(InMemoryTelemetryRepository $repository, bool $enabled = true): MiddlewarePipeline
-    {
+    private function pipeline(
+        InMemoryTelemetryRepository $repository,
+        bool $enabled = true,
+        ?ProviderRetryCounter $retryCounter = null,
+    ): MiddlewarePipeline {
         $middleware = new TelemetryMiddleware(
             $repository,
             $this->contextWithAmbientUser(0),
             $this->extensionConfiguration($enabled),
             new NullLogger(),
+            $retryCounter ?? new ProviderRetryCounter(),
         );
 
         return new MiddlewarePipeline([$middleware]);

--- a/Tests/Unit/Provider/Middleware/TelemetrySignalsTest.php
+++ b/Tests/Unit/Provider/Middleware/TelemetrySignalsTest.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace Netresearch\NrLlm\Tests\Unit\Provider\Middleware;
 
+use Netresearch\NrLlm\Domain\Enum\RequestShape;
+use Netresearch\NrLlm\Domain\ValueObject\ProviderCallUsage;
+use Netresearch\NrLlm\Domain\ValueObject\RequestFacts;
 use Netresearch\NrLlm\Provider\Middleware\TelemetrySignals;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -45,5 +48,45 @@ final class TelemetrySignalsTest extends TestCase
         $signals->recordFallbackAttempt();
 
         self::assertSame(3, $signals->fallbackAttempts);
+    }
+
+    /**
+     * ADR-174 states the two writers resolve collisions in OPPOSITE directions,
+     * and both docblocks say so. Neither rule was asserted anywhere, and both
+     * are silent when broken: the facts and the usage would simply describe a
+     * different call than the one the row claims.
+     *
+     * The facts keep the FIRST write. They describe the request the caller
+     * made, and the manager records them once per call — but the method is on
+     * the `@api` surface, so a second writer is reachable from outside this
+     * extension, and this is the answer it gets.
+     */
+    #[Test]
+    public function theFirstRequestFactsWriteIsTheOneThatSurvives(): void
+    {
+        $signals = new TelemetrySignals();
+        $first   = new RequestFacts(4, 3, 1, 400, 120, RequestShape::MULTI_TURN->value);
+
+        $signals->recordRequestFacts($first);
+        $signals->recordRequestFacts(new RequestFacts(9, 9, 9, 9000, 9000, RequestShape::TOOL_ASSISTED->value));
+
+        self::assertSame($first, $signals->requestFacts);
+    }
+
+    /**
+     * The usage keeps the LAST write, and that is not symmetry for its own
+     * sake: on a fallback swap the sibling's response is the one that was
+     * served, so its tokens are the ones that were spent.
+     */
+    #[Test]
+    public function theLastCallUsageWriteIsTheOneThatSurvives(): void
+    {
+        $signals = new TelemetrySignals();
+        $served  = new ProviderCallUsage(1200, 340, 0.02, 'fallback-model');
+
+        $signals->recordCallUsage(new ProviderCallUsage(10, 5, 0.001, 'primary-model'));
+        $signals->recordCallUsage($served);
+
+        self::assertSame($served, $signals->callUsage);
     }
 }

--- a/Tests/Unit/Provider/Middleware/UsageMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/UsageMiddlewareTest.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
+use Netresearch\NrLlm\Domain\ValueObject\ProviderCallUsage;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
@@ -505,6 +506,148 @@ final class UsageMiddlewareTest extends AbstractUnitTestCase
             context: ProviderCallContext::forConfiguration(ProviderOperation::Chat, $this->configurationWithModel($model, uid: 7)),
             terminal: static fn(): CompletionResponse => $response,
         );
+    }
+
+    /**
+     * The per-call copy on the scratchpad (ADR-174): the same tokens and the
+     * same derived cost the daily aggregate gets, but reachable by correlation
+     * id.
+     */
+    #[Test]
+    public function recordsTheProviderReportedTokensAndDerivedCostOnTheCallContext(): void
+    {
+        $model = new Model();
+        $model->setModelId('gpt-4o');
+        $model->setCostInput(250);
+        $model->setCostOutput(1000);
+        $this->setModelUid($model, 99);
+
+        $context = ProviderCallContext::forConfiguration(
+            ProviderOperation::Chat,
+            $this->configurationWithModel($model, uid: 7),
+        );
+
+        $this->pipeline()->run(
+            context: $context,
+            terminal: static fn(): CompletionResponse => new CompletionResponse(
+                content: 'hi',
+                // The provider answered on a dated snapshot of the alias the
+                // configuration named; the row must say which one answered.
+                model: 'gpt-4o-2024-08-06',
+                usage: new UsageStatistics(1000, 500, 1500),
+                finishReason: 'stop',
+                provider: 'openai',
+            ),
+        );
+
+        $usage = $context->telemetrySignals->callUsage;
+        self::assertInstanceOf(ProviderCallUsage::class, $usage);
+        self::assertSame(1000, $usage->inputTokens);
+        self::assertSame(500, $usage->outputTokens);
+        self::assertSame(0.0075, $usage->cost);
+        self::assertSame('gpt-4o-2024-08-06', $usage->responseModel);
+    }
+
+    /**
+     * The defect issue #770 names: a model priced at zero — Ollama, Groq, any
+     * local one — reports a cost of 0 by construction, and 0 is also what an
+     * unpriced model reports. The arm a cheap-model experiment is about is
+     * exactly the one that cannot be told from a missing measurement.
+     *
+     * Tokens are real here and the cost is NULL. Both halves matter: dropping
+     * the tokens too would lose the only real measurement the call produced.
+     */
+    #[Test]
+    public function aModelWithoutPricingRecordsRealTokensAndANullCost(): void
+    {
+        $model = new Model();
+        $model->setModelId('qwen3:4b');
+        $model->setCostInput(0);
+        $model->setCostOutput(0);
+        $this->setModelUid($model, 42);
+
+        $context = ProviderCallContext::forConfiguration(
+            ProviderOperation::Chat,
+            $this->configurationWithModel($model, uid: 7),
+        );
+
+        $this->pipeline()->run(
+            context: $context,
+            terminal: static fn(): CompletionResponse => new CompletionResponse(
+                content: 'hi',
+                model: 'qwen3:4b',
+                usage: new UsageStatistics(1000, 500, 1500),
+                finishReason: 'stop',
+                provider: 'ollama',
+            ),
+        );
+
+        $usage = $context->telemetrySignals->callUsage;
+        self::assertInstanceOf(ProviderCallUsage::class, $usage);
+        self::assertSame(1000, $usage->inputTokens);
+        self::assertSame(500, $usage->outputTokens);
+        self::assertNull($usage->cost, 'An unpriced model has no cost; 0 would claim the call was free.');
+    }
+
+    /**
+     * A provider that sends no `usage` block leaves the adapter building
+     * UsageStatistics(0, 0, 0) — the same object it would build for a measured
+     * zero. All three at zero is the only signal that separates them, because a
+     * call that reached a provider consumed prompt tokens.
+     */
+    #[Test]
+    public function aResponseWithNoUsageBlockRecordsNullTokensRatherThanZeros(): void
+    {
+        $context = ProviderCallContext::forConfiguration(
+            ProviderOperation::Chat,
+            $this->configuration(uid: 7),
+        );
+
+        $this->pipeline()->run(
+            context: $context,
+            terminal: static fn(): CompletionResponse => new CompletionResponse(
+                content: 'hi',
+                model: 'some-model',
+                usage: new UsageStatistics(0, 0, 0),
+                finishReason: 'stop',
+                provider: 'openai',
+            ),
+        );
+
+        $usage = $context->telemetrySignals->callUsage;
+        self::assertInstanceOf(ProviderCallUsage::class, $usage);
+        self::assertNull($usage->inputTokens);
+        self::assertNull($usage->outputTokens);
+    }
+
+    /**
+     * The mirror case, and the reason the rule asks for all three counts rather
+     * than for the one being read: a response that produced no output still
+     * reports its prompt tokens, so this zero is a measurement.
+     */
+    #[Test]
+    public function aResponseThatProducedNoOutputKeepsAMeasuredZero(): void
+    {
+        $context = ProviderCallContext::forConfiguration(
+            ProviderOperation::Chat,
+            $this->configuration(uid: 7),
+        );
+
+        $this->pipeline()->run(
+            context: $context,
+            terminal: static fn(): CompletionResponse => new CompletionResponse(
+                content: '',
+                model: 'some-model',
+                usage: new UsageStatistics(120, 0, 120),
+                finishReason: 'length',
+                provider: 'openai',
+            ),
+        );
+
+        $usage = $context->telemetrySignals->callUsage;
+        self::assertInstanceOf(ProviderCallUsage::class, $usage);
+        self::assertSame(120, $usage->inputTokens);
+        self::assertSame(0, $usage->outputTokens);
     }
 
     #[Test]

--- a/Tests/Unit/Service/Complexity/MessageInspectorTest.php
+++ b/Tests/Unit/Service/Complexity/MessageInspectorTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Complexity;
+
+use Netresearch\NrLlm\Domain\Enum\RequestShape;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\ToolCall;
+use Netresearch\NrLlm\Service\Complexity\MessageInspector;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The one definition of "a turn", "tool traffic" and "payload bytes" that both
+ * the pre-routing fact set and the post-fit complexity record read by (ADR-174).
+ *
+ * These tests exist because the two records are written to one row in order to
+ * be compared: a second, subtly different definition would break the comparison
+ * without breaking either caller's own tests.
+ */
+#[CoversClass(MessageInspector::class)]
+final class MessageInspectorTest extends TestCase
+{
+    #[Test]
+    public function bothMessageShapesAnswerTheSameWay(): void
+    {
+        $inspector = new MessageInspector();
+
+        $typed = [ChatMessage::system('sys'), ChatMessage::user('hello')];
+        $array = [
+            ['role' => 'system', 'content' => 'sys'],
+            ['role' => 'user', 'content' => 'hello'],
+        ];
+
+        self::assertSame($inspector->turnCount($typed), $inspector->turnCount($array));
+        self::assertSame($inspector->payloadBytes($typed), $inspector->payloadBytes($array));
+        self::assertSame(1, $inspector->turnCount($typed));
+        self::assertSame(8, $inspector->payloadBytes($typed));
+    }
+
+    #[Test]
+    public function anAssistantMessageRequestingCallsIsToolTraffic(): void
+    {
+        $inspector = new MessageInspector();
+
+        self::assertTrue($inspector->carriesToolTraffic([
+            ChatMessage::assistantToolCalls([new ToolCall('call-1', 'list_pages', [])]),
+        ]));
+        self::assertTrue($inspector->carriesToolTraffic([
+            ['role' => 'assistant', 'content' => '', 'tool_calls' => [['id' => 'call-1']]],
+        ]));
+        self::assertFalse($inspector->carriesToolTraffic([ChatMessage::user('hello')]));
+    }
+
+    #[Test]
+    public function aToolResultIsToolTrafficWithoutAnySchemaOnTheWire(): void
+    {
+        self::assertTrue((new MessageInspector())->carriesToolTraffic([
+            ['role' => 'tool', 'content' => '{"ok":true}'],
+        ]));
+    }
+
+    #[Test]
+    public function toolTrafficOutranksTheTurnCountWhenNamingTheShape(): void
+    {
+        $inspector = new MessageInspector();
+
+        self::assertSame(RequestShape::TOOL_ASSISTED, $inspector->shape(9, true));
+        self::assertSame(RequestShape::MULTI_TURN, $inspector->shape(2, false));
+        self::assertSame(RequestShape::SINGLE_TURN, $inspector->shape(1, false));
+        self::assertSame(RequestShape::SINGLE_TURN, $inspector->shape(0, false));
+    }
+
+    /**
+     * Non-string content (a multimodal part list) contributes no bytes rather
+     * than throwing — the measurement is an observation and must never be the
+     * thing that fails a call.
+     */
+    #[Test]
+    public function nonStringContentContributesNothing(): void
+    {
+        self::assertSame(0, (new MessageInspector())->payloadBytes([
+            ['role' => 'user', 'content' => [['type' => 'image_url']]],
+        ]));
+    }
+}

--- a/Tests/Unit/Service/Complexity/RequestFactsCollectorTest.php
+++ b/Tests/Unit/Service/Complexity/RequestFactsCollectorTest.php
@@ -1,0 +1,179 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Complexity;
+
+use Netresearch\NrLlm\Domain\Enum\RequestShape;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Service\Complexity\RequestFactsCollector;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionParameter;
+
+/**
+ * The pre-routing fact set (ADR-174).
+ *
+ * The first test is the load-bearing one and it is a structural assertion, not
+ * a behavioural one: this collector may not be able to see a model. Everything
+ * else here pins the individual figures.
+ */
+#[CoversClass(RequestFactsCollector::class)]
+final class RequestFactsCollectorTest extends TestCase
+{
+    /**
+     * The point of the whole class: nothing it can reach knows which model will
+     * serve the request. A collaborator that could answer that would let the
+     * "model-independent" claim rot silently, because every figure below would
+     * still look right.
+     */
+    #[Test]
+    public function theCollectorCanReachNothingThatKnowsAModel(): void
+    {
+        $reflection = new ReflectionClass(RequestFactsCollector::class);
+
+        $parameterTypes = [];
+        foreach ($reflection->getConstructor()?->getParameters() ?? [] as $parameter) {
+            $parameterTypes[] = (string)$parameter->getType();
+        }
+
+        self::assertSame(
+            [
+                'Netresearch\NrLlm\Service\Complexity\MessageInspector',
+                'Netresearch\NrLlm\Service\Context\TranscriptEstimator',
+            ],
+            $parameterTypes,
+            'A new collaborator here needs ADR-174 read first: neither of these can name a model, '
+            . 'a window or a price, and that is what separates this measurement from the complexity one.',
+        );
+
+        // And the entry point takes no configuration, model or fit either.
+        $collect = $reflection->getMethod('collect');
+        self::assertSame(['array', 'array'], array_map(
+            static fn(ReflectionParameter $p): string => (string)$p->getType(),
+            $collect->getParameters(),
+        ));
+    }
+
+    #[Test]
+    public function theSystemPromptIsCountedAsAMessageButNotAsATurn(): void
+    {
+        // Both figures are kept because they answer different questions: how
+        // much went on the wire, and how much of it was conversation.
+        $facts = (new RequestFactsCollector())->collect(
+            [ChatMessage::system('You are terse.'), ChatMessage::user('Why?')],
+            [],
+        );
+
+        self::assertSame(2, $facts->messageCount);
+        self::assertSame(1, $facts->turnCount);
+        self::assertSame(RequestShape::SINGLE_TURN->value, $facts->shape);
+    }
+
+    #[Test]
+    public function severalConversationTurnsMakeItMultiTurn(): void
+    {
+        $facts = (new RequestFactsCollector())->collect(
+            [
+                ChatMessage::system('You are terse.'),
+                ChatMessage::user('Why?'),
+                ChatMessage::assistant('Because.'),
+                ChatMessage::user('And?'),
+            ],
+            [],
+        );
+
+        self::assertSame(4, $facts->messageCount);
+        self::assertSame(3, $facts->turnCount);
+        self::assertSame(RequestShape::MULTI_TURN->value, $facts->shape);
+    }
+
+    #[Test]
+    public function toolSchemasOnTheWireMakeItToolAssistedAndAreCounted(): void
+    {
+        $facts = (new RequestFactsCollector())->collect(
+            [ChatMessage::user('List the pages.')],
+            [
+                ['type' => 'function', 'function' => ['name' => 'list_pages']],
+                ['type' => 'function', 'function' => ['name' => 'get_page']],
+            ],
+        );
+
+        self::assertSame(2, $facts->toolCount);
+        self::assertSame(RequestShape::TOOL_ASSISTED->value, $facts->shape);
+    }
+
+    /**
+     * BYTES, not characters — the same unit
+     * {@see \Netresearch\NrLlm\Domain\ValueObject\RequestComplexity::$payloadBytes}
+     * uses (ADR-121). A CJK payload is the case that separates the two: three
+     * characters, nine bytes.
+     */
+    #[Test]
+    public function thePayloadIsMeasuredInBytes(): void
+    {
+        $facts = (new RequestFactsCollector())->collect([ChatMessage::user('日本語')], []);
+
+        self::assertSame(9, $facts->payloadBytes);
+    }
+
+    #[Test]
+    public function theTokenEstimateGrowsWithThePayloadAndIsNotZeroForANonEmptySend(): void
+    {
+        $collector = new RequestFactsCollector();
+
+        $small = $collector->collect([ChatMessage::user('Why?')], []);
+        $large = $collector->collect([ChatMessage::user(str_repeat('a lot of prose. ', 200))], []);
+
+        self::assertGreaterThan(0, $small->tokenEstimate);
+        self::assertGreaterThan($small->tokenEstimate, $large->tokenEstimate);
+    }
+
+    /**
+     * The tool schemas go on the wire, so they are part of what the request
+     * costs to send — leaving them out would make a tool-heavy request look
+     * like a bare one.
+     */
+    #[Test]
+    public function theTokenEstimateIncludesTheToolSchemas(): void
+    {
+        $collector = new RequestFactsCollector();
+        $messages  = [ChatMessage::user('List the pages.')];
+
+        $without = $collector->collect($messages, []);
+        $with    = $collector->collect($messages, [
+            ['type' => 'function', 'function' => ['name' => 'list_pages', 'description' => 'Lists pages in a tree']],
+        ]);
+
+        self::assertGreaterThan($without->tokenEstimate, $with->tokenEstimate);
+    }
+
+    /**
+     * The manager normalises before it measures, but the legacy array shape
+     * still reaches this class through callers that pass a raw transcript.
+     */
+    #[Test]
+    public function legacyArrayShapedMessagesAreReadTheSameWay(): void
+    {
+        $facts = (new RequestFactsCollector())->collect(
+            [
+                ['role' => 'system', 'content' => 'You are terse.'],
+                ['role' => 'user', 'content' => 'Why?'],
+                ['role' => 'tool', 'content' => '{"ok":true}'],
+            ],
+            [],
+        );
+
+        self::assertSame(3, $facts->messageCount);
+        self::assertSame(2, $facts->turnCount);
+        // A tool RESULT is tool traffic even when the send carries no schemas.
+        self::assertSame(RequestShape::TOOL_ASSISTED->value, $facts->shape);
+    }
+}

--- a/Tests/Unit/Service/Complexity/RequestFactsCollectorTest.php
+++ b/Tests/Unit/Service/Complexity/RequestFactsCollectorTest.php
@@ -11,7 +11,9 @@ namespace Netresearch\NrLlm\Tests\Unit\Service\Complexity;
 
 use Netresearch\NrLlm\Domain\Enum\RequestShape;
 use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Service\Complexity\MessageInspector;
 use Netresearch\NrLlm\Service\Complexity\RequestFactsCollector;
+use Netresearch\NrLlm\Service\Context\TranscriptEstimator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -46,8 +48,8 @@ final class RequestFactsCollectorTest extends TestCase
 
         self::assertSame(
             [
-                'Netresearch\NrLlm\Service\Complexity\MessageInspector',
-                'Netresearch\NrLlm\Service\Context\TranscriptEstimator',
+                MessageInspector::class,
+                TranscriptEstimator::class,
             ],
             $parameterTypes,
             'A new collaborator here needs ADR-174 read first: neither of these can name a model, '

--- a/Tests/Unit/Service/RequestFactsEntryPointTest.php
+++ b/Tests/Unit/Service/RequestFactsEntryPointTest.php
@@ -1,0 +1,231 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service;
+
+use Closure;
+use Netresearch\NrLlm\Domain\Enum\RequestShape;
+use Netresearch\NrLlm\Domain\Model\CompletionResponse;
+use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
+use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\Provider;
+use Netresearch\NrLlm\Domain\Model\UsageStatistics;
+use Netresearch\NrLlm\Domain\ValueObject\ChatMessage;
+use Netresearch\NrLlm\Domain\ValueObject\RequestFacts;
+use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
+use Netresearch\NrLlm\Provider\Contract\ProviderInterface;
+use Netresearch\NrLlm\Provider\Contract\ToolCapableInterface;
+use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\ProviderMiddlewareInterface;
+use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
+use Netresearch\NrLlm\Service\CacheManagerInterface;
+use Netresearch\NrLlm\Service\LlmServiceManager;
+use Netresearch\NrLlm\Tests\LlmServiceManagerTestFactory;
+use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\LoggerInterface;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+/**
+ * The request facts exist before the pipeline runs (ADR-174, issue #771).
+ *
+ * WHERE they are recorded is the whole claim, and it is not visible in the
+ * numbers: `resolveModel()` runs inside the pipeline TERMINAL, so a fact set
+ * assembled anywhere in there would be measured after the model was chosen and
+ * would be worth nothing to the question it exists to answer. These tests
+ * observe the scratchpad from a middleware — which the pipeline runs strictly
+ * before the terminal — so a later recording point fails them even though every
+ * recorded figure would still be correct.
+ */
+#[CoversClass(LlmServiceManager::class)]
+final class RequestFactsEntryPointTest extends AbstractUnitTestCase
+{
+    use LlmServiceManagerTestFactory;
+
+    #[Test]
+    public function aChatSendCarriesItsFactsIntoThePipelineBeforeTheTerminalRuns(): void
+    {
+        $seen = null;
+
+        $this->manager($this->chatAdapter(), $this->probe($seen))->chatWithConfiguration(
+            [ChatMessage::system('You are terse.'), ChatMessage::user('Why is the sky blue?')],
+            $this->configuration(),
+        );
+
+        self::assertInstanceOf(RequestFacts::class, $seen, 'The facts must be on the context before the terminal.');
+        self::assertSame(2, $seen->messageCount);
+        self::assertSame(1, $seen->turnCount);
+        self::assertSame(0, $seen->toolCount);
+        self::assertSame(34, $seen->payloadBytes);
+        self::assertGreaterThan(0, $seen->tokenEstimate);
+        self::assertSame(RequestShape::SINGLE_TURN->value, $seen->shape);
+    }
+
+    /**
+     * The configuration's system prompt is NOT in the counts, and that is a
+     * property of where the measurement sits (ADR-174).
+     *
+     * `applySystemPrompt()` runs inside the terminal, on call options built out
+     * of the RESOLVED model — so a fact set that included the prompt would be a
+     * fact set measured after the decision it exists to precede. The docblocks
+     * say the counts describe the caller's transcript; this is what makes that
+     * statement fail if the collection point ever moves.
+     */
+    #[Test]
+    public function theConfigurationsSystemPromptIsNotCounted(): void
+    {
+        $seen = null;
+
+        $configuration = $this->configuration();
+        $configuration->setSystemPrompt('You are a terse assistant that never mentions the weather.');
+
+        $this->manager($this->chatAdapter(), $this->probe($seen))->chatWithConfiguration(
+            [ChatMessage::user('Why is the sky blue?')],
+            $configuration,
+        );
+
+        self::assertInstanceOf(RequestFacts::class, $seen);
+        self::assertSame(1, $seen->messageCount, 'One caller message; the configuration prompt is not one of them.');
+        self::assertSame(1, $seen->turnCount);
+        self::assertSame(20, $seen->payloadBytes, 'The bytes of the user turn alone.');
+    }
+
+    #[Test]
+    public function aCompletionSendMeasuresItsPromptAsOneUserTurn(): void
+    {
+        $seen = null;
+
+        $this->manager($this->chatAdapter(), $this->probe($seen))->completeWithConfiguration(
+            'Summarise the release notes.',
+            $this->configuration(),
+        );
+
+        self::assertInstanceOf(RequestFacts::class, $seen);
+        self::assertSame(1, $seen->messageCount);
+        self::assertSame(1, $seen->turnCount);
+        self::assertSame(28, $seen->payloadBytes);
+        self::assertSame(RequestShape::SINGLE_TURN->value, $seen->shape);
+    }
+
+    #[Test]
+    public function aToolSendCountsItsSchemasAndIsShapedByThem(): void
+    {
+        $seen = null;
+
+        $this->manager($this->toolAdapter(), $this->probe($seen))->chatWithToolsForConfiguration(
+            [ChatMessage::user('List the pages.')],
+            [
+                new ToolSpec('list_pages', 'Lists pages', []),
+                new ToolSpec('get_page', 'Reads one page', []),
+            ],
+            $this->configuration(),
+        );
+
+        self::assertInstanceOf(RequestFacts::class, $seen);
+        self::assertSame(2, $seen->toolCount);
+        self::assertSame(RequestShape::TOOL_ASSISTED->value, $seen->shape);
+    }
+
+    /**
+     * A middleware that copies the scratchpad's fact set on the way IN — i.e.
+     * before the terminal, which is where the model is resolved.
+     */
+    private function probe(?RequestFacts &$seen): ProviderMiddlewareInterface
+    {
+        $capture = static function (?RequestFacts $facts) use (&$seen): void {
+            $seen = $facts;
+        };
+
+        return new class ($capture) implements ProviderMiddlewareInterface {
+            /**
+             * @param Closure(?RequestFacts): void $capture
+             */
+            public function __construct(private readonly Closure $capture) {}
+
+            public function handle(ProviderCallContext $context, callable $next): mixed
+            {
+                ($this->capture)($context->telemetrySignals->requestFacts);
+
+                return $next($context);
+            }
+        };
+    }
+
+    private function manager(ProviderInterface $adapter, ProviderMiddlewareInterface $probe): LlmServiceManager
+    {
+        $registry = self::createStub(ProviderAdapterRegistryInterface::class);
+        $registry->method('createAdapterFromModel')->willReturn($adapter);
+
+        return $this->createLlmServiceManager(
+            $this->extensionConfigStub(),
+            self::createStub(LoggerInterface::class),
+            $registry,
+            new MiddlewarePipeline([$probe]),
+            self::createStub(CacheManagerInterface::class),
+        );
+    }
+
+    private function chatAdapter(): ProviderInterface
+    {
+        $adapter = self::createStub(ProviderInterface::class);
+        $adapter->method('chatCompletion')->willReturn($this->response());
+        $adapter->method('complete')->willReturn($this->response());
+
+        return $adapter;
+    }
+
+    private function toolAdapter(): ProviderInterface
+    {
+        $adapter = self::createStubForIntersectionOfInterfaces([
+            ProviderInterface::class,
+            ToolCapableInterface::class,
+        ]);
+        $adapter->method('chatCompletionWithTools')->willReturn($this->response());
+
+        return $adapter;
+    }
+
+    private function extensionConfigStub(): ExtensionConfiguration
+    {
+        $stub = self::createStub(ExtensionConfiguration::class);
+        $stub->method('get')->willReturn(['providers' => []]);
+
+        return $stub;
+    }
+
+    private function configuration(): LlmConfiguration
+    {
+        $provider = new Provider();
+        $provider->setIdentifier('openai');
+        $provider->setAdapterType('openai');
+
+        $model = new Model();
+        $model->setModelId('small');
+        $model->setContextLength(4000);
+        $model->setProvider($provider);
+
+        $configuration = new LlmConfiguration();
+        $configuration->setIdentifier('primary');
+        $configuration->setLlmModel($model);
+
+        return $configuration;
+    }
+
+    private function response(): CompletionResponse
+    {
+        return new CompletionResponse(
+            content: 'ok',
+            model: 'small',
+            usage: new UsageStatistics(1, 1, 2),
+            provider: 'openai',
+        );
+    }
+}

--- a/Tests/Unit/Service/Streaming/StreamingDispatcherTest.php
+++ b/Tests/Unit/Service/Streaming/StreamingDispatcherTest.php
@@ -28,6 +28,7 @@ use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Service\Guardrail\GuardrailInterface;
 use Netresearch\NrLlm\Service\Guardrail\SecretRedactionGuardrail;
 use Netresearch\NrLlm\Service\Streaming\StreamingDispatcher;
+use Netresearch\NrLlm\Service\Telemetry\ProviderRetryCounter;
 use Netresearch\NrLlm\Tests\Fixture\GuardrailIdentityDoubleTrait;
 use Netresearch\NrLlm\Tests\Unit\AbstractUnitTestCase;
 use Netresearch\NrLlm\Tests\Unit\Fixture\InMemoryTelemetryRepository;
@@ -463,6 +464,118 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
         self::assertLessThan(60000, $record->timeToFirstTokenMs);
         // A completed stream is never the "aborted before completion" path.
         self::assertNull($this->logger->firstMatching('info', 'aborted before completion'));
+    }
+
+    /**
+     * The retry count on a streamed row covers what THIS STREAM consumed, and
+     * nothing the consumer did between two chunks (ADR-174).
+     *
+     * drain() is a generator: it suspends at every yield, and the consumer is
+     * free to make provider calls of its own in that gap — each of which
+     * increments the same process-wide counter. A single difference taken
+     * around the whole drain attributes those to this stream, so the figure an
+     * operator reads as "how often did we have to try again" would grow with
+     * how busy the consumer was between chunks.
+     */
+    #[Test]
+    public function countsOnlyTheRetriesConsumedWhileTheStreamItselfHoldsTheStack(): void
+    {
+        $counter = new ProviderRetryCounter();
+
+        // Two retries inside the stream: one while the opener primes, one while
+        // the inner generator produces its second chunk.
+        $open = static function () use ($counter): Generator {
+            $counter->recordRetry();
+
+            yield 'Hello';
+
+            $counter->recordRetry();
+
+            yield ' World';
+        };
+
+        foreach ($this->dispatcher(retryCounter: $counter)->stream(
+            $this->context(),
+            $this->configuration('primary'),
+            $open,
+        ) as $ignored) {
+            // The consumer's own work while the drain is suspended — a nested
+            // call of its own that retried three times. Not this stream's.
+            $counter->recordRetry();
+            $counter->recordRetry();
+            $counter->recordRetry();
+        }
+
+        self::assertCount(1, $this->telemetry->records);
+        self::assertSame(2, $this->telemetry->records[0]->providerRetries);
+        self::assertSame(8, $counter->total(), 'The counter itself stays monotonic and process-wide.');
+    }
+
+    /**
+     * The same, on the redacted path: the chunks are yielded out of the
+     * redaction window rather than verbatim, and the remainder out of its flush.
+     * Both are yields, so both suspend into the consumer.
+     */
+    #[Test]
+    public function countsOnlyTheStreamsOwnRetriesWhenAGuardrailRedactsTheChunks(): void
+    {
+        $counter = new ProviderRetryCounter();
+
+        $open = static function () use ($counter): Generator {
+            $counter->recordRetry();
+
+            yield 'Hello';
+
+            $counter->recordRetry();
+
+            yield ' World';
+        };
+
+        foreach ($this->dispatcher(
+            guardrails: [new SecretRedactionGuardrail()],
+            retryCounter: $counter,
+        )->stream($this->context(), $this->configuration('primary'), $open) as $ignored) {
+            $counter->recordRetry();
+        }
+
+        self::assertCount(1, $this->telemetry->records);
+        self::assertSame(2, $this->telemetry->records[0]->providerRetries);
+    }
+
+    /**
+     * A consumer that walks away mid-stream leaves the drain suspended until the
+     * generator is collected, and the finally then runs at an arbitrary later
+     * moment. Whatever the process retried in the meantime is not this row's.
+     */
+    #[Test]
+    public function anAbandonedStreamCountsNothingThatHappenedAfterItsLastChunk(): void
+    {
+        $counter = new ProviderRetryCounter();
+
+        $open = static function () use ($counter): Generator {
+            $counter->recordRetry();
+
+            yield 'Hello';
+
+            yield ' World';
+        };
+
+        $stream = $this->dispatcher(retryCounter: $counter)->stream(
+            $this->context(),
+            $this->configuration('primary'),
+            $open,
+        );
+        $stream->current();
+
+        // The consumer gives up, and something else in the request retries
+        // while the abandoned generator is still alive. Only when it is
+        // collected does the finally run and write the row.
+        $counter->recordRetry();
+        $counter->recordRetry();
+        unset($stream);
+
+        self::assertCount(1, $this->telemetry->records);
+        self::assertSame(1, $this->telemetry->records[0]->providerRetries);
     }
 
     #[Test]
@@ -1008,6 +1121,7 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
         ?LlmConfigurationRepository $repository = null,
         ?ExtensionConfiguration $extensionConfiguration = null,
         iterable $guardrails = [],
+        ?ProviderRetryCounter $retryCounter = null,
     ): StreamingDispatcher {
         return new StreamingDispatcher(
             $budget ?? $this->budget(BudgetCheckResult::allowed()),
@@ -1018,6 +1132,7 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
             $this->contextWithAmbientUser(0),
             $extensionConfiguration ?? $this->extensionConfiguration(true),
             guardrails: $guardrails,
+            retryCounter: $retryCounter ?? new ProviderRetryCounter(),
         );
     }
 

--- a/Tests/Unit/Service/Telemetry/ProviderRetryCounterTest.php
+++ b/Tests/Unit/Service/Telemetry/ProviderRetryCounterTest.php
@@ -40,6 +40,7 @@ final class ProviderRetryCounterTest extends TestCase
         $innerBefore = $counter->total();
         $counter->recordRetry();
         $counter->recordRetry();
+
         $innerDelta = $counter->total() - $innerBefore;
 
         $counter->recordRetry();

--- a/Tests/Unit/Service/Telemetry/ProviderRetryCounterTest.php
+++ b/Tests/Unit/Service/Telemetry/ProviderRetryCounterTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service\Telemetry;
+
+use Netresearch\NrLlm\Service\Telemetry\ProviderRetryCounter;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ProviderRetryCounter::class)]
+final class ProviderRetryCounterTest extends TestCase
+{
+    #[Test]
+    public function aFreshCounterHasSeenNoRetries(): void
+    {
+        self::assertSame(0, (new ProviderRetryCounter())->total());
+    }
+
+    /**
+     * Monotonic on purpose (ADR-174). The write sites take a difference, and a
+     * difference is what makes nesting work: a tool loop runs pipeline runs
+     * inside a pipeline run, and a counter that reset would make the outer row
+     * report only the retries that happened after the inner one finished.
+     */
+    #[Test]
+    public function theCounterOnlyEverGrowsSoNestedRunsBothCountCorrectly(): void
+    {
+        $counter = new ProviderRetryCounter();
+
+        $outerBefore = $counter->total();
+        $counter->recordRetry();
+
+        $innerBefore = $counter->total();
+        $counter->recordRetry();
+        $counter->recordRetry();
+        $innerDelta = $counter->total() - $innerBefore;
+
+        $counter->recordRetry();
+        $outerDelta = $counter->total() - $outerBefore;
+
+        self::assertSame(2, $innerDelta, 'The inner run consumed two retries.');
+        self::assertSame(4, $outerDelta, 'The outer run consumed four, the inner run’s two included.');
+    }
+}

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -649,9 +649,11 @@ CREATE TABLE tx_nrllm_telemetry (
     --
     -- complexity_shape is '' on the paths that measure nothing: the provider-
     -- pinned entry points (chatWithTools(), vision(), and chat()/complete()
-    -- with no default configuration), embeddings by identifier, and the
-    -- specialized image/speech services. Only a configuration-driven chat,
-    -- completion, tool or stream send runs the context fit the measurement
+    -- with no default configuration), embeddings by identifier, and every
+    -- specialized service — image, speech and translation alike, all of which
+    -- run through this pipeline and so reach this row. Only a
+    -- configuration-driven chat, completion, tool or stream send runs the
+    -- context fit the measurement
     -- hangs off. The empty shape is the flag for "this row carries no
     -- complexity", the way routing_policy_mode is for the decision, and the
     -- Governance readout reads it before showing the other five figures.
@@ -665,6 +667,78 @@ CREATE TABLE tx_nrllm_telemetry (
     -- and clamping it here would hide it.
     complexity_context_percent int(11) unsigned DEFAULT NULL,
     complexity_shape varchar(32) DEFAULT '' NOT NULL,
+
+    -- What the request WAS, measured BEFORE any model was chosen (ADR-174).
+    -- The complexity group above is measured after the model is chosen and
+    -- partly FROM it (its size term is estimated tokens against the budget of
+    -- the model already selected), so it can describe a decision but never
+    -- inform one. This group is model-independent by construction: no window,
+    -- no price, no utilisation, no chosen model. The operation is not repeated
+    -- either — `operation` above already names it.
+    --
+    -- OBSERVATION ONLY, exactly like the complexity group: nothing routes on
+    -- these columns, and ADR-156 still names what must hold before anything may.
+    --
+    -- The counts describe the CALLER's transcript, not the bytes on the wire:
+    -- the configuration's system prompt is prepended later, from options built
+    -- out of the resolved model, so counting it would mean measuring after the
+    -- decision. The complexity group draws the same line, which is what keeps
+    -- the two comparable.
+    --
+    -- All five figures are measured in one pass or not at all, so they are NULL
+    -- together on every path that forms no fact set — only the four
+    -- configuration-driven sends (chat, completion, tools, stream) form one, so
+    -- the provider-pinned entry points, embeddings and every specialized
+    -- service (image, speech and translation alike) write NULL here — and
+    -- facts_shape is '' there, the same "nothing was measured" flag
+    -- complexity_shape is. NULL rather than 0 throughout: a request nobody
+    -- measured is not a request with no messages.
+    facts_messages smallint(5) unsigned DEFAULT NULL,
+    facts_turns smallint(5) unsigned DEFAULT NULL,
+    facts_tools smallint(5) unsigned DEFAULT NULL,
+    facts_payload_bytes int(11) unsigned DEFAULT NULL,
+    -- Provider- and model-independent, from the same estimator the context fit
+    -- uses but uncalibrated — so it can be compared with complexity_tokens
+    -- without being derived from the model that answered.
+    facts_token_estimate int(11) unsigned DEFAULT NULL,
+    facts_shape varchar(32) DEFAULT '' NOT NULL,
+
+    -- What the call actually consumed, and what it cost (ADR-174).
+    -- tx_nrllm_service_usage carries the same figures as a DAILY AGGREGATE with
+    -- no correlation_id, so nothing there can be joined to a call, a request
+    -- shape or a complexity bucket. These columns can, because they sit on the
+    -- row the correlation id already identifies.
+    --
+    -- NULL is a measurement that did not happen and is never a zero. Both token
+    -- columns are NULL where the provider reported no usage block at all
+    -- (adapters build UsageStatistics with plain ints, so all three counts zero
+    -- at once is the only signal an absent block leaves). actual_cost is NULL
+    -- where the serving model carries no pricing — which is the defect these
+    -- columns exist to fix: a free local model and an unpriced one both used to
+    -- report a cost of 0, and the free arm is precisely what a cheap-model
+    -- experiment is about.
+    --
+    -- All four are NULL/'' wherever no provider call produced a token-shaped
+    -- response: a cache hit (Cache short-circuits above Usage), a failed run, a
+    -- streamed run (no usage block, only a char estimate — which is not what
+    -- "actual" means), and the specialized image/speech/translation operations
+    -- that record through their own extractors.
+    actual_input_tokens int(11) unsigned DEFAULT NULL,
+    actual_output_tokens int(11) unsigned DEFAULT NULL,
+    -- Dollars. decimal, not float: a per-call cost of a cheap model is small
+    -- enough that binary rounding shows up once these are summed.
+    actual_cost decimal(14,8) DEFAULT NULL,
+    -- The model the PROVIDER named on the response, which need not be the one
+    -- the configuration asked for: an alias can resolve to a dated snapshot,
+    -- and which one answered is the joinable fact. '' where none was named.
+    response_model varchar(128) DEFAULT '' NOT NULL,
+    -- HTTP attempts an adapter had to repeat during this run, fallback re-sends
+    -- included. Unlike the columns above, this one is always written: both write
+    -- sites hold the counter, so a recorded 0 is a measured "no retry" and no
+    -- row from this version reports NULL here. Nullable because the rows that
+    -- existed before the column did have no value for it — which is the only
+    -- population `provider_retries IS NULL` selects.
+    provider_retries smallint(5) unsigned DEFAULT NULL,
 
     -- Standard TYPO3 field (append-only; no tstamp — rows are never updated)
     crdate int(11) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
## Description

Everything adaptive rests on two measurements the extension did not have. **Neither needed production data to build** — they need it to *evaluate*, and conflating those two is why this looked blocked when it was not.

## #770 — per-call cost and real tokens

`tx_nrllm_telemetry` carried routing, success, latency and a complexity estimate but no money and no actual counts. `routing_signal_cost` is a ranking signal, not a price; `complexity_tokens` is explicitly a guess. Real cost lived in `tx_nrllm_service_usage` as a **daily aggregate with no `correlation_id`**, so no cost could be joined to a call, a request shape or a complexity bucket.

Five columns now carry it under the id the call already has: `actual_input_tokens`, `actual_output_tokens`, `actual_cost`, `response_model`, `provider_retries`.

**`NULL`, never `0` — and that distinction is the defect this closes, not a nicety.** `Model::hasPricing()` is false when both prices are zero, so Ollama, Groq and every local model recorded `estimated_cost: 0`, indistinguishable from *unpriced* — on precisely the arm a cheap-model experiment is about. `actual_cost` is `NULL` there instead.

Token columns are `NULL` where the provider reported no usage block. `UsageStatistics` types its counts as plain `int`, so the only available signal is **all three zero at once**; a surviving `0` is therefore a measurement, not a gap. Making that type nullable was the alternative and is a breaking `@api` change — named and rejected in the ADR rather than done quietly.

## #771 — pre-routing request facts

The complexity score is measured **after** the model is chosen and partly **from** it: `resolveModel()` runs before `fitToContextWindow()`, and the size term is estimated tokens against the budget of the model already selected. The decision path never sees the messages at all — `decide()` takes criteria, not a payload.

So a second, model-independent fact set is formed **before** selection: message and turn count, tool count, payload bytes, a provider-independent token estimate, request shape.

Deliberately out: context utilisation, the chosen model, its window, its price. Those are exactly what made the first measurement unusable as an input.

**The post-fit record stays.** The two answer different questions, and the ADR states where they diverge rather than calling them equivalent: the system prompt is never the difference between them, **pruning is**, and on a row where the fit dropped turns the pre-routing counts are the larger of the two.

## Nothing routes on any of it

ADR-174 keeps ADR-156's observer-only status intact. This supplies the evidence its three activation criteria need instead of pre-empting them. Two of those criteria were unmeasurable before this change; the third — an online quality signal — still is, and #772 is where that lives.

## Verified against real traffic, with the limits stated

The instrumented path was driven against the seeded local Ollama with deliberately varied turn counts, tool presence and payload sizes, and the recorded rows were read back rather than assumed.

That proves the instruments write real values end to end. It produces **no representative cost data** — a local model is priced at zero, which is the very case `NULL` now distinguishes — and **no quality data at all**.

## Related Issue

Closes #770, closes #771

## Type of Change

- [x] New feature (non-breaking)
- [x] Documentation update
- [x] Schema change (`ext_tables.sql`)

## Known limits, named rather than buried

- **Streaming retry attribution.** `ProviderRetryCounter` is process-wide, and `drain()` is a generator: between the capture and the `finally`, the consumer's own code runs, so retries it causes land on this stream's `provider_retries`. Scoped in the ADR rather than justified with reasoning that does not hold for a generator.
- **`provider_retries IS NULL`** was documented as a meaningful state that no production write site can produce. Corrected.
- The wiring of the shared counter through three constructors is now pinned by a functional test rather than working by luck.

## Gates

`cgl -n`, `phpstan` level 10, `unit` (7166 tests) and functional scoped to `--filter 'Telemetry|Complexity|RequestFacts'` (37 tests) all exit 0, plus all three repo checks.

**`rector -n` at the CI-pinned PHP 8.2 did not run** — `.Build` here is resolved at 8.4 and `platform_check.php` fatals before it starts.

## Note on ADR numbering

This record was written as ADR-173 and is renumbered to **174**: a sibling branch independently claimed 173. Both were told to "confirm the next free number" instead of being given disjoint ranges — the parallel-agent collision that rule exists to prevent. The toctree jumps 172 → 174 until the sibling merges.

## Checklist

- [x] My code follows the project's coding standards
- [x] Tests prove the feature works
- [x] Documentation updated
- [x] `CHANGELOG.md` entry under existing headings
- [x] ADR-174 added and listed in `Documentation/Adr/Index.rst`
- [x] Schema change carries its `ext_tables.sql` entry
