### PR TITLE
docs(adr): ADR-176, a per-call outcome kept apart from the approval gate

### DIFF
--- a/Documentation/Adr/Adr156PersistTheRoutingDecisionObserveComplexity.rst
+++ b/Documentation/Adr/Adr156PersistTheRoutingDecisionObserveComplexity.rst
@@ -7,7 +7,9 @@ ADR-156: Persist the routing decision, and observe complexity without routing
 :Status: Accepted
 :Date: 2026-08-11
 :Amends: :ref:`ADR-142 <adr-142>` (both of its deferrals are lifted, one of them only halfway)
-:Amended: 2026-08-14 by :ref:`ADR-174 <adr-174>`
+:Amended: 2026-08-14 by :ref:`ADR-174 <adr-174>`; 2026-08-18 by
+   :ref:`ADR-176 <adr-176>` (its second activation criterion cited ADR-060,
+   whose per-model value cannot distinguish two canary arms)
 :Authors: Netresearch DTT GmbH
 
 Context

--- a/Documentation/Adr/Adr176PerCallOutcomeSeparateFromApproval.rst
+++ b/Documentation/Adr/Adr176PerCallOutcomeSeparateFromApproval.rst
@@ -1,0 +1,144 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-176:
+
+==============================================================================
+ADR-176: A per-call outcome, kept apart from the approval gate
+==============================================================================
+
+:Status: Accepted
+:Date: 2026-08-18
+:Amends: :ref:`ADR-156 <adr-156>` (its second activation criterion cited
+    ADR-060 as "the measured quality signal"; that per-model value cannot
+    answer it, and this record supplies the one that can)
+:Authors: Netresearch DTT GmbH
+
+Context
+=======
+
+:ref:`ADR-156 <adr-156>`'s second activation criterion asks whether quality
+degrades on a population served by a cheaper model, and points at
+:ref:`ADR-060 <adr-060>` for the measurement. ADR-060 is the golden-set layer:
+a value per **model**, graded out of request by a CLI command nothing
+schedules. In a canary both arms carry the same model-level value, so the
+criterion evaluates to "no difference" by construction, whatever the models
+did. The citation has never been able to answer the question it is cited for.
+
+Nothing else fills the gap. Governance events record blocks and never allows,
+so there is no denominator. There is no rating, no acceptance signal and no
+feedback of any kind, and retries are not counted. A promotion rule phrased as
+a quality delta would be a rule over a metric nobody records — the
+declaration-nothing-reads failure :ref:`ADR-142 <adr-142>` and ADR-156 exist to
+avoid.
+
+Decision
+========
+
+**A per-call outcome row, keyed on** ``correlation_id`` — the same key
+:ref:`ADR-174 <adr-174>` writes cost and pre-routing facts against, so a
+quality figure and a cost figure join without a second identity.
+
+**Approval is not quality, and the two never meet in one code path.** An
+approval can be withheld for governance, policy or content reasons that say
+nothing about how the model did; :ref:`ADR-172 <adr-172>` even refuses one on
+who the approver is. Folding the gate into this metric would measure governance
+behaviour and call it quality. No writer of an outcome row reads an approval
+state, and the readout has no column for one.
+
+**No person on the row.** No ``be_user`` column, and nr_llm ships no
+per-editor readout. What identifies a call is the correlation id; who ran it is
+already on the run record, because budgets and
+:php:`AiActorContext::mayActOnRun()` need it there. This record does not add a
+second copy, and it does not build an anonymisation of its own: erasure rides
+on the installation's ``be_users`` lifecycle, which is the framework's
+responsibility. Saying "we store no names" would be true and misleading — the
+join through the run still exists, and that is stated here rather than
+implied.
+
+**Two sources, and they are never averaged into one number.**
+
+.. list-table::
+   :header-rows: 1
+
+   * - Source
+     - What it means
+     - Where it is available
+   * - ``explicit``
+     - a backend user rated the result
+     - every path that shows a result
+   * - ``observed``
+     - what happened to the text afterwards
+     - only where a record was written
+
+That split is not a preference. It was read off the code:
+:php:`AiTaskController` renders the result into ``Backend/AiTask/Execute`` and
+the editor copies it by hand — there is no write target, so there is nothing to
+observe. :php:`EditorActionController` starts tools that write through the
+DataHandler against a named ``recordTable`` and ``recordUid``.
+
+So ``observed`` is not a cheaper substitute for ``explicit`` that happens to be
+available everywhere. A figure averaging both would compare a population that
+can be observed against one that cannot, and the difference between two canary
+arms would carry that asymmetry rather than the models' quality. The readout
+reports them separately or not at all.
+
+**The observed signal is an event, not a window.** The write tools refuse the
+draft workspace and edit live
+(:php:`WritesThroughDataHandlerTrait::refuseOutsideLiveWorkspace()`), and
+:php:`CreateContentElementDraftTool` creates its element ``hidden``. "Draft"
+here is a hidden live record, not a workspace version, so there is no publish
+or discard event to hang a measurement on. What a human does next is
+observable in ``sys_history``: unhide it, change it first, or delete it. A
+record still hidden records no outcome — "undecided" is the honest answer and
+not a third quality value.
+
+Sequencing, and the prerequisite it exposes
+===========================================
+
+**``explicit`` ships first, and alone.** It needs no new contract: the result
+is on screen, the correlation id is in hand, and the row can be written from
+the surface that shows the result.
+
+**``observed`` is blocked on something this record did not expect to find.**
+Nothing persists *which record* a tool write produced. The uid the model chose
+is inside :php:`ToolInvocation::$arguments` as free-form JSON, and
+:php:`ToolEffectInterface` declares only :php:`getEffect()` — a classification,
+not an identity. Without a queryable write target there is no join to
+``sys_history`` and therefore no observed outcome.
+
+That is :ref:`ADR-122 <adr-122>`'s deferred territory. It declined to build a
+side-effecting tool contract because no tool had side effects, and its status
+already records that premise as expired. Five builtins write through the
+DataHandler today. So the prerequisite is not new work invented here; it is the
+part of ADR-122 whose reason for waiting has gone, and the outcome signal is
+the first reader it lacked.
+
+What this does not do
+=====================
+
+**It does not route anything.** ADR-156's three activation criteria still
+decide, all three, measured over real traffic. This makes the second one
+computable; it does not meet it.
+
+**It does not replace ADR-060.** The golden set answers "is model A better than
+model B on our prompts", out of request and repeatably. This answers "did this
+call go well". Neither substitutes for the other, and ADR-156's criterion 2 now
+cites this record for the online half.
+
+**It does not touch the send path.** No writer runs during a send, nothing
+blocks, and a call whose outcome is never recorded is the normal case rather
+than an error.
+
+**It does not aggregate at write time.** A per-call row is what a canary reads;
+collapsing to a per-arm counter at write time would save nothing and destroy
+the ability to re-cut the population later.
+
+Revisit when
+============
+
+- The task path gains a write target. Then ``observed`` covers it too and the
+  population asymmetry above narrows.
+- A second reader wants the outcome per person. It is not available, by
+  decision — reopen this record rather than adding the column.
+- ADR-122's prerequisite lands. The observed source stops being blocked and
+  this record's sequencing note becomes history.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -527,3 +527,4 @@ Tools
    Adr173SelfApprovalIsVisibleInTheRecord
    Adr174PerCallCostAndPreRoutingFacts
    Adr175ForcedSkillsBindByTheSnippetRule
