### PR TITLE
docs(adr): accept ADR-169 and retire the management grant reservation

### DIFF
--- a/Classes/Domain/Enum/BackendUserGrant.php
+++ b/Classes/Domain/Enum/BackendUserGrant.php
@@ -23,8 +23,14 @@ namespace Netresearch\NrLlm\Domain\Enum;
  *
  * Each case maps to exactly one enforcement point — there is no wildcard
  * grant, and a case is only added TOGETHER with its consumer (a grant
- * nothing reads is worse than none). `tasks_manage` therefore arrives with
- * the editing module, not here.
+ * nothing reads is worse than none).
+ *
+ * This docblock used to reserve `tasks_manage` for the editing module.
+ * ADR-169 retired that reservation: the records a management surface would
+ * own are authorised by `tables_modify` and `non_exclude_fields`, so the
+ * enforcement point it was waiting for is TYPO3's, not ours. Do not add the
+ * case back without naming an action those two permissions do not already
+ * cover.
  *
  * The values are deliberately underscore-separated, not colon-namespaced
  * like {@see ServiceAccountScope}: TYPO3 strips `:|,` from custom

--- a/Documentation/Adr/Adr130BackendUserGrants.rst
+++ b/Documentation/Adr/Adr130BackendUserGrants.rst
@@ -7,7 +7,9 @@ ADR-130: Capability grants for backend users
 :Status: Accepted (constraint 3 enumerated the approval surfaces and the
    enumeration was not exhaustive — see :ref:`ADR-131 <adr-131>`)
 :Date: 2026-08-06
-:Amended: 2026-08-06 by :ref:`ADR-131 <adr-131>`
+:Amended: 2026-08-06 by :ref:`ADR-131 <adr-131>`; 2026-08-18 by
+   :ref:`ADR-169 <adr-169>` (named constraint 4's reserved ``tasks_manage`` is
+   retired rather than fulfilled)
 
 Context
 =======
@@ -207,11 +209,25 @@ Named constraints, each verified against the code
    and the gate would be decorative. There is no four-eyes check on that
    path: :ref:`ADR-172 <adr-172>` refuses a self-*approval*, and
    supplying input is not one.
-4. **``tasks_manage`` does not exist yet.** The list/wizard actions have
-   no per-action gate to migrate (they are module-gated only), and the
-   trait's JSON 403 body is the wrong shape for HTML module actions. The
-   grant arrives together with its consumer in the editing-module
-   milestone.
+4. **``tasks_manage`` is retired, not pending** — amended, see
+   :ref:`ADR-169 <adr-169>`. This constraint reserved the name and said the
+   grant would arrive with the editing module.
+
+   It will not, and the reason is this record's own rule rather than a change
+   of mind: a case is added together with its enforcement point. ADR-169
+   section 2 settles which records a non-admin may manage — ``tx_nrllm_task``,
+   ``tx_nrllm_promptsnippet`` and ``tx_nrllm_configuration`` — and section 4
+   settles that they are managed through FormEngine with ``exclude => true``
+   on the governance and spend fields. Both halves are then authorised by
+   ``tables_modify`` and ``non_exclude_fields``, which are TYPO3's own
+   permissions on the same fields. A ``tasks_manage`` case would sit in front
+   of nothing.
+
+   The original observation still holds and is why the name was reserved
+   rather than built: the list and wizard actions carry no per-action gate to
+   migrate, and the trait's JSON 403 body is the wrong shape for an HTML
+   module action. What changed is that the gate they lack turns out not to be
+   ours to add.
 5. **The record picker stays admin-only.** ``TaskRecordsController``
    reads arbitrary table rows with only a housekeeping-prefix exclusion —
    no ``tables_select`` check, no denylist for ``be_users``/``sys_log``/

--- a/Documentation/Adr/Adr131EditorModule.rst
+++ b/Documentation/Adr/Adr131EditorModule.rst
@@ -8,6 +8,8 @@ ADR-131: The editor-facing module
 :Date: 2026-08-06
 :Amends: :ref:`ADR-130 <adr-130>` (constraint 3: this module is a third
    approval surface its enumeration did not have)
