### PR TITLE
docs(roadmap): the last known gap closed in code

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,13 +20,14 @@ closes them. The [`deferred`](https://github.com/netresearch/t3x-nr-llm/issues?q
 label marks issues an ADR explicitly deferred; it spans this section and
 Toward 1.0 alike, so it defines neither.
 
-- **[#731](https://github.com/netresearch/t3x-nr-llm/issues/731) — a per-call injected snippet has no trust-zone ceiling.**
-  The sources a *record* declares are classified and gated: snippets and skills
-  (ADR-144), and the configuration's system prompt (ADR-155), judged against
-  the zone of the model that actually serves the call (ADR-149). Context a
-  *caller* hands the send is not, because it has no per-record home a
-  declaration could live on — the same argument that keeps task input
-  unclassified. ADR-155's own `Revisit when`.
+None open. #731 was the last, and ADR-164 with ADR-165 closed it in code: a
+run's forced sources now bind against the same trust ceiling as a
+configuration's own, at assembly and again on resume.
+
+The task input stays unclassified and does not belong here. ADR-144 declined it
+for want of a per-record home the declaration could live on, and ADR-164
+restates that reason where it declines to extend the ceiling to it — no code
+closes it, so no issue tracks it.
 
 ## Toward 1.0
 


### PR DESCRIPTION
ROADMAP.md listed #731 — "a per-call injected snippet has no trust-zone ceiling" — as open work under **Known gaps**. It is closed, and closed by code rather than by a decision: ADR-164 binds a run's forced sources against the same trust ceiling as a configuration's own, and ADR-165 does it again on resume. That distinction is what the section is about, so the entry had to be checked against the ADRs rather than against the issue state alone — the section says in its own words that an ADR declining to build something closes the decision, not the gap.

**The neighbouring pass the issue asks for, with its result.** Every `#N` in the file was resolved against the API, not read: #731 is the only closed one, #691 is open and correctly listed under Toward 1.0. Nothing else in the file references an issue.

**Known gaps is now empty and says so** instead of being dropped. Its definition is load-bearing: it is what keeps a declined decision from being filed as a non-goal, and the `deferred`-label paragraph refers to it.

**One sentence was added that is not a deletion.** The old entry ended by noting that context a *caller* hands the send stays unclassified — and that half is still true. ADR-164 says so explicitly where it declines to extend the ceiling to the task input, and ADR-144 gives the reason: a declaration with nowhere to live. Deleting the entry without saying that leaves the next reader to re-derive it and file it as a gap, which is the exact failure this issue is about. It is named as *not* belonging in the section, because no code closes it and no issue tracks it.

**Not fixed here, and filed separately:** nothing detects this drift. The file has now been corrected by hand three times — 2e2d5431, 90780db1 and this one — and 90780db1's own message names why (`"sixteen sibling merges changed that answer while it waited"`). A guard would have to ask GitHub for issue state, which is a real design question rather than a line to add to a docs PR, so it gets its own issue.

Tests: none. No PHP is touched. The four `ci:test:repo` checks were run directly and pass — the worktree has no `.Build`, so captainhook was not installed and the commit hook did not run them for me.

Closes #776