### PR TITLE
feat: caller-source attribution on the options path (ADR-177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Telemetry rows can name their caller** (`#816`, ADR-177). A downstream consumer tags its calls with `->withCallerSource('my_extension', 'operation')` on any options object; the identity is persisted on the telemetry row as `source_extension` / `source_operation` and never sent to the provider. Unannotated calls keep writing `''`, so existing rows and consumers are untouched. Driving consumer: the nr-llm-compat bridge layer.
 - **A self-approved run says so** (`#785`). An approval granted by the backend user who started the run is now labelled as such — on the run timeline, and in the *Recent runs* table of the Agent Runs inbox, which gains an *Approval* column. An approval granted by anybody else is labelled too, so the two are told apart at a glance instead of by comparing two uid numbers.
 
   Derived at read time from values that were already stored, so it is right for runs recorded before this change. The readout compares the two uids in one place, `Domain\Enum\ApprovalAttribution`, and both surfaces render its answer; ADR-172's four-eyes gate keeps its own, stricter comparison in `AiActorContext::isInitiatorOf()`.

--- a/Classes/Provider/Middleware/TelemetryMiddleware.php
+++ b/Classes/Provider/Middleware/TelemetryMiddleware.php
@@ -77,6 +77,16 @@ use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 final readonly class TelemetryMiddleware implements ProviderMiddlewareInterface
 {
     /**
+     * Context-metadata key naming the calling software (ADR-177), set by
+     * {@see \Netresearch\NrLlm\Service\CallMetadataFactory::callerSource()}
+     * from the options object; persisted as `source_extension`.
+     */
+    public const METADATA_SOURCE_EXTENSION = 'sourceExtension';
+
+    /** Companion to {@see self::METADATA_SOURCE_EXTENSION}; persisted as `source_operation`. */
+    public const METADATA_SOURCE_OPERATION = 'sourceOperation';
+
+    /**
      * Pipeline priority, read by the tagged iterator via
      * `defaultPriorityMethod` (ADR-085 ordering).
      *
@@ -208,6 +218,12 @@ final readonly class TelemetryMiddleware implements ProviderMiddlewareInterface
                 requestFacts: $signals->requestFacts,
                 callUsage: $signals->callUsage,
                 providerRetries: $providerRetries,
+                // Caller identity (ADR-177), set on the way in by
+                // CallMetadataFactory::callerSource() from the options object.
+                // '' for unannotated calls — indistinguishable from a
+                // pre-feature row on purpose.
+                sourceExtension: $this->metadataString($context, self::METADATA_SOURCE_EXTENSION),
+                sourceOperation: $this->metadataString($context, self::METADATA_SOURCE_OPERATION),
             ));
         } catch (Throwable $e) {
             // Observability must not break the call it observes. safeRecord()
@@ -229,6 +245,13 @@ final readonly class TelemetryMiddleware implements ProviderMiddlewareInterface
                 // Nothing safe left to do; never let observability break the call.
             }
         }
+    }
+
+    private function metadataString(ProviderCallContext $context, string $key): string
+    {
+        $value = $context->metadata[$key] ?? '';
+
+        return \is_string($value) ? $value : '';
     }
 
     /**

--- a/Classes/Service/CallMetadataFactory.php
+++ b/Classes/Service/CallMetadataFactory.php
@@ -13,17 +13,20 @@ use Netresearch\NrLlm\Domain\ValueObject\AgentRunReference;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\GuardrailMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\IdempotencyMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\TelemetryMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
+use Netresearch\NrLlm\Service\Option\AbstractOptions;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
 
 /**
  * Builds the pipeline metadata the middlewares read, extracted verbatim from
  * LlmServiceManager (ADR-059 stage 2).
  *
- * Four producers, four disjoint key sets — budget, idempotency, request
- * counting, agent run — which is why every call site merges them with `+` and
- * must keep doing so: the disjointness is load-bearing, and array_merge would
- * let a later set silently win over an earlier one if a key ever collided.
+ * Five producers, five disjoint key sets — budget, idempotency, request
+ * counting, caller source, agent run — which is why every call site merges
+ * them with `+` and must keep doing so: the disjointness is load-bearing, and
+ * array_merge would let a later set silently win over an earlier one if a key
+ * ever collided.
  *
  * Stateless and pure; the manager holds one instance.
  */
@@ -95,6 +98,28 @@ final readonly class CallMetadataFactory
         return $options->getSuppressRequestCount()
             ? [UsageMiddleware::METADATA_SKIP_REQUEST_COUNT => true]
             : [];
+    }
+
+    /**
+     * Translate the caller identity (ADR-177) into the metadata keys the
+     * TelemetryMiddleware persists as source_extension / source_operation.
+     * An unannotated call produces no entry, so its telemetry row keeps the
+     * '' defaults and stays indistinguishable from a pre-feature row.
+     * Disjoint from every other producer's keys, so it merges with `+`.
+     *
+     * @return array<string, string>
+     */
+    public function callerSource(AbstractOptions $options): array
+    {
+        $extension = $options->getCallerSourceExtension();
+        if ($extension === null || $extension === '') {
+            return [];
+        }
+
+        return [
+            TelemetryMiddleware::METADATA_SOURCE_EXTENSION => $extension,
+            TelemetryMiddleware::METADATA_SOURCE_OPERATION => $options->getCallerSourceOperation() ?? '',
+        ];
     }
 
     /**

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -562,7 +562,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             return $this->chatWithConfiguration(
                 $this->injectConfigSkillsIntoMessages($messages, $defaultConfiguration),
                 $defaultConfiguration,
-                $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->idempotency($options->getIdempotencyKey()) + $this->metadata->requestCount($options),
+                $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->idempotency($options->getIdempotencyKey()) + $this->metadata->requestCount($options) + $this->metadata->callerSource($options),
                 $optionsArray,
             );
         }
@@ -576,7 +576,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             $this->synthesizeTransientConfiguration(ProviderOperation::Chat, $providerKey),
             ProviderOperation::Chat,
             fn(): CompletionResponse => $this->getProvider($providerKey)->chatCompletion($this->applyAndScreenSystemPrompt($normalisedMessages, $optionsArray), $optionsArray),
-            $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->idempotency($options->getIdempotencyKey()) + $this->metadata->requestCount($options),
+            $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->idempotency($options->getIdempotencyKey()) + $this->metadata->requestCount($options) + $this->metadata->callerSource($options),
         );
     }
 
@@ -594,7 +594,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             return $this->completeWithConfiguration(
                 $this->injectConfigSkillsIntoPrompt($prompt, $defaultConfiguration),
                 $defaultConfiguration,
-                $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->idempotency($options->getIdempotencyKey()),
+                $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->idempotency($options->getIdempotencyKey()) + $this->metadata->callerSource($options),
                 $optionsArray,
             );
         }
@@ -606,7 +606,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
             $this->synthesizeTransientConfiguration(ProviderOperation::Completion, $providerKey),
             ProviderOperation::Completion,
             fn(): CompletionResponse => $this->getProvider($providerKey)->complete($prompt, $optionsArray),
-            $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->idempotency($options->getIdempotencyKey()),
+            $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->idempotency($options->getIdempotencyKey()) + $this->metadata->callerSource($options),
         );
     }
 
@@ -625,7 +625,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         // is left out and CacheMiddleware becomes a no-op for this call. The
         // ad-hoc path keys by provider identifier.
         $cacheTtl = is_int($optionsArray['cache_ttl'] ?? null) ? $optionsArray['cache_ttl'] : 0;
-        $metadata = $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->idempotency($options->getIdempotencyKey());
+        $metadata = $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->idempotency($options->getIdempotencyKey()) + $this->metadata->callerSource($options);
         $resolvedProvider = $providerKey ?? 'default';
         $metadata += $this->embedCacheKeyBuilder->build(
             $cacheTtl,
@@ -724,7 +724,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
 
                 return $provider->analyzeImage($normalisedContent, $optionsArray);
             },
-            $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->idempotency($options->getIdempotencyKey()),
+            $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->idempotency($options->getIdempotencyKey()) + $this->metadata->callerSource($options),
         );
     }
 
@@ -753,7 +753,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
                 $this->injectConfigSkillsIntoMessages($messages, $defaultConfiguration),
                 $defaultConfiguration,
                 $optionsArray,
-                $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()),
+                $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->callerSource($options),
             );
         }
 
@@ -783,7 +783,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         // first iteration inside the dispatcher.
         $this->assertStreamingCapable($this->getProvider($providerKey), 1581627129);
 
-        $metadata = $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost());
+        $metadata = $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->callerSource($options);
         $metadata[StreamingDispatcher::METADATA_PROVIDER]     = $providerKey ?? 'default';
         $metadata[StreamingDispatcher::METADATA_PROMPT_CHARS] = $this->estimatePromptChars($messages);
 
@@ -839,7 +839,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
 
                 return $provider->chatCompletionWithTools($this->applyAndScreenSystemPrompt($normalisedMessages, $optionsArray), $normalisedTools, $optionsArray);
             },
-            $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->idempotency($options->getIdempotencyKey()),
+            $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->idempotency($options->getIdempotencyKey()) + $this->metadata->callerSource($options),
         );
     }
 
@@ -923,7 +923,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
                     $callOptions,
                 );
             },
-            $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->idempotency($options->getIdempotencyKey()),
+            $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->idempotency($options->getIdempotencyKey()) + $this->metadata->callerSource($options),
             $run,
             $injectedContext,
             $this->collectRequestFacts(
@@ -965,7 +965,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         $optionOverrides = $options->toArray();
         unset($optionOverrides['provider']);
 
-        $metadata = $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->idempotency($options->getIdempotencyKey());
+        $metadata = $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->idempotency($options->getIdempotencyKey()) + $this->metadata->callerSource($options);
 
         // Cache metadata mirrors embed(), but the configuration path keys by
         // configuration identifier plus the effective model (options override
@@ -1188,7 +1188,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         return $this->chatWithConfiguration(
             $this->injectConfigSkillsIntoMessages($messages, $configuration),
             $configuration,
-            $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->idempotency($options->getIdempotencyKey()),
+            $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->idempotency($options->getIdempotencyKey()) + $this->metadata->callerSource($options),
             $optionsArray,
         );
     }
@@ -1209,7 +1209,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         return $this->chatWithConfiguration(
             $this->injectConfigSkillsIntoMessages($messages, $configuration),
             $configuration,
-            $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->idempotency($options->getIdempotencyKey()),
+            $this->metadata->budget($options->getBeUserUid(), $options->getPlannedCost()) + $this->metadata->idempotency($options->getIdempotencyKey()) + $this->metadata->callerSource($options),
             $optionsArray,
         );
     }

--- a/Classes/Service/Option/AbstractOptions.php
+++ b/Classes/Service/Option/AbstractOptions.php
@@ -56,6 +56,42 @@ abstract class AbstractOptions
     }
 
     /**
+     * Which piece of software makes this call (ADR-177). Like the idempotency
+     * key, deliberately kept out of {@see self::toArray()}: it is call
+     * metadata persisted on the telemetry row, never a provider option.
+     */
+    protected ?string $callerSourceExtension = null;
+
+    /** The operation inside the calling software (ADR-177); '' = unspecified. */
+    protected ?string $callerSourceOperation = null;
+
+    /**
+     * Return a copy tagged with the caller's identity — the extension key of
+     * the calling software and optionally the operation inside it (e.g.
+     * "ai_seo_helper" / "requestAi"). Persisted on the telemetry row as
+     * source_extension / source_operation (ADR-177); never sent to the
+     * provider.
+     */
+    public function withCallerSource(string $extension, string $operation = ''): static
+    {
+        $clone                        = clone $this;
+        $clone->callerSourceExtension = $extension;
+        $clone->callerSourceOperation = $operation;
+
+        return $clone;
+    }
+
+    public function getCallerSourceExtension(): ?string
+    {
+        return $this->callerSourceExtension;
+    }
+
+    public function getCallerSourceOperation(): ?string
+    {
+        return $this->callerSourceOperation;
+    }
+
+    /**
      * Validate value is within numeric range.
      *
      * @throws InvalidArgumentException

--- a/Classes/Service/Streaming/StreamingDispatcher.php
+++ b/Classes/Service/Streaming/StreamingDispatcher.php
@@ -21,6 +21,7 @@ use Netresearch\NrLlm\Provider\Fallback\FallbackCandidateResolver;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\FailureClassifier;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
+use Netresearch\NrLlm\Provider\Middleware\TelemetryMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Service\Guardrail\GuardrailInterface;
@@ -696,7 +697,19 @@ final readonly class StreamingDispatcher
             // the exact confusion between an estimate and a measurement that
             // ADR-174 exists to end. The estimate stays in the usage aggregate.
             providerRetries: $providerRetries,
+            // Caller identity (ADR-177), from the same metadata keys the
+            // non-streaming TelemetryMiddleware reads — the two write sites
+            // move together, as above.
+            sourceExtension: $this->metadataString($context, TelemetryMiddleware::METADATA_SOURCE_EXTENSION),
+            sourceOperation: $this->metadataString($context, TelemetryMiddleware::METADATA_SOURCE_OPERATION),
         ));
+    }
+
+    private function metadataString(ProviderCallContext $context, string $key): string
+    {
+        $value = $context->metadata[$key] ?? '';
+
+        return \is_string($value) ? $value : '';
     }
 
     private function resolveProvider(ProviderCallContext $context, LlmConfiguration $served): string

--- a/Classes/Service/Telemetry/TelemetryRecord.php
+++ b/Classes/Service/Telemetry/TelemetryRecord.php
@@ -68,6 +68,13 @@ final readonly class TelemetryRecord
      *                                                          production caller does; the column is
      *                                                          nullable because rows written before it
      *                                                          existed have no value for it.
+     * @param string             $sourceExtension               which piece of software made the call
+     *                                                          (ADR-177), e.g. "ai_seo_helper"; '' for an
+     *                                                          unannotated call — identical to a
+     *                                                          pre-feature row on purpose.
+     * @param string             $sourceOperation               the operation inside the calling software
+     *                                                          (ADR-177), e.g. "requestAi"; '' when the
+     *                                                          caller named only itself.
      */
     public function __construct(
         public string $correlationId,
@@ -90,5 +97,7 @@ final readonly class TelemetryRecord
         public ?RequestFacts $requestFacts = null,
         public ?ProviderCallUsage $callUsage = null,
         public ?int $providerRetries = null,
+        public string $sourceExtension = '',
+        public string $sourceOperation = '',
     ) {}
 }