+:Amended: 2026-08-18 by :ref:`ADR-169 <adr-169>` (its "``tasks_manage`` still
+   does not exist" bullet said the grant was pending; it is retired)
 
 Context
 =======
@@ -66,8 +68,12 @@ What stays out, and why
   :php:`TableReadAccessService` into the picker would also restrict
   administrators, which is its own decision, not a side effect of this
   module.
-- **``tasks_manage`` still does not exist.** This module adds no
-  management surface, so the grant would still have no enforcement point.
+- **``tasks_manage`` does not exist, and will not** — amended, see
+  :ref:`ADR-169 <adr-169>`. This bullet said the grant had no enforcement
+  point *yet*. ADR-169 settles that the records a management surface would
+  own are authorised by ``tables_modify`` and ``non_exclude_fields``, so the
+  enforcement point it was waiting for belongs to TYPO3 rather than to this
+  extension. The reservation is retired.
 - **"Own runs" for editors is mostly the approver's view.** Task
   executions do not create agent runs (they are usage rows); agent runs
   are currently started from admin surfaces. The ownership filter matters

--- a/Documentation/Adr/Adr169RecordManagementUsesTypo3Permissions.rst
+++ b/Documentation/Adr/Adr169RecordManagementUsesTypo3Permissions.rst
@@ -6,9 +6,38 @@
 ADR-169: Record management belongs to TYPO3's permission model
 ============================================================================
 
-:Status: Proposed
+:Status: Accepted (section 6's recommendation is the one exception — it is
+    recorded as open, see `Disposition`_)
 :Date: 2026-08-13
+:Accepted: 2026-08-18
+:Amends: :ref:`ADR-130 <adr-130>` (named constraint 4 reserved ``tasks_manage``;
+    it is retired rather than fulfilled) and :ref:`ADR-131 <adr-131>` (whose
+    "``tasks_manage`` still does not exist" bullet said the same)
 :Authors: Netresearch DTT GmbH
+
+.. _adr-169-disposition:
+
+Disposition
+===========
+
+Accepted on 2026-08-18, section by section, on the personas
+:ref:`ADR-171 <adr-171>` derived. Those personas were still unvalidated at that
+moment — NEXT-152 asks Stefan and Sandra to check them and had no answer. That
+is stated here rather than hidden, because it names where a later answer would
+have to land: persona 7, the management-grant holder, is the one this record
+retires, and if it turns out to be real, section 5 is what an answer would
+reopen.
+
+Sections 1, 2, 3, 4, 5 and 7 are accepted as written.
+
+**Section 6 is not.** It recommends reopening :ref:`ADR-119 <adr-119>` and says
+so as a recommendation "not done here". Reopening it creates a new top-level
+backend section shared with nr_ai_search, nr_repurpose and the cowriter, so it
+is not a side effect of a grant decision in this repository. It is issue `#812`,
+with ADR-119 as its addressee. Nothing is misrepresented in the meantime:
+ADR-119's own status already says the placement is unsettled, and its trigger —
+the first cross-consumer editor surface — has not fired by :ref:`ADR-131 <adr-131>`'s
+own account.
 
 .. _adr-169-context:
 
@@ -17,7 +46,7 @@ Context
 
 Issue `#691` declines to add a ``MANAGE`` grant case until a management surface
 exists, under :ref:`ADR-130 <adr-130>`'s rule that a case arrives together with
-its enforcement point (``Adr130BackendUserGrants.rst:34-38``). That rule exists
+its enforcement point (its Decision, "Grants, not roles"). That rule exists
 because :ref:`ADR-023 <adr-023>` shipped backend-group checkboxes that gated
 nothing and :ref:`ADR-117 <adr-117>` had to remove them: "a control that has to
 be labelled 'has no effect' is worse than its absence"
@@ -242,11 +271,11 @@ acceptable grant of ``allowed_groups``.
 5. The grant's name
 -------------------
 
-``tasks_manage`` is reserved in three places: ADR-130 named constraint 4
-(``Adr130BackendUserGrants.rst:199-203``), ADR-131's "what stays out"
-(``Adr131EditorModule.rst:69-70``) and the enum docblock
-(``Classes/Domain/Enum/BackendUserGrant.php:24-27``). `#691` asks for something
-wider — providers, models, configurations and tasks.
+``tasks_manage`` was reserved in three places: :ref:`ADR-130 <adr-130>`'s named
+constraint 4, :ref:`ADR-131 <adr-131>`'s "what stays out" bullet, and the class
+docblock of :php:`BackendUserGrant`. `#691` asks for something wider —
+providers, models, configurations and tasks. All three now record the
+reservation as retired; see `Disposition`_.
 
 **Recommendation: neither name. Close `#691` as answered.** Section 2 removes
 providers and models from the manageable set, and what remains is governed by
@@ -277,7 +306,7 @@ first; old routes keep working through kept identifiers plus
 an actor-scoped run viewport, but the record states that "'Own runs' for editors
 is mostly the approver's view", that agent runs "are currently started from
 admin surfaces", and that the ownership filter "matters the moment any non-admin
-path starts runs" (``Adr131EditorModule.rst:71-74``). A personal run history is
+path starts runs". A personal run history is
 what that surface will become, not what it is.
 
 What has changed is the count and the constraint. ADR-119 describes twelve
@@ -287,7 +316,7 @@ registered outside it under ``parent => 'web'``
 file). It sits there for a verified platform reason: the module menu drops every
 top-level module whose own access check fails, so a child of the admin-only
 ``nrllm`` (``:53``) would be invisible to non-admins
