### PR TITLE
feat(outcome): record whether a call was useful, asked of the person who read it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 - **Agent-harness verification.** `docs/ARCHITECTURE.md` (component map + phpat dependency-rule summary), `docs/exec-plans/` scaffold, `Build/Scripts/verify-harness.sh`, and a `harness-verify.yml` workflow — a thin caller of the shared `script-check` reusable — that fails CI on an AGENTS.md line-budget or dead-reference regression.
 
+- A caller can choose the correlation id its call is traced under, through
+  `ChatOptions::withCorrelationId()` and its siblings on `AbstractOptions`
+  (ADR-176).
+
+  Every send already got an id — the provider pipeline mints a UUID when none
+  is passed — but it was minted inside and never handed back, so a caller could
+  not say afterwards which telemetry row was its own call. Supplying it is the
+  answer: the caller knows the id because it chose it.
+
+  Inside an agent run the run's id still wins, so one run stays one trace. Like
+  the idempotency key, the value never reaches a provider.
+
+  This is what makes a per-call outcome recordable. It is an option rather than
+  a return value because `CompletionResponse` is frozen, so growing it would
+  have been a breaking change.
+
+- The AI tasks module asks whether a result was useful, and stores the answer
+  against the call that produced it (ADR-176).
+
+  The rating lands on `tx_nrllm_call_outcome`, keyed on the same
+  `correlation_id` the cost and pre-routing facts already sit on, so quality and
+  cost join without a second identity. It carries no backend user and no
+  per-editor readout exists: who ran the call is on the run record where budgets
+  need it, and erasure rides on the installation's `be_users` lifecycle.
+
+  An approval is never treated as a rating. It can be withheld for governance
+  reasons that say nothing about the model, so folding it in would measure the
+  gate instead of the answer.
+
 ### Changed
 - **AGENTS.md files synchronized with the repository state.** Root slimmed from 356 to 119 lines by moving content into the scoped files it belongs to; stale inventories refreshed (TCA files, database tables, backend templates, JS modules, `Services.Dashboard.php`); phantom `TCA/Overrides/` and dead `MEMORY.md` references removed; generic workflow boilerplate in `.github/workflows/AGENTS.md` replaced with this repository's actual conventions (no local jobs, release flow, dependency automation).
 

--- a/Classes/Command/PurgePrivacyDataCommand.php
+++ b/Classes/Command/PurgePrivacyDataCommand.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrLlm\Command;
 use Netresearch\NrLlm\Domain\Enum\PrivacyDataCategory;
 use Netresearch\NrLlm\Service\Evaluation\EvaluationResultRepositoryInterface;
 use Netresearch\NrLlm\Service\Governance\GovernanceEventRepositoryInterface;
+use Netresearch\NrLlm\Service\Outcome\CallOutcomeRepositoryInterface;
 use Netresearch\NrLlm\Service\Privacy\PrivacyPolicyInterface;
 use Netresearch\NrLlm\Service\Session\AiSessionRepositoryInterface;
 use Netresearch\NrLlm\Service\Skill\SkillAuditRepositoryInterface;
@@ -57,6 +58,7 @@ final class PurgePrivacyDataCommand extends Command
         private readonly AiSessionRepositoryInterface $sessions,
         private readonly AgentRunRepositoryInterface $agentRuns,
         private readonly GovernanceEventRepositoryInterface $governanceEvents,
+        private readonly CallOutcomeRepositoryInterface $callOutcomes,
     ) {
         parent::__construct();
     }
@@ -96,6 +98,10 @@ final class PurgePrivacyDataCommand extends Command
 
         [$days, $cutoff] = $window(PrivacyDataCategory::TELEMETRY);
         $purged[]        = sprintf('Telemetry (%d d): %d', $days, $this->telemetry->purgeOlderThan($cutoff));
+        // Same window on purpose: a call outcome is only readable joined to the
+        // telemetry row carrying its model and cost (ADR-176), so it must not
+        // outlive it or go before it.
+        $purged[]        = sprintf('Call outcomes (%d d): %d', $days, $this->callOutcomes->purgeOlderThan($cutoff));
 
         [$days, $cutoff] = $window(PrivacyDataCategory::CONVERSATION);
         $purged[]        = sprintf('Conversation sessions (%d d): %d', $days, $this->sessions->purgeInactiveSince($cutoff));

--- a/Classes/Controller/Backend/Response/TaskExecutionResponse.php
+++ b/Classes/Controller/Backend/Response/TaskExecutionResponse.php
@@ -48,6 +48,16 @@ final readonly class TaskExecutionResponse implements JsonSerializable
         public int $totalTokens,
         public bool $success = true,
         public array $appliedSkills = [],
+        /**
+         * The call this result came from (ADR-176).
+         *
+         * Sent so the surface showing the result can record an outcome against
+         * the call that produced it. Empty means "not rateable" rather than
+         * "not yet rated" — a result built outside TaskExecutionService has no
+         * call to point at, and a rating keyed on the empty string would fold
+         * every such result into one row.
+         */
+        public string $correlationId = '',
     ) {}
 
     public static function fromResult(TaskExecutionResult $result): self
@@ -60,6 +70,7 @@ final readonly class TaskExecutionResponse implements JsonSerializable
             completionTokens: $result->usage->completionTokens,
             totalTokens: $result->usage->totalTokens,
             appliedSkills: $result->appliedSkills,
+            correlationId: $result->correlationId,
         );
     }
 
@@ -70,7 +81,8 @@ final readonly class TaskExecutionResponse implements JsonSerializable
      *   model: string,
      *   outputFormat: string,
      *   usage: array{promptTokens: int, completionTokens: int, totalTokens: int},
-     *   appliedSkills: list<string>
+     *   appliedSkills: list<string>,
+     *   correlationId: string
      * }
      */
     public function jsonSerialize(): array
@@ -85,7 +97,8 @@ final readonly class TaskExecutionResponse implements JsonSerializable
                 'completionTokens' => $this->completionTokens,
                 'totalTokens'      => $this->totalTokens,
             ],
-            'appliedSkills' => $this->appliedSkills,
+            'appliedSkills'  => $this->appliedSkills,
+            'correlationId'  => $this->correlationId,
         ];
     }
 }

--- a/Classes/Controller/Backend/TaskExecutionController.php
+++ b/Classes/Controller/Backend/TaskExecutionController.php
@@ -15,19 +15,22 @@ use Netresearch\NrLlm\Controller\Backend\Response\ErrorResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\TaskExecutionResponse;
 use Netresearch\NrLlm\Controller\Backend\Response\TaskInputResponse;
 use Netresearch\NrLlm\Domain\Enum\BackendUserGrant;
+use Netresearch\NrLlm\Domain\Enum\CallOutcome;
+use Netresearch\NrLlm\Domain\Enum\CallOutcomeSource;
 use Netresearch\NrLlm\Domain\Model\Task;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
 use Netresearch\NrLlm\Domain\Repository\TaskRepository;
+use Netresearch\NrLlm\Exception\BudgetExceededException;
 // Aliased to make the catch arm explicit about which
 // `InvalidArgumentException` it expects — the project-level one
 // thrown by `TaskExecutionService::execute()`, not PHP's built-in
 // (which is also raised in sibling controllers, e.g. by
 // `RecordTableReader::ensureNotExcluded` in `TaskRecordsController`).
-use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Exception\InvalidArgumentException as DomainInvalidArgumentException;
 use Netresearch\NrLlm\Provider\Exception\ProviderConfigurationException;
 use Netresearch\NrLlm\Provider\Exception\ProviderException;
 use Netresearch\NrLlm\Provider\Exception\ProviderResponseException;