--- a/Classes/Service/Telemetry/TelemetryRepository.php
+++ b/Classes/Service/Telemetry/TelemetryRepository.php
@@ -56,6 +56,11 @@ final readonly class TelemetryRepository implements TelemetryRepositoryInterface
             'served_provider'          => $record->servedProvider,
             'served_model'             => $record->servedModel,
             'time_to_first_token_ms'   => $record->timeToFirstTokenMs,
+            // Caller identity (ADR-177). Truncated to the column width rather
+            // than left to the database to reject — a telemetry write must
+            // never be the thing that fails a call.
+            'source_extension'         => substr($record->sourceExtension, 0, 64),
+            'source_operation'         => substr($record->sourceOperation, 0, 64),
             'crdate'                   => time(),
         ]);
     }

--- a/Tests/Functional/Service/Telemetry/CallerSourceTelemetryTest.php
+++ b/Tests/Functional/Service/Telemetry/CallerSourceTelemetryTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Service\Telemetry;
+
+use Netresearch\NrLlm\Service\Telemetry\TelemetryRecord;
+use Netresearch\NrLlm\Service\Telemetry\TelemetryRepository;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Caller-source attribution (ADR-177): the two identity columns reach the
+ * database, and an unannotated record keeps the '' defaults so its row is
+ * indistinguishable from one written before the feature existed.
+ */
+#[CoversClass(TelemetryRepository::class)]
+final class CallerSourceTelemetryTest extends AbstractFunctionalTestCase
+{
+    private const TABLE = 'tx_nrllm_telemetry';
+
+    private TelemetryRepository $repository;
+
+    private ConnectionPool $connectionPool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+        $this->connectionPool = $connectionPool;
+
+        // Private in the container by design; instantiate it directly with the
+        // real ConnectionPool, as the sibling telemetry tests do.
+        $this->repository = new TelemetryRepository($this->connectionPool);
+    }
+
+    #[Test]
+    public function anAnnotatedRecordStoresItsCallerIdentity(): void
+    {
+        $this->repository->record($this->record('corr-annotated', 'ai_seo_helper', 'requestAi'));
+
+        $row = $this->row('corr-annotated');
+
+        self::assertSame('ai_seo_helper', $row['source_extension']);
+        self::assertSame('requestAi', $row['source_operation']);
+    }
+
+    #[Test]
+    public function anUnannotatedRecordStoresEmptyStrings(): void
+    {
+        $this->repository->record($this->record('corr-plain', '', ''));
+
+        $row = $this->row('corr-plain');
+
+        self::assertSame('', $row['source_extension']);
+        self::assertSame('', $row['source_operation']);
+    }
+
+    #[Test]
+    public function anOverlongIdentityIsTruncatedInsteadOfFailingTheWrite(): void
+    {
+        $this->repository->record($this->record('corr-long', str_repeat('x', 200), str_repeat('y', 200)));
+
+        $row = $this->row('corr-long');
+
+        self::assertIsString($row['source_extension']);
+        self::assertSame(64, \strlen($row['source_extension']));
+        self::assertIsString($row['source_operation']);
+        self::assertSame(64, \strlen($row['source_operation']));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function row(string $correlationId): array
+    {
+        $row = $this->connectionPool->getConnectionForTable(self::TABLE)
+            ->select(['*'], self::TABLE, ['correlation_id' => $correlationId])
+            ->fetchAssociative();
+        self::assertIsArray($row);
+
+        return $row;
+    }
+
+    private function record(string $correlationId, string $sourceExtension, string $sourceOperation): TelemetryRecord
+    {
+        return new TelemetryRecord(
+            correlationId: $correlationId,
+            operation: 'chat',
+            provider: 'openai',
+            model: 'gpt-4o',
+            configurationIdentifier: 'primary',
+            beUser: 1,
+            success: true,
+            errorClass: '',
+            latencyMs: 100,
+            cacheHit: false,
+            fallbackAttempts: 0,
+            servedConfigurationIdentifier: 'primary',
+            servedProvider: 'openai',
+            servedModel: 'gpt-4o',
+            providerRetries: 0,
+            sourceExtension: $sourceExtension,
+            sourceOperation: $sourceOperation,
+        );
+    }
+}