-(``Adr131EditorModule.rst:31-35``). A management surface has that same
+(:ref:`ADR-131 <adr-131>`, Context). A management surface has that same
 constraint.
 
 **Recommendation: reopen ADR-119 — recommended here, not done here.** Without
@@ -409,12 +438,14 @@ Consequences
 
 If the recommendations are accepted as they stand:
 
-- :ref:`ADR-119 <adr-119>` is reopened by the accepting change, which edits its
-  ``:Status:`` and ``:Amended:`` fields and applies the four pre-settled answers.
+- :ref:`ADR-119 <adr-119>` is **not** reopened by the accepting change. This
+  bullet said it would be, and the acceptance deliberately did not — see
+  `Disposition`_. ADR-119 keeps its ``Accepted (deferred)`` status and its four
+  pre-settled answers stand unapplied.
 - :ref:`ADR-130 <adr-130>` named constraint 4, :ref:`ADR-131 <adr-131>`'s
-  ``tasks_manage`` bullet and the docblock at
-  ``Classes/Domain/Enum/BackendUserGrant.php:24-27`` are amended together: the
-  grant is retired, not pending. Issue `#691` closes as answered.
+  ``tasks_manage`` bullet and the class docblock of :php:`BackendUserGrant` are
+  amended together: the grant is retired, not pending. Issue `#691` closes as
+  answered.
 - **Upgrade note.** A group holding ``tables_modify`` on a ``tx_nrllm_*`` table
   can already edit any record of that table sitting on a page it can edit —
   today, with no flag and no module. Such an entry is inert only where every
@@ -438,5 +469,13 @@ Revisit when
   for credentials; if the usage path stops reading them, the reason expires.
 - Anything starts filtering ``tx_nrllm_*`` reads by pid — that turns page
   storage into a scoping boundary and changes section 1's second cost.
-- TYPO3 changes what ``ignoreRootLevelRestriction`` grants. Section 1 is read
-  off 14.3.5; the 13.4 leg of the matrix was not enumerated.
+- TYPO3 changes what ``ignoreRootLevelRestriction`` grants. Section 1 was read
+  off 14.3.5 and this bullet used to say the 13.4 leg was not enumerated. It has
+  since been read as well, and 13.4 answers identically: the same three
+  ``RootLevelCapability`` constants with ``TYPE_BOTH = -1``, the same skipped
+  early return for ``TYPE_BOTH`` in
+  :php:`isTableAllowedForThisPage()`, the same
+  :php:`admin || shallIgnoreRootLevelRestriction()` at pid 0 and doktype-only
+  above it, and the same split in :php:`hasPageContextPermission()` between
+  ``VirtualRecord::RootPage`` and the web mount plus the ``perms_*`` bitmask. So
+  the trigger is a future core change, not an unchecked leg of the matrix.

