### PR TITLE
ci(roadmap): fail when the roadmap lists an issue that is already closed

### DIFF
--- a/.github/workflows/roadmap-check.yml
+++ b/.github/workflows/roadmap-check.yml
@@ -1,0 +1,37 @@
+name: Roadmap Issue State
+
+# Fails when ROADMAP.md lists an issue that is already closed.
+#
+# Runs on a SCHEDULE as well as on pull requests, and the schedule is the part
+# that matters: the drift is produced by sibling merges, not by the pull request
+# that touches ROADMAP.md, so a pull-request-only check would never see it. The
+# three corrections this exists to prevent (2e2d5431, 90780db1, #804) were all
+# caused that way.
+#
+# Thin caller of the shared script-check reusable, so the checkout pin and
+# harden-runner stay maintained centrally. That workflow forwards no secrets and
+# runs without an authenticated GH_TOKEN — the script therefore reads the public
+# issues endpoint anonymously, and reports "could not determine" (exit 2, a
+# warning that passes) rather than failing when the shared runner IP has
+# exhausted the 60/hour anonymous quota.
+
+on:
+  schedule:
+    # Weekly. The drift accrues over merges, not over hours.
+    - cron: '17 6 * * 1'
+  pull_request:
+    paths:
+      - 'ROADMAP.md'
+      - 'Build/Scripts/check-roadmap-issue-state.sh'
+      - '.github/workflows/roadmap-check.yml'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  roadmap-check:
+    uses: netresearch/.github/.github/workflows/script-check.yml@main
+    permissions:
+      contents: read
+    with:
+      check-cmd: bash Build/Scripts/check-roadmap-issue-state.sh || [ $? -eq 2 ]

--- a/Build/Scripts/check-roadmap-issue-state.sh
+++ b/Build/Scripts/check-roadmap-issue-state.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# Fails when ROADMAP.md names an issue that is already closed.
+#
+# WHY THIS EXISTS. The file asserts which issues are open, and that assertion
+# has been wrong three times (2e2d5431, 90780db1, #804). The cause is not
+# carelessness: the drift is produced by SIBLING merges, not by the pull request
+# that touches ROADMAP.md — 90780db1's own message says "sixteen sibling merges
+# changed that answer while it waited". A check that only ran on pull requests
+# touching the file would therefore never see it, which is why the caller also
+# runs this on a schedule.
+#
+# WHY UNAUTHENTICATED. The shared script-check workflow deliberately runs with
+# no GH_TOKEN and forwards no secrets. This repository is public, so the issues
+# endpoint answers anonymously; the rate limit is 60/hour per IP.
+#
+# EXIT CODES. 0 = every referenced issue is open. 1 = at least one is closed.
+# 2 = the state could not be determined (rate limit, network). Two is a WARNING
+# the caller lets pass, because a shared runner IP can exhaust the anonymous
+# quota through no fault of ours — and a check that fails on that would be
+# turned off within a week. The distinction is the point: "wrong" and "could not
+# ask" must not look the same.
+
+set -uo pipefail
+
+ROADMAP="${1:-ROADMAP.md}"
+REPO="${GITHUB_REPOSITORY:-netresearch/t3x-nr-llm}"
+API="https://api.github.com/repos/${REPO}/issues"
+
+if [ ! -f "$ROADMAP" ]; then
+    echo "::error::$ROADMAP not found"
+    exit 1
+fi
+
+# ENTRIES only, not every mention. The file's own rule is "every item in the two
+# sections below is an open GitHub issue", and an item is a bullet of the form
+#   - **[#123](url) — title.**
+# Prose elsewhere cites closed issues on purpose — #804 removed an entry and
+# kept a sentence saying which record closed it. A grep over every "#123" reads
+# that sentence as a claim that the issue is open, which it is not. Scoping to
+# the entry form is what separates the assertion from the history.
+numbers=$(grep -oE '^- \*\*\[#[0-9]{2,6}\]' "$ROADMAP" | grep -oE '[0-9]{2,6}' | sort -un)
+
+if [ -z "$numbers" ]; then
+    echo "No issue references in $ROADMAP."
+    exit 0
+fi
+
+closed=""
+unknown=""
+open_count=0
+
+for n in $numbers; do
+    body=$(curl -sS --max-time 20 -w '\n%{http_code}' "$API/$n" 2>/dev/null)
+    code=$(printf '%s' "$body" | tail -n1)
+    json=$(printf '%s' "$body" | sed '$d')
+
+    case "$code" in
+        200)
+            state=$(printf '%s' "$json" | grep -m1 -oE '"state"[[:space:]]*:[[:space:]]*"[a-z]+"' | grep -oE '[a-z]+"$' | tr -d '"')
+            if [ "$state" = "closed" ]; then
+                closed="$closed $n"
+            elif [ "$state" = "open" ]; then
+                open_count=$((open_count + 1))
+            else
+                unknown="$unknown $n"
+            fi
+            ;;
+        403|429)
+            # Anonymous quota exhausted on this runner's IP.
+            unknown="$unknown $n"
+            ;;
+        404)
+            echo "::error::$ROADMAP references #$n, which does not exist in $REPO."
+            closed="$closed $n"
+            ;;
+        *)
+            unknown="$unknown $n"
+            ;;
+    esac
+done
+
+if [ -n "$closed" ]; then
+    for n in $closed; do
+        echo "::error file=$ROADMAP::#$n is closed but $ROADMAP still lists it as open work."
+    done
+    echo "A closed item in the roadmap sends the next reader to re-derive a decision that already shipped."
+    exit 1
+fi
+
+if [ -n "$unknown" ]; then
+    echo "::warning file=$ROADMAP::Could not determine the state of:$unknown (rate limit or network). $open_count reference(s) verified open."
+    exit 2
+fi
+
+echo "All $open_count issue reference(s) in $ROADMAP are open."
+exit 0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,9 +31,17 @@ closes it, so no issue tracks it.
 
 ## Toward 1.0
 
