### PR TITLE
fix(build): accept the security commit type the hook already sees on main

### DIFF
--- a/Build/captainhook.json
+++ b/Build/captainhook.json
@@ -11,7 +11,7 @@
             {
                 "action": "\\CaptainHook\\App\\Hook\\Message\\Action\\Regex",
                 "options": {
-                    "regex": "#^(feat|fix|chore|docs|test|refactor|style|ci|perf|build|revert)(\\([^)]+\\))?!?: .{1,72}$#"
+                    "regex": "#^(feat|fix|chore|docs|test|refactor|style|ci|perf|build|revert|security)(\\([^)]+\\))?!?: .{1,72}$#"
                 },
                 "conditions": []
             }


### PR DESCRIPTION
AGENTS.md documents the allowed conventional-commit types as including `security`. The `commit-msg` Regex action in `Build/captainhook.json` did not list it, so a commit typed the way the contributor guidance says is valid was rejected locally — and the natural next move, `--no-verify`, is the wrong lesson to teach.

#775 framed this as a real choice: add `security` to the regex, or drop it from the docs and let security fixes be typed `fix`. The repository has already answered it, in three places that were checked rather than assumed.

- **32 commits use the type**, two of them on `main` — `5339098f` and `63a9e40a`, via #753 and #730.
- **Two merged PR titles are of that form**, so the shared `pr-quality` check accepts it. That surface is not this repository's to change, which settles the direction: aligning the docs down to the hook would have put them out of step with a workflow we do not own.
- **CHANGELOG.md carries five `### Security` sections.** The issue offered "keeps the type list aligned with the changelog sections" as the argument for dropping it, but Security *is* one of Keep a Changelog's sections — that argument points the other way once the file is read.

So the hook was the only surface that disagreed, and it was never right: `security` is absent from the file's first version (`ab381010`, the grumphp → captainhook migration), not removed from it later.

## Verification

A before/after on the regex, not a reading of it. `security(agent): bind the input to its turn` — the exact subject of `5339098f` — is rejected by the old pattern and accepted by the new one.

The controls matter more than the fix here, because widening an alternation is exactly how a guard stops guarding. All still refuse after the change:

| Subject | Expected |
|---|---|
| `securityfoo: not a type` | rejected — the alternation did not become a prefix match |
| `nonsense(x): whatever` | rejected |
| `fix: ` (empty subject) | rejected |
| `feat: ` + 73 characters | rejected |

Tests: no PHP is touched. The four `ci:test:repo` checks pass.

No CHANGELOG entry: this changes a contributor-side hook, not behaviour of the extension.

Closes #775