--- a/Documentation/Adr/Adr171PersonasTheCodeAlreadyAssumes.rst
+++ b/Documentation/Adr/Adr171PersonasTheCodeAlreadyAssumes.rst
@@ -56,7 +56,7 @@ short-circuits :php:`hasGrant()`, :php:`mayAccessSession()` and
 the configuration group restriction (``ConfigurationResolver.php:218``). The
 docblock records where that comes from: "Administrators hold every grant
 implicitly (the core ``check()`` short-circuits on isAdmin)"
-(``BackendUserGrant.php:19-21``) — the platform's rule, not ours.
+(:php:`BackendUserGrant`'s class docblock) — the platform's rule, not ours.
 
 **Human (unvalidated).** One person owning the instance's AI capability end to
 end: holds the vault key, chooses providers and models, decides which tools exist
@@ -109,9 +109,9 @@ per-task, per-category or per-group scoping, and no task ownership field.
 3. Approver (``agent_approve``)
 -------------------------------
 
-**Code.** ``BackendUserGrant.php:47-52``; the grant branch in
+**Code.** :php:`BackendUserGrant::AGENT_APPROVE`; the grant branch in
 :php:`AiActorContext::mayActOnRun()` (``:229``) — "deliberately the only scope
-with a grant equivalent" (``Adr130:59-62``); the write side at
+with a grant equivalent" (:ref:`ADR-130 <adr-130>`, Decision); the write side at
 ``ResumeCoordinator.php:205`` and ``:650``; the list viewport at
 ``AgentRunController.php:267``. It sits in no recommended preset: "granting it is
 an explicit trust decision"
@@ -170,7 +170,9 @@ and which model and configuration it uses is defined by whoever manages the task
 (``Permissions.rst:40-43``). Nothing checks it:
 :php:`TaskExecutionService::execute()` takes ``(Task, string, ?int $beUserUid)`` —
 no actor, nothing to check against. ``tasks_manage`` occurs once in ``Classes/``,
-in a docblock saying it does not exist yet (``BackendUserGrant.php:24-27``).
+in :php:`BackendUserGrant`'s class docblock — which, since
+:ref:`ADR-169 <adr-169>` was accepted, records the reservation as retired rather
+than pending.
 
 **Human (unvalidated).** Writes the prompt, picks the configuration, and thereby
 sets the data reach of everything an editor runs — without holding credentials.
@@ -215,19 +217,22 @@ one of ours. No third-party integrator is evidenced anywhere.
 --------------------------
 
 **Code.** None, by design: "a case is only added TOGETHER with its consumer (a
-grant nothing reads is worse than none)" (``BackendUserGrant.php:24-27``);
-reserved again at ``Adr130:199-203`` and ``Adr131:69-70``.
+grant nothing reads is worse than none)" (:php:`BackendUserGrant`'s class
+docblock). It was reserved again in :ref:`ADR-130 <adr-130>` and
+:ref:`ADR-131 <adr-131>`; all three reservations are now retired.
 
 **Human (unvalidated).** Curates the AI catalogue for their own team while keys
 and endpoints stay administrator-only.
 
-**Confidence.** Required by a planned feature that
-``Adr169…rst:251-255`` now recommends **deleting**: "Recommendation: neither name.
-Close `#691` as answered."
+**Confidence.** Was required by a planned feature that
+:ref:`ADR-169 <adr-169>` section 5 recommended deleting: "Recommendation:
+neither name. Close `#691` as answered."
 
-**Blocks.** `#691`, `#768`, and whether ADR-169 is accepted. If this person is
-real, ADR-169's section 5 is wrong; if not, three documents carry a reservation
-that should be retired.
+**Blocks.** Nothing any more, and how it stopped is worth recording. ADR-169 was
+accepted on 2026-08-18 while this persona was still unvalidated, so section 5's
+recommendation carried. If a validated persona 7 turns up later, section 5 is
+the decision that was made without them and the one an answer would reopen —
+not this paragraph.
 
 .. _adr-171-contradictions:
 