--- a/Tests/Unit/Api/api-surface.txt
+++ b/Tests/Unit/Api/api-surface.txt
@@ -1402,8 +1402,11 @@ Netresearch\NrLlm\Service\LlmServiceManagerInterface (interface)
   method vision(array $content, ?Netresearch\NrLlm\Service\Option\VisionOptions $options = …): Netresearch\NrLlm\Domain\Model\VisionResponse
 
 Netresearch\NrLlm\Service\Option\AbstractOptions (class)
+  method getCallerSourceExtension(): ?string
+  method getCallerSourceOperation(): ?string
   method getIdempotencyKey(): ?string
   method toArray(): array
+  method withCallerSource(string $extension, string $operation = …): static
   method withIdempotencyKey(string $idempotencyKey): static
 
 Netresearch\NrLlm\Service\Option\BudgetAwareOptionsInterface (interface)

--- a/Tests/Unit/Provider/Middleware/TelemetryMiddlewareTest.php
+++ b/Tests/Unit/Provider/Middleware/TelemetryMiddlewareTest.php
@@ -306,6 +306,44 @@ final class TelemetryMiddlewareTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function persistsTheCallerSourceFromMetadata(): void
+    {
+        $repository = $this->recordingRepository();
+
+        $context = new ProviderCallContext(
+            ProviderOperation::Chat,
+            'corr',
+            metadata: [
+                TelemetryMiddleware::METADATA_SOURCE_EXTENSION => 'ai_seo_helper',
+                TelemetryMiddleware::METADATA_SOURCE_OPERATION => 'requestAi',
+            ],
+        );
+
+        $this->pipeline($repository)->run(
+            $context->withConfiguration($this->configuration('primary')),
+            static fn(): string => 'x',
+        );
+
+        self::assertSame('ai_seo_helper', $repository->records[0]->sourceExtension);
+        self::assertSame('requestAi', $repository->records[0]->sourceOperation);
+    }
+
+    #[Test]
+    public function anUnannotatedCallPersistsEmptySourceFields(): void
+    {
+        $repository = $this->recordingRepository();
+
+        $this->pipeline($repository)->run(
+            (new ProviderCallContext(ProviderOperation::Chat, 'corr'))
+                ->withConfiguration($this->configuration('primary')),
+            static fn(): string => 'x',
+        );
+
+        self::assertSame('', $repository->records[0]->sourceExtension);
+        self::assertSame('', $repository->records[0]->sourceOperation);
+    }
+
+    #[Test]
     public function resolvesBeUserFromAmbientAspectWhenMetadataAbsent(): void
     {
         $repository = $this->recordingRepository();

--- a/Tests/Unit/Service/CallMetadataFactoryCallerSourceTest.php
+++ b/Tests/Unit/Service/CallMetadataFactoryCallerSourceTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Service;
+
+use Netresearch\NrLlm\Provider\Middleware\TelemetryMiddleware;
+use Netresearch\NrLlm\Service\CallMetadataFactory;
+use Netresearch\NrLlm\Service\Option\ChatOptions;
+use Netresearch\NrLlm\Service\Option\VisionOptions;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The caller-source producer (ADR-177): the metadata keys TelemetryMiddleware
+ * persists as source_extension / source_operation.
+ */
+#[CoversClass(CallMetadataFactory::class)]
+final class CallMetadataFactoryCallerSourceTest extends TestCase
+{
+    #[Test]
+    public function anAnnotatedCallBecomesTheTwoSourceKeys(): void
+    {
+        $options = (new ChatOptions())->withCallerSource('ai_seo_helper', 'requestAi');
+
+        $metadata = (new CallMetadataFactory())->callerSource($options);
+
+        self::assertSame([
+            TelemetryMiddleware::METADATA_SOURCE_EXTENSION => 'ai_seo_helper',
+            TelemetryMiddleware::METADATA_SOURCE_OPERATION => 'requestAi',
+        ], $metadata);
+    }
+
+    #[Test]
+    public function anUnannotatedCallProducesNoEntrySoTheRowKeepsItsEmptyDefaults(): void
+    {
+        self::assertSame([], (new CallMetadataFactory())->callerSource(new ChatOptions()));
+    }
+
+    #[Test]
+    public function anEmptyExtensionProducesNoEntry(): void
+    {
+        // '' would claim an identity that names nothing; the row's '' default
+        // already says "unannotated".
+        $options = (new ChatOptions())->withCallerSource('');
+
+        self::assertSame([], (new CallMetadataFactory())->callerSource($options));
+    }
+
+    #[Test]
+    public function theOperationDefaultsToAnEmptyString(): void
+    {
+        $options = (new ChatOptions())->withCallerSource('ai_filemetadata');
+
+        $metadata = (new CallMetadataFactory())->callerSource($options);
+
+        self::assertSame('', $metadata[TelemetryMiddleware::METADATA_SOURCE_OPERATION]);
+    }
+
+    #[Test]
+    public function everyOptionTypeCarriesTheChannel(): void
+    {
+        // The wither lives on AbstractOptions, so the vision path (the compat
+        // layer's second consumer) annotates the same way as chat.
+        $options = (new VisionOptions())->withCallerSource('ai_filemetadata', 'buildAltText');
+
+        $metadata = (new CallMetadataFactory())->callerSource($options);
+
+        self::assertSame('ai_filemetadata', $metadata[TelemetryMiddleware::METADATA_SOURCE_EXTENSION]);
+    }
+
+    #[Test]
+    public function theKeySetIsDisjointFromTheOtherProducers(): void
+    {
+        $factory = new CallMetadataFactory();
+
+        $merged = $factory->budget(5, 0.25)
+            + $factory->idempotency('key-1')
+            + $factory->callerSource((new ChatOptions())->withCallerSource('ai_seo_helper', 'requestAi'));
+
+        // Disjointness is load-bearing: every call site merges with `+`, which
+        // keeps the FIRST value on a collision.
+        self::assertCount(5, $merged);
+        self::assertSame('ai_seo_helper', $merged[TelemetryMiddleware::METADATA_SOURCE_EXTENSION]);
+    }
+}

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -44,6 +44,7 @@ use Netresearch\NrLlm\Provider\Middleware\MiddlewarePipeline;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderMiddlewareInterface;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\TelemetryMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
 use Netresearch\NrLlm\Provider\ProviderAdapterRegistryInterface;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
@@ -2640,6 +2641,41 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $metadata = $spy->calls[0]['metadata'];
         self::assertArrayNotHasKey(BudgetMiddleware::METADATA_BE_USER_UID, $metadata);
         self::assertArrayNotHasKey(BudgetMiddleware::METADATA_PLANNED_COST, $metadata);
+    }
+
+    #[Test]
+    public function chatPlumbsCallerSourceMetadataFromOptions(): void
+    {
+        // ADR-177 — the manager translates the caller identity on the
+        // options object into the metadata keys TelemetryMiddleware
+        // persists as source_extension / source_operation.
+        $spy     = new RecordingMiddleware();
+        $manager = $this->buildManagerWithMiddleware([$spy]);
+
+        $options = (new ChatOptions())
+            ->withProvider('openai')
+            ->withCallerSource('ai_seo_helper', 'requestAi');
+
+        $manager->chat([['role' => 'user', 'content' => 'hi']], $options);
+
+        self::assertCount(1, $spy->calls);
+        $metadata = $spy->calls[0]['metadata'];
+        self::assertSame('ai_seo_helper', $metadata[TelemetryMiddleware::METADATA_SOURCE_EXTENSION]);
+        self::assertSame('requestAi', $metadata[TelemetryMiddleware::METADATA_SOURCE_OPERATION]);
+    }
+
+    #[Test]
+    public function chatOmitsCallerSourceMetadataWhenOptionsAreUnannotated(): void
+    {
+        $spy     = new RecordingMiddleware();
+        $manager = $this->buildManagerWithMiddleware([$spy]);
+
+        $manager->chat([['role' => 'user', 'content' => 'hi']], new ChatOptions(provider: 'openai'));
+
+        self::assertCount(1, $spy->calls);
+        $metadata = $spy->calls[0]['metadata'];
+        self::assertArrayNotHasKey(TelemetryMiddleware::METADATA_SOURCE_EXTENSION, $metadata);
+        self::assertArrayNotHasKey(TelemetryMiddleware::METADATA_SOURCE_OPERATION, $metadata);
     }
 
     #[Test]