+use Netresearch\NrLlm\Service\Outcome\CallOutcomeRepositoryInterface;
 use Netresearch\NrLlm\Service\Task\TaskExecutionServiceInterface;
 use Netresearch\NrLlm\Service\Task\TaskInputResolverInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -85,6 +88,7 @@ final class TaskExecutionController extends ActionController
         private readonly PageRenderer $pageRenderer,
         private readonly BackendUriBuilder $backendUriBuilder,
         private readonly LoggerInterface $logger,
+        private readonly CallOutcomeRepositoryInterface $callOutcomeRepository,
     ) {}
 
     /**
@@ -288,6 +292,56 @@ final class TaskExecutionController extends ActionController
      * Same TASKS_USE gate as {@see executeAction()}: refreshing the input a
      * task's MANAGER configured is part of using the task.
      */
+    /**
+     * Record how one call turned out, as judged by the person who read it.
+     *
+     * The rating is keyed on the correlation id the execution handed back, so
+     * it lands on the same call the cost and the routing facts sit on
+     * (ADR-174, ADR-176). Nothing here reads or writes an approval state: an
+     * approval can be withheld for reasons that say nothing about the model,
+     * and folding the gate in would measure governance instead of quality.
+     *
+     * No backend user is stored. Who ran the call is already on the run
+     * record where budgets need it; this table adds no second copy and nr_llm
+     * ships no per-editor readout.
+     */
+    public function recordOutcomeAction(ServerRequestInterface $request): ResponseInterface
+    {
+        if (($deny = $this->denyWithoutGrant(BackendUserGrant::TASKS_USE)) instanceof ResponseInterface) {
+            return $deny;
+        }
+
+        $body          = $request->getParsedBody();
+        $body          = is_array($body) ? $body : [];
+
+        $correlationId = $body['correlationId'] ?? null;
+        $rating        = $body['outcome'] ?? null;
+
+        $outcome = is_string($rating) ? CallOutcome::tryFrom($rating) : null;
+
+        // Only the explicit cases are acceptable here. The observed ones are
+        // derived from what happened to a record, never claimed by a caller —
+        // accepting one over this route would let a client write a measurement
+        // nobody measured.
+        if (!$outcome instanceof CallOutcome || $outcome->source() !== CallOutcomeSource::EXPLICIT) {
+            return new JsonResponse((new ErrorResponse($this->localize(
+                'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.outcome.unknownRating',
+                'Unknown rating.',
+            )))->jsonSerialize(), 400);
+        }
+
+        if (!is_string($correlationId) || $correlationId === '') {
+            return new JsonResponse((new ErrorResponse($this->localize(
+                'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:error.outcome.missingCall',
+                'This result cannot be rated: it carries no call reference.',
+            )))->jsonSerialize(), 400);
+        }
+
+        $this->callOutcomeRepository->record($correlationId, $outcome);
+
+        return new JsonResponse(['success' => true, 'outcome' => $outcome->value]);
+    }
+
     public function refreshInputAction(ServerRequestInterface $request): ResponseInterface
     {
         if (($deny = $this->denyWithoutGrant(BackendUserGrant::TASKS_USE)) instanceof ResponseInterface) {

--- a/Classes/Domain/Enum/CallOutcome.php
+++ b/Classes/Domain/Enum/CallOutcome.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\Enum;
+
+/**
+ * How one call turned out, per ADR-176.
+ *
+ * The source is derived from the case rather than stored beside it. ADR-176
+ * forbids folding the two sources into one figure, and a separate column would
+ * make "explicit row carrying an observed value" a state the database can hold.
+ * Here it is not expressible.
+ *
+ * No case describes an approval. An approval can be withheld for governance,
+ * policy or content reasons that say nothing about how the model did, so
+ * treating a refusal as a quality signal would measure the gate instead
+ * (ADR-176, ADR-172).
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
+enum CallOutcome: string
+{
+    /**
+     * A backend user said the result was useful.
+     */
+    case HELPFUL = 'helpful';
+
+    /**
+     * A backend user said it was not.
+     */
+    case NOT_HELPFUL = 'not_helpful';
+
+    /**
+     * The generated text reached a record and was released untouched.
+     *
+     * Not yet written by anything: the observed source needs a persisted write
+     * target, which ADR-176 records as blocked on ADR-122's deferred contract.
+     * The case is declared with its siblings so the source split has one home,
+     * and {@see self::isImplemented()} says which cases a writer exists for.
+     */
+    case ACCEPTED_UNCHANGED = 'accepted_unchanged';
+
+    /**
+     * It reached a record and a human changed it before releasing it.
+     */
+    case EDITED = 'edited';
+
+    /**
+     * It reached a record and the record was deleted.
+     */
+    case DISCARDED = 'discarded';
+
+    public function source(): CallOutcomeSource
+    {
+        return match ($this) {
+            self::HELPFUL, self::NOT_HELPFUL => CallOutcomeSource::EXPLICIT,
+            self::ACCEPTED_UNCHANGED, self::EDITED, self::DISCARDED => CallOutcomeSource::OBSERVED,
+        };
+    }
+
+    /**
+     * Whether a writer for this case exists today.
+     *
+     * False is not a defect. ADR-176 ships the explicit source first and the
+     * observed one with its prerequisite; this method is what keeps that
+     * statement checkable instead of a sentence in a record.
+     */
+    public function isImplemented(): bool
+    {
+        return $this->source() === CallOutcomeSource::EXPLICIT;
+    }
+}

--- a/Classes/Domain/Enum/CallOutcomeSource.php
+++ b/Classes/Domain/Enum/CallOutcomeSource.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Domain\Enum;
+
+/**
+ * Where a {@see CallOutcome} came from (ADR-176).
+ *
+ * The two never average into one figure. They do not cover the same traffic:
+ * a task execution renders a result the editor copies by hand, so there is no
+ * write target and nothing to observe, while an editorial action writes
+ * through the DataHandler against a named record. A mean over both would
+ * compare an observable population against an unobservable one, and in a
+ * canary the arm difference would carry that asymmetry rather than the models'
+ * quality.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
+enum CallOutcomeSource: string
+{
+    case EXPLICIT = 'explicit';
+    case OBSERVED = 'observed';
+}

--- a/Classes/Provider/Middleware/ProviderCallContext.php
+++ b/Classes/Provider/Middleware/ProviderCallContext.php
@@ -122,6 +122,13 @@ final readonly class ProviderCallContext
      * writing '' into `tx_nrllm_telemetry.correlation_id` would collide every
      * such call into one bucket instead of leaving them individually traceable.
      */
+    /**
+     * Call metadata key a caller uses to choose its own correlation id
+     * (ADR-176). Read by {@see LlmServiceManager} rather than here, because a
+     * run's own id has to win over it and this class never sees the run.
+     */
+    public const METADATA_CORRELATION_ID = 'nrllm.correlationId';
+
     private static function resolveCorrelationId(?string $correlationId): string
     {
         return ($correlationId === null || $correlationId === '')

--- a/Classes/Service/CallMetadataFactory.php
+++ b/Classes/Service/CallMetadataFactory.php
@@ -13,6 +13,7 @@ use Netresearch\NrLlm\Domain\ValueObject\AgentRunReference;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\GuardrailMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\IdempotencyMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\TelemetryMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
 use Netresearch\NrLlm\Service\Option\AbstractOptions;
@@ -65,6 +66,24 @@ final readonly class CallMetadataFactory
         }
 
         return $metadata;
+    }
+
+    /**
+     * The caller's own correlation id, or nothing.
+     *
+     * Mirrors {@see self::idempotency()}: an empty value produces no entry at
+     * all, so "not given" and "given as empty" cannot be told apart downstream
+     * — they are the same thing.
+     *
+     * @return array<string, string>
+     */
+    public function correlation(?string $correlationId): array
+    {
+        if ($correlationId === null || $correlationId === '') {
+            return [];
+        }
+
+        return [ProviderCallContext::METADATA_CORRELATION_ID => $correlationId];
     }
 
     /**

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -1264,7 +1264,16 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         // operation runs through this pipeline.
         $this->assertContextPermitted($configuration, $metadata, $operation, $run->uid ?? 0, $injectedContext);
 
-        $context = ProviderCallContext::forConfiguration($operation, $configuration, $metadata, $run?->correlationId());
+        // A run's own id wins: inside an agent run every call belongs to that
+        // run's trace, and a caller-supplied id would split it. Outside one,
+        // the caller's id is used so it can find its own call afterwards
+        // (ADR-176); with neither, ProviderCallContext generates one.
+        $context = ProviderCallContext::forConfiguration(
+            $operation,
+            $configuration,
+            $metadata,
+            $run?->correlationId() ?? $this->callerCorrelationId($metadata),
+        );
 
         // Recorded here rather than inside the terminal, and that placement is
         // the entire point (ADR-174): the terminal is where resolveModel() runs,
@@ -1481,4 +1490,23 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
     {
         return $this->adapterRegistry;
     }
+
+    /**
+     * The correlation id a caller chose, if it passed one.
+     *
+     * Read out of the metadata array rather than taken as a parameter: seven
+     * call sites reach runThroughPipeline(), and metadata is the channel this
+     * codebase already uses for call-scoped side-band values (idempotency,
+     * budget, the agent run). A parameter would have been an eighth argument
+     * that six of the seven never set.
+     *
+     * @param array<string, mixed> $metadata
+     */
+    private function callerCorrelationId(array $metadata): ?string
+    {
+        $value = $metadata[ProviderCallContext::METADATA_CORRELATION_ID] ?? null;
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
 }