+   Adr176PerCallOutcomeSeparateFromApproval

--- a/specs/002-per-call-outcome/spec.md
+++ b/specs/002-per-call-outcome/spec.md
@@ -1,0 +1,65 @@
+# Per-call outcome signal (#772)
+
+ADR-156's second activation criterion asks whether quality degrades on a
+population served by a cheaper model. It cites ADR-060, which is the golden-set
+layer: a value per **model**, produced out of request by a CLI command nothing
+schedules. In a canary both arms are the same model-level value, so the
+criterion cannot be evaluated. This adds the missing per-call signal.
+
+## What it must do
+
+1. Record an outcome per call, keyed on `correlation_id` — the key ADR-174
+   already writes cost and pre-routing facts against.
+2. Carry two sources and keep them apart:
+   - **explicit** — a backend user rates the result;
+   - **observed** — what happened to the generated text afterwards.
+3. Be readable grouped by model and canary arm, so ADR-156 criterion 2 becomes
+   computable.
+
+## What it must NOT do
+
+- **Not treat approval or refusal as quality.** An approval can be withheld for
+  governance, policy or content reasons that say nothing about the model.
+  Folding the approval gate into this metric would measure governance
+  behaviour. #772 names this and it is the reason the signal is separate.
+- **Not carry a person.** No `be_user` column on the outcome row, and no
+  per-editor readout anywhere in nr_llm. Erasure rides on the installation's
+  `be_users` lifecycle; nr_llm builds no anonymisation of its own, because that
+  is the framework's job and duplicating it creates a second truth.
+- **Not mix the two sources in one number.** See the constraint below — they do
+  not cover the same population, so an average over both would describe neither.
+- **Not block, delay or alter a send.** Observation only, like ADR-174.
+
+## The constraint that shapes it, verified in the code
+
+The two sources reach different traffic, and this was checked rather than
+assumed:
+
+| Path | Write target | Signal available |
+|---|---|---|
+| `AiTaskController` — task execution | none; the result is rendered into `Backend/AiTask/Execute` and the editor copies it by hand | explicit only |
+| `EditorActionController` — editorial actions | `recordTable` / `recordUid`, written through the DataHandler by one of the five write tools | explicit **and** observed |
+
+So "observed" is not a cheaper substitute for "explicit" that happens to be
+available everywhere. It is available on one path. A readout that averages both
+would compare a population that can be observed against one that cannot, and
+the difference between the arms would carry that asymmetry rather than the
+model's quality.
+
+## Which suite proves what
+
+| Requirement | Suite |
+|---|---|
+| Outcome row writes and reads back, grouped by model and arm | functional, repository test |
+| The row carries no `be_user` and the table has no such column | functional, asserted against the schema rather than the writer |
+| Explicit and observed never fold into one figure | unit, on the readout |
+| No approval or governance state reaches the outcome | unit, and an inventory test over the writers in the ADR-130 style |
+| Nothing on the send path calls the writer | unit, on the send path |
+
+## Open, deliberately
+
+Whether the observed signal is also derived for a suspended-then-approved
+editorial write. The preview is captured at suspension (ADR-136), so a
+comparison is possible in principle; it is left out of the first change because
+the approval decision sits between, and the "approval is not quality" rule is
+easiest to keep if the two never meet in one code path.


