### PR TITLE
ci: test MariaDB on the current LTS series, 11.8 and 12.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,11 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   # MariaDB functional leg (one cell): keeps the MySQL-only branches —
   # ke_search MATCH...AGAINST retrieval — permanently exercised in CI.
-  # mariadb:10.11 LTS: images >= 11 ship only mariadb-admin, which fails
-  # the reusable workflow's hardcoded mysqladmin health check.
+  # mariadb:11.8 — one of the two current LTS series (11.8, 12.3); the e2e
+  # leg runs the other, so CI covers both. This sat on 10.11 because images
+  # >= 11 ship only mariadb-admin while the reusable workflow health-checked
+  # with a hardcoded mysqladmin, so the service never turned healthy
+  # (netresearch/typo3-ci-workflows#128, fixed there in #174).
   # The full matrix above stays on SQLite; this narrow second call exists ONLY
   # for the MariaDB functional leg.
   ci-functional-mariadb:
@@ -112,7 +115,7 @@ jobs:
       typo3-versions: '["^14.3"]'
       run-functional-tests: true
       functional-test-db: mariadb
-      db-image: 'mariadb:10.11'
+      db-image: 'mariadb:11.8'
       # Shard by test class here too. With the SQLite cells down to ~2.5min this
       # leg became the single longest job in CI at 6min, i.e. the whole
       # critical-path term of the wall clock.
@@ -122,7 +125,7 @@ jobs:
       # identifier — $originalDatabaseName . '_ft' . substr(sha1(static::class), 0, 7)
       # (FunctionalTestCase.php:361) — so each process creates its OWN database
       # (typo3_test_ft<hash>). No CREATE race, no shared state, and 4 processes
-      # are nowhere near mariadb:10.11's default max_connections of 151.
+      # are nowhere near mariadb:11.8's default max_connections of 151.
       #
       # No event split: this leg never uploaded coverage (upload-coverage is
       # unset here, so the reusable resolves coverage: none). It exists purely to

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,9 @@ jobs:
       contents: read
     with:
       php-version: '8.5'