--- a/Classes/Service/Option/AbstractOptions.php
+++ b/Classes/Service/Option/AbstractOptions.php
@@ -31,6 +31,25 @@ abstract class AbstractOptions
     protected ?string $idempotencyKey = null;
 
     /**
+     * Optional caller-supplied correlation id (ADR-176).
+     *
+     * Every send already gets one — {@see ProviderCallContext} generates a
+     * UUID when none is passed — but it is generated inside the pipeline and
+     * never handed back, so a caller cannot say afterwards which row on
+     * tx_nrllm_telemetry was its own call. Supplying it here is the answer to
+     * that: the caller knows the id because it chose it.
+     *
+     * That is what makes a per-call outcome recordable at all. It is also the
+     * reason this is not a return value: {@see CompletionResponse} is frozen
+     * (Tests/Unit/Api/api-surface.txt), so growing it would be a breaking
+     * change, while an option is additive.
+     *
+     * Like the idempotency key it is deliberately kept out of
+     * {@see self::toArray()} and never reaches a provider.
+     */
+    protected ?string $correlationId = null;
+
+    /**
      * Convert options to array format for providers.
      *
      * @return array<string, mixed>
@@ -51,6 +70,30 @@ abstract class AbstractOptions
     {
         $clone = clone $this;
         $clone->idempotencyKey = $idempotencyKey;
+
+        return $clone;
+    }
+
+    public function getCorrelationId(): ?string
+    {
+        return $this->correlationId;
+    }
+
+    /**
+     * Return a copy that will be traced under the given correlation id.
+     *
+     * An empty string is ignored rather than stored: the pipeline treats it as
+     * "none given" anyway, and keeping it would make the getter answer with a
+     * value no telemetry row can ever carry.
+     */
+    public function withCorrelationId(string $correlationId): static
+    {
+        if ($correlationId === '') {
+            return $this;
+        }
+
+        $clone = clone $this;
+        $clone->correlationId = $correlationId;
 
         return $clone;
     }

--- a/Classes/Service/Outcome/CallOutcomeRepository.php
+++ b/Classes/Service/Outcome/CallOutcomeRepository.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Outcome;
+
+use Netresearch\NrLlm\Domain\Enum\CallOutcome;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\SingletonInterface;
+
+/**
+ * Writes and reads the per-call outcome rows (ADR-176).
+ *
+ * Uses the Doctrine ConnectionPool directly, like
+ * {@see \Netresearch\NrLlm\Service\Telemetry\TelemetryRepository}: a UI-less
+ * table with no Extbase persistence needs.
+ *
+ * The table has no source column. This class is where the one-row-per-source
+ * rule is enforced, by clearing the same source before inserting — so a rater
+ * who changes their mind replaces their answer rather than leaving two rows
+ * and a readout that has to guess which one counts.
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
+final readonly class CallOutcomeRepository implements CallOutcomeRepositoryInterface, SingletonInterface
+{
+    private const TABLE = 'tx_nrllm_call_outcome';
+
+    public function __construct(
+        private ConnectionPool $connectionPool,
+    ) {}
+
+    public function record(string $correlationId, CallOutcome $outcome): void
+    {
+        if ($correlationId === '') {
+            return;
+        }
+
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
+        $now        = time();
+
+        $sameSource = array_map(
+            static fn(CallOutcome $case): string => $case->value,
+            array_filter(
+                CallOutcome::cases(),
+                static fn(CallOutcome $case): bool => $case->source() === $outcome->source(),
+            ),
+        );
+
+        $query = $connection->createQueryBuilder();
+        $query->delete(self::TABLE)
+            ->where(
+                $query->expr()->eq('correlation_id', $query->createNamedParameter($correlationId)),
+                $query->expr()->in('outcome', $query->createNamedParameter($sameSource, Connection::PARAM_STR_ARRAY)),
+            )
+            ->executeStatement();
+
+        $connection->insert(self::TABLE, [
+            'pid'            => 0,
+            'correlation_id' => $correlationId,
+            'outcome'        => $outcome->value,
+            'crdate'         => $now,
+            'tstamp'         => $now,
+        ]);
+    }
+
+    public function purgeOlderThan(int $timestamp): int
+    {
+        $query = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+
+        return $query->delete(self::TABLE)
+            ->where($query->expr()->lt('crdate', $query->createNamedParameter($timestamp, Connection::PARAM_INT)))
+            ->executeStatement();
+    }
+
+    public function findByCorrelation(string $correlationId): array
+    {
+        if ($correlationId === '') {
+            return [];
+        }
+
+        $query = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $rows  = $query->select('outcome')
+            ->from(self::TABLE)
+            ->where($query->expr()->eq('correlation_id', $query->createNamedParameter($correlationId)))
+            ->orderBy('uid', 'ASC')
+            ->executeQuery()
+            ->fetchFirstColumn();
+
+        $outcomes = [];
+        foreach ($rows as $value) {
+            // An unknown value is a row written by a newer version, or by hand.
+            // Skipping it keeps the reader working; failing would take a whole
+            // page down over one row nothing depends on.
+            $case = is_string($value) ? CallOutcome::tryFrom($value) : null;
+            if ($case instanceof CallOutcome) {
+                $outcomes[] = $case;
+            }
+        }
+
+        return $outcomes;
+    }
+}

--- a/Classes/Service/Outcome/CallOutcomeRepositoryInterface.php
+++ b/Classes/Service/Outcome/CallOutcomeRepositoryInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Service\Outcome;
+
+use Netresearch\NrLlm\Domain\Enum\CallOutcome;
+
+/**
+ * Reads and writes how a call turned out (ADR-176).
+ *
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
+interface CallOutcomeRepositoryInterface
+{
+    public function record(string $correlationId, CallOutcome $outcome): void;
+
+    /**
+     * Every outcome recorded for one call, at most one per source.
+     *
+     * @return list<CallOutcome>
+     */
+    public function findByCorrelation(string $correlationId): array;
+
+    /**
+     * Drop rows created before the cutoff, returning how many went.
+     *
+     * Runs under the telemetry retention window rather than one of its own
+     * (ADR-064): an outcome is only readable joined to the telemetry row that
+     * carries its model and cost, so outliving that row would leave a rating
+     * nothing can interpret, and predeceasing it would silently shrink the
+     * denominator of any comparison.
+     */
+    public function purgeOlderThan(int $timestamp): int;
+}