### PR DESCRIPTION
The decision behind #772, before any code. No behaviour changes here.

## The problem

We cannot tell whether a single AI answer was good. There is no measurement per request.

That blocks one thing: sending simple requests to a cheaper model. ADR-156 allows it only if quality does not drop, and that is exactly what we cannot check.

A quality value does exist, but it does not help. It is per model, from a test set. Comparing two models, it is the same on both sides. So it can never show a difference — the citation in ADR-156's second criterion could never answer the question it was cited for.

## The decision

One outcome row per call, on `correlation_id` — the key ADR-174 already writes cost against, so quality and cost join without a second identity.

**Approval is not quality.** An approval can be withheld for governance or content reasons that say nothing about the model. No writer reads an approval state and the readout has no column for one.

**No person on the row.** No `be_user`, and no per-editor readout anywhere. The run record already carries who ran it, because budgets need it there. Erasure rides on the installation's `be_users` lifecycle — that is the framework's job and nr_llm does not build a second one. The join through the run still exists, and the record says so instead of resting on "we store no names".

## Two measurements, never averaged into one number

| | What it is | Where it works |
|---|---|---|
| **explicit** | the editor rates the result | everywhere |
| **observed** | what happened to the text afterwards | only where a tool wrote a record |

That split was read off the code, not assumed. `AiTaskController` renders the result and the editor copies it by hand — no write target, nothing to observe. `EditorActionController` writes through the DataHandler against a named record.

So `observed` is not a cheaper version of `explicit` that happens to be available everywhere. A figure averaging both would compare an observable population against an unobservable one, and a canary's arm difference would carry that asymmetry instead of the models' quality.

## Two things the draft turned up

**The observed signal is an event, not a time window.** The write tools refuse the draft workspace and write live; `CreateContentElementDraftTool` creates its element `hidden`. So "draft" here is a hidden live record, not a workspace version, and there is no publish or discard to measure. What the human does next is in `sys_history`: unhide, change first, or delete. A record still hidden gets no outcome — "undecided" is honest and is not a third quality value.

**And `observed` is blocked on something already deferred once.** Nothing persists *which* record a tool write produced: the uid sits in `ToolInvocation::$arguments` as free-form JSON, and `ToolEffectInterface` declares only `getEffect()` — a classification, not an identity. No write target, no join to `sys_history`.

That is ADR-122's territory. It declined the side-effecting tool contract because no tool had side effects, and its own status already records that premise as expired. Five builtins write through the DataHandler today. The prerequisite is not new work invented here; it is the part of ADR-122 whose reason for waiting is gone, and this outcome signal is the first reader it lacked.

## Sequencing

`explicit` ships first and alone — it needs no new contract. `observed` ships with the prerequisite above.

## Verification

The ADR suites caught a real mistake in this record. `AdrLifecycleTest` reads **every** `:ref:` inside an `:Amends:` field as an amend target, and my parenthetical linked ADR-060 — so the record claimed to amend it. Now only ADR-156 is named, and ADR-156 carries the matching `:Amended:`.

68 ADR-suite tests pass, `unit` 7200 pass, the three repo checks pass. No PHP is touched, so no CHANGELOG entry.

Refs #772