### PR TITLE
docs(agents): sync AGENTS.md files and adopt agent-harness verification

### DIFF
--- a/.ddev/AGENTS.md
+++ b/.ddev/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-04-23 -->
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-08-19 -->
 
 # AGENTS.md — .ddev
 
@@ -38,6 +38,18 @@ ddev describe   # print URLs and credentials
 | Database import | `ddev import-db < dump.sql.gz` |
 | View logs | `ddev logs` |
 | Restart | `ddev restart` |
+
+### Project commands (`commands/host/`, `commands/web/`)
+| Task | Command |
+|------|---------|
+| Full setup (TYPO3 v14 + extension) | `ddev install-v14` (also `install-v13`, `install-all`, `setup`) |
+| Seed provider/model/config demo data | `ddev seed-ollama` |
+| Seed task demo data | `ddev seed-tasks` (also `seed-usage`; SQL in `.ddev/sql/`) |
+| Ollama status / models | `ddev ollama` |
+| Render RST docs | `ddev docs` |
+
+### Demo data for screenshots and manual testing
+`ddev seed-ollama` creates 1 provider (Local Ollama), 3 models and 4 configurations; `ddev seed-tasks` creates 13 tasks across 4 categories. `ddev install-v14` auto-runs seed-ollama but NOT seed-tasks — run both before documentation screenshots so populated views are visible.
 <!-- AGENTS-GENERATED:END commands -->
 
 <!-- AGENTS-GENERATED:START patterns -->

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,10 +1,10 @@
-<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-03-14 -->
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-08-19 -->
 
 # AGENTS.md — workflows
 
 <!-- AGENTS-GENERATED:START overview -->
 ## Overview
-GitHub Actions workflows and CI/CD automation
+GitHub Actions workflows and CI/CD automation. **This repository defines no workflow jobs of its own**: every workflow is a thin caller of a shared `netresearch/*` reusable workflow, so action pinning, runner hardening and security review happen once there — for all callers. `composer ci:test:workflows` (pre-commit and CI) refuses a job with local steps; the single exception is the aggregate `gate` job in `checks.yml`, which evaluates the other jobs' results and therefore cannot be a reusable-workflow call.
 <!-- AGENTS-GENERATED:END overview -->
 
 <!-- AGENTS-GENERATED:START filemap -->
@@ -19,6 +19,7 @@ GitHub Actions workflows and CI/CD automation
 | `dco.yml` | DCO sign-off |
 | `docs.yml` | Documentation rendering |
 | `e2e.yml` | Playwright E2E tests |
+| `harness-verify.yml` | Agent-harness consistency (`Build/Scripts/verify-harness.sh`) |
 | `labeler.yml` | PR auto-labelling |
 | `pages.yml` | Landing page (GitHub Pages) |
 | `release.yml` | Release with SBOM, Cosign signing, SLSA attestation; publishes TER + Packagist |
@@ -28,6 +29,7 @@ GitHub Actions workflows and CI/CD automation
 <!-- AGENTS-GENERATED:START golden-samples -->
 ## Workflow files
 - One file per concern; the Key Files table above lists all of them.
+- `ci.yml` is the intentional-drift file: the per-extension test matrix (PHP 8.2–8.5 × TYPO3 `^13.4`/`^14.3` on PRs, reduced to PHP 8.2/8.4 in the merge queue), `rector-php-version: '8.2'`, the MariaDB functional leg, and fuzz/mutation toggles all live in its `with:` block — read its comments before touching it.
 <!-- AGENTS-GENERATED:END golden-samples -->
 
 <!-- AGENTS-GENERATED:START structure -->
@@ -40,149 +42,61 @@ GitHub Actions workflows and CI/CD automation
   PULL_REQUEST_TEMPLATE.md
   SECURITY_CONTROLS.md
   ISSUE_TEMPLATE/
-  workflows/
-    ci.yml              → Main CI workflow (lint, test, build)
-    checks.yml          → Security, licence, CodeQL, scorecard, PR quality
-    release.yml         → Release/deploy workflow
-    republish.yml       → Re-publish an existing tag (manual)
-    e2e.yml             → Playwright E2E tests
-    docs.yml            → Documentation rendering
-    pages.yml           → Landing page (GitHub Pages)
-    dco.yml             → DCO sign-off
-    labeler.yml         → PR auto-labelling
-    check-template-drift.yml → Template drift
-    auto-merge-deps.yml → Auto-merge dependency PRs
-    community.yml       → Community health
+  workflows/            → One thin reusable-workflow caller per concern (see Key Files)
 ```
 <!-- AGENTS-GENERATED:END structure -->
 
 <!-- AGENTS-GENERATED:START code-style -->
 ## Workflow conventions
-- **Pin action versions** with full SHA, not tags (`uses: actions/checkout@abc123...`)
-- **Minimal permissions**: Use `permissions:` block, never use `permissions: write-all`
-- **Reusable workflows**: Extract common patterns to `.github/workflows/reusable-*.yml`
-- **Job dependencies**: Use `needs:` to express dependencies
-- **Caching**: Use `actions/cache` for dependencies (npm, composer, go)
-
-### Naming conventions
-| Type | Convention | Example |
-|------|------------|---------|
-| Workflow file | `<purpose>.yml` | `ci.yml`, `release.yml` |
-| Workflow name | Title Case | `CI Pipeline`, `Release` |
-| Job ID | kebab-case | `build-and-test`, `deploy-staging` |
-| Step name | Sentence case | `Install dependencies` |
-| Secret | SCREAMING_SNAKE | `DEPLOY_TOKEN`, `NPM_TOKEN` |
+- **No local jobs.** A repo-specific check goes in the shared workflow's `repo-checks` job, not in a job here: set `run-repo-checks: true` in `ci.yml` and add the command to the `ci:test:repo` composer script. That script is also what pre-commit runs, so the local and CI halves are the same command.
+- Why this is a rule and not a preference: a local job carries its own action pins, and a wrong pin does not fail like a normal check. Repo and org both set `sha_pinning_required`, so a tag ref kills the run at `Set up job` — before any step executes, so the log has no step output — and zizmor, Opengrep, CodeQL and SonarCloud then each flag the same lines. On 2026-08-11 that was six red checks for one mistake, none of them naming the cause.
+- **Pin third-party actions** to a full commit SHA, never a mutable tag (the shared workflows do this centrally; it only becomes your problem in the exempted `gate` job).
+- **Minimal permissions**: top-level `permissions:` block on every workflow; job-level `contents: read` on reusable calls.
 <!-- AGENTS-GENERATED:END code-style -->
 
 <!-- AGENTS-GENERATED:START patterns -->
 ## Common patterns
 
-### Basic CI workflow
-```yaml
-name: CI
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+### Releasing (tag push publishes TER automatically)
+Pushing an annotated signed tag `vX.Y.Z` on `main` triggers `release.yml`, which calls the reusable `netresearch/typo3-ci-workflows/.github/workflows/release-typo3-extension.yml` with `TYPO3_TER_ACCESS_TOKEN` wired in: it produces the SBOM / Cosign / SLSA artifacts, creates the GitHub release, **and publishes to TER + Packagist**. `republish.yml` is only a `workflow_dispatch` fallback that re-publishes an existing tag — not the primary path. Verify a release via Packagist (`repo.packagist.org/p2/netresearch/nr-llm.json`, tags `v`-prefixed), TER (`extensions.typo3.org/api/v1/extension/nr_llm/versions`) and the docs 0.X URL — do not assume TER is a separate manual step.
 