--- a/Classes/Service/Task/TaskExecutionResult.php
+++ b/Classes/Service/Task/TaskExecutionResult.php
@@ -40,5 +40,19 @@ final readonly class TaskExecutionResult
         public string $outputFormat,
         public UsageStatistics $usage,
         public array $appliedSkills = [],
+        /**
+         * The correlation id this run was traced under (ADR-176).
+         *
+         * Chosen here rather than read back: the id is minted inside the
+         * provider pipeline and never returned, and CompletionResponse is
+         * frozen, so the caller supplies one instead. It is what lets the
+         * surface showing this result record an outcome against the call that
+         * produced it.
+         *
+         * Empty only for a result built by something that did not go through
+         * TaskExecutionService — a test double, most likely. A surface must
+         * treat empty as "cannot be rated" rather than as a call id.
+         */
+        public string $correlationId = '',
     ) {}
 }

--- a/Classes/Service/Task/TaskExecutionService.php
+++ b/Classes/Service/Task/TaskExecutionService.php
@@ -14,9 +14,11 @@ use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Task;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
 use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
+use Netresearch\NrLlm\Service\CallMetadataFactory;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
 use Netresearch\NrLlm\Service\Skill\SkillInjectionService;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * Orchestrates running a `Task` through the LLM.
@@ -39,6 +41,7 @@ final readonly class TaskExecutionService implements TaskExecutionServiceInterfa
     public function __construct(
         private LlmServiceManagerInterface $llmServiceManager,
         private SkillInjectionService $skillInjection,
+        private CallMetadataFactory $callMetadata = new CallMetadataFactory(),
     ) {}
 
     public function execute(Task $task, string $input, ?int $beUserUid = null): TaskExecutionResult
@@ -99,14 +102,22 @@ final readonly class TaskExecutionService implements TaskExecutionServiceInterfa
             $fallbackOptions = $fallbackOptions->withBeUserUid($beUserUid);
         }
 
+        // Minted here so the result can carry it. The pipeline would generate
+        // one anyway, but inside itself and without handing it back, which
+        // leaves a caller unable to say which telemetry row was its own call
+        // (ADR-176). Both branches must receive the SAME id — they reach the
+        // pipeline through different channels, and a second id here would
+        // split one execution across two traces.
+        $correlationId = Uuid::v4()->toRfc4122();
+
         $response = $configuration instanceof LlmConfiguration
             ? $this->llmServiceManager->completeWithConfiguration(
                 $prompt,
                 $configuration,
-                $metadata,
+                $metadata + $this->callMetadata->correlation($correlationId),
                 $jsonOutput ? ['response_format' => 'json'] : [],
             )
-            : $this->llmServiceManager->complete($prompt, $fallbackOptions);
+            : $this->llmServiceManager->complete($prompt, $fallbackOptions->withCorrelationId($correlationId));
 
         // The skills injected above contributed to the prompt the provider
         // tokenised, so their cost is already part of $response->usage. Surface
@@ -117,6 +128,7 @@ final readonly class TaskExecutionService implements TaskExecutionServiceInterfa
             outputFormat: $task->getOutputFormat(),
             usage: $response->usage,
             appliedSkills: $appliedSkills,
+            correlationId: $correlationId,
         );
     }
 }

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -148,6 +148,14 @@ return [
         'path' => '/nrllm/task/execute',
         'target' => TaskExecutionController::class . '::executeAction',
     ],
+    // How one call turned out, rated by the person who read the result
+    // (ADR-176). Behind the same TASKS_USE grant as the execution itself: a
+    // rating is about a result the rater was allowed to produce, so there is
+    // no case where someone may run a task but not say how it went.
+    'nrllm_task_outcome' => [
+        'path' => '/nrllm/task/outcome',
+        'target' => TaskExecutionController::class . '::recordOutcomeAction',
+    ],
 
     // Configuration preset routes (ADR-056): pending presets declared by
     // consuming extensions (GET, incl. preflight result per preset) and

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -2890,6 +2890,26 @@
                 <source>Provider and models are required</source>
                 <target>Provider und Modelle sind erforderlich</target>
             </trans-unit>
+            <trans-unit id="outcome.prompt" approved="yes">
+                <source>Was this useful?</source>
+                <target>War das brauchbar?</target>
+            </trans-unit>
+            <trans-unit id="outcome.helpful" approved="yes">
+                <source>Yes</source>
+                <target>Ja</target>
+            </trans-unit>
+            <trans-unit id="outcome.notHelpful" approved="yes">
+                <source>No</source>
+                <target>Nein</target>
+            </trans-unit>
+            <trans-unit id="error.outcome.unknownRating" approved="yes">
+                <source>Unknown rating.</source>
+                <target>Unbekannte Bewertung.</target>
+            </trans-unit>
+            <trans-unit id="error.outcome.missingCall" approved="yes">
+                <source>This result cannot be rated: it carries no call reference.</source>
+                <target>Dieses Ergebnis ist nicht bewertbar: es trägt keinen Bezug zum Aufruf.</target>
+            </trans-unit>
             <trans-unit id="error.task.notFound">
                 <source>Task not found</source>
                 <target>Aufgabe nicht gefunden</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -2182,6 +2182,21 @@
             <trans-unit id="error.wizard.providerModelsRequired">
                 <source>Provider and models are required</source>
             </trans-unit>
+            <trans-unit id="outcome.prompt" resname="outcome.prompt">
+                <source>Was this useful?</source>
+            </trans-unit>
+            <trans-unit id="outcome.helpful" resname="outcome.helpful">
+                <source>Yes</source>
+            </trans-unit>
+            <trans-unit id="outcome.notHelpful" resname="outcome.notHelpful">
+                <source>No</source>
+            </trans-unit>
+            <trans-unit id="error.outcome.unknownRating" resname="error.outcome.unknownRating">
+                <source>Unknown rating.</source>
+            </trans-unit>
+            <trans-unit id="error.outcome.missingCall" resname="error.outcome.missingCall">
+                <source>This result cannot be rated: it carries no call reference.</source>
+            </trans-unit>
             <trans-unit id="error.task.notFound">
                 <source>Task not found</source>
             </trans-unit>

--- a/Resources/Private/Templates/Backend/AiTask/Execute.html
+++ b/Resources/Private/Templates/Backend/AiTask/Execute.html
@@ -144,6 +144,18 @@
                             </div>
                         </div>
 
+                        <div data-call-outcome class="d-none d-flex align-items-center gap-2 mb-3">
+                            <span class="small text-body-secondary">
+                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:outcome.prompt" default="Was this useful?" />
+                            </span>
+                            <button type="button" class="btn btn-sm btn-outline-secondary" data-outcome="helpful">
+                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:outcome.helpful" default="Yes" />
+                            </button>
+                            <button type="button" class="btn btn-sm btn-outline-secondary" data-outcome="not_helpful">
+                                <f:translate key="LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:outcome.notHelpful" default="No" />
+                            </button>
+                        </div>
+
                         <div id="outputResult" class="d-none">
                             <div class="d-flex justify-content-between align-items-center mb-2">
                                 <div class="btn-group btn-group-sm" role="group" aria-label="{f:translate(key: 'LLL:EXT:nr_llm/Resources/Private/Language/locallang.xlf:task.execute.output.formatAria', default: 'Output format')}" id="outputFormatToggle">

