### PR TITLE
fix(usecase): carry the pack's recommended profile into the governance link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   usage and limit only when it refuses, so a row could not tell "near the limit"
   from "nothing measured".
 
+- The governance link on a use-case pack page now carries the pack's
+  recommended profile.
+
+  The page names the recommendation and then invites the operator to compare it
+  against what is in force. The link went to the readout with nothing selected,
+  so the profile had to be found again by hand, one screen after reading its
+  name. The readout has always honoured a `profile` query parameter; only the
+  link never sent one.
+
+
 ## [0.29.1] - 2026-08-13
 
 ### Fixed

--- a/Classes/Controller/Backend/UseCasePackController.php
+++ b/Classes/Controller/Backend/UseCasePackController.php
@@ -114,7 +114,13 @@ final class UseCasePackController extends ActionController
             'pack' => $useCasePack,
             'plan' => $this->installer->plan($useCasePack),
             'wizardUrl' => $this->wizardUrl(),
-            'governanceUrl' => $this->routeUrl('nrllm_overview', 'Backend\\LlmModule', 'governance'),
+            // Carries the pack's recommended profile as the readout's `profile`
+            // query parameter, so the comparison the hint asks for is one click
+            // rather than a hunt through the profile buttons. The readout has
+            // always honoured it; only the link never sent it.
+            'governanceUrl' => $this->routeUrl('nrllm_overview', 'Backend\\LlmModule', 'governance', [
+                'profile' => $useCasePack->recommendedGovernanceProfile->value,
+            ]),
             'toolsUrl' => $this->routeUrl('nrllm_tools', 'Backend\\Tool', 'list'),
             // The Editor Action Center lives in the editor-facing module
             // (ADR-158), not in the admin tree. Linked because the plan names
@@ -206,12 +212,15 @@ final class UseCasePackController extends ActionController
         return $this->routeUrl('nrllm_wizard', 'Backend\\SetupWizard', 'index');
     }
 
-    private function routeUrl(string $route, string $controller, string $action): string
+    /**
+     * @param array<string, string> $extra additional query parameters
+     */
+    private function routeUrl(string $route, string $controller, string $action, array $extra = []): string
     {
         return (string)$this->backendUriBuilder->buildUriFromRoute($route, [
             'controller' => $controller,
             'action' => $action,
-        ]);
+        ] + $extra);
     }
 
     private function enqueueFlashMessage(string $message, string $title, ContextualFeedbackSeverity $severity): void

--- a/Tests/Functional/Controller/Backend/UseCasePackRenderTest.php
+++ b/Tests/Functional/Controller/Backend/UseCasePackRenderTest.php
@@ -26,9 +26,11 @@ use Netresearch\NrLlm\Service\UseCase\UseCasePackRegistry;
 use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Backend\Routing\Route;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\View\ViewFactoryData;
 use TYPO3\CMS\Core\View\ViewFactoryInterface;
@@ -367,6 +369,64 @@ final class UseCasePackRenderTest extends AbstractFunctionalTestCase
         $view->assignMultiple($variables);
 
         return $view->render();
+    }
+
+    #[Test]
+    public function theGovernanceLinkCarriesThePacksRecommendedProfile(): void
+    {
+        // The whole point of the link: the operator has just read the
+        // recommendation's name and wants it compared against what is in force.
+        // Asserted through a dispatched action rather than by handing the URL to
+        // the template, which would only prove the template prints what it is
+        // given (#778).
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+
+        // The request has to exist before the controller is resolved: Extbase's
+        // ConfigurationManager captures the ambient one when it is constructed,
+        // which is what theControllerIsRegisteredInTheContainer() already works
+        // around.
+        $request    = $this->actionRequest('show', ['pack' => 'editorial-starter']);
+        $controller = $this->getService(UseCasePackController::class);
+        $body       = (string)$controller->processRequest($request)->getBody();
+
+        self::assertStringContainsString('profile=controlled-cloud', $body);
+    }
+
+    /**
+     * A request for one action of the real controller, with its arguments.
+     *
+     * The other tests here hand variables to a view, which can only prove the
+     * template prints what it is given. A URL the controller builds needs the
+     * controller to have built it.
+     *
+     * @param array<string, string> $arguments
+     */
+    private function actionRequest(string $action, array $arguments = []): ExtbaseRequest
+    {
+        $parameters = new ExtbaseRequestParameters();
+        $parameters->setControllerName('Backend\\UseCasePack');
+        $parameters->setControllerActionName($action);
+        $parameters->setControllerExtensionName('NrLlm');
+        foreach ($arguments as $name => $value) {
+            $parameters->setArgument($name, $value);
+        }
+
+        // BackendViewFactory resolves its template paths from the route's
+        // packageName, so a module action cannot be dispatched without one.
+        $route = new Route('/module/nrllm/usecase', ['packageName' => 'netresearch/nr-llm']);
+
+        $serverRequest = (new ServerRequest('https://typo3-testing.local/typo3/', 'GET'))
+            ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE)
+            ->withAttribute('route', $route)
+            ->withAttribute('extbase', $parameters);
+        $serverRequest = $serverRequest->withAttribute('normalizedParams', NormalizedParams::createFromRequest($serverRequest));
+        $GLOBALS['TYPO3_REQUEST'] = $serverRequest;
+        // ModuleTemplate translates its own chrome and reads $GLOBALS['LANG'].
+        $GLOBALS['LANG'] = $this->getService(LanguageServiceFactory::class)
+            ->createFromUserPreferences($GLOBALS['BE_USER'] ?? null);
+
+        return new ExtbaseRequest($serverRequest);
     }
 
     /**


### PR DESCRIPTION
The pack detail page prints the governance profile a pack recommends, then says "Compare this posture with what is in force" and links the readout. The link carried no profile, so the operator landed on an unselected readout and had to find the recommendation again by hand — one screen after reading its name.

## One thing the issue expected turned out to be already done

#778 asked for the route parameter "plus whatever the readout needs to honour a pre-selection". The readout needs nothing: `LlmModuleController::governanceAction()` already reads `profile` off the query string, and its own profile buttons already link that way. Only the sender was missing.

So this is `routeUrl()` gaining an optional extra-parameter argument and one call site using it. `GovernanceProfile` is a backed enum, so the value is the same string the buttons use.

## The test dispatches the controller, which is new here

`UseCasePackRenderTest` hands `governanceUrl` to a view as a fixed string. That is right for what those tests check — the template's markup — and it means **none of them could ever have caught this**, because the value under test was supplied by the test.

So this one runs the real action and asserts on the rendered body. Nothing in the suite dispatched a backend module action before, and three things were needed to make it work; each is commented where it sits rather than left as incantation:

- the request must exist **before** the controller is resolved — Extbase's `ConfigurationManager` captures the ambient one, which the neighbouring DI test already works around;
- `BackendViewFactory` resolves template paths from the route's `packageName`, so the request needs a `route` attribute;
- `ModuleTemplate` translates its own chrome from `$GLOBALS['LANG']`.

**Seen to fail first.** With the argument removed the assertion fails on the rendered body; restored, the fifteen tests in the class pass.

Gates: `phpstan` level 10 clean, `unit` 7137 pass, `functional -d sqlite` on `UseCasePack*` 32 pass, `cgl` and `rector -n` stable at PHP 8.2 after applying.

Closes #778