-- **[#691](https://github.com/netresearch/t3x-nr-llm/issues/691) — a management grant, once a management surface exists.**
-  `BackendUserGrant` holds two cases, each with an enforcement point. A third
-  without a surface would be the checkbox ADR-117 had to remove (ADR-130).
+None open. #691 was the last, and it closed as *answered* rather than built:
+[ADR-169](Documentation/Adr/Adr169RecordManagementUsesTypo3Permissions.rst) settles that the records a management surface would own are
+authorised by ``tables_modify`` and ``non_exclude_fields``, so a third
+`BackendUserGrant` case would gate nothing. The reservation is retired in all
+three places that carried it rather than left pending.
+
+What that decision did **not** settle is where such a surface lives. ADR-119's
+placement question is open as issue #812, and its trigger — the first
+cross-consumer editor surface — has not fired. It is not listed as roadmap
+here because it is a decision shared with nr_ai_search, nr_repurpose and the
+cowriter, not work this extension can schedule alone.
 
 ## Decisions that live elsewhere
 


### PR DESCRIPTION
ROADMAP.md asserts which issues are open, nothing checked it, and the assertion has been wrong three times — 2e2d5431, 90780db1 and #804. Every one was found by a person reading the file.

## Why it runs on a schedule and not only on pull requests

The drift is produced by **sibling merges**, not by the pull request that touches ROADMAP.md. 90780db1's own commit message says it: *"This PR was held back to last on purpose: it asserts which gaps are open, and sixteen sibling merges changed that answer while it waited."*

So a pull-request check would sit on a branch that never touches the file and never run. That is the whole reason #805 offered three options rather than "add a check".

## It found real drift on its first run

**#691 was still listed as open work.** ADR-169 retired the management grant and #813 closed it as *answered*. The entry is removed here. Both roadmap sections are now empty and say so — including why the placement question (#812) is deliberately not listed: it is a decision shared with `nr_ai_search`, `nr_repurpose` and the cowriter, not work this extension can schedule alone.

## And a fault in itself

Scanning every `#123` flagged **#731**, which #804 mentions only as history — the sentence naming the ADRs that closed it. That is not a claim it is open, and a check that cannot tell an assertion from prose would have to be silenced within a week.

Scoping the scan to the file's own entry form — a bullet `- **[#N](url) — title.**` — is what separates them. That form is not invented for the check: the file already states "every item in the two sections below is an open GitHub issue".

## The constraint that shaped the implementation

`script-check.yml` says in its own header that it forwards no secrets and runs **without an authenticated `GH_TOKEN`**, so a `gh`-based check is not buildable against it. This repository is public, so the script reads the issues endpoint anonymously; the anonymous limit is 60/hour per IP.

That makes a third state real, and it is handled rather than ignored: rate-limited or unreachable exits **2**, a warning the caller lets pass. A shared runner IP can exhaust the quota through no fault of ours, and a check that failed on that would be switched off. **"Wrong" and "could not ask" must not look the same.**

## Controls, each observed

| Case | Expected | Result |
|---|---|---|
| entry naming a closed issue | fail | exit 1, names it |
| entry naming an open issue | pass | exit 0 |
| entry naming a non-existent number | fail | exit 1 |
| closed issue mentioned in prose | pass | exit 0 |

## One honest limit

**The check currently passes vacuously** — no entries remain after removing #691, so there is nothing to verify. It starts guarding with the first entry added. The controls above are what show it works in the meantime.

Repo rules checked: no local job (thin caller of the shared reusable, `check-workflow-ownership.php` passes), and `drift_compare.py` against the org template reports no drift.

Closes #805