--- a/Resources/Public/JavaScript/Backend/TaskExecute.js
+++ b/Resources/Public/JavaScript/Backend/TaskExecute.js
@@ -25,6 +25,8 @@ class TaskExecute {
         this.fetchRecordsUrl = TYPO3.settings.ajaxUrls.nrllm_task_fetch_records;
         this.refreshInputUrl = TYPO3.settings.ajaxUrls.nrllm_task_refresh_input;
         this.loadRecordDataUrl = TYPO3.settings.ajaxUrls.nrllm_task_load_record_data;
+        this.outcomeUrl = TYPO3.settings.ajaxUrls.nrllm_task_outcome;
+        this.outcomeBar = document.querySelector('[data-call-outcome]');
 
         this.elapsedTimer = null;
 
@@ -70,6 +72,10 @@ class TaskExecute {
         }
 
         // Load records when table is selected
+        this.outcomeBar?.querySelectorAll('[data-outcome]').forEach(button => {
+            button.addEventListener('click', () => this.recordOutcome(button));
+        });
+
         this.tableSelect?.addEventListener('change', () => this.onTableChange());
 
         // Load selected records into input
@@ -289,8 +295,13 @@ class TaskExecute {
                 if (this.outputTokens) this.outputTokens.textContent = response.usage?.totalTokens ?? '-';
                 this.outputResult?.classList.remove('d-none');
 
+                this.showOutcomeBar(response.correlationId || '');
+
                 Notification.success('Task completed', 'The task has been executed successfully.');
             } else {
+                // A failed run has nothing to rate: the rating is about the
+                // answer, and there is none.
+                this.hideOutcomeBar();
                 if (this.errorMessage) this.errorMessage.textContent = response.error || 'Unknown error';
                 this.outputError?.classList.remove('d-none');
                 Notification.error('Task failed', response.error || 'Unknown error');
@@ -479,4 +490,69 @@ if (document.readyState === 'loading') {
 } else {
     // DOM already loaded, initialize immediately
     new TaskExecute();
+
+    /**
+     * Offer the rating for the call that just answered (ADR-176).
+     *
+     * Hidden when the response carries no correlation id. That is "not
+     * rateable" rather than "not yet rated": a rating keyed on the empty
+     * string would fold every such result into one row, so no button is
+     * better than a button that writes the wrong key.
+     */
+    showOutcomeBar(correlationId) {
+        if (!this.outcomeBar) {
+            return;
+        }
+
+        if (!correlationId) {
+            this.hideOutcomeBar();
+            return;
+        }
+
+        this.outcomeBar.dataset.correlationId = correlationId;
+        this.outcomeBar.classList.remove('d-none');
+        this.outcomeBar.querySelectorAll('[data-outcome]').forEach(button => {
+            button.disabled = false;
+            button.classList.remove('active');
+        });
+    }
+
+    hideOutcomeBar() {
+        if (!this.outcomeBar) {
+            return;
+        }
+
+        this.outcomeBar.classList.add('d-none');
+        delete this.outcomeBar.dataset.correlationId;
+    }
+
+    async recordOutcome(button) {
+        const correlationId = this.outcomeBar?.dataset.correlationId || '';
+        const outcome = button.dataset.outcome || '';
+        if (!correlationId || !outcome) {
+            return;
+        }
+
+        const formData = new FormData();
+        formData.append('correlationId', correlationId);
+        formData.append('outcome', outcome);
+
+        try {
+            const response = await new AjaxRequest(this.outcomeUrl)
+                .post(formData)
+                .then(r => r.resolve());
+
+            if (response.success) {
+                // The stored answer replaces any earlier one, so the UI shows
+                // exactly one active button rather than accumulating them.
+                this.outcomeBar.querySelectorAll('[data-outcome]').forEach(other => other.classList.remove('active'));
+                button.classList.add('active');
+            } else {
+                Notification.error('Rating not saved', response.error || 'Unknown error');
+            }
+        } catch (error) {
+            Notification.error('Rating not saved', error.message || 'Unknown error');
+        }
+    }
+
 }

--- a/Resources/Public/JavaScript/Backend/TaskExecute.js
+++ b/Resources/Public/JavaScript/Backend/TaskExecute.js
@@ -479,17 +479,6 @@ class TaskExecute {
             Notification.error('Failed', 'Could not copy to clipboard');
         });
     }
