### PR TITLE
chore(release): 0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.30.0] - 2026-08-18
+
 ### Added
 - **Telemetry rows can name their caller** (`#816`, ADR-177). A downstream consumer tags its calls with `->withCallerSource('my_extension', 'operation')` on any options object; the identity is persisted on the telemetry row as `source_extension` / `source_operation` and never sent to the provider. Unannotated calls keep writing `''`, so existing rows and consumers are untouched. Driving consumer: the nr-llm-compat bridge layer.
 - **A self-approved run says so** (`#785`). An approval granted by the backend user who started the run is now labelled as such — on the run timeline, and in the *Recent runs* table of the Agent Runs inbox, which gains an *Approval* column. An approval granted by anybody else is labelled too, so the two are told apart at a glance instead of by comparing two uid numbers.

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -11,7 +11,7 @@
 >
     <project
         title="TYPO3 LLM Extension"
-        version="0.29.1"
+        version="0.30.0"
         release="0.30.0"
         copyright="since 2025 by Netresearch DTT GmbH"
     />

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -12,7 +12,7 @@
     <project
         title="TYPO3 LLM Extension"
         version="0.29.1"
-        release="0.29.1"
+        release="0.30.0"
         copyright="since 2025 by Netresearch DTT GmbH"
     />
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "netresearch/nr-llm",
-    "description": "Shared AI/LLM foundation for TYPO3 \u2014 centralized provider management, encrypted API keys, and ready-to-use services for chat, translation, vision, and embeddings",
+    "description": "Shared AI/LLM foundation for TYPO3 — centralized provider management, encrypted API keys, and ready-to-use services for chat, translation, vision, and embeddings",
     "license": "GPL-2.0-or-later",
     "type": "typo3-cms-extension",
     "keywords": [
@@ -49,7 +49,7 @@
     },
     "suggest": {
         "apache-solr-for-typo3/solr": "Site-search RAG tools retrieve evidence from the Solr index when installed",
-        "poppler-utils": "System package (not a Composer package) providing pdftoppm/pdfimages \u2014 enables DocumentAnalysisService's rasterization fallback for providers without native PDF ingestion",
+        "poppler-utils": "System package (not a Composer package) providing pdftoppm/pdfimages — enables DocumentAnalysisService's rasterization fallback for providers without native PDF ingestion",
         "tpwd/ke_search": "Site-search RAG tools retrieve evidence from the ke_search index when installed",
         "typo3/cms-dashboard": "Adds AI usage / cost widgets to the TYPO3 dashboard",
         "typo3/cms-indexed-search": "Site-search RAG tools retrieve evidence from the indexed_search index when installed"
@@ -87,7 +87,7 @@
                 "providesPackages": {}
             },
             "extension-key": "nr_llm",
-            "version": "0.29.1",
+            "version": "0.30.0",
             "web-dir": ".Build/Web"
         }
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => '',
     'author_company' => 'Netresearch DTT GmbH',
     'state' => 'beta',
-    'version' => '0.29.1',
+    'version' => '0.30.0',
     'constraints' => [
         // composer.json is the authoritative dependency constraint
         // ("typo3/cms-core": "^13.4 || ^14.3"). The TER `depends` format only


### PR DESCRIPTION
Release commit for 0.30.0 — bumps ext_emconf.php, composer.json (extra.typo3/cms.version), Documentation/guides.xml and dates the CHANGELOG section. 80 commits since v0.29.1; headline changes per the CHANGELOG: caller-source attribution on the options path (#816/#818, ADR-177), the self-approval label on runs (#785), plus the ADR records and fixes listed there. Tag v0.30.0 follows on the merge commit and publishes TER + Packagist via release.yml.