--- a/Tests/Unit/Service/Option/ChatOptionsTest.php
+++ b/Tests/Unit/Service/Option/ChatOptionsTest.php
@@ -512,4 +512,37 @@ class ChatOptionsTest extends AbstractUnitTestCase
         self::assertArrayNotHasKey('planned_cost', $array);
         self::assertArrayNotHasKey('plannedCost', $array);
     }
+
+    #[Test]
+    public function withCallerSourceReturnsATaggedCopy(): void
+    {
+        $original = new ChatOptions();
+
+        $tagged = $original->withCallerSource('ai_seo_helper', 'requestAi');
+
+        self::assertSame('ai_seo_helper', $tagged->getCallerSourceExtension());
+        self::assertSame('requestAi', $tagged->getCallerSourceOperation());
+        self::assertNull($original->getCallerSourceExtension());
+        self::assertNull($original->getCallerSourceOperation());
+    }
+
+    #[Test]
+    public function callerSourceIsOmittedFromToArray(): void
+    {
+        // The caller identity is telemetry metadata (ADR-177), not provider
+        // wire payload — like the budget fields and the idempotency key it
+        // must never reach the provider's options array.
+        $options = (new ChatOptions())->withCallerSource('ai_seo_helper', 'requestAi');
+
+        $array = $options->toArray();
+
+        self::assertArrayNotHasKey('caller_source_extension', $array);
+        self::assertArrayNotHasKey('callerSourceExtension', $array);
+        self::assertArrayNotHasKey('source_extension', $array);
+        self::assertArrayNotHasKey('sourceExtension', $array);
+        self::assertArrayNotHasKey('caller_source_operation', $array);
+        self::assertArrayNotHasKey('callerSourceOperation', $array);
+        self::assertArrayNotHasKey('source_operation', $array);
+        self::assertArrayNotHasKey('sourceOperation', $array);
+    }
 }