-}
-
-// Initialize when DOM is ready
-// Note: For ES6 modules loaded via importmap, DOMContentLoaded may have already fired
-if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => {
-        new TaskExecute();
-    });
-} else {
-    // DOM already loaded, initialize immediately
-    new TaskExecute();
 
     /**
      * Offer the rating for the call that just answered (ADR-176).
@@ -554,5 +543,15 @@ if (document.readyState === 'loading') {
             Notification.error('Rating not saved', error.message || 'Unknown error');
         }
     }
+}
 
+// Initialize when DOM is ready
+// Note: For ES6 modules loaded via importmap, DOMContentLoaded may have already fired
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+        new TaskExecute();
+    });
+} else {
+    // DOM already loaded, initialize immediately
+    new TaskExecute();
 }

--- a/Tests/Functional/Controller/Backend/TaskOutcomeEndpointTest.php
+++ b/Tests/Functional/Controller/Backend/TaskOutcomeEndpointTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Controller\Backend;
+
+use Netresearch\NrLlm\Controller\Backend\TaskExecutionController;
+use Netresearch\NrLlm\Domain\Enum\CallOutcome;
+use Netresearch\NrLlm\Service\Outcome\CallOutcomeRepositoryInterface;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Http\NormalizedParams;
+use TYPO3\CMS\Core\Http\ServerRequest;
+
+/**
+ * The endpoint that records an explicit rating (ADR-176).
+ */
+#[CoversClass(TaskExecutionController::class)]
+final class TaskOutcomeEndpointTest extends AbstractFunctionalTestCase
+{
+    private const CALL = '9f8e7d6c-5b4a-4392-8180-0f1e2d3c4b5a';
+
+    private TaskExecutionController $controller;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importFixture('BeUsers.csv');
+        $this->setUpBackendUser(1);
+        // Extbase's ConfigurationManager captures the ambient request when it
+        // is constructed, so it has to exist before the controller is resolved
+        // — resolving first and setting it after fails with
+        // NoServerRequestGivenException.
+        $this->ambientBackendRequest();
+        $controller = $this->get(TaskExecutionController::class);
+        self::assertInstanceOf(TaskExecutionController::class, $controller);
+        $this->controller = $controller;
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     */
+    private function post(array $body): ResponseInterface
+    {
+        return $this->controller->recordOutcomeAction((new ServerRequest())->withParsedBody($body));
+    }
+
+    /**
+     * @return list<CallOutcome>
+     */
+    private function stored(): array
+    {
+        return $this->get(CallOutcomeRepositoryInterface::class)->findByCorrelation(self::CALL);
+    }
+
+    #[Test]
+    public function anExplicitRatingIsStoredAgainstTheCall(): void
+    {
+        $response = $this->post(['correlationId' => self::CALL, 'outcome' => 'helpful']);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame([CallOutcome::HELPFUL], $this->stored());
+    }
+
+    #[Test]
+    public function anObservedValueIsRefusedOverThisRoute(): void
+    {
+        // The observed cases are derived from what happened to a record. A
+        // client claiming one would be writing a measurement nobody measured,
+        // and the canary would read it as if something had been observed.
+        $response = $this->post(['correlationId' => self::CALL, 'outcome' => 'accepted_unchanged']);
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertSame([], $this->stored());
+    }
+
+    #[Test]
+    public function anUnknownRatingIsRefused(): void
+    {
+        $response = $this->post(['correlationId' => self::CALL, 'outcome' => 'excellent']);
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertSame([], $this->stored());
+    }
+
+    #[Test]
+    public function aMissingCallReferenceIsRefusedRatherThanStoredEmpty(): void
+    {
+        // Every such row would key on the empty string and read as the same
+        // call, which is worse than losing the rating.
+        $response = $this->post(['outcome' => 'helpful']);
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function aNonAdminWithoutTheGrantIsRefused(): void
+    {
+        // uid 2 is a non-admin editor without TASKS_USE.
+        $this->setUpBackendUser(2);
+        $this->ambientBackendRequest();
+        $controller = $this->get(TaskExecutionController::class);
+        self::assertInstanceOf(TaskExecutionController::class, $controller);
+
+        $response = $controller->recordOutcomeAction(
+            (new ServerRequest())->withParsedBody(['correlationId' => self::CALL, 'outcome' => 'helpful']),
+        );
+
+        self::assertSame(403, $response->getStatusCode());
+        self::assertSame([], $this->stored());
+    }
+
+    private function ambientBackendRequest(): void
+    {
+        $request = (new ServerRequest('https://typo3-testing.local/typo3/', 'POST'))
+            ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE);
+        $GLOBALS['TYPO3_REQUEST'] = $request->withAttribute(
+            'normalizedParams',
+            NormalizedParams::createFromRequest($request),
+        );
+    }
+
+}

--- a/Tests/Functional/Repository/CallOutcomeRepositoryTest.php
+++ b/Tests/Functional/Repository/CallOutcomeRepositoryTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Repository;
+
+use Netresearch\NrLlm\Domain\Enum\CallOutcome;
+use Netresearch\NrLlm\Domain\Enum\CallOutcomeSource;
+use Netresearch\NrLlm\Service\Outcome\CallOutcomeRepository;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * The per-call outcome row (ADR-176), against a real schema.
+ */
+#[CoversClass(CallOutcomeRepository::class)]
+final class CallOutcomeRepositoryTest extends AbstractFunctionalTestCase
+{
+    private const CALL = '11111111-2222-4333-8444-555555555555';
+
+    private CallOutcomeRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $repository = $this->get(CallOutcomeRepository::class);
+        self::assertInstanceOf(CallOutcomeRepository::class, $repository);
+        $this->repository = $repository;
+    }
+
+    #[Test]
+    public function anOutcomeIsWrittenAndReadBack(): void
+    {
+        $this->repository->record(self::CALL, CallOutcome::HELPFUL);
+
+        self::assertSame([CallOutcome::HELPFUL], $this->repository->findByCorrelation(self::CALL));
+    }
+
+    #[Test]
+    public function aSecondRatingReplacesTheFirstRatherThanAddingToIt(): void
+    {
+        // The rater changed their mind. Two rows would leave the readout to
+        // guess which one counts, which is the whole reason the repository
+        // clears the same source first.
+        $this->repository->record(self::CALL, CallOutcome::HELPFUL);
+        $this->repository->record(self::CALL, CallOutcome::NOT_HELPFUL);
+
+        self::assertSame([CallOutcome::NOT_HELPFUL], $this->repository->findByCorrelation(self::CALL));
+        self::assertSame(1, $this->rowCount());
+    }
+
+    #[Test]
+    public function theTwoSourcesDoNotDisplaceEachOther(): void
+    {
+        // ADR-176 keeps them apart, so an observed outcome must not clear an
+        // explicit one. Asserted now rather than when the observed writer
+        // arrives, because that writer would otherwise be the thing that
+        // discovers it.
+        $this->repository->record(self::CALL, CallOutcome::HELPFUL);
+        $this->repository->record(self::CALL, CallOutcome::EDITED);
+
+        self::assertSame(
+            [CallOutcome::HELPFUL, CallOutcome::EDITED],
+            $this->repository->findByCorrelation(self::CALL),
+        );
+    }
+
+    #[Test]
+    public function anEmptyCorrelationIdWritesNothing(): void
+    {
+        // Every send has a correlation id, but a caller that lost it must not
+        // create a row keyed on the empty string — every such row would look
+        // like the same call.
+        $this->repository->record('', CallOutcome::HELPFUL);
+
+        self::assertSame(0, $this->rowCount());
+        self::assertSame([], $this->repository->findByCorrelation(''));
+    }
+
+    #[Test]
+    public function anUnknownStoredValueIsSkippedRatherThanFatal(): void
+    {
+        $this->connection()->insert('tx_nrllm_call_outcome', [
+            'pid'            => 0,
+            'correlation_id' => self::CALL,
+            'outcome'        => 'from_a_newer_version',
+            'crdate'         => 1_700_000_000,
+            'tstamp'         => 1_700_000_000,
+        ]);
+        $this->repository->record(self::CALL, CallOutcome::HELPFUL);
+
+        self::assertSame([CallOutcome::HELPFUL], $this->repository->findByCorrelation(self::CALL));
+    }
+
+    #[Test]
+    public function everyCaseAnswersExactlyOneSource(): void
+    {
+        // The source is derived, not stored. If a case ever answered neither,
+        // record() would clear nothing and the replace-in-place rule above
+        // would silently stop holding.
+        foreach (CallOutcome::cases() as $case) {
+            self::assertContains($case->source(), CallOutcomeSource::cases());
+        }
+
+        $explicit = array_filter(CallOutcome::cases(), static fn(CallOutcome $c): bool => $c->source() === CallOutcomeSource::EXPLICIT);
+        $observed = array_filter(CallOutcome::cases(), static fn(CallOutcome $c): bool => $c->source() === CallOutcomeSource::OBSERVED);
+
+        self::assertNotSame([], $explicit);
+        self::assertNotSame([], $observed);
+        self::assertCount(count(CallOutcome::cases()), [...$explicit, ...$observed]);
+    }
+
+    private function connection(): Connection
+    {
+        return $this->get(ConnectionPool::class)->getConnectionForTable('tx_nrllm_call_outcome');
+    }
+
+    private function rowCount(): int
+    {
+        return $this->connection()->count('uid', 'tx_nrllm_call_outcome', []);
+    }
+}