@@ -242,8 +247,7 @@ nobody reads it as an already-active control." It shipped: ``Modules.php:375-381
 registers ``AgentRunController::approve`` and ``submitInput`` in
 ``nrllm_aitasks``, ``'access' => 'user'`` (``:344``). A non-admin who holds the
 grant and whose group has that module ticked decides another user's write today.
-ADR-130 now carries ``:Amended:`` and a rewritten constraint 3
-(``Adr130BackendUserGrants.rst:80-198``), and
+ADR-130 now carries ``:Amended:`` and a rewritten constraint 3, and
 ``Tests/Unit/Configuration/ApprovalSurfaceInventoryTest.php`` pins the module
 inventory, so a new approval *module* cannot be registered without ADR-130
 naming it. It does not cover every shape an approval surface could take;
@@ -259,8 +263,9 @@ module** does not: ``TaskExecutionService.php:63`` calls
 configuration, returned unchecked; the method has no actor to check with. A task
 pinned to a restricted configuration bypasses that restriction.
 
-**C. The bound that justifies the grant is opt-in.** ``Adr130:57-58``: "The
-per-user budget pre-flight … bounds what a grant holder can spend."
+**C. The bound that justifies the grant is opt-in.** :ref:`ADR-130 <adr-130>`,
+Decision: "The per-user budget pre-flight … bounds what a grant holder can
+spend."
 ``Permissions.rst:43-45`` states it in its own words, not this one's — "Every run
 is pre-flighted against the user's own usage budget and attributed to them."
 ``BudgetService.php:76-79``: with no ``tx_nrllm_user_budget``
@@ -285,11 +290,12 @@ configuration (``Adr140:164``), and a person with shell and cron
 operator" that is a **non-admin** holding one grant, and says so: "identical to
 *AI editor* on purpose".
 
-**F. The enum's own invariant no longer holds.** ``BackendUserGrant.php:24-25``:
+**F. The enum's own invariant no longer holds.** :php:`BackendUserGrant`'s class docblock:
 "Each case maps to exactly one enforcement point — there is no wildcard"; the
 ``TASKS_USE`` docblock names two. There are nine, across task execution, a module
 index, the Editor Action Center and a record context menu. That is a role-ladder
-rung, which ``Adr130:26`` promised the design would not grow.
+rung, which :ref:`ADR-130 <adr-130>`'s Context promised the design would not
+grow.
 
 .. _adr-171-invented:
 
@@ -300,7 +306,7 @@ These exist because a gate exists, not because anyone does the job. A reviewer
 should read this section first.
 
 - **The approver, as a distinct person.** The gate is real and tested. But
-  ``Adr130:59-62`` calls it "**deliberately** the only scope with a grant
+  :ref:`ADR-130 <adr-130>` calls it "**deliberately** the only scope with a grant
   equivalent" — a design choice, not an observed org chart. Until
   contradiction A shipped, no non-admin could reach it at all. We built the
   separation before meeting anyone who wants it.
@@ -325,7 +331,7 @@ should read this section first.
   approved it — belongs to the editor, where a human can be asked about it.
 - **The anonymous caller and the backend group.** A fail-closed null object
   (``AiActorContext.php:72-79``) and the unit of entitlement