--- a/Tests/Unit/Service/Streaming/StreamingDispatcherTest.php
+++ b/Tests/Unit/Service/Streaming/StreamingDispatcherTest.php
@@ -24,6 +24,7 @@ use Netresearch\NrLlm\Provider\Fallback\FallbackCandidateResolver;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\ProviderOperation;
+use Netresearch\NrLlm\Provider\Middleware\TelemetryMiddleware;
 use Netresearch\NrLlm\Service\BudgetServiceInterface;
 use Netresearch\NrLlm\Service\Guardrail\GuardrailInterface;
 use Netresearch\NrLlm\Service\Guardrail\SecretRedactionGuardrail;
@@ -464,6 +465,31 @@ final class StreamingDispatcherTest extends AbstractUnitTestCase
         self::assertLessThan(60000, $record->timeToFirstTokenMs);
         // A completed stream is never the "aborted before completion" path.
         self::assertNull($this->logger->firstMatching('info', 'aborted before completion'));
+        // No caller annotation supplied — the source fields keep their ''
+        // defaults, indistinguishable from a pre-ADR-177 row.
+        self::assertSame('', $record->sourceExtension);
+        self::assertSame('', $record->sourceOperation);
+    }
+
+    #[Test]
+    public function recordsTheCallerSourceFromMetadata(): void
+    {
+        // ADR-177: the streaming write site reads the same metadata keys as
+        // the non-streaming TelemetryMiddleware — the two sites move together.
+        $dispatcher = $this->dispatcher();
+
+        iterator_to_array($dispatcher->stream(
+            $this->context([
+                TelemetryMiddleware::METADATA_SOURCE_EXTENSION => 'ai_seo_helper',
+                TelemetryMiddleware::METADATA_SOURCE_OPERATION => 'requestAi',
+            ]),
+            $this->configuration('primary', providerType: 'openai', modelId: 'gpt-4o', model: $this->model(pricing: false), uid: 9),
+            $this->staticStream(['Hello']),
+        ));
+
+        self::assertCount(1, $this->telemetry->records);
+        self::assertSame('ai_seo_helper', $this->telemetry->records[0]->sourceExtension);
+        self::assertSame('requestAi', $this->telemetry->records[0]->sourceOperation);
     }
 
     /**

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -602,6 +602,13 @@ CREATE TABLE tx_nrllm_telemetry (
     -- Attribution (backend user; 0 for CLI / scheduler / unauthenticated)
     be_user int(11) unsigned DEFAULT '0' NOT NULL,
 
+    -- Caller identity (ADR-177): which piece of software made the call and
+    -- which operation inside it (e.g. 'ai_seo_helper' / 'requestAi'), set via
+    -- AbstractOptions::withCallerSource(). '' = unannotated call — identical
+    -- to a pre-feature row on purpose.
+    source_extension varchar(64) DEFAULT '' NOT NULL,
+    source_operation varchar(64) DEFAULT '' NOT NULL,
+
     -- Outcome. error_class is the exception FQCN on failure ('' on success);
     -- the message is deliberately NOT stored (privacy).
     success smallint(5) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
Closes #816. Implements ADR-177 (#817).

## What

A downstream consumer can now tag any call with its identity, and the telemetry row records it:

```php
$options = (new ChatOptions())->withCallerSource('ai_seo_helper', 'requestAi');
```

- **`AbstractOptions::withCallerSource(string $extension, string $operation = '')`** plus the two getters — the same channel and wire-leak rule as the idempotency key: call metadata, never part of `toArray()`, so it cannot reach a provider.
- **`CallMetadataFactory::callerSource()`** maps it into the pipeline metadata as the fifth disjoint producer (keys published as `TelemetryMiddleware::METADATA_SOURCE_*` constants); all 13 option-carrying entry points in `LlmServiceManager` add the term to their existing `budget() + idempotency()` sums.
- **`TelemetryMiddleware`** persists it through `TelemetryRecord` into two new `tx_nrllm_telemetry` columns, `source_extension` / `source_operation` (`varchar(64)`, truncated rather than write-failing, `''` default). An unannotated call writes `''` — indistinguishable from a pre-feature row, so existing rows, queries and consumers are untouched.

Driving consumer: the nr-llm-compat bridge layer, which will tag every intercepted third-party request once its dependency floor reaches a release carrying this.

api-surface: +3 methods on `AbstractOptions`, additive (regenerated; `### Added` in the CHANGELOG entry).

Deliberately out of scope per ADR-177: analytics/dashboard aggregation by source, and authentication of the claimed identity — telemetry is an observability surface.

## Tests

- `CallMetadataFactoryCallerSourceTest` (mapping, empty-extension guard, operation default, cross-option-type via `VisionOptions`, key disjointness),
- `ChatOptionsTest`: wither immutability + the `toArray()` wire-leak exclusion,
- `TelemetryMiddlewareTest`: annotated metadata persisted, unannotated stays `''`,
- `LlmServiceManagerTest`: `chat()` plumbs / omits the metadata from the options (mirroring the budget-plumbing tests),
- functional `CallerSourceTelemetryTest`: both columns reach the database, `''` defaults hold, overlong identities truncate instead of failing the write.

Local gate: cgl, PHPStan (level 10), unit (7212+), fuzzy green; functional for the touched dirs (`Tests/Functional/Service/Telemetry`, `Tests/Functional/Provider/Middleware`) green on sqlite — the full functional matrix is CI's. The Rector gate could not run locally (worktree `.Build` resolved under PHP 8.5 vs the pinned 8.2 — the platform_check case `make gate` names); CI's pinned Rector job is the verdict for it. Mutation proof: nulling the factory's extension lookup turns 5 tests red.