--- a/Tests/Functional/Service/Privacy/RetentionCoverageTest.php
+++ b/Tests/Functional/Service/Privacy/RetentionCoverageTest.php
@@ -42,6 +42,9 @@ final class RetentionCoverageTest extends AbstractFunctionalTestCase
      * deleted by the central purge; the test below proves it.
      */
     private const CONTENT_TABLES = [
+        // Ratings of single calls. Purged on the telemetry window, since a
+        // rating without its telemetry row cannot be read (ADR-176).
+        'tx_nrllm_call_outcome',
         'tx_nrllm_eval_result',
         'tx_nrllm_skill_audit',
         'tx_nrllm_telemetry',
@@ -189,6 +192,14 @@ final class RetentionCoverageTest extends AbstractFunctionalTestCase
             'run_date'       => $timestamp,
             'tstamp'         => $timestamp,
             'crdate'         => $timestamp,
+        ]);
+
+        $connectionPool->getConnectionForTable('tx_nrllm_call_outcome')->insert('tx_nrllm_call_outcome', [
+            'pid'            => 0,
+            'correlation_id' => 'aged-call',
+            'outcome'        => 'helpful',
+            'crdate'         => $timestamp,
+            'tstamp'         => $timestamp,
         ]);
 
         $connectionPool->getConnectionForTable('tx_nrllm_skill_audit')->insert('tx_nrllm_skill_audit', [

--- a/Tests/Unit/Api/api-surface.txt
+++ b/Tests/Unit/Api/api-surface.txt
@@ -1035,6 +1035,7 @@ Netresearch\NrLlm\Provider\Exception\ProviderResponseException (class)
 Netresearch\NrLlm\Provider\Exception\UnsupportedFeatureException (class)
 
 Netresearch\NrLlm\Provider\Middleware\ProviderCallContext (class)
+  const METADATA_CORRELATION_ID = "nrllm.correlationId"
   constructor(Netresearch\NrLlm\Provider\Middleware\ProviderOperation $operation, string $correlationId, ?Netresearch\NrLlm\Domain\Model\LlmConfiguration $configuration = …, string $provider = …, string $model = …, string $configurationIdentifier = …, array $metadata = …, Netresearch\NrLlm\Provider\Middleware\TelemetrySignals $telemetrySignals = …)
   method static for(Netresearch\NrLlm\Provider\Middleware\ProviderOperation $operation, array $metadata = …): self
   method static forConfiguration(Netresearch\NrLlm\Provider\Middleware\ProviderOperation $operation, Netresearch\NrLlm\Domain\Model\LlmConfiguration $configuration, array $metadata = …, ?string $correlationId = …): self
@@ -1404,9 +1405,11 @@ Netresearch\NrLlm\Service\LlmServiceManagerInterface (interface)
 Netresearch\NrLlm\Service\Option\AbstractOptions (class)
   method getCallerSourceExtension(): ?string
   method getCallerSourceOperation(): ?string
+  method getCorrelationId(): ?string
   method getIdempotencyKey(): ?string
   method toArray(): array
   method withCallerSource(string $extension, string $operation = …): static
+  method withCorrelationId(string $correlationId): static
   method withIdempotencyKey(string $idempotencyKey): static
 
 Netresearch\NrLlm\Service\Option\BudgetAwareOptionsInterface (interface)

--- a/Tests/Unit/Command/Fixture/InMemoryCallOutcomeRepository.php
+++ b/Tests/Unit/Command/Fixture/InMemoryCallOutcomeRepository.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit\Command\Fixture;
+
+use Netresearch\NrLlm\Domain\Enum\CallOutcome;
+use Netresearch\NrLlm\Service\Outcome\CallOutcomeRepositoryInterface;
+
+/**
+ * Records what the purge asked of the outcome table, so the command's
+ * retention wiring can be asserted instead of mocked.
+ *
+ * The cutoff is the point: ADR-176 runs call outcomes on the TELEMETRY window
+ * rather than one of their own, and only comparing the two cutoffs proves it.
+ */
+final class InMemoryCallOutcomeRepository implements CallOutcomeRepositoryInterface
+{
+    /** The cutoff the last purgeOlderThan() was asked to delete below. */
+    public ?int $purgeCutoff = null;
+
+    /** The row count purgeOlderThan() reports as deleted. */
+    public int $purgeReturns = 0;
+
+    /** @var list<array{correlationId: string, outcome: CallOutcome}> */
+    public array $recorded = [];
+
+    public function record(string $correlationId, CallOutcome $outcome): void
+    {
+        $this->recorded[] = ['correlationId' => $correlationId, 'outcome' => $outcome];
+    }
+
+    public function findByCorrelation(string $correlationId): array
+    {
+        $found = [];
+        foreach ($this->recorded as $entry) {
+            if ($entry['correlationId'] === $correlationId) {
+                $found[] = $entry['outcome'];
+            }
+        }
+
+        return $found;
+    }
+
+    public function purgeOlderThan(int $timestamp): int
+    {
+        $this->purgeCutoff = $timestamp;
+
+        return $this->purgeReturns;
+    }
+}

--- a/Tests/Unit/Command/PurgePrivacyDataCommandTest.php
+++ b/Tests/Unit/Command/PurgePrivacyDataCommandTest.php
@@ -14,6 +14,7 @@ use Netresearch\NrLlm\Service\Privacy\ContentRedactor;
 use Netresearch\NrLlm\Service\Privacy\PrivacyPolicy;
 use Netresearch\NrLlm\Tests\Unit\Command\Fixture\InMemoryAgentRunRepository;
 use Netresearch\NrLlm\Tests\Unit\Command\Fixture\InMemoryAiSessionRepository;
+use Netresearch\NrLlm\Tests\Unit\Command\Fixture\InMemoryCallOutcomeRepository;
 use Netresearch\NrLlm\Tests\Unit\Command\Fixture\InMemoryEvaluationResultRepository;
 use Netresearch\NrLlm\Tests\Unit\Command\Fixture\InMemoryGovernanceEventRepository;
 use Netresearch\NrLlm\Tests\Unit\Command\Fixture\InMemorySkillAuditRepository;
@@ -40,6 +41,8 @@ final class PurgePrivacyDataCommandTest extends TestCase
 
     private InMemoryGovernanceEventRepository $governance;
 
+    private InMemoryCallOutcomeRepository $callOutcomes;
+
     protected function setUp(): void
     {
         $this->eval       = new InMemoryEvaluationResultRepository();
@@ -47,7 +50,8 @@ final class PurgePrivacyDataCommandTest extends TestCase
         $this->telemetry  = new InMemoryTelemetryRepository();
         $this->sessions   = new InMemoryAiSessionRepository();
         $this->agentRuns  = new InMemoryAgentRunRepository();
-        $this->governance = new InMemoryGovernanceEventRepository();
+        $this->governance   = new InMemoryGovernanceEventRepository();
+        $this->callOutcomes = new InMemoryCallOutcomeRepository();
     }
 
     #[Test]
@@ -76,6 +80,10 @@ final class PurgePrivacyDataCommandTest extends TestCase
             $this->eval->purgeCutoff,
             $this->audit->purgeCutoff,
             $this->telemetry->purgeCutoff,
+            // Same window as telemetry by decision, not by accident: an outcome
+            // is only readable joined to its telemetry row (ADR-176). Listing it
+            // here is what would fail if someone gave it a window of its own.
+            $this->callOutcomes->purgeCutoff,
             $this->sessions->purgeCutoff,
             $this->agentRuns->purgeCutoff,
             $this->agentRuns->purgeUnfinishedCutoff,
@@ -187,6 +195,7 @@ final class PurgePrivacyDataCommandTest extends TestCase
             $this->sessions,
             $this->agentRuns,
             $this->governance,
+            $this->callOutcomes,
         );
     }
 }

--- a/Tests/Unit/Controller/Backend/Response/ResponseDtoTest.php
+++ b/Tests/Unit/Controller/Backend/Response/ResponseDtoTest.php
@@ -366,9 +366,16 @@ final class ResponseDtoTest extends TestCase
             completionTokens: $usage->completionTokens,
             totalTokens: $usage->totalTokens,
             appliedSkills: ['cfg:baseline', 'task:additive'],
+            correlationId: '3f2a1b0c-9d8e-4f70-8a61-2b3c4d5e6f70',
         ))->jsonSerialize();
 
-        self::assertSame(['success', 'content', 'model', 'outputFormat', 'usage', 'appliedSkills'], array_keys($data));
+        self::assertSame(
+            ['success', 'content', 'model', 'outputFormat', 'usage', 'appliedSkills', 'correlationId'],
+            array_keys($data),
+        );
+        // The rating bar keys on this, so an omitted or renamed field silently
+        // turns every result into an unrateable one (ADR-176).
+        self::assertSame('3f2a1b0c-9d8e-4f70-8a61-2b3c4d5e6f70', $data['correlationId']);
         self::assertTrue($data['success']);
         self::assertSame('Hello', $data['content']);
         self::assertSame('gpt-4', $data['model']);

--- a/Tests/Unit/Service/Task/TaskExecutionServiceTest.php
+++ b/Tests/Unit/Service/Task/TaskExecutionServiceTest.php
@@ -16,6 +16,7 @@ use Netresearch\NrLlm\Domain\Model\Skill;
 use Netresearch\NrLlm\Domain\Model\Task;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\ProviderCallContext;
 use Netresearch\NrLlm\Provider\Middleware\UsageMiddleware;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
 use Netresearch\NrLlm\Service\Option\ChatOptions;
@@ -32,6 +33,8 @@ use ReflectionProperty;
 #[CoversClass(TaskExecutionService::class)]
 final class TaskExecutionServiceTest extends AbstractUnitTestCase
 {
+    private ?string $seenCorrelationId = null;
+
     private LlmServiceManagerInterface&MockObject $llmServiceManager;
 
     private TaskExecutionService $subject;
@@ -71,12 +74,19 @@ final class TaskExecutionServiceTest extends AbstractUnitTestCase
             ->with(
                 'Analyse the logs',
                 $configuration,
-                [UsageMiddleware::METADATA_TASK_UID => 99],
+                self::callback($this->metadataCarrying([UsageMiddleware::METADATA_TASK_UID => 99])),
                 [],
             )
             ->willReturn($response);
 
         $result = $this->subject->execute($task, 'the logs');
+
+        // The id the manager was handed and the id the caller gets back are the
+        // same one. Without this, the metadata matcher above would accept ANY
+        // correlation id, and a service minting a second one for the result
+        // would split one execution across two traces without failing a test.
+        self::assertNotSame('', $result->correlationId);
+        self::assertSame($this->seenCorrelationId, $result->correlationId);
 
         self::assertSame('result', $result->content);
     }