-      db-image: 'mariadb:12.2'
+      # 12.3, not 12.2: 12.0-12.2 are rolling releases, 12.3 is the LTS of
+      # the 12 series (and the only 12.x still built — 12.2 stopped in May).
+      db-image: 'mariadb:12.3'
       # Seed WAITING_FOR_APPROVAL/INPUT runs before Playwright so the a11y
       # suite can exercise the approve/deny + schema-input forms (ADR-109).
       # Default-mode override: the workflow sets up TYPO3 and starts the

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -86,10 +86,34 @@ handle_dbms_options() {
             # The MariaDB series still in community support (mariadb.org
             # maintenance policy): 10.11 until 2028-02, 11.4 until 2029-05,
             # 11.8 until 2028-06, 12.3 until 2029-06. 10.5, 10.6 and 11.0 are
-            # EOL and were dropped; 12.0-12.2 are rolling releases, not LTS.
-            if ! [[ ${DBMS_VERSION} =~ ^(10.11|11.4|11.8|12.3)$ ]]; then
-                echo "Invalid combination -d ${DBMS} -i ${DBMS_VERSION}" >&2
-                exit 1
+            # EOL; 12.0-12.2 are rolling releases, not LTS.
+            #
+            # A version that has left support is mapped onto the LTS of its own
+            # series rather than refused: `-i 10.5` sits in Makefiles, READMEs
+            # and muscle memory, and failing those calls buys nothing. The
+            # substitution is announced on every run, because a suite that
+            # silently ran a different engine than it was asked for is worse
+            # than a broken call. DBMS_VERSION_EXACT=1 skips mapping and check
+            # both, for reproducing a bug on the engine a customer operates.
+            if [[ "${DBMS_VERSION_EXACT:-0}" != "1" ]]; then
+                case "${DBMS_VERSION}" in
+                    10.5|10.6)           DBMS_VERSION_LTS="10.11" ;;
+                    11.0|11.1|11.2|11.3) DBMS_VERSION_LTS="11.4" ;;
+                    11.5|11.6|11.7)      DBMS_VERSION_LTS="11.8" ;;
+                    12.0|12.1|12.2)      DBMS_VERSION_LTS="12.3" ;;
+                    *)                   DBMS_VERSION_LTS="" ;;
+                esac
+                if [[ -n "${DBMS_VERSION_LTS}" ]]; then
+                    echo "WARNING: MariaDB ${DBMS_VERSION} is out of support (EOL, or a rolling release)." >&2
+                    echo "         Running ${DBMS_VERSION_LTS} instead — the supported series it belongs to." >&2
+                    echo "         Set DBMS_VERSION_EXACT=1 to run ${DBMS_VERSION} anyway." >&2
+                    DBMS_VERSION="${DBMS_VERSION_LTS}"
+                fi
+                if ! [[ ${DBMS_VERSION} =~ ^(10.11|11.4|11.8|12.3)$ ]]; then
+                    echo "Invalid combination -d ${DBMS} -i ${DBMS_VERSION}" >&2
+                    echo "Supported: 10.11, 11.4, 11.8, 12.3. Set DBMS_VERSION_EXACT=1 to run an unsupported version." >&2
+                    exit 1
+                fi
             fi
             ;;
         mysql)

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -82,8 +82,12 @@ handle_dbms_options() {
                 echo "Invalid combination -d ${DBMS} -a ${DATABASE_DRIVER}" >&2
                 exit 1
             fi
-            [[ -z "${DBMS_VERSION}" ]] && DBMS_VERSION="11.4"
-            if ! [[ ${DBMS_VERSION} =~ ^(10.5|10.6|10.11|11.0|11.4)$ ]]; then
+            [[ -z "${DBMS_VERSION}" ]] && DBMS_VERSION="11.8"
+            # The MariaDB series still in community support (mariadb.org
+            # maintenance policy): 10.11 until 2028-02, 11.4 until 2029-05,
+            # 11.8 until 2028-06, 12.3 until 2029-06. 10.5, 10.6 and 11.0 are
+            # EOL and were dropped; 12.0-12.2 are rolling releases, not LTS.
+            if ! [[ ${DBMS_VERSION} =~ ^(10.11|11.4|11.8|12.3)$ ]]; then
                 echo "Invalid combination -d ${DBMS} -i ${DBMS_VERSION}" >&2
                 exit 1
             fi
@@ -157,7 +161,7 @@ Options:
         Database for functional tests (default: sqlite)
 
     -i version
-        Database version (mariadb: 11.4, mysql: 8.4, postgres: 16)
+        Database version (mariadb: 11.8, mysql: 8.4, postgres: 16)
 
     -p <8.2|8.3|8.4|8.5>
         PHP version (default: 8.5)


### PR DESCRIPTION
CI runs the MariaDB series that MariaDB still supports. Per the vendor's [maintenance policy](https://mariadb.org/about/#maintenance-policy) those are 10.11 (until 2028-02), 11.4 (2029-05), 11.8 (2028-06) and 12.3 (2029-06). 12.0 to 12.2 are rolling releases, not LTS — and Docker Hub last rebuilt `mariadb:12.2` on 2026-05-30 while 12.3 is rebuilt daily.

| Surface | Before | After |
|---|---|---|
| `ci.yml`, functional leg | `mariadb:10.11` | `mariadb:11.8` |
| `e2e.yml` | `mariadb:12.2` (rolling, stale image) | `mariadb:12.3` |
| `runTests.sh`, allowed `-i` | `10.5\|10.6\|10.11\|11.0\|11.4` | `10.11\|11.4\|11.8\|12.3`, default `11.8` |

The two legs run different series on purpose, so CI covers both current LTS lines at no extra cost.

## Why the pin existed, and why it can go

The functional leg sat on 10.11 because the shared workflow health-checked the DB service with a hardcoded `mysqladmin ping --silent`, which mariadb images from 11.0 no longer ship — the service never turned healthy and the job died with "Failed to initialize container" (#334, worked around in #337). That is fixed upstream ([typo3-ci-workflows#128](https://github.com/netresearch/typo3-ci-workflows/issues/128), landed in [#174](https://github.com/netresearch/typo3-ci-workflows/pull/174)), and this repository tracks that workflow `@main`.

## Old versions are mapped, not refused

Dropping `10.5`, `10.6` and `11.0` from the accepted set would have broken every existing `-i 10.5` in a Makefile, a README or someone's shell history. Such a version is mapped onto the LTS of its own series and the substitution is printed:

| Requested | Runs | |
|---|---|---|
| `10.5`, `10.6` | `10.11` | with a warning |
| `11.0`–`11.3` | `11.4` | with a warning |
| `11.5`–`11.7` | `11.8` | with a warning |
| `12.0`–`12.2` | `12.3` | with a warning |
| `10.11`, `11.4`, `11.8`, `12.3` | as requested | silent |
| anything else | — | `Invalid combination`, naming the supported set |

The warning is not decoration: a suite that silently ran a different engine than it was asked for is worse than a call that failed. `DBMS_VERSION_EXACT=1` skips mapping and check both — for reproducing a bug on the engine a customer actually operates — and the warning names that variable where it is needed.

## Why `runTests.sh` changes too

Its list offered neither 11.8 nor 12.3, so the versions CI runs could not be reproduced locally — the script was one version behind the fleet, not the other way round. 10.5, 10.6 and 11.0 leave the accepted set but keep working through the mapping above.

## Verified

- `./Build/Scripts/runTests.sh -s functional -d mariadb -i 11.8 -p 8.4 Tests/Functional/Schema/` → `SUCCESS`, 1 test, 9 assertions.
- `-i 12.2` end to end: warns, runs 12.3, suite green — so both the mapping and 12.3 as an engine are proven, not argued.
- Every row of the mapping table was exercised against the function as it stands in the file: the eight out-of-support versions each resolve to the LTS shown and print the warning, the four supported ones pass through silently, `9.9` fails and lists the supported set, and `DBMS_VERSION_EXACT=1 -i 10.5` keeps 10.5 and says nothing. Checked by invoking, not by reading the regex.
- `mariadb:11.8` and `mariadb:12.3` both reach `healthy` under the fixed health command; `max_connections` reads 151 on both, as on 10.11, so the note above `db-image` explaining why four parallel shards are safe still holds.
- TYPO3 sets no upper bound: `EXT:install` declares a minimum of 10.4.3 for MariaDB and no maximum (`DatabaseCheck/Platform/MySql.php:52`). The `<= 10.99.99` shown on get.typo3.org is release metadata, not an engine check.
- `shellcheck --severity=warning` on `runTests.sh` reports the same 21 pre-existing findings as `origin/main` — none new.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01GSptxPLHWsttu9FuqVkvYZ)_
