### PR TITLE
chore(release): 0.31.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.31.1] - 2026-08-20
+
 ### Changed
 - **The MCP client talks to the public Streamable-HTTP servers** (ADR-181).
   It now offers both media types the transport requires

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -11,8 +11,8 @@
 >
     <project
         title="TYPO3 LLM Extension"
-        version="0.31.0"
-        release="0.31.0"
+        version="0.31.1"
+        release="0.31.1"
         copyright="since 2025 by Netresearch DTT GmbH"
     />
 

--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
                 "providesPackages": {}
             },
             "extension-key": "nr_llm",
-            "version": "0.31.0",
+            "version": "0.31.1",
             "web-dir": ".Build/Web"
         }
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => '',
     'author_company' => 'Netresearch DTT GmbH',
     'state' => 'beta',
-    'version' => '0.31.0',
+    'version' => '0.31.1',
     'constraints' => [
         // composer.json is the authoritative dependency constraint
         // ("typo3/cms-core": "^13.4 || ^14.3"). The TER `depends` format only


### PR DESCRIPTION
Cuts the CHANGELOG and bumps the four version surfaces to 0.31.1. Ships the MCP transport change (ADR-181, #835): both media types offered, event-stream framed answers unframed — the public servers answered 0.31.0 with 406. Follows #830's form; VersionConsistencyTest and the changelog check pass locally.