@@ -108,10 +118,10 @@ final class TaskExecutionServiceTest extends AbstractUnitTestCase
             ->with(
                 'Analyse the logs',
                 $configuration,
-                [
+                self::callback($this->metadataCarrying([
                     UsageMiddleware::METADATA_TASK_UID     => 99,
                     BudgetMiddleware::METADATA_BE_USER_UID => 42,
-                ],
+                ])),
                 [],
             )
             ->willReturn($response);
@@ -145,7 +155,7 @@ final class TaskExecutionServiceTest extends AbstractUnitTestCase
             ->with(
                 self::anything(),
                 $configuration,
-                [UsageMiddleware::METADATA_TASK_UID => 99],
+                self::callback($this->metadataCarrying([UsageMiddleware::METADATA_TASK_UID => 99])),
                 [],
             )
             ->willReturn($response);
@@ -210,7 +220,7 @@ final class TaskExecutionServiceTest extends AbstractUnitTestCase
             ->with(
                 self::anything(),
                 $defaultConfiguration,
-                [UsageMiddleware::METADATA_TASK_UID => 77],
+                self::callback($this->metadataCarrying([UsageMiddleware::METADATA_TASK_UID => 77])),
                 [],
             )
             ->willReturnCallback(
@@ -374,4 +384,40 @@ final class TaskExecutionServiceTest extends AbstractUnitTestCase
         $prop = new ReflectionProperty($task, 'uid');
         $prop->setValue($task, $uid);
     }
+
+    /**
+     * Matcher for the metadata array a task execution forwards.
+     *
+     * The exact-array assertions these replace broke the moment the execution
+     * started tagging its own correlation id (ADR-176), and rewriting them as
+     * "expected keys plus that one" would have asserted the shape without
+     * asserting the thing that matters. So this checks the expected entries are
+     * present unchanged AND that a correlation id came along, and the tests
+     * that care assert separately that the id handed to the manager is the one
+     * the caller gets back.
+     *
+     * @param array<string, mixed> $expected
+     *
+     * @return callable(mixed): bool
+     */
+    private function metadataCarrying(array $expected): callable
+    {
+        return function (mixed $metadata) use ($expected): bool {
+            if (!is_array($metadata)) {
+                return false;
+            }
+
+            foreach ($expected as $key => $value) {
+                if (($metadata[$key] ?? null) !== $value) {
+                    return false;
+                }
+            }
+
+            $correlation = $metadata[ProviderCallContext::METADATA_CORRELATION_ID] ?? null;
+            $this->seenCorrelationId = is_string($correlation) ? $correlation : null;
+
+            return is_string($correlation) && $correlation !== '';
+        };
+    }
+
 }

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1183,3 +1183,45 @@ CREATE TABLE tx_nrllm_mcp_tool (
     KEY server (server),
     UNIQUE KEY tool_name (tool_name)
 );
+
+--
+-- Table structure for table 'tx_nrllm_call_outcome'
+--
+-- How one call turned out (ADR-176). Joined to tx_nrllm_telemetry by
+-- correlation_id, which is why neither the model nor the routing arm is
+-- repeated here: they sit on the telemetry row already and a second copy could
+-- only drift from it.
+--
+-- There is no be_user column, and none is coming. Who ran the call is on the
+-- run record, because budgets and the resume authorisation need it there;
+-- nr_llm ships no per-editor readout and builds no anonymisation of its own,
+-- because erasure belongs to the installation's be_users lifecycle. The join
+-- through the run still exists — that is stated rather than dressed up as
+-- "we store no names".
+--
+-- The source (explicit or observed) is NOT a column. It is derived from the
+-- outcome value, so a row carrying an explicit rating under an observed value
+-- is not a state this table can hold.
+--
+CREATE TABLE tx_nrllm_call_outcome (
+    uid int(11) NOT NULL auto_increment,
+    pid int(11) unsigned DEFAULT '0' NOT NULL,
+
+    -- Trace correlation (UUID v4, RFC 4122 = 36 chars), as on tx_nrllm_telemetry
+    correlation_id varchar(36) DEFAULT '' NOT NULL,
+
+    -- A CallOutcome case. Its enum decides which source it belongs to.
+    outcome varchar(24) DEFAULT '' NOT NULL,
+
+    crdate int(11) unsigned DEFAULT '0' NOT NULL,
+    tstamp int(11) unsigned DEFAULT '0' NOT NULL,
+
+    PRIMARY KEY (uid),
+    KEY parent (pid),
+    -- One row per call per source, so a rater who changes their mind replaces
+    -- their answer instead of adding a second one and leaving the readout to
+    -- guess which counts. The source is part of the key through the outcome
+    -- value's own grouping, enforced by the repository rather than by SQL.
+    KEY correlation (correlation_id),
+    KEY outcome_lookup (outcome, crdate)
+);


### PR DESCRIPTION
The explicit half of #772, decided in ADR-176 (#814).

**The problem:** we cannot tell whether one AI answer was good. ADR-156 allows cheaper routing only if quality does not drop, and the value it cited is per model — identical on both sides of a canary, so it can never show a difference.

**What ships:** a rating per call, stored on `correlation_id`, the key ADR-174 already writes cost against. Two buttons under the result in the AI tasks module.

## Three refusals, enforced rather than documented

- **No `source` column.** Derived from the enum case, so "an explicit rating carrying an observed value" is not a state the table can hold.
- **No `be_user`, no model, no arm.** Who ran it is on the run record where budgets need it; model and arm are on the telemetry row. A second copy could only drift. Erasure rides on the installation's `be_users` lifecycle — that is the framework's job, and the join through the run still exists, which the schema comment says rather than resting on "we store no names".
- **The endpoint refuses an observed value.** Those are derived from what happened to a record, never claimed by a caller. Accepting one would let a client write a measurement nobody measured, and the canary would read it as an observation. Asserted in `TaskOutcomeEndpointTest`.

## The part that was not in the plan

A rating needs to name its call, and no caller could. Every send gets a correlation id — `ProviderCallContext` mints one when none is passed — but it is minted inside the pipeline and never handed back.

So `AbstractOptions` gains `withCorrelationId()`. The id travels as call metadata like the idempotency key and never reaches a provider; inside an agent run the run's own id still wins, so one run stays one trace. It is an option rather than a return value because `CompletionResponse` is frozen — growing it would have been a breaking change.

`api-surface.txt` gains three entries and loses none. Additive, with the `### Added` entry.

## Tests, and one that got stronger

11 functional (repository + endpoint), including a non-admin without `TASKS_USE` getting 403, a second rating replacing the first rather than adding a row, and an observed value never displacing an explicit one — asserted now rather than when the observed writer arrives, because that writer would otherwise be what discovers it.

**Four existing `TaskExecutionService` tests broke** on the new metadata key. They compared the array exactly. I did not just add the key to the expectation — that asserts the shape and misses the point. They now check the expected entries are present unchanged **and** that a correlation id came along, plus that the id handed to the manager is the one the caller gets back. The exact-array form never checked that, so a service minting a second id for the result would have passed.

PHPStan caught a real one along the way: the new test helper recorded the id and never read it — the assertion I had promised in its own docblock. That is now the assertion above.

Gates: `phpstan` level 10 clean, `unit` 7200 pass, `functional -d sqlite` on the touched classes 11 pass, `cgl` and `rector -n` stable at PHP 8.2.

## Not in this PR

The observed half. It needs a persisted write target — nothing records *which* record a tool write produced — which ADR-176 sets out as blocked on ADR-122's deferred contract.

Refs #772