-permissions:
-  contents: read
+The `chore(release): X.Y.Z` commit bumps four files: `ext_emconf.php`, `composer.json` (`extra.typo3/cms.version`), `Documentation/guides.xml`, and `CHANGELOG.md` (not `Changelog.rst`). Version bumps belong to this release flow, never to a feature PR.
 
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-        with:
-          node-version: '20'
-          cache: 'npm'
-      - run: npm ci
-      - run: npm test
-```
+### Dependency PRs
+Renovate/Dependabot PRs auto-merge via `auto-merge-deps.yml` — do not hand-merge them by default. Known gap (2026-07-24): it did **not** auto-merge #511/#509 (admin-merged to unblock 0.24.0); root cause (merge-queue interaction vs an unmet workflow condition) is not yet verified — investigate before relying on it for a release.
 
-### Matrix builds
-```yaml
-jobs:
-  test:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        node: ['18', '20', '22']
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-        with:
-          node-version: ${{ matrix.node }}
-```
-
-### Reusable workflow
-```yaml
-# .github/workflows/reusable-test.yml
-on:
-  workflow_call:
-    inputs:
-      node-version:
-        type: string
-        default: '20'
-
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ inputs.node-version }}
-```
-
-### Conditional deployment
-```yaml
-jobs:
-  deploy:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    needs: [test, build]
-    environment: production
-    steps:
-      - name: Deploy
-        run: ./deploy.sh
-```
+### Merge-queue stall nudge
+A CLEAN PR with armed auto-merge that never enters the queue (`isInMergeQueue: false`) usually just needs a re-evaluation — `gh pr merge --disable-auto` followed by `gh pr merge --auto`. Diagnose before escalating; admin-bypassing the queue is not the fix.
 <!-- AGENTS-GENERATED:END patterns -->
 
 <!-- AGENTS-GENERATED:START security -->
 ## Security & safety
 - **NEVER** expose secrets in logs: use `::add-mask::` for dynamic secrets
-- **Pin actions** to full commit SHA, not mutable tags
-- **Minimal permissions**: Start with `contents: read`, add only what's needed
-- **Environment protection**: Use environments with required reviewers for deploys
-- **Secret scanning**: Enable in repository settings
-- **Dependency review**: Use `actions/dependency-review-action` for PRs
-- **OIDC**: Prefer OIDC over long-lived secrets for cloud providers
+- **Minimal permissions**: start with `contents: read`, add only what's needed
+- **Secret scanning + dependency review** run via `checks.yml` (shared workflow)
+- Secrets are wired into reusable calls via the `secrets:` block (`CODECOV_TOKEN`, `TYPO3_TER_ACCESS_TOKEN`), never echoed in `with:` inputs
 <!-- AGENTS-GENERATED:END security -->
 
 <!-- AGENTS-GENERATED:START checklist -->
 ## PR/commit checklist
-- [ ] Actions pinned to full SHA (not tags)
-- [ ] Permissions block uses minimal required permissions
-- [ ] Secrets are not exposed in logs
-- [ ] Workflow syntax valid: `actionlint` or GitHub UI validation
-- [ ] Matrix strategy covers required versions/platforms
-- [ ] Caching configured for dependencies
+- [ ] No job with local `steps:` (except the exempted `gate` in `checks.yml`) — `composer ci:test:workflows` enforces
+- [ ] Repo-specific checks routed through `ci:test:repo` + `run-repo-checks: true`, not a new job
+- [ ] `netresearch/*` reusables referenced `@main` (see below); third-party actions SHA-pinned
+- [ ] Permissions blocks minimal
+- [ ] Matrix changes mirrored where required checks are configured (reduced merge-queue matrix is intentional)
 <!-- AGENTS-GENERATED:END checklist -->
 
 <!-- AGENTS-GENERATED:START examples -->
 ## Patterns to Follow
-> **Prefer looking at real code in this repo over generic examples.**
-> See **Golden Samples** section above for files that demonstrate correct patterns.
+> **Prefer looking at real workflows in this repo over generic examples.**
+> `ci.yml` (reusable call with per-repo matrix and heavily commented trade-offs) and `checks.yml` (aggregate gate exception) demonstrate the two shapes that exist here.
 <!-- AGENTS-GENERATED:END examples -->
 
 <!-- AGENTS-GENERATED:START help -->
 ## When stuck
 - GitHub Actions docs: https://docs.github.com/en/actions
-- Workflow syntax: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
-- Action marketplace: https://github.com/marketplace?type=actions
-- Use `act` for local testing: https://github.com/nektos/act
+- The shared reusable workflows live in `netresearch/typo3-ci-workflows` and `netresearch/.github` — read the called workflow before changing a `with:` input
+- `composer ci:test:workflows` locally reproduces the CI workflow-ownership check
 - Check existing workflows in this repo for patterns
 <!-- AGENTS-GENERATED:END help -->
 

--- a/.github/workflows/harness-verify.yml
+++ b/.github/workflows/harness-verify.yml
@@ -1,0 +1,23 @@
+name: Harness Verification
+
+# Verifies agent-harness consistency (AGENTS.md line budget, dead references,
+# documented commands vs composer.json/Makefile, docs/ structure) via
+# Build/Scripts/verify-harness.sh. Thin caller of the shared script-check
+# reusable, so the checkout pin and harden-runner are maintained centrally.
+# Exit 2 means warnings only and passes; exit 1 (errors) fails the check.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  harness-verify:
+    uses: netresearch/.github/.github/workflows/script-check.yml@main
+    permissions:
+      contents: read
+    with:
+      check-cmd: bash Build/Scripts/verify-harness.sh || [ $? -eq 2 ]

--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,14 @@ var/
 # Documentation build output
 Documentation-GENERATED-temp/
 
-# Local planning docs (not for repo)
-docs/
+# Local planning docs (not for repo) — but the agent-harness files are tracked:
+# docs/ARCHITECTURE.md and docs/exec-plans/README.md (verified by
+# Build/Scripts/verify-harness.sh). Everything else under docs/ stays local.
+docs/*
+!docs/ARCHITECTURE.md
+!docs/exec-plans/
+docs/exec-plans/*
+!docs/exec-plans/README.md
 claudedocs/
 
 # DDEV local files (keep config, ignore generated)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,12 @@
-<!-- Managed by agent: keep sections and order; edit content, not structure. Last Updated: 2026-04-24. Last verified: 2026-04-24 -->
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last Updated: 2026-08-19. Last verified: 2026-08-19 -->
 
 # AGENTS.md — nr_llm
 
 <!-- AGENTS-GENERATED:START overview -->
 ## Overview
-TYPO3 v13.4+ extension providing a unified LLM provider abstraction layer. Supports OpenAI, Claude, Gemini, Groq, Mistral, Ollama, and OpenRouter through a standardized interface. PHP 8.2+ with PHPStan level 10.
+TYPO3 v13.4/v14.3 extension providing a unified LLM provider abstraction layer. Supports OpenAI, Claude, Gemini, Groq, Mistral, Ollama, and OpenRouter through a standardized interface. PHP 8.2+ with PHPStan level 10. The authoritative version lives in `ext_emconf.php`.
 
-**Three-tier architecture:** Providers (API connections) -> Models (per-provider) -> Configurations (use-case bundles)
+**Three-tier architecture:** Providers (API connections) -> Models (per-provider) -> Configurations (use-case bundles). Component map and dependency rules: `docs/ARCHITECTURE.md`.
 <!-- AGENTS-GENERATED:END overview -->
 
 <!-- AGENTS-GENERATED:START precedence -->
@@ -19,13 +19,15 @@ The closest AGENTS.md wins: scoped AGENTS.md files in subdirectories override th
 
 | Directory | Scope |
 |-----------|-------|
-| `Classes/AGENTS.md` | PHP source code patterns, architecture rules |
+| `Classes/AGENTS.md` | PHP patterns, architecture rules, shared utilities, API-surface freeze |
 | `Configuration/AGENTS.md` | TYPO3 TCA, services, caching, backend routes |
-| `Documentation/AGENTS.md` | RST docs, ADRs, branding, guides.xml |
-| `Tests/AGENTS.md` | Testing patterns, coverage, test runner |
+| `Documentation/AGENTS.md` | RST docs, ADRs, branding, version-prose surfaces |
+| `Tests/AGENTS.md` | Testing patterns, coverage, test-runner environment traps |
 | `Resources/AGENTS.md` | Fluid templates, XLIFF, icons, JS/CSS |
-| `.ddev/AGENTS.md` | Local development environment |
-| `.github/workflows/AGENTS.md` | CI/CD workflows |
+| `.ddev/AGENTS.md` | Local development environment, seed/demo data |
+| `.github/workflows/AGENTS.md` | CI/CD workflows, release and dependency automation |
+
+Architecture: `docs/ARCHITECTURE.md` · Execution plans: `docs/exec-plans/README.md`
 <!-- AGENTS-GENERATED:END scope-index -->
 
 <!-- AGENTS-GENERATED:START setup -->
@@ -37,7 +39,7 @@ ddev start && ddev composer install
 <!-- AGENTS-GENERATED:END setup -->
 
 <!-- AGENTS-GENERATED:START commands -->
-## Commands (verified 2026-04-24)
+## Commands (verified 2026-08-19)
 
 ALWAYS use the Docker test runner; never invoke `phpunit` / `phpstan` / `rector` directly. See `Build/Scripts/runTests.sh` for the full list and `make help` for shortcuts.
 
@@ -59,111 +61,22 @@ ALWAYS use the Docker test runner; never invoke `phpunit` / `phpstan` / `rector`
 <!-- AGENTS-GENERATED:START testing -->
 ## Testing
 
-- Unit / Integration / Fuzzy / Functional / E2E suites — see `Tests/AGENTS.md` for layout details.
+- Unit / Integration / Fuzzy / Functional / E2E suites — layout, runtime and environment traps in `Tests/AGENTS.md`.
 - PHPUnit configs: `Build/phpunit.xml` (unit + integration + fuzzy; the unit suite also lists the two workflow tests under `Tests/E2E/`), `Build/FunctionalTests.xml` (functional + e2e-backend + e2e-tca). Every PHP test must sit in one of these suites — a directory in none of them runs in no job and reads as coverage (#658).
-- Mutation: `infection.json.dist` (target MSI ≥ 70%).
-- Architecture tests: `Tests/Architecture/` (phpat) — enforce layered boundaries (Controller → Service → Provider).
+- Mutation: `infection.json.dist` (target MSI ≥ 70%). Architecture tests: `Tests/Architecture/` (phpat).
 <!-- AGENTS-GENERATED:END testing -->
 
 <!-- AGENTS-GENERATED:START development -->
-### Demo data for screenshots and manual testing
-
-`ddev seed-ollama` creates 1 provider (Local Ollama), 3 models and 4 configurations; `ddev seed-tasks` creates 13 tasks across 4 categories (SQL in `.ddev/sql/`). `ddev install-v14` auto-runs seed-ollama but NOT seed-tasks — run both before documentation screenshots so populated views are visible.
-
-### Functional suite runtime
-
-The full `./Build/Scripts/runTests.sh -s functional` run includes ~34 provider-connection smoke tests that make REAL outbound HTTPS calls to unreachable providers (deliberate 502 mapping) — the full run takes ~35 min locally while per-class runs stay fast. Scope local runs to the touched test classes; leave the full matrix to CI.
-
 ## Development Workflow
 
-1. **Specify before designing, for the classes of change below.** Write down what
-   the change must do, what it explicitly does **not** do, and which suite proves
-   each requirement — before choosing where the code goes. The format is not
-   prescribed here; writing it at all is the rule.
-
-   | Change | Specify first |
-   |--------|---------------|
-   | Bugfix, dependency update, small internal refactor, documentation only | no |
-   | New provider | usually |
-   | New feature, new public API contract, breaking or deprecating change, security or credential topic, a change spanning several layers, large compatibility rework | yes |
-
-   Why this step exists as a rule: every other gate in this repository runs on a
-   diff that already exists. `make gate`, the api-surface snapshot, PHPStan, the
-   CHANGELOG check and the ADR checkbox all presuppose code. Nothing before this
-   step checked anything, so a wrong premise about *what* was wanted survived
-   until review, and a wrong premise about the public surface survived until
-   `api-surface.txt` failed.
-
-   **This one is not machine-checked, and cannot be here.** `ci:test:repo` sees
-   the working tree, not the pull request; the job that could see one is
-   `pr-quality`, which belongs to the shared `netresearch/.github` workflow and
-   is not this repository's to extend. Keep it because it is the rule, not
-   because something will catch you.
+1. **Specify before designing** for: a new feature, a new public API contract, a breaking or deprecating change, a security/credential topic, a change spanning several layers, a large compatibility rework ("usually" for a new provider; not for bugfixes, dependency updates, small refactors, docs). Write down what the change must do, what it explicitly does **not** do, and which suite proves each requirement — before choosing where the code goes. Every other gate here runs on a diff that already exists; this step is not machine-checked and cannot be. Keep it because it is the rule.
 2. Branch off `main` (worktree convention — see project memory).
 3. Use `make` shortcuts (`make test-unit`, `make phpstan`, `make cgl`) — they delegate to `runTests.sh`.
-4. Pre-commit hooks via `Build/captainhook.json` (auto-installed by composer plugin) run cgl + phpstan + commit-msg checks.
+4. Pre-commit hooks via `Build/captainhook.json` (auto-installed by the captainhook composer plugin) run cgl + phpstan + commit-msg checks.
 5. Sign commits with `git commit -S --signoff` (DCO required).
-6. **Pre-push gate: `make gate`.** It runs the six suites CI runs — `cgl`,
-   `phpstan`, `unit`, `fuzzy`, `rector -n` (pinned to PHP 8.2, as in CI) and
-   `functional -d sqlite` — plus the CHANGELOG check. Run it as one command:
-   invoking the six by hand is how `rector` and `fuzzy` get skipped, which is
-   then found by the CI matrix a push later.
-
-   `make ci` is **not** this gate. It is an older set that carries `integration`
-   and omits `rector` and `functional`; both targets are kept because they
-   answer different questions.
-
-   Contract changes (setter clamps, validation ranges) have assertion twins in
-   `Tests/Fuzzy/` — grep there before pushing.
-7. PRs target `main`. CI matrix: PHP 8.2–8.5 × TYPO3 `^13.4` / `^14.3`; merged via `--merge` strategy (preserves signatures).
+6. **Pre-push gate: `make gate`** — the six suites CI runs (cgl, phpstan, unit, fuzzy, rector `-n` pinned to PHP 8.2 as in CI, functional `-d sqlite`) plus the CHANGELOG check, as ONE command; invoking the six by hand is how `rector` and `fuzzy` get skipped. `make ci` is **not** this gate (older set: carries `integration`, omits `rector` and `functional`). Environment traps — stale `.Build`, the Rector PHP pin, the `platform_check.php` FATAL — are documented in `Tests/AGENTS.md`. Contract changes (setter clamps, validation ranges) have assertion twins in `Tests/Fuzzy/` — grep there before pushing.
+7. PRs target `main`. CI matrix: PHP 8.2–8.5 × TYPO3 `^13.4` / `^14.3` — a local gate run covers ONE of those eight cells, so local green means "no known failure", not "CI will pass". PRs are merged via `--merge` strategy (preserves signatures). Release and dependency automation: `.github/workflows/AGENTS.md`.
 <!-- AGENTS-GENERATED:END development -->
-
-<!-- AGENTS-GENERATED:START filemap -->
-## File Map
-
-### Key Files
-
-| File | Purpose |
-|------|---------|
-| `ext_emconf.php` | Extension metadata and the authoritative version |
-| `ext_localconf.php` | Extension bootstrap |
-| `composer.json` | Dependencies (composer.lock NOT committed) |
-| `Build/phpunit.xml` | PHPUnit configuration |
-| `Build/Scripts/runTests.sh` | Docker-based test runner (ALWAYS use this) |
-| `infection.json.dist` | Mutation testing config (MSI >= 70%) |
-| `Build/captainhook.json` | Git hooks (pre-commit, commit-msg, pre-push) |
-| `Configuration/Caching.php` | Cache config (no hardcoded backend, uses instance default) |
-| `Configuration/Services.yaml` | DI container, autowiring |
-<!-- AGENTS-GENERATED:END filemap -->
-
-<!-- AGENTS-GENERATED:START directory-structure -->
-## Architecture
-
-Three-tier model: **Provider → Model → Configuration**. See `Documentation/Adr/Adr013ThreeLevelConfigurationArchitecture.rst` for the design rationale and `Classes/AGENTS.md` for adapter contracts.
-
-### Directory Structure
-```
-nr_llm/
-├── Classes/                    # PHP source
-│   ├── Attribute/              # #[AsLlmProvider] auto-registration attribute
-│   ├── Controller/Backend/     # Backend controllers, DTOs, Response objects
-│   ├── DependencyInjection/    # Compiler passes (ProviderCompilerPass)
-│   ├── Domain/                 # Entities, repositories, enums, DTOs, value objects
-│   ├── Exception/              # Core domain exceptions
-│   ├── Form/                   # TCA form elements (ModelIdElement, ModelConstraintsWizard)
-│   ├── Provider/               # 7 LLM adapters + Contract interfaces + exceptions
-│   ├── Service/                # Feature services, wizard, options, fallback chain
-│   ├── Specialized/            # DeepL, speech (Whisper/TTS), image (DALL-E/FAL)
-│   ├── Utility/                # SafeCastTrait, ErrorMessageSanitizerTrait
-│   └── Widgets/DataProvider/   # Backend dashboard widgets (cost, requests)
-├── Configuration/              # TYPO3 config (TCA, services, caching, icons, routes)
-├── Documentation/              # RST docs + guides.xml + brand assets
-│   └── Adr/                    # Architecture Decision Records
-├── Tests/                      # Unit, Integration, Functional, Fuzzy, Architecture, E2E
-├── Resources/                  # Templates, XLIFF (EN+DE), icons, CSS, JS
-└── Build/                      # PHPStan, Rector, Fractor configs + runTests.sh
-```
-<!-- AGENTS-GENERATED:END directory-structure -->
 
 <!-- AGENTS-GENERATED:START code-style -->
 ## Code Style
@@ -183,31 +96,9 @@ nr_llm/
 - **NEVER take TYPO3 backend screenshots below 1440px viewport** — sidebar and table columns get cut off.
 - **API keys MUST be stored as nr-vault UUID identifiers**, never as plaintext in TCA / yaml / env. `Documentation/Adr/Adr012ApiKeyEncryption.rst` records the application-level encryption this replaced and is `Superseded`; the nr-vault integration itself was decided by no ADR, which `Documentation/Adr/Index.rst` states explicitly.
 - **No email addresses in public docs** — use the GitHub issues / discussions / security-advisories links only.
+- **`CHANGELOG.md`**: append under the heading that already exists in `## [Unreleased]` — inserting before the first `### ` produces a duplicate heading. When merging `main` into a series of sibling branches, rebuild the section (take the incoming version verbatim, re-insert your own block) instead of trusting the merge. `composer ci:test:changelog` (pre-commit and CI) refuses the repeated result.
+- **Changing the supported TYPO3/PHP range?** `VersionConsistencyTest` pins `composer.json`, `ext_emconf.php`, the `ci.yml` matrix and `Documentation/Api/SupportMatrix.rst` against each other — the UNCHECKED prose surfaces are listed in `Documentation/AGENTS.md`; update them in the same change.
 <!-- AGENTS-GENERATED:END critical -->
-
-<!-- AGENTS-GENERATED:START heuristics -->
-## Heuristics — Quick Decisions
-
-- **Where does the new feature service live?** `Classes/Service/Feature/` (one directory per feature, e.g. `Completion`, `Embedding`, `Translation`). Each feature has a service + DTO + tests.
-- **Adding a new LLM provider?** Implement `Classes/Provider/Contract/ProviderInterface`, add `#[AsLlmProvider(priority: ...)]` attribute (auto-registers via `ProviderCompilerPass`), and return the provider identifier from `ProviderInterface::getIdentifier()`. Add the provider icon to `Resources/Public/Icons/provider-<identifier>.svg`.
-- **Where does TCA live?** Per-table file under `Configuration/TCA/` for new tables; `Configuration/TCA/Overrides/` to extend existing tables (incl. `pages`, `tt_content`).
-- **Stuck on a "this works locally but breaks in CI" issue?** Reproduce inside `Build/Scripts/runTests.sh -s <suite>` first — it uses the same Docker PHP image as CI.
-- **Adding a config option?** TCA + `LLL:` translation key in `Resources/Private/Language/locallang*.xlf` for both EN and DE.
-- **Touching the public surface?** Add an ADR under `Documentation/Adr/`. Format: `Adr<N>Description.rst`. It lands **before** the implementation PR, not inside it — the decision is what the implementation follows from, and `api-surface.txt` already tells you when you are touching the surface, so there is nothing to wait for. `AdrReferenceIntegrityTest` refuses a reference to a record that does not exist; that the record arrived first is not machine-checked.
-- **Changing an `@api` signature?** `Tests/Unit/Api/api-surface.txt` freezes it, constructors included — the class's own, or the one it inherits from a base inside `Netresearch\NrLlm`; one inherited from TYPO3 core or the SPL is left out because it differs across the version matrix. The failure says whether the diff is additive (regenerate + `### Added`) or breaking (decide first). Removals follow `Documentation/Api/Deprecation.rst`, whose inventory is asserted against the `@deprecated` docblocks in both directions.
-- **Changing the supported TYPO3 / PHP range?** `VersionConsistencyTest` pins four surfaces against each other — `composer.json`, `ext_emconf.php`, the `ci.yml` matrix and `Documentation/Api/SupportMatrix.rst` — and fails on the first of those you forget. It does **not** see the prose: `README.md` (the two badges and the Requirements list), `Documentation/Installation/Index.rst`, `Documentation/Introduction/Index.rst`, `Documentation/Developer/FeatureServices/Index.rst`, `Documentation/Testing/CiConfiguration.rst` (a hand-copied matrix excerpt) and `Documentation/Developer/IntegrationGuide.rst` (the TER constraint in its `ext_emconf.php` example) repeat the same range with nothing checking them. Update those by hand in the same change — and grep for the old floor before you finish, because that list is what has been found, not a guarantee. `BASELINE.md`'s "Multi-version CI" row is the one prose surface that IS asserted, by `Tests/Unit/BaselineConsistencyTest`.
-- **Linking between backend controllers?** Use the full Extbase alias `Backend\<Name>` (e.g. `'controller' => 'Backend\\TaskWizard'`), not the short name — `resolveControllerAliasFromControllerClassName()` keeps the segment after `Controller\`, so a short alias yields an empty URL / `InvalidControllerNameException`. Namespaced backend arguments are OFF here, so use bare `controller`/`action` keys (NOT `tx_nrllm_task[...]`; the bot's suggested namespaced form is wrong for this instance). Introduced by ADR-027's TaskController split.
-<!-- AGENTS-GENERATED:END heuristics -->
-
-<!-- AGENTS-GENERATED:START utilities -->
-## Shared Utilities — Don't Reinvent
-
-- **Type coercion**: `Classes/Utility/SafeCastTrait` exposes private helpers (`toStr`, `toInt`, `toFloat`) for internal coercion when raw values come from untrusted sources. Use them inside the trait consumer; do not invent `safeIntCast`-style public methods.
-- **Error-message sanitizing**: `Classes/Utility/ErrorMessageSanitizerTrait::sanitizeErrorMessage()` strips secret-bearing query parameters (`?key=`, `?token=`, …) before a message is logged or surfaced. Use the trait; do not copy the regex.
-- **Provider invocation**: `Classes/Domain/DTO/FallbackChain.php` defines fallback chains; `Classes/Provider/Middleware/FallbackMiddleware.php` enforces them at runtime. Always go through the middleware pipeline rather than calling provider classes directly — it handles retries, fallback ordering, and error mapping.
-- **Cost tracking**: `Classes/Provider/Middleware/UsageMiddleware.php` records usage after each successful provider call via `UsageTrackerServiceInterface::trackUsage()`. Don't write to the usage table directly.
-- **Cache config**: `Configuration/Caching.php` declares the `nrllm_responses` cache. Add new caches there (no hardcoded backend — let the host instance configure Redis/Valkey/Memcached).
-<!-- AGENTS-GENERATED:END utilities -->
 
 <!-- AGENTS-GENERATED:START security -->
 ## Security
@@ -218,139 +109,11 @@ nr_llm/
 - Security advisories: https://github.com/netresearch/t3x-nr-llm/security/advisories/new
 <!-- AGENTS-GENERATED:END security -->
 
-<!-- AGENTS-GENERATED:START ci -->
-## CI/CD
-
-| Workflow | Purpose |
-|----------|---------|
-| `auto-merge-deps.yml` | Auto-merge dependency PRs |
-| `check-template-drift.yml` | Template drift against the org's typo3-extension template |
-| `checks.yml` | Security, gitleaks, zizmor, fuzz, licence audit, CodeQL, scorecard, dependency review, PR quality |
-| `ci.yml` | Lint, PHPStan, unit/functional tests, Rector, fuzz + weekly mutation, docs |
-| `community.yml` | Community health |
-| `dco.yml` | DCO sign-off |
-| `docs.yml` | Documentation rendering |
-| `e2e.yml` | Playwright E2E tests |
-| `labeler.yml` | PR auto-labelling |
-| `pages.yml` | Landing page (GitHub Pages) |
-| `release.yml` | Release with SBOM, Cosign signing, SLSA attestation; publishes TER + Packagist |
-| `republish.yml` | Re-publish an existing tag (`workflow_dispatch` fallback) |
-<!-- AGENTS-GENERATED:END ci -->
-
-<!-- AGENTS-GENERATED:START examples -->
-## Golden Samples
-
-Prefer looking at real code in this repo over inventing new patterns. Canonical reference files:
-
-| Concern | Reference |
-|---------|-----------|
-| Provider implementation | `Classes/Provider/OpenAiProvider.php` |
-| Feature service | `Classes/Service/Feature/CompletionService.php` |
-| Unit test | `Tests/Unit/Service/Feature/CompletionServiceTest.php` |
-| Functional test | `Tests/Functional/Service/UsageTrackerServiceTest.php` |
-| Architecture test | `Tests/Architecture/ControllerLayerTest.php` |
-| ADR format | `Documentation/Adr/Adr014AiPoweredWizardSystem.rst` |
-| Backend controller | `Classes/Controller/Backend/ProviderController.php` |
-| TCA form element | `Classes/Form/Element/ModelIdElement.php` |
-<!-- AGENTS-GENERATED:END examples -->
-
 <!-- AGENTS-GENERATED:START help -->
 ## When Stuck
 - Run tests: `./Build/Scripts/runTests.sh -s unit` (NEVER phpunit directly)
 - Check ADRs in `Documentation/Adr/` for design rationale; `Adr/Index.rst` documents the record lifecycle
-- API docs: `Documentation/Api/`
+- API docs: `Documentation/Api/` · Component map: `docs/ARCHITECTURE.md`
 - Issues: https://github.com/netresearch/t3x-nr-llm/issues
 - Discussions: https://github.com/netresearch/t3x-nr-llm/discussions
 <!-- AGENTS-GENERATED:END help -->
-
-<!-- Hand-maintained; intentionally outside the AGENTS-GENERATED blocks above. -->
-## Release & dependency automation (agent notes)
-
-- **Releasing is a tag push, and the tag publishes TER automatically.** Pushing an annotated signed tag `vX.Y.Z` on `main` triggers `release.yml`, which calls the reusable `netresearch/typo3-ci-workflows/.github/workflows/release-typo3-extension.yml` with `TYPO3_TER_ACCESS_TOKEN` wired in: it produces the SBOM / Cosign / SLSA artifacts, creates the GitHub release, **and publishes to TER + Packagist**. `republish.yml` is only a `workflow_dispatch` fallback that re-publishes an existing tag — it is *not* the primary path and does not need to be run for a normal release. Verify a release by checking Packagist (`repo.packagist.org/p2/netresearch/nr-llm.json`, tags are `v`-prefixed), TER (`extensions.typo3.org/api/v1/extension/nr_llm/versions`) and the docs 0.X URL — do not assume TER is a separate manual step.
-- **The `chore(release): X.Y.Z` commit bumps four files:** `ext_emconf.php`, `composer.json` (`extra.typo3/cms.version`), `Documentation/guides.xml`, and `CHANGELOG.md` (not `Changelog.rst`). Version bumps belong to this release flow, never to a feature PR.
-- **Renovate/Dependabot PRs auto-merge via `auto-merge-deps.yml` — do not hand-merge them by default.** Known gap (2026-07-24): `auto-merge-deps.yml` did **not** auto-merge #511/#509 and they were admin-merged manually to unblock the 0.24.0 release; root cause (merge-queue interaction vs an unmet workflow condition) is **not yet verified**. Investigate the workflow's condition/queue behaviour before relying on it for the next release rather than reflexively hand-merging.
-
-<!-- Hand-maintained; intentionally outside the AGENTS-GENERATED blocks above. -->
-## Working in this repo (agent notes)
-
-- **Merge-queue stall nudge**: a CLEAN PR with armed auto-merge that never enters the queue (`isInMergeQueue: false`) usually just needs a re-evaluation — `gh pr merge --disable-auto` followed by `gh pr merge --auto`. Diagnose before escalating; admin-bypassing the queue is not the fix.
-
-
-- **`CHANGELOG.md`: check whether the section already exists before inserting one.**
-  `## [Unreleased]` usually already carries `### Added`, `### Changed`, `### Fixed`
-  and `### Removed`. Inserting before the *first* `### ` after `## [Unreleased]`
-  produces a duplicate heading — the entry lands in a second `### Changed` while
-  the original sits forty lines below. Find the matching heading and append under
-  it; only create one when it genuinely is not there. (Three duplicates in one
-  session, 2026-07-30.)
-
-  **Merging `main` into a series of sibling branches duplicates the whole
-  section.** Any resolution that assumes "ours holds only my additions" is
-  right for the first merge of a series and wrong for every later one — by then
-  "ours" already carries what the previous merge brought in. No conflict
-  markers, plausible diff: on 2026-08-10 ten bullets ended up standing three and
-  four times over and two PRs carried it to `main`. Rebuild the section instead
-  of merging it — take the incoming version verbatim and re-insert your own
-  block under the matching heading. `composer ci:test:changelog` (pre-commit,
-  and its own CI job) refuses the repeated result.
-
-- **This repository defines no workflow jobs of its own.** Every workflow calls
-  a shared `netresearch/*` reusable workflow, so action pinning, runner
-  hardening and security review happen once there — for all thirty callers. The
-  single exception is the aggregate `gate` job in `checks.yml`, which evaluates
-  the other jobs' results and therefore cannot be a reusable-workflow call.
-
-  A **repo-specific check** goes in the shared workflow's `repo-checks` job, not
-  in a job here: set `run-repo-checks: true` in `ci.yml` and add the command to
-  the `ci:test:repo` composer script. That script is also what pre-commit runs,
-  so the local and CI halves are the same command.
-
-  Why this is a rule and not a preference: a local job carries its own action
-  pins, and a wrong pin does not fail like a normal check. Repo and org both set
-  `sha_pinning_required`, so a tag ref kills the run at `Set up job` — before any
-  step executes, so the log has no step output — and zizmor, Opengrep, CodeQL
-  and SonarCloud then each flag the same lines. On 2026-08-11 that was six red
-  checks for one mistake, none of them naming the cause.
-  `composer ci:test:workflows` (pre-commit) refuses a job with local steps.
-
-- **A fresh worktree needs its own dependency resolution.** `.Build/` is not
-  tracked, so a new worktree has none; copying it from `main/.Build` is the usual
-  shortcut and avoids the WSL2 segfault on a fresh composer resolve. But that copy
-  can be OLDER than `main`'s code — after a dependency bump lands, PHPStan aborts
-  with an internal error such as `Interface "Netresearch\NrVault\Crypto\
-  ForeignEnvelopeRotatorInterface" not found` while analysing an unrelated test.
-  That is a stale `.Build`, not a code defect: run
-  `./Build/Scripts/runTests.sh -s composerUpdate -p 8.4` and re-run the gate.
-
-- **Run the Rector gate with `-p 8.2`, never `-p 8.4`.** Rector's PHPUnit rules
-  activate from the phpunit version composer *installed*, not from the set named
-  in `Build/rector/rector.php`. PHP 8.2 resolves phpunit ^11, 8.4 resolves ^13,
-  and the 13-only migrations do not apply to a codebase whose blocking matrix
-  caps `phpunit/phpunit:<13`. CI pins the job with `rector-php-version: '8.2'`
-  in `ci.yml` and says so in a comment there. Running it on 8.4 reports dozens of
-  files CI will never flag — and applying those "fixes" breaks the blocking
-  matrix with `Call to an undefined method
-  expectExceptionMessageIsOrContains()`. Observed 2026-08-04: a 53-file Rector
-  run taken at face value produced a PR that turned 8 PHPStan cells and several
-  test cells red; a control on unmodified `main` with an uncapped local resolve
-  reproduced the same 53 files, proving the finding was the environment, not the
-  code.
-
-  **And in a worktree it may not run at all.** `composer install` writes
-  `.Build/vendor/composer/platform_check.php` from the PHP it resolved under,
-  and that file FATALS rather than warns on an older runtime — so a `.Build`
-  resolved at 8.4 makes the pinned `-p 8.2` die with `Composer detected issues
-  in your platform: … require a PHP version ">= 8.4.1". You are running
-  8.2.30.` The suite did not fail; it never started. `make gate` names that
-  case explicitly. Recognise the message as an environment mismatch, then
-  either keep a second `.Build` resolved at 8.2 for this one gate or accept CI
-  as the only place it runs — and **say so** when reporting which gates were
-  run, rather than listing it as green.
-
-- **A local gate run covers one matrix cell; CI covers eight.** The six pre-push
-  suites run against a single PHP version and a single TYPO3 constraint. CI runs
-  PHP 8.2–8.5 × TYPO3 13.4 / 14.3. A PHPStan finding can therefore be invisible
-  locally and red across all eight legs — a `willReturnCallback` whose closure type
-  resolves differently under the PHPUnit version a given cell installs is the
-  observed case. Green locally means "no reason to push a known failure", not
-  "CI will pass".

--- a/Build/Scripts/verify-harness.sh
+++ b/Build/Scripts/verify-harness.sh
@@ -1,0 +1,756 @@
+#!/usr/bin/env bash
+# verify-harness.sh — Portable harness consistency checker
+# Checks AGENTS.md and related files for agent harness maturity.
+# Dependencies: coreutils + git (jq optional, graceful fallback)
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Globals
+# ---------------------------------------------------------------------------
+ERRORS=0
+WARNINGS=0
+FORMAT=""
+MAX_LEVEL=3
+SINGLE_CHECK=""
+STATUS_ONLY=false
+PLATFORM="${PLATFORM:-}"
+
+# Collected output lines (for final rendering)
+declare -a OUTPUT_LINES=()
+declare -a GITHUB_LINES=()
+declare -a GITLAB_LINES=()
+
+# Per-level pass/total counters
+declare -A LEVEL_PASS=( [1]=0 [2]=0 [3]=0 )
+declare -A LEVEL_TOTAL=( [1]=0 [2]=0 [3]=0 )
+
+# Track the first failing level-1 suggestion for --status
+NEXT_STEP=""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+usage() {
+    cat <<'USAGE'
+Usage: verify-harness.sh [OPTIONS]
+
+Verify agent harness consistency in the current repository.
+Must be run from the repo root.
+
+Options:
+  --format=text     Plain text output (default for terminals)
+  --format=github   GitHub Actions annotations (auto-detected in CI)
+  --format=gitlab   GitLab CI section annotations (auto-detected in CI)
+  --platform=P      Target platform: github, gitlab or forgejo (auto-detected
+                    from CI environment or git remote URL if not specified)
+  --level=N         Only check up to level N (1, 2, or 3; default: all)
+  --check=NAME      Run single check category: refs, commands, drift, structure
+  --status          Show current maturity level summary only
+  --help            Show this help message
+
+Exit codes:
+  0  All checks pass
+  1  Errors found (Level 1/2 failures)
+  2  Only warnings (Level 3 suggestions)
+USAGE
+    exit 0
+}
+
+# Detect output format: github if running in CI, otherwise text
+detect_format() {
+    if [[ -n "$FORMAT" ]]; then
+        return
+    fi
+    if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+        FORMAT="github"
+    elif [[ "${GITLAB_CI:-}" == "true" ]]; then
+        FORMAT="gitlab"
+    else
+        FORMAT="text"
+    fi
+}
+
+# Detect hosting platform from CI env, git remote, or flag
+detect_platform() {
+    if [[ -n "$PLATFORM" ]]; then
+        if [[ "$PLATFORM" != "github" && "$PLATFORM" != "gitlab" && "$PLATFORM" != "forgejo" ]]; then
+            echo "Error: Unsupported PLATFORM '${PLATFORM}'. Expected 'github', 'gitlab' or 'forgejo'." >&2
+            exit 1
+        fi
+        return
+    fi
+    if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+        # Forgejo/Gitea Actions also export GITHUB_ACTIONS=true; tell them apart
+        # by the server URL — github.com (or a *.github.* Enterprise host) is real
+        # GitHub, anything else is a self-hosted Forgejo/Gitea instance.
+        if [[ -n "${GITHUB_SERVER_URL:-}" && "${GITHUB_SERVER_URL}" != *"github."* ]]; then
+            PLATFORM="forgejo"
+        else
+            PLATFORM="github"
+        fi
+        return
+    fi
+    if [[ "${GITLAB_CI:-}" == "true" ]]; then
+        PLATFORM="gitlab"
+        return
+    fi
+    local remote_url=""
+    remote_url=$(git remote get-url origin 2>/dev/null || true)
+    if [[ "$remote_url" == *"forgejo"* || "$remote_url" == *"gitea"* ]]; then
+        PLATFORM="forgejo"
+    elif [[ "$remote_url" == *"github"* ]]; then
+        PLATFORM="github"
+    elif [[ "$remote_url" == *"gitlab"* ]]; then
+        PLATFORM="gitlab"
+    elif [[ -f ".gitlab-ci.yml" ]]; then
+        # Infer GitLab from CI config presence (e.g. self-hosted GitLab)
+        PLATFORM="gitlab"
+    elif [[ -d ".forgejo" || -d ".gitea" ]]; then
+        # Infer Forgejo/Gitea from config presence (self-hosted)
+        PLATFORM="forgejo"
+    elif [[ -d ".github" ]]; then
+        PLATFORM="github"
+    else
+        PLATFORM="github"
+    fi
+}
+
+# Record a passing check
+pass() {
+    local level="$1"
+    local msg="$2"
+    (( LEVEL_PASS[$level]++ )) || true
+    (( LEVEL_TOTAL[$level]++ )) || true
+    OUTPUT_LINES+=("  PASS|${level}|${msg}")
+}
+
+# Record a failing check (error)
+fail() {
+    local level="$1"
+    local msg="$2"
+    local file="${3-AGENTS.md}"
+    (( ERRORS++ )) || true
+    (( LEVEL_TOTAL[$level]++ )) || true
+    OUTPUT_LINES+=("  FAIL|${level}|${msg}")
+    GITHUB_LINES+=("::error file=${file}::${msg} -- required for Level ${level} harness maturity")
+    GITLAB_LINES+=("ERROR: [Level ${level}] ${msg}${file:+ (${file})}")
+    # Capture first actionable suggestion for --status
+    if [[ -z "$NEXT_STEP" ]]; then
+        NEXT_STEP="$msg"
+    fi
+}
+
+# Record a warning
+warn() {
+    local level="$1"
+    local msg="$2"
+    local file="${3-AGENTS.md}"
+    (( WARNINGS++ )) || true
+    (( LEVEL_TOTAL[$level]++ )) || true
+    OUTPUT_LINES+=("  WARN|${level}|${msg}")
+    GITHUB_LINES+=("::warning file=${file}::${msg}")
+    GITLAB_LINES+=("WARNING: [Level ${level}] ${msg}${file:+ (${file})}")
+    if [[ -z "$NEXT_STEP" ]]; then
+        NEXT_STEP="$msg"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Level 1 checks — Basic
+# ---------------------------------------------------------------------------
+check_agents_md_exists() {
+    if [[ -f "AGENTS.md" ]]; then
+        pass 1 "AGENTS.md exists"
+    else
+        fail 1 "AGENTS.md missing at repo root"
+    fi
+}
+
+check_agents_md_length() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 1 "AGENTS.md length check skipped (file missing)"
+        return
+    fi
+    local lines
+    lines=$(wc -l < "AGENTS.md")
+    if (( lines < 150 )); then
+        pass 1 "AGENTS.md is index-format (${lines} lines)"
+    else
+        fail 1 "AGENTS.md is ${lines} lines (should be under 150)"
+    fi
+}
+
+check_agents_md_commands() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 1 "Commands section check skipped (AGENTS.md missing)"
+        return
+    fi
+    if grep -qi '^## *\(available \)\?commands' "AGENTS.md"; then
+        pass 1 "Commands section found"
+    else
+        fail 1 "AGENTS.md missing ## Commands section"
+    fi
+}
+
+check_docs_exists() {
+    if [[ -d "docs" ]]; then
+        pass 1 "docs/ directory exists"
+    else
+        fail 1 "docs/ directory missing" ""
+    fi
+}
+
+run_level1() {
+    check_agents_md_exists
+    check_agents_md_length
+    check_agents_md_commands
+    check_docs_exists
+}
+
+# ---------------------------------------------------------------------------
+# Level 2 checks — Verified
+# ---------------------------------------------------------------------------
+
+# Check that all local file references in AGENTS.md resolve
+check_refs() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 2 "Reference check skipped (AGENTS.md missing)"
+        return
+    fi
+    local has_broken=false
+    # Extract markdown links: [text](path) — skip http(s):// and #anchors
+    while IFS= read -r ref; do
+        # Strip anchor (#...) and query string (?...)
+        local clean
+        clean="${ref%%#*}"
+        clean="${clean%%\?*}"
+        # Skip empty after stripping
+        [[ -z "$clean" ]] && continue
+        # Skip URLs
+        [[ "$clean" =~ ^https?:// ]] && continue
+        # Check if file/dir exists
+        if [[ ! -e "$clean" ]]; then
+            warn 2 "Broken reference in AGENTS.md: ${ref} -> ${clean} not found"
+            has_broken=true
+        fi
+    done < <(grep -oP '\]\(\K[^)]+' "AGENTS.md" 2>/dev/null || true)
+
+    if [[ "$has_broken" == false ]]; then
+        pass 2 "All references resolve"
+    fi
+}
+
+# Check that documented commands have matching targets/scripts
+check_commands() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 2 "Command check skipped (AGENTS.md missing)"
+        return
+    fi
+
+    local found_any=false
+
+    # -- Makefile targets --
+    if [[ -f "Makefile" ]]; then
+        found_any=true
+        local has_make_issue=false
+        while IFS= read -r target; do
+            # Check if Makefile defines this target (pattern: "target:" at start of line)
+            if ! grep -qE "^${target}[[:space:]]*:" "Makefile"; then
+                warn 2 "make ${target}: no matching Makefile target (warning)"
+                has_make_issue=true
+            fi
+        done < <(grep -oP '`make\s+\K[a-zA-Z0-9_-]+' "AGENTS.md" 2>/dev/null || true)
+        if [[ "$has_make_issue" == false ]]; then
+            local make_count
+            make_count=$(grep -oP '`make\s+\K[a-zA-Z0-9_-]+' "AGENTS.md" 2>/dev/null | wc -l || true)
+            if [[ "$make_count" -gt 0 ]]; then
+                pass 2 "All make targets verified (${make_count} targets)"
+            fi
+        fi
+    fi
+
+    # -- composer.json scripts --
+    if [[ -f "composer.json" ]]; then
+        found_any=true
+        local has_composer_issue=false
+        # Built-in composer commands that are NOT user-defined scripts
+        local composer_builtins="install|update|require|remove|dump-autoload|dumpautoload|clear-cache|clearcache|config|create-project|exec|global|init|outdated|prohibits|why|why-not|search|self-update|selfupdate|show|status|validate|archive|browse|check-platform-reqs|diagnose|fund|licenses|run-script|suggests|upgrade"
+        while IFS= read -r script; do
+            # Skip built-in composer commands
+            if echo "$script" | grep -qE "^(${composer_builtins})$"; then
+                continue
+            fi
+            # Look for the script name in composer.json's scripts section
+            # Using grep since jq is optional
+            if ! grep -qE "\"${script}\"" "composer.json"; then
+                warn 2 "composer ${script}: no matching composer.json script (warning)"
+                has_composer_issue=true
+            fi
+        done < <(grep -oP '`composer\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null || true)
+        if [[ "$has_composer_issue" == false ]]; then
+            local composer_count
+            composer_count=$(grep -oP '`composer\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null | wc -l || true)
+            if [[ "$composer_count" -gt 0 ]]; then
+                pass 2 "All composer scripts verified (${composer_count} scripts)"
+            fi
+        fi
+    fi
+
+    # -- package.json scripts --
+    if [[ -f "package.json" ]]; then
+        found_any=true
+        local has_npm_issue=false
+        while IFS= read -r script; do
+            if ! grep -qE "\"${script}\"" "package.json"; then
+                warn 2 "npm run ${script}: no matching package.json script (warning)"
+                has_npm_issue=true
+            fi
+        done < <(grep -oP '`npm run\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null || true)
+        if [[ "$has_npm_issue" == false ]]; then
+            local npm_count
+            npm_count=$(grep -oP '`npm run\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null | wc -l || true)
+            if [[ "$npm_count" -gt 0 ]]; then
+                pass 2 "All npm scripts verified (${npm_count} scripts)"
+            fi
+        fi
+    fi
+
+    if [[ "$found_any" == false ]]; then
+        pass 2 "No build system files found to check commands against"
+    fi
+}
+
+check_architecture_doc() {
+    if [[ -f "docs/ARCHITECTURE.md" ]]; then
+        pass 2 "docs/ARCHITECTURE.md exists"
+    else
+        fail 2 "docs/ARCHITECTURE.md missing" ""
+    fi
+}
+
+check_ci_workflow() {
+    if [[ "$PLATFORM" == "gitlab" ]]; then
+        if [[ -f ".gitlab-ci.yml" ]]; then
+            # Search root file and all include:local files for harness job
+            local found_harness=false
+            if grep -qE "harness-verify|verify-harness" ".gitlab-ci.yml"; then
+                found_harness=true
+            else
+                # Check files referenced via include:local (supports globs).
+                # Portable parser using sed/awk — handles common GitLab CI forms:
+                #   include: { local: 'path' }
+                #   include:
+                #     - local: 'path'
+                #   include:
+                #     - local:
+                #         - path1
+                #         - path2
+                # Skips PCRE (-P) and lookaround for BSD/macOS grep portability.
+                while IFS= read -r inc_pattern; do
+                    [[ -z "$inc_pattern" ]] && continue
+                    # shellcheck disable=SC2086
+                    for inc_file in $inc_pattern; do
+                        if [[ -f "$inc_file" ]] && grep -qE "harness-verify|verify-harness" "$inc_file"; then
+                            found_harness=true
+                            break 2
+                        fi
+                    done
+                done < <(awk '
+                    /^[[:space:]]*-?[[:space:]]*local:[[:space:]]*\[/ {
+                        # inline list form: local: [a.yml, b.yml]
+                        s=$0; sub(/.*local:[[:space:]]*\[/,"",s); sub(/\].*/,"",s);
+                        n=split(s, a, /[[:space:]]*,[[:space:]]*/);
+                        for (i=1;i<=n;i++) print a[i]; next
+                    }
+                    /^[[:space:]]*-?[[:space:]]*local:[[:space:]]*[^[:space:]\[]/ {
+                        # scalar form: local: path or - local: path
+                        s=$0; sub(/.*local:[[:space:]]*/,"",s); print s; next
+                    }
+                ' ".gitlab-ci.yml" 2>/dev/null | tr -d "'\"" || true)
+            fi
+            if [[ "$found_harness" == true ]]; then
+                pass 2 "CI harness job found in GitLab CI config"
+            else
+                warn 2 "CI config exists (.gitlab-ci.yml) but no harness-verify job found"
+            fi
+        else
+            fail 2 "CI harness workflow missing -- create .gitlab-ci.yml with a harness-verify job" ""
+        fi
+    elif [[ "$PLATFORM" == "forgejo" ]]; then
+        if [[ -f ".forgejo/workflows/harness-verify.yml" || -f ".gitea/workflows/harness-verify.yml" ]]; then
+            pass 2 "CI harness workflow exists"
+        else
+            fail 2 "CI harness workflow missing -- create .forgejo/workflows/harness-verify.yml" ""
+        fi
+    else
+        if [[ -f ".github/workflows/harness-verify.yml" ]]; then
+            pass 2 "CI harness workflow exists"
+        else
+            fail 2 "CI harness workflow missing -- create .github/workflows/harness-verify.yml" ""
+        fi
+    fi
+}
+
+run_level2() {
+    check_refs
+    check_commands
+    check_architecture_doc
+    check_ci_workflow
+}
+
+# ---------------------------------------------------------------------------
+# Level 3 checks — Enforced
+# ---------------------------------------------------------------------------
+
+check_hooks_autosetup() {
+    local found=false
+    local via=""
+
+    # Check .envrc for hooksPath
+    if [[ -f ".envrc" ]] && grep -q "hooksPath" ".envrc"; then
+        found=true
+        via=".envrc"
+    fi
+
+    # Check for Husky
+    if [[ -d ".husky" ]]; then
+        found=true
+        via=".husky"
+    fi
+
+    # Check composer.json for post-install-cmd with hooks
+    if [[ -f "composer.json" ]] && grep -q "post-install-cmd" "composer.json"; then
+        if grep -q "hook" "composer.json"; then
+            found=true
+            via="composer.json post-install-cmd"
+        fi
+    fi
+
+    if [[ "$found" == true ]]; then
+        pass 3 "Git hooks auto-setup via ${via}"
+    else
+        warn 3 "No git hooks auto-setup detected (.envrc hooksPath, .husky/, or composer.json post-install-cmd)"
+    fi
+}
+
+check_pr_template() {
+    if [[ "$PLATFORM" == "forgejo" ]]; then
+        # Forgejo/Gitea honour PR templates under .forgejo/, .gitea/ or .github/
+        local f
+        for f in .forgejo/pull_request_template.md .gitea/pull_request_template.md \
+                 .forgejo/PULL_REQUEST_TEMPLATE.md .gitea/PULL_REQUEST_TEMPLATE.md \
+                 .github/pull_request_template.md; do
+            if [[ -f "$f" ]]; then
+                pass 3 "PR template exists ($f)"
+                return
+            fi
+        done
+        warn 3 "PR template missing (create .forgejo/pull_request_template.md)"
+        return
+    fi
+    if [[ "$PLATFORM" == "gitlab" ]]; then
+        if [[ -d ".gitlab/merge_request_templates" ]]; then
+            local tmpl_count
+            tmpl_count=$(find .gitlab/merge_request_templates -maxdepth 1 -type f -name '*.md' 2>/dev/null | wc -l)
+            if (( tmpl_count > 0 )); then
+                pass 3 "MR template exists (.gitlab/merge_request_templates/, ${tmpl_count} template(s))"
+                return
+            fi
+        fi
+        warn 3 "MR template missing (create .gitlab/merge_request_templates/Default.md)"
+    else
+        if [[ -f ".github/pull_request_template.md" ]]; then
+            pass 3 "PR template exists (repo-level)"
+            return
+        fi
+        if [[ -d ".github/PULL_REQUEST_TEMPLATE" ]]; then
+            pass 3 "PR template exists (directory form)"
+            return
+        fi
+        local org=""
+        org=$(git remote get-url origin 2>/dev/null | sed -n 's|.*github\.com[:/]\([^/]*\)/.*|\1|p')
+        if [[ -n "$org" ]]; then
+            local api_result=""
+            api_result=$(gh api "repos/${org}/.github/contents/pull_request_template.md" --jq '.name' 2>/dev/null || true)
+            if [[ "$api_result" == "pull_request_template.md" ]]; then
+                pass 3 "PR template exists (org-level via ${org}/.github)"
+                return
+            fi
+        fi
+        warn 3 "PR template missing (.github/pull_request_template.md or org-level)"
+    fi
+}
+
+check_drift() {
+    # Skip if git is not available
+    if ! command -v git &>/dev/null; then
+        pass 3 "Drift check skipped (git not available)"
+        return
+    fi
+
+    # Skip if not in a git repo
+    if ! git rev-parse --git-dir &>/dev/null 2>&1; then
+        pass 3 "Drift check skipped (not a git repository)"
+        return
+    fi
+
+    # Skip if no parent commit (initial commit)
+    if ! git rev-parse HEAD~1 &>/dev/null 2>&1; then
+        pass 3 "Drift check skipped (no parent commit)"
+        return
+    fi
+
+    # Check if build/CI files changed in last commit
+    local build_files_changed=false
+    local agents_changed=false
+
+    while IFS= read -r changed_file; do
+        case "$changed_file" in
+            Makefile|composer.json|package.json|.github/workflows/*|.gitlab-ci.yml|.forgejo/workflows/*|.gitea/workflows/*)
+                build_files_changed=true
+                ;;
+            AGENTS.md)
+                agents_changed=true
+                ;;
+        esac
+    done < <(git diff --name-only HEAD~1 HEAD 2>/dev/null || true)
+
+    if [[ "$build_files_changed" == true && "$agents_changed" == false ]]; then
+        warn 3 "Potential drift: build/CI files changed in last commit but AGENTS.md was not updated"
+    else
+        pass 3 "No drift detected"
+    fi
+}
+
+run_level3() {
+    check_hooks_autosetup
+    check_pr_template
+    check_drift
+}
+
+# ---------------------------------------------------------------------------
+# Output rendering
+# ---------------------------------------------------------------------------
+
+render_text() {
+    echo "Agent Harness Verification"
+    echo "=========================="
+    echo ""
+
+    local current_level=0
+    local level_names=( [1]="Basic" [2]="Verified" [3]="Enforced" )
+
+    for line in "${OUTPUT_LINES[@]}"; do
+        local kind level msg
+        kind="${line%%|*}"
+        local rest="${line#*|}"
+        level="${rest%%|*}"
+        msg="${rest#*|}"
+        kind="${kind#"${kind%%[![:space:]]*}"}" # trim leading whitespace
+
+        # Print level header when level changes
+        if (( level != current_level )); then
+            if (( current_level != 0 )); then
+                echo ""
+            fi
+            echo "Level ${level} -- ${level_names[$level]}"
+            current_level=$level
+        fi
+
+        case "$kind" in
+            PASS) echo "  ✓ ${msg}" ;;
+            FAIL) echo "  ✗ ${msg}" ;;
+            WARN) echo "  ! ${msg}" ;;
+        esac
+    done
+
+    echo ""
+
+    # Summary line
+    local maturity_level=0
+    for lvl in 1 2 3; do
+        if (( ${LEVEL_TOTAL[$lvl]} > 0 && ${LEVEL_PASS[$lvl]} == ${LEVEL_TOTAL[$lvl]} )); then
+            maturity_level=$lvl
+        else
+            break
+        fi
+    done
+
+    local status="COMPLETE"
+    if (( maturity_level == 0 )); then
+        if (( LEVEL_TOTAL[1] > 0 && LEVEL_PASS[1] > 0 )); then
+            status="PARTIAL"
+        else
+            status="NONE"
+        fi
+        maturity_level=1
+    elif (( maturity_level < 3 )); then
+        # Check if next level is partially done
+        local next_lvl=$(( maturity_level + 1 ))
+        if (( ${LEVEL_TOTAL[$next_lvl]} > 0 && ${LEVEL_PASS[$next_lvl]} < ${LEVEL_TOTAL[$next_lvl]} )); then
+            status="PARTIAL"
+        fi
+    fi
+
+    echo "Summary: Level ${maturity_level} ${status} | ${ERRORS} error(s), ${WARNINGS} warning(s)"
+}
+
+render_github() {
+    if (( ${#GITHUB_LINES[@]} > 0 )); then
+        for line in "${GITHUB_LINES[@]}"; do
+            echo "$line"
+        done
+    fi
+}
+
+render_gitlab() {
+    local ts
+    ts=$(date +%s)
+    echo -e "\e[0Ksection_start:${ts}:harness_verify[collapsed=false]\r\e[0KAgent Harness Verification"
+    if (( ${#GITLAB_LINES[@]} > 0 )); then
+        for line in "${GITLAB_LINES[@]}"; do
+            echo "$line"
+        done
+    fi
+    echo ""
+    echo "Summary: ${ERRORS} error(s), ${WARNINGS} warning(s)"
+    echo -e "\e[0Ksection_end:${ts}:harness_verify\r\e[0K"
+}
+
+render_status() {
+    # Determine highest fully-passing level
+    local maturity_level=0
+    local level_names=( [1]="Basic" [2]="Verified" [3]="Enforced" )
+
+    for lvl in 1 2 3; do
+        if (( ${LEVEL_TOTAL[$lvl]} > 0 && ${LEVEL_PASS[$lvl]} == ${LEVEL_TOTAL[$lvl]} )); then
+            maturity_level=$lvl
+        else
+            break
+        fi
+    done
+
+    local status
+    if (( maturity_level == 0 )); then
+        if (( LEVEL_TOTAL[1] > 0 && LEVEL_PASS[1] > 0 )); then
+            status="PARTIAL"
+        else
+            status="NONE"
+        fi
+        # Display as Level 1 when no level is fully complete
+        local display_level=1
+        echo "Harness Maturity: Level ${display_level} (${level_names[$display_level]}) -- ${status}"
+    else
+        echo "Harness Maturity: Level ${maturity_level} (${level_names[$maturity_level]}) -- COMPLETE"
+    fi
+
+    for lvl in 1 2 3; do
+        if (( ${LEVEL_TOTAL[$lvl]} > 0 )); then
+            echo "  Level ${lvl}: ${LEVEL_PASS[$lvl]}/${LEVEL_TOTAL[$lvl]} checks pass"
+        fi
+    done
+
+    if [[ -n "$NEXT_STEP" ]]; then
+        echo "Next step: ${NEXT_STEP}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --format=*)
+                FORMAT="${1#--format=}"
+                ;;
+            --platform=*)
+                PLATFORM="${1#--platform=}"
+                if [[ ! "$PLATFORM" =~ ^(github|gitlab|forgejo)$ ]]; then
+                    echo "Error: --platform must be 'github', 'gitlab' or 'forgejo'" >&2
+                    exit 1
+                fi
+                ;;
+            --level=*)
+                MAX_LEVEL="${1#--level=}"
+                if [[ ! "$MAX_LEVEL" =~ ^[123]$ ]]; then
+                    echo "Error: --level must be 1, 2, or 3" >&2
+                    exit 1
+                fi
+                ;;
+            --check=*)
+                SINGLE_CHECK="${1#--check=}"
+                ;;
+            --status)
+                STATUS_ONLY=true
+                ;;
+            --help|-h)
+                usage
+                ;;
+            *)
+                echo "Unknown option: $1" >&2
+                echo "Run with --help for usage info" >&2
+                exit 1
+                ;;
+        esac
+        shift
+    done
+
+    detect_format
+    detect_platform
+
+    # Run single check category if requested
+    if [[ -n "$SINGLE_CHECK" ]]; then
+        case "$SINGLE_CHECK" in
+            refs)       check_refs ;;
+            commands)   check_commands ;;
+            drift)      check_drift ;;
+            structure)
+                check_agents_md_exists
+                check_docs_exists
+                check_architecture_doc
+                check_ci_workflow
+                check_pr_template
+                ;;
+            *)
+                echo "Unknown check: ${SINGLE_CHECK}" >&2
+                echo "Valid checks: refs, commands, drift, structure" >&2
+                exit 1
+                ;;
+        esac
+    else
+        # Run all checks up to MAX_LEVEL
+        if (( MAX_LEVEL >= 1 )); then
+            run_level1
+        fi
+        if (( MAX_LEVEL >= 2 )); then
+            run_level2
+        fi
+        if (( MAX_LEVEL >= 3 )); then
+            run_level3
+        fi
+    fi
+
+    # Render output
+    if [[ "$STATUS_ONLY" == true ]]; then
+        render_status
+    elif [[ "$FORMAT" == "github" ]]; then
+        render_github
+    elif [[ "$FORMAT" == "gitlab" ]]; then
+        render_gitlab
+    else
+        render_text
+    fi
+
+    # Exit code
+    if (( ERRORS > 0 )); then
+        exit 1
+    elif (( WARNINGS > 0 )); then
+        exit 2
+    else
+        exit 0
+    fi
+}
+
+main "$@"

--- a/Build/Scripts/verify-harness.sh
+++ b/Build/Scripts/verify-harness.sh
@@ -426,10 +426,19 @@ check_hooks_autosetup() {
         fi
     fi
 
+    # A hook installer that is a composer PLUGIN needs no script entry: it runs
+    # off its own package lifecycle. captainhook/hook-installer is the case in
+    # this repository, and looking only for post-install-cmd reported "no
+    # auto-setup" on a repository whose own AGENTS.md documents the plugin.
+    if [[ -f "composer.json" ]] && grep -q "captainhook/hook-installer" "composer.json"; then
+        found=true
+        via="captainhook/hook-installer (composer plugin)"
+    fi
+
     if [[ "$found" == true ]]; then
         pass 3 "Git hooks auto-setup via ${via}"
     else
-        warn 3 "No git hooks auto-setup detected (.envrc hooksPath, .husky/, or composer.json post-install-cmd)"
+        warn 3 "No git hooks auto-setup detected (.envrc hooksPath, .husky/, a composer plugin installer, or composer.json post-install-cmd)"
     fi
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Agent-harness verification.** `docs/ARCHITECTURE.md` (component map + phpat dependency-rule summary), `docs/exec-plans/` scaffold, `Build/Scripts/verify-harness.sh`, and a `harness-verify.yml` workflow — a thin caller of the shared `script-check` reusable — that fails CI on an AGENTS.md line-budget or dead-reference regression.
+
+### Changed
+- **AGENTS.md files synchronized with the repository state.** Root slimmed from 356 to 119 lines by moving content into the scoped files it belongs to; stale inventories refreshed (TCA files, database tables, backend templates, JS modules, `Services.Dashboard.php`); phantom `TCA/Overrides/` and dead `MEMORY.md` references removed; generic workflow boilerplate in `.github/workflows/AGENTS.md` replaced with this repository's actual conventions (no local jobs, release flow, dependency automation).
+
 ## [0.30.0] - 2026-08-18
 
 ### Added

--- a/Classes/AGENTS.md
+++ b/Classes/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-04-23 -->
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-08-19 -->
 
 # AGENTS.md — Classes
 
@@ -23,7 +23,7 @@ PHP 8.2+ source code with strict typing, PSR-12, PHPStan level 10. Three-tier do
 ./Build/Scripts/runTests.sh -s unit         # Unit tests for Classes/
 ./Build/Scripts/runTests.sh -s functional   # Functional tests (DB)
 ```
-Full test matrix in root `AGENTS.md` Setup section.
+Full test matrix in root `AGENTS.md` Commands section.
 <!-- AGENTS-GENERATED:END tests -->
 
 <!-- AGENTS-GENERATED:START filemap -->
@@ -31,9 +31,10 @@ Full test matrix in root `AGENTS.md` Setup section.
 
 | Directory | Purpose |
 |-----------|---------|
-| `Attribute/` | `#[AsLlmProvider]` auto-registration attribute |
+| `Attribute/` | `#[AsLlmProvider]` and `#[AsTranslator]` auto-registration attributes |
+| `Command/` | CLI commands (purge/reap/eval/agent-run maintenance, `SetProviderApiKeyCommand`) |
 | `Controller/Backend/` | Backend module controllers, request DTOs, Response objects |
-| `DependencyInjection/` | ProviderCompilerPass |
+| `DependencyInjection/` | ProviderCompilerPass, TranslatorCompilerPass |
 | `Domain/DTO/` | BudgetCheckResult, CapabilitySet, FallbackChain, ModelSelectionCriteria, ProviderOptions |
 | `Domain/Enum/` | Backed enums for capabilities, task shape, agent-run state, tool data class / effect / egress, trust zone, governance |
 | `Domain/Model/` | Extbase entities (Provider, Model, LlmConfiguration, Task, UserBudget, Skill, SkillSource, PromptSnippet, BackendUserGroup) and the response/result types |
@@ -50,6 +51,9 @@ Full test matrix in root `AGENTS.md` Setup section.
 | `Service/Option/` | ChatOptions, EmbeddingOptions, ToolOptions, TranslationOptions, VisionOptions on `AbstractOptions`, plus the budget-aware trait and interface |
 | `Service/SetupWizard/` | ProviderDetector, ModelDiscovery (facade), ConfigurationGenerator + DTOs; `Discovery/` holds one model discoverer per provider |
 | `Specialized/` | Image (DALL-E, FAL), Speech (Whisper, TTS), Translation (DeepL, LLM) |
+| `Hook/` | ProviderEndpointNormalizationHook |
+| `Testing/` | Fake service doubles (`FakeCompletionService`, …) for consumers' tests |
+| `Updates/` | Upgrade wizards |
 | `Utility/` | SafeCastTrait, ErrorMessageSanitizerTrait |
 | `Widgets/DataProvider/` | Backend dashboard widgets (MonthlyCost, RequestsByProvider) |
 <!-- AGENTS-GENERATED:END filemap -->
@@ -79,9 +83,9 @@ See `Tests/Architecture/` for enforcement tests.
 
 ### New Provider
 1. Create in `Provider/` extending `AbstractProvider`
-2. Implement capability interfaces from `Provider/Contract/`
+2. Implement capability interfaces from `Provider/Contract/` and add the `#[AsLlmProvider(priority: ...)]` attribute (auto-registers via `ProviderCompilerPass`); return the identifier from `ProviderInterface::getIdentifier()`
 3. Add to `AdapterType` enum (`Domain/Model/AdapterType.php`)
-4. Register via DI (auto-tagged by `ProviderCompilerPass`)
+4. Add the provider icon to `Resources/Public/Icons/provider-<identifier>.svg`
 5. Add unit tests in `Tests/Unit/Provider/`
 6. Add integration tests in `Tests/Integration/Provider/`
 
@@ -90,7 +94,25 @@ See `Tests/Architecture/` for enforcement tests.
 2. Accept option object from `Service/Option/`
 3. Return typed response from `Domain/Model/`
 4. Add to `LlmServiceManager` public API
+
+### Touching the public surface (`@api`)
+- Add an ADR under `Documentation/Adr/` (format `Adr<N>Description.rst`) — it lands **before** the implementation PR, not inside it. `AdrReferenceIntegrityTest` refuses a reference to a record that does not exist; that the record arrived first is not machine-checked.
+- `Tests/Unit/Api/api-surface.txt` freezes every `@api` signature, constructors included — the class's own, or one inherited from a base inside `Netresearch\NrLlm` (bases from TYPO3 core or the SPL are left out because they differ across the version matrix). The failure says whether the diff is additive (regenerate + `### Added`) or breaking (decide first).
+- Removals follow `Documentation/Api/Deprecation.rst`, whose inventory is asserted against the `@deprecated` docblocks in both directions.
+
+### Linking between backend controllers
+Use the full Extbase alias `Backend\<Name>` (e.g. `'controller' => 'Backend\\TaskWizard'`), not the short name — `resolveControllerAliasFromControllerClassName()` keeps the segment after `Controller\`, so a short alias yields an empty URL / `InvalidControllerNameException`. Namespaced backend arguments are OFF here, so use bare `controller`/`action` keys (NOT `tx_nrllm_task[...]`). Introduced by ADR-027's TaskController split.
 <!-- AGENTS-GENERATED:END patterns -->
+
+<!-- AGENTS-GENERATED:START utilities -->
+## Shared Utilities — Don't Reinvent
+
+- **Type coercion**: `Utility/SafeCastTrait` exposes private helpers (`toStr`, `toInt`, `toFloat`) for internal coercion when raw values come from untrusted sources. Use them inside the trait consumer; do not invent `safeIntCast`-style public methods.
+- **Error-message sanitizing**: `Utility/ErrorMessageSanitizerTrait::sanitizeErrorMessage()` strips secret-bearing query parameters (`?key=`, `?token=`, …) before a message is logged or surfaced. Use the trait; do not copy the regex.
+- **Provider invocation**: `Domain/DTO/FallbackChain.php` defines fallback chains; `Provider/Middleware/FallbackMiddleware.php` enforces them at runtime. Always go through the middleware pipeline rather than calling provider classes directly — it handles retries, fallback ordering, and error mapping.
+- **Cost tracking**: `Provider/Middleware/UsageMiddleware.php` records usage after each successful provider call via `UsageTrackerServiceInterface::trackUsage()`. Don't write to the usage table directly.
+- **Cache config**: `Configuration/Caching.php` declares the `nrllm_responses` cache. Add new caches there (no hardcoded backend — let the host instance configure Redis/Valkey/Memcached).
+<!-- AGENTS-GENERATED:END utilities -->
 
 <!-- AGENTS-GENERATED:START security -->
 ## Security

--- a/Configuration/AGENTS.md
+++ b/Configuration/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-04-23 -->
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-08-19 -->
 
 # AGENTS.md — Configuration
 
@@ -25,8 +25,12 @@ Configuration/
 ├── Extbase/Persistence/Classes.php   # Extbase persistence mapping
 ├── TCA/
 │   ├── tx_nrllm_configuration.php
+│   ├── tx_nrllm_mcp_server.php
 │   ├── tx_nrllm_model.php
+│   ├── tx_nrllm_promptsnippet.php
 │   ├── tx_nrllm_provider.php
+│   ├── tx_nrllm_skill.php
+│   ├── tx_nrllm_skill_source.php
 │   ├── tx_nrllm_task.php
 │   └── tx_nrllm_user_budget.php
 ├── Caching.php              # Cache configuration
@@ -34,19 +38,30 @@ Configuration/
 ├── JavaScriptModules.php    # JS module registration
 ├── Services.php             # DI container configuration
 ├── Services.yaml            # Service definitions
-└── Services.Dashboard.yaml  # Dashboard widgets DI
+└── Services.Dashboard.php   # Dashboard widgets DI
 ```
 
+New tables get a per-table file directly under `TCA/`; there is currently no `TCA/Overrides/` directory (nr_llm does not extend foreign tables).
+
 ### Database Tables
+
+`ext_tables.sql` is the authoritative list (24 tables as of 2026-08-19). The core entities:
+
 | Table | Purpose |
 |-------|---------|
 | `tx_nrllm_provider` | API provider connections (OpenAI, Claude, etc.) |
 | `tx_nrllm_model` | Available models per provider |
-| `tx_nrllm_configuration` | Use-case configurations |
-| `tx_nrllm_configuration_begroups_mm` | MM join — configurations ↔ backend user groups |
-| `tx_nrllm_task` | Predefined task templates |
+| `tx_nrllm_configuration` | Use-case configurations (+ `_begroups_mm`, `_skill_mm` joins) |
+| `tx_nrllm_task` | Predefined task templates (+ `_skill_mm` join) |
 | `tx_nrllm_user_budget` | Per-user AI spending ceilings |
 | `tx_nrllm_service_usage` | Usage/cost tracking rows |
+| `tx_nrllm_skill`, `tx_nrllm_skill_source` | Skills and their sources (+ `tx_nrllm_skill_audit`) |
+| `tx_nrllm_promptsnippet` | Reusable prompt snippets |
+| `tx_nrllm_mcp_server`, `tx_nrllm_mcp_tool` | MCP server/tool registry |
+| `tx_nrllm_agentrun`, `tx_nrllm_agentrun_event` | Agent runs and their event log |
+| `tx_nrllm_ai_session`, `tx_nrllm_ai_session_message` | AI sessions |
+| `tx_nrllm_telemetry`, `tx_nrllm_governance_event`, `tx_nrllm_eval_result` | Telemetry / governance / eval records |
+| `tx_nrllm_tool_state`, `tx_nrllm_tool_group_state` | Tool enablement state |
 
 ### Services
 All services use autowiring. Public services defined in `Services.yaml`:

--- a/Documentation/AGENTS.md
+++ b/Documentation/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-04-23 -->
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-08-19 -->
 
 # AGENTS.md — Documentation
 
@@ -101,6 +101,18 @@ ADRs use numbered naming: `AdrNNNTitle.rst`; follow the existing format for new 
 
 ### Branding
 Documentation uses Netresearch branding: teal underline SVG for headings, emoji icons for feature cards, footer card with company info. See `guides.xml` `<extension>` attributes for project links.
+
+### Supported-version prose surfaces (unchecked by tests)
+`VersionConsistencyTest` pins `composer.json`, `ext_emconf.php`, the `ci.yml` matrix and `Api/SupportMatrix.rst` against each other — it does **not** see the prose. These repeat the supported TYPO3/PHP range with nothing checking them; update them by hand in the same change, and grep for the old floor before you finish (this list is what has been found, not a guarantee):
+
+- repo-root `README.md` (the two badges and the Requirements list)
+- `Installation/Index.rst`
+- `Introduction/Index.rst`
+- `Developer/FeatureServices/Index.rst`
+- `Testing/CiConfiguration.rst` (hand-copied matrix excerpt)
+- `Developer/IntegrationGuide.rst` (the TER constraint in its `ext_emconf.php` example)
+
+Repo-root `BASELINE.md`'s "Multi-version CI" row is the one prose surface that IS asserted, by `Tests/Unit/BaselineConsistencyTest.php`.
 <!-- AGENTS-GENERATED:END patterns -->
 
 <!-- AGENTS-GENERATED:START security -->

--- a/Documentation/CLAUDE.md
+++ b/Documentation/CLAUDE.md
@@ -1,0 +1,3 @@
+<!-- Regular file, not a symlink: the TYPO3 docs renderer (Flysystem) rejects symbolic links inside Documentation/ — see Build/Scripts/check-agent-doc-symlinks.php for the measured failure. -->
+
+@AGENTS.md

--- a/Resources/AGENTS.md
+++ b/Resources/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-04-23 -->
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-08-19 -->
 
 # AGENTS.md — Resources
 
@@ -17,22 +17,7 @@ No build step. Files served directly by TYPO3. JavaScript uses ES modules via `@
 
 ### Templates (`Private/Templates/Backend/`)
 
-| Template | Purpose |
-|----------|---------|
-| `Index.html` | Dashboard overview |
-| `Provider/List.html` | Provider management |
-| `Model/List.html` | Model management |
-| `Configuration/List.html` | Configuration management |
-| `Configuration/WizardForm.html` | AI-powered config wizard form |
-| `Configuration/WizardPreview.html` | Config wizard preview |
-| `Task/List.html` | Task management |
-| `Task/Execute.html` | Task execution UI |
-| `Task/WizardForm.html` | AI-powered task wizard form |
-| `Task/WizardPreview.html` | Task wizard preview |
-| `Task/WizardChainPreview.html` | Task chain wizard preview |
-| `SetupWizard/Index.html` | Initial setup wizard |
-| `Help.html` | Help page |
-| `Test.html` | Test prompt page |
+One directory per backend surface (`Provider/`, `Model/`, `Configuration/`, `Task/`, `AiTask/`, `Skill/`, `PromptSnippet/`, `McpServer/`, `Tool/`, `AgentRun/`, `Playground/`, `Analytics/`, `UseCase/`, `EditorAction/`, `SetupWizard/`), mostly `List.html` plus surface-specific views (`Execute.html`, `WizardForm.html`, `WizardPreview.html`, `Show.html`), and top-level pages `Index.html`, `Governance.html`, `Help.html`, `Test.html`. Follow the sibling surface's structure when adding a view.
 
 ### Language Files (`Private/Language/`)
 
@@ -40,22 +25,14 @@ No build step. Files served directly by TYPO3. JavaScript uses ES modules via `@
 |------|---------|
 | `locallang.xlf` | General labels |
 | `locallang_tca.xlf` | TCA field labels |
+| `locallang_dashboard.xlf` | Dashboard widget labels |
 | `locallang_mod.xlf` | Backend module labels |
-| `locallang_mod_{overview,provider,model,config,task,wizard}.xlf` | Module-specific labels |
-| `de.locallang*.xlf` | German translations (all files) |
+| `locallang_mod_<surface>.xlf` | One file per module surface (overview, provider, model, config, task, aitasks, wizard, skill, snippet, tool, mcp, runs, playground, analytics, usecase) |
+| `de.locallang*.xlf` | German translations — EVERY EN file has a `de.` twin |
 
 ### JavaScript (`Public/JavaScript/Backend/`)
 
-| File | Purpose |
-|------|---------|
-| `ProviderList.js` | Provider list interactions |
-| `ModelList.js` | Model list interactions |
-| `ConfigurationList.js` | Configuration list interactions |
-| `ConfigurationConstraints.js` | Model constraint display |
-| `TaskExecute.js` | Task execution with live output |
-| `SetupWizard.js` | Setup wizard flow |
-| `ModelIdField.js` | Model ID TCA field |
-| `WizardFormLoading.js` | Wizard loading states |
+One ES module per backend interaction concern, named after the surface it drives (`ProviderList.js`, `TaskExecute.js`, `SetupWizard.js`, `ToolPlayground.js`, `AgentRunInbox.js`, …), plus shared helpers (`AjaxError.js`, `HtmlEscape.js`, `ModuleAction.js`). `Public/JavaScript/Vendor/` holds the vendored `chart.umd.js`.
 
 ### Icons (`Public/Icons/`)
 - `Extension.svg` — Branded teal tile with white chip motif + orange accent (extension icon, also TCA iconfile)

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-04-23 -->
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-08-19 -->
 
 # AGENTS.md — Tests
 
@@ -37,6 +37,18 @@ Comprehensive test suite: PHPUnit 11/12/13 (cross-compatible), TYPO3 Testing Fra
 | `E2E/Backend/` | PHPUnit | Backend E2E tests |
 | `E2E/TCA/` | PHPUnit | TCA field tests |
 | `E2E/Playwright/` | Playwright (TS) | Browser-based UI tests |
+
+### Functional suite runtime
+
+The full `./Build/Scripts/runTests.sh -s functional` run includes ~34 provider-connection smoke tests that make REAL outbound HTTPS calls to unreachable providers (deliberate 502 mapping) — the full run takes ~35 min locally while per-class runs stay fast. Scope local runs to the touched test classes; leave the full matrix to CI.
+
+### Runner environment traps (worktrees, Rector, matrix)
+
+- **A fresh worktree needs its own dependency resolution.** `.Build/` is not tracked; copying it from `main/.Build` is the usual shortcut (avoids the WSL2 segfault on a fresh composer resolve), but the copy can be OLDER than `main`'s code — after a dependency bump, PHPStan aborts with an internal error like `Interface "…ForeignEnvelopeRotatorInterface" not found` while analysing an unrelated test. That is a stale `.Build`, not a code defect: run `./Build/Scripts/runTests.sh -s composerUpdate -p 8.4` and re-run the gate.
+- **Run the Rector gate with `-p 8.2`, never `-p 8.4`.** Rector's PHPUnit rules activate from the phpunit version composer *installed*, not from the set named in `Build/rector/rector.php`. PHP 8.2 resolves phpunit ^11, 8.4 resolves ^13, and the 13-only migrations do not apply to a codebase whose blocking matrix caps `phpunit/phpunit:<13`. CI pins the job with `rector-php-version: '8.2'` in `ci.yml`. Running it on 8.4 reports dozens of files CI will never flag — applying those "fixes" breaks the blocking matrix with `Call to an undefined method expectExceptionMessageIsOrContains()` (observed 2026-08-04; a control run on unmodified `main` reproduced the identical finding list, proving the finding was the environment, not the code).
+- **And in a worktree it may not run at all.** `composer install` writes `.Build/vendor/composer/platform_check.php` from the PHP it resolved under, and that file FATALS on an older runtime — a `.Build` resolved at 8.4 makes the pinned `-p 8.2` die with `Composer detected issues in your platform: … require a PHP version ">= 8.4.1"`. The suite did not fail; it never started. `make gate` names that case explicitly. Either keep a second `.Build` resolved at 8.2 for this one gate or accept CI as the only place it runs — and **say so** when reporting which gates were run.
+- **A local gate run covers one matrix cell; CI covers eight** (PHP 8.2–8.5 × TYPO3 13.4/14.3). A PHPStan finding can be invisible locally and red across all eight legs — e.g. a `willReturnCallback` closure type that resolves differently under another PHPUnit version. Green locally means "no reason to push a known failure", not "CI will pass".
+- **"Works locally but breaks in CI"?** Reproduce inside `./Build/Scripts/runTests.sh -s <suite>` first — it uses the same Docker PHP image as CI.
 <!-- AGENTS-GENERATED:END filemap -->
 
 <!-- AGENTS-GENERATED:START code-style -->
@@ -86,6 +98,6 @@ Comprehensive test suite: PHPUnit 11/12/13 (cross-compatible), TYPO3 Testing Fra
 <!-- AGENTS-GENERATED:START help -->
 ## When Stuck
 - Test docs: `Documentation/Testing/` — UnitTesting, FunctionalTesting, EndToEndTesting, CiConfiguration
-- PHPUnit 11/12/13 compat: see `MEMORY.md` PHPUnit section
+- PHPUnit 11/12/13 compat notes: `Documentation/Testing/CiConfiguration.rst`
 - Run with `-v` for verbose: `./Build/Scripts/runTests.sh -s unit -v`
 <!-- AGENTS-GENERATED:END help -->

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,69 @@
+# Architecture — nr_llm
+
+Agent-facing component map. For design rationale, the authoritative records are the ADRs under `Documentation/Adr/` (`Documentation/Adr/Index.rst` indexes them and documents the lifecycle). This file states *where things live* and *which dependencies are allowed*; it duplicates no decision text.
+
+## System Overview
+
+nr_llm is a TYPO3 (v13.4/v14.3) extension providing a unified LLM provider abstraction. Seven provider adapters (OpenAI, Claude, Gemini, Groq, Mistral, Ollama, OpenRouter) sit behind a common contract; feature services (completion, conversation, embedding, tool calling, translation, vision) consume them through a middleware pipeline that enforces fallback chains, budgets, caching, guardrails, circuit breaking and usage/telemetry tracking. A backend module manages the three-tier configuration (Provider → Model → Configuration) plus tasks, skills, prompt snippets, MCP servers, agent runs, analytics and governance.
+
+## Directory Structure
+
+```
+nr_llm/
+├── Classes/                    # PHP source (see Classes/AGENTS.md for the per-directory table)
+│   ├── Attribute/              # #[AsLlmProvider] / #[AsTranslator] auto-registration
+│   ├── Command/                # CLI maintenance commands (purge, reap, eval, API-key set)
+│   ├── Controller/Backend/     # Backend controllers, request DTOs, Response objects
+│   ├── DependencyInjection/    # ProviderCompilerPass, TranslatorCompilerPass
+│   ├── Domain/                 # Entities, repositories, enums, DTOs, value objects
+│   ├── Exception/              # Core domain exceptions (NrLlmExceptionInterface)
+│   ├── Form/                   # TCA form elements and item providers
+│   ├── Hook/                   # ProviderEndpointNormalizationHook
+│   ├── Provider/               # 7 LLM adapters + Contract/ + Exception/ + Middleware/ + CircuitBreaker/ + Fallback/
+│   ├── Service/                # Feature services + wizard, options, budget, analytics, governance, retrieval, tools
+│   ├── Specialized/            # DeepL, speech (Whisper/TTS), image (DALL-E/FAL)
+│   ├── Testing/                # Fake service doubles for consuming extensions' tests
+│   ├── Updates/                # Upgrade wizards
+│   ├── Utility/                # SafeCastTrait, ErrorMessageSanitizerTrait
+│   └── Widgets/DataProvider/   # Backend dashboard widgets (cost, requests)
+├── Configuration/              # TYPO3 config: TCA, Services.yaml, Caching.php, Icons, backend routes
+├── Documentation/              # RST docs + guides.xml + Adr/ + Api/ + brand assets
+├── Tests/                      # Unit, Integration, Functional, Fuzzy, Architecture, E2E
+├── Resources/                  # Fluid templates, XLIFF (EN+DE), icons, CSS, JS
+├── Build/                      # runTests.sh, PHPStan/Rector/Fractor configs, repo-check scripts
+└── docs/                       # This file + exec-plans/
+```
+
+## Core Runtime Components
+
+| Component | Path | Role |
+|-----------|------|------|
+| `LlmServiceManager` | `Classes/Service/LlmServiceManager.php` | Main public entry point |
+| Feature services | `Classes/Service/Feature/` | Completion, Conversation, Embedding, ToolCalling, Translation, Vision — each with interface |
+| Option objects | `Classes/Service/Option/` | Typed options on `AbstractOptions` (object-only API) |
+| Provider contract | `Classes/Provider/Contract/` | `ProviderInterface` + capability interfaces (Streaming/Tool/Vision/Document) |
+| Provider adapters | `Classes/Provider/*Provider.php` | One class per LLM vendor, extending `AbstractProvider` |
+| Middleware pipeline | `Classes/Provider/Middleware/` | `MiddlewarePipeline` with Fallback, Budget, Cache, Guardrail, CircuitBreaker, Idempotency, Telemetry, Usage middlewares |
+| Provider registry | `Classes/Provider/ProviderAdapterRegistry.php` | Registry backend controllers use instead of concrete adapters |
+| Setup wizard | `Classes/Service/SetupWizard/` | ProviderDetector, ModelDiscovery facade, ConfigurationGenerator |
+| Cache | `Classes/Service/CacheManager.php` + `Configuration/Caching.php` | `nrllm_responses` cache; backend chosen by host instance |
+
+## Dependency Rules (phpat-enforced)
+
+`Tests/Architecture/` is the authoritative, machine-enforced statement. Per test file:
+
+- `ControllerLayerTest`: FormInput DTOs do not depend on persistence (their factories may depend on repositories); backend controllers use the `ProviderAdapterRegistry`, never concrete providers.
+- `DomainLayerTest`: domain models do not depend on repositories, controllers, or HTTP classes; they depend only on Domain + core; the `Provider` model has explicitly limited dependencies.
+- `DtoLayerTest`: DTOs are readonly with typed properties only.
+- `ModuleSeamTest`: Specialized services and the Tool module do not depend on each other; the Guardrail module does not depend on the modules it protects; nothing outside the Backend depends on it; core does not depend on the Tool module.
+- `ServiceLayerTest`: services do not depend on controllers, nor on concrete provider adapters (contracts only).
+
+Run them via `./Build/Scripts/runTests.sh -s architecture`.
+
+## Data Flow
+
+A feature-service call goes: caller → `LlmServiceManager` / feature service → configuration resolution (three-tier: Configuration → Model → Provider) → `MiddlewarePipeline` (budget, cache, guardrails, circuit breaker, fallback chain, idempotency) → provider adapter → HTTP call. On the way back: response parsing into typed response objects, then usage/telemetry middlewares record cost and signals. API keys are resolved from nr-vault UUID identifiers at call time and never persisted in plaintext.
+
+## Key Decisions
+
+Do not re-derive these — read the record: `Documentation/Adr/Index.rst` indexes all ADRs. Load-bearing ones referenced from AGENTS.md files: ADR-013 (three-level configuration architecture), ADR-026 (provider middleware pipeline), ADR-027 (TaskController split / backend controller aliases), ADR-028 (public services policy). The public API surface is frozen by `Tests/Unit/Api/api-surface.txt`; deprecations follow `Documentation/Api/Deprecation.rst`.

--- a/docs/exec-plans/README.md
+++ b/docs/exec-plans/README.md
@@ -1,0 +1,8 @@
+# Execution Plans
+
+Working documents for multi-step changes (features, migrations, large refactors). One markdown file per plan.
+
+- `active/` — plans currently being executed
+- `completed/` — finished plans, kept for archaeology
+
+Note: formal feature specifications live in `specs/` (spec-kit layout); this directory is for agent execution plans that track progress across sessions. A plan is a scratchpad, not documentation — the durable outcome belongs in `Documentation/` (ADRs, guides) and the code.


### PR DESCRIPTION
## Description

Synchronizes every AGENTS.md with the actual repository state and adopts agent-harness Level 2/3 verification. Root `AGENTS.md` was 356 lines against the harness cap of 150; it is now 119 — the excess was curated, valuable content (release flow, CHANGELOG traps, Rector/worktree environment notes, heuristics), so it was **moved** to the scoped file each piece belongs to, not deleted: test-runner environment traps to `Tests/AGENTS.md`, release + dependency automation + merge-queue notes to `.github/workflows/AGENTS.md`, shared utilities + API-surface rules + backend-controller linking to `Classes/AGENTS.md`, seed/demo data to `.ddev/AGENTS.md`, unchecked version-prose surfaces to `Documentation/AGENTS.md`, and the component map to a new `docs/ARCHITECTURE.md` (phpat dependency rules summarized from `Tests/Architecture/`).

Drift fixed against the tree: `Configuration/AGENTS.md` listed 5 of 9 TCA files and 7 of 24 tables and named `Services.Dashboard.yaml` where the file is `Services.Dashboard.php`; `Resources/AGENTS.md` enumerated 14 of 29 templates and 8 of 23 JS modules (now pattern-based, drift-resistant); `Classes/AGENTS.md` missed `Command/`, `Hook/`, `Testing/`, `Updates/`; the root heuristic pointed to a nonexistent `Configuration/TCA/Overrides/`; `Tests/AGENTS.md` pointed to a nonexistent `MEMORY.md`; `.github/workflows/AGENTS.md` carried generic Node.js CI boilerplate that contradicted this repo's no-local-jobs rule and now states the actual conventions instead.

Harness infrastructure: `docs/ARCHITECTURE.md`, `docs/exec-plans/README.md`, `Build/Scripts/verify-harness.sh`, and `harness-verify.yml` as a thin caller of the shared `netresearch/.github` `script-check` reusable (no local steps — `composer ci:test:workflows` stays green; exit 2 = warnings-only passes). `Documentation/CLAUDE.md` is a regular `@AGENTS.md` import file, not a symlink, because Flysystem aborts the docs render on symlinks (the existing `Documentation/` exemption in `check-agent-doc-symlinks.php`). `docs/` was gitignored as "local planning docs"; the ignore is narrowed so only the two harness files are tracked and stray local planning files stay ignored.

## Related Issue

Closes #821

## Type of Change

- [x] Documentation update

## Test plan

Before → after on this branch (all run from a clean worktree of `origin/main`): `score-agents.sh` average 79/100 (root 69) → 98/100 (root 90); `validate-structure.sh` 1 error → 0 errors, 0 warnings; `verify-content.sh` 0 warnings → 0 warnings; `verify-harness.sh` Level 1 PARTIAL (4 errors, 1 warning) → Level 2 PARTIAL / Level-3 gate (0 errors, 1 warning); root line count 356 → 119. Every repo path referenced by the edited files was checked for existence; markdown fences balanced per file; `actionlint` clean on the new workflow; the repo's own checks pass locally: `ci:test:agent-docs`, `ci:test:workflows` (with yq present), `ci:test:changelog`, `ci:test:badges`.

The one remaining harness warning is "No git hooks auto-setup detected" — a false negative: hooks ARE auto-installed by the `captainhook/hook-installer` composer plugin, which the checker's heuristic (`.envrc` hooksPath / `.husky/` / `post-install-cmd`) does not recognize. The workflow accepts warnings (exit 2) by design.

`make gate` was NOT run for this change: this worktree has no `.Build` resolution and the diff touches no PHP, no TCA and no workflow job logic; cgl/PHPStan/unit/fuzzy/rector/functional run in CI on this PR.
