### PR TITLE
chore(release): 0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.31.0] - 2026-08-20
+
 ### Added
 - **Analytics answers "which extension spent what"** (ADR-178). The usage
   table carries the caller's extension key next to the money, so the

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -11,8 +11,8 @@
 >
     <project
         title="TYPO3 LLM Extension"
-        version="0.30.0"
-        release="0.30.0"
+        version="0.31.0"
+        release="0.31.0"
         copyright="since 2025 by Netresearch DTT GmbH"
     />
 

--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
                 "providesPackages": {}
             },
             "extension-key": "nr_llm",
-            "version": "0.30.0",
+            "version": "0.31.0",
             "web-dir": ".Build/Web"
         }
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => '',
     'author_company' => 'Netresearch DTT GmbH',
     'state' => 'beta',
-    'version' => '0.30.0',
+    'version' => '0.31.0',
     'constraints' => [
         // composer.json is the authoritative dependency constraint
         // ("typo3/cms-core": "^13.4 || ^14.3"). The TER `depends` format only


### PR DESCRIPTION
Cuts the CHANGELOG and bumps the four version surfaces (ext_emconf.php, `extra.typo3/cms.version`, `guides.xml` `version=` and `release=`) to 0.31.0. 21 commits since v0.30.0, 8 of them feat/fix.

**What ships:**

- Analytics answers "which extension spent what" (#829, ADR-178): `source_extension` on `tx_nrllm_service_usage` and in its daily aggregation key, a *By extension* chart and a per-extension table in the Analytics module. Unannotated usage is labelled *Unattributed*. Driving consumer: [nr-llm-compat](https://github.com/netresearch/t3x-nr-llm-compat), whose bridges annotate every intercepted third-party call.
- Per-call outcome, explicit half (#823, ADR-176): the outcome table, purge, endpoint and buttons, end to end. `CallOutcome` declares five cases, of which **three are reserved and have no writer yet** — `isImplemented()` returns false for them, which is the sequencing ADR-176 lays down (the observed half waits on a prerequisite from ADR-122). The explicit thumb works in full.
- ADR-179 (#828), a record ahead of its implementation, as this repo's convention prescribes. Its own sequencing section says so.
- Roadmap-drift check (#826).

**Release safety was checked with the other session working in this repository**, not assumed: none of its in-flight #809 work is on `main` (`DroppedSourceReason.php` / `DroppedSource.php` absent, `RunAugmentation` carries no `droppedSources`), and each of its merged changes stands on its own.

After merge: signed tag `v0.31.0` on the merge commit; release.yml publishes to TER and Packagist.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_0144iD1P22LotW8rxmxrNGro)_