-  (``BackendUserGrant.php:20-22``). Both are load-bearing; neither is a person.
+  (:php:`BackendUserGrant`'s class docblock). Both are load-bearing; neither is a person.
 - **The service account.** A machine, not a persona — and the counter-example to
   ADR-023: fail-closed from its first line. One exists, ``cli:nrllm:agent:cancel``
   (``CancelAgentRunCommand.php:69``), declaring one of the five scopes.
@@ -376,7 +382,7 @@ What TYPO3 gives us and what it does not
 
 TYPO3 gives **roles**: three enforcement primitives, all of which nr_llm uses.
 ``admin`` is the whole default posture. ``user`` on a module means one tick in a
-group's module list and nothing more — ``Adr131:36-41`` records the verified trap
+group's module list and nothing more — :ref:`ADR-131 <adr-131>` records the verified trap
 that ``'user,group'`` denies everyone. ``systemMaintainer`` we never check but
 depend on.
 


### PR DESCRIPTION
#768 asks for "an ADR that decides, together, before code exists" — seven questions, listed. **That ADR already exists.** ADR-169 is 442 lines, covers all seven, carries a recommendation for each, and sat at `Proposed`. What was missing was the decision, not the record. So this accepts it instead of writing a second one.

## The decisions

| § | Recommendation | Disposition |
|---|---|---|
| 1 | Records on a page inside a web mount (Option P), **not** opening `security.ignoreRootLevelRestriction` | accepted |
| 2 | Manageable: `tx_nrllm_task`, `tx_nrllm_promptsnippet`, `tx_nrllm_configuration` (last one minus governance and spend fields) | accepted |
| 3 | Both wizards move onto the DataHandler or stay admin-only | accepted |
| 4 | FormEngine plus `exclude => true` (Option C) | accepted |
| 5 | Neither grant name; close #691 as answered | accepted |
| 6 | Reopen ADR-119 | **not accepted here** → #812 |
| 7 | No grant case; preset import and pack install write as the acting user | accepted |

**Section 6 is the one exception and the record now says so.** Reopening ADR-119 creates a top-level backend section shared with `nr_ai_search`, `nr_repurpose` and the cowriter. That is a decision about three other products' backend UI and should not arrive as a side effect of retiring a permission grant here. ADR-169's Consequences bullet promised the accepting change *would* reopen it; leaving that standing would have made the record false the moment it was accepted, so it is corrected rather than ignored.

## What this retires

`tasks_manage` was reserved in three places. It is retired, and the reason is ADR-130's own rule rather than a change of mind: after sections 2 and 4 the manageable records are authorised by `tables_modify` and `non_exclude_fields` — TYPO3's own permissions on the same fields — so the grant would sit in front of nothing. ADR-130 named constraint 4, ADR-131's bullet and `BackendUserGrant`'s class docblock all record that now.

**The `:Amended:` pairing was verified by breaking it**, not by reading it: removing ADR-130's half makes `AdrLifecycleTest::amendingAndAmendedRecordsPointAtEachOther` name the missing side. Restored, green.

## One premise I checked before signing it

Section 1's Revisit list said it was read off 14.3.5 and that "the 13.4 leg of the matrix was not enumerated". The whole Option P conclusion rests on it, and this extension supports `^13.4 || ^14.3`, so accepting on one leg would have been signing for both.

13.4 answers identically: the same three `RootLevelCapability` constants with `TYPE_BOTH = -1`, the same skipped early return for `TYPE_BOTH` in `isTableAllowedForThisPage()`, the same `admin || shallIgnoreRootLevelRestriction()` at pid 0 with doktype-only above it, and the same split in `hasPageContextPermission()` between `VirtualRecord::RootPage` and the web mount plus the `perms_*` bitmask. The Revisit bullet now records the verification instead of the gap.

## Citation cleanup, and a limit it demonstrates

Fourteen `File:NNN` citations pointed into the four files this change edits — and one of them, ADR-169's own reference to ADR-130 constraint 4, was **already wrong before I touched anything**. They are replaced with references carrying no line numbers rather than renumbered, because renumbering only resets the clock.

Worth naming: `AdrCodeCitationTest`, merged three hours ago in #807, does not catch this. A citation whose target moved is still a non-blank line in an existing file. Its docblock says exactly that, and this is the first change to demonstrate it.

## Personas

Accepted on ADR-171's personas while they are still unvalidated — NEXT-152 has no answer yet. That is recorded in the new `Disposition` section rather than left implicit, and persona 7 (the management-grant holder) is named as the one this retires, so a later answer from Stefan has a stated place to land: section 5 is what it would reopen.

Gates: `phpstan` level 10 clean, `unit` 7200 pass (68 of them ADR suites), `cgl` clean, `rector -n` clean at PHP 8.2, the three repo checks pass. No PHP behaviour changes — the only code edit is a docblock.

Closes #768