### PR TITLE
fix(mcp): say why a tool was skipped on import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **An MCP tool that is skipped on import now says why.** The report used to state that a tool had "no usable parameter schema", which is true and unactionable: an operator could not tell a malformed schema from an oversized one from a well-formed one this import deliberately does not carry. It now names the reason — for the common case, the keyword (`anyOf`, `$ref`, …) whose removal would widen what the tool accepts. The rejections themselves are unchanged.
+
 ## [0.31.1] - 2026-08-20
 
 ### Changed

--- a/Classes/Service/Tool/Mcp/McpImportService.php
+++ b/Classes/Service/Tool/Mcp/McpImportService.php
@@ -172,7 +172,11 @@ final readonly class McpImportService
 
         $schema = $this->schemas->normalise($tool['inputSchema'] ?? null);
         if ($schema === null) {
-            return sprintf('"%s" has no usable parameter schema and was skipped.', $remoteName);
+            $reason = $this->schemas->rejectionReason($tool['inputSchema'] ?? null);
+
+            return $reason !== null
+                ? sprintf('"%s" was skipped: %s.', $remoteName, $reason)
+                : sprintf('"%s" has no usable parameter schema and was skipped.', $remoteName);
         }
 
         $encodedSchema = $this->encode($schema);

--- a/Classes/Service/Tool/Mcp/McpSchemaNormalizer.php
+++ b/Classes/Service/Tool/Mcp/McpSchemaNormalizer.php
@@ -138,6 +138,100 @@ final readonly class McpSchemaNormalizer
     }
 
     /**
+     * Why {@see self::normalise()} refused a schema, in words an operator can
+     * act on — or null when it did not refuse.
+     *
+     * The rejections are deliberate, but "no usable parameter schema" tells the
+     * person reading the import report nothing: they cannot see whether the
+     * server sent something malformed, something too large, or something well
+     * formed that this import does not carry (a `$ref`, a union). Naming the
+     * reason is the difference between a dead end and a decision.
+     *
+     * The checks below mirror {@see self::normalise()} in the same order and on
+     * the same data — in particular the keyword walk runs over the FILTERED
+     * schema, so a keyword sitting in a key that is dropped anyway is not
+     * reported as the reason it was refused.
+     */
+    public function rejectionReason(mixed $inputSchema): ?string
+    {
+        if (!is_array($inputSchema)) {
+            return 'the server advertised no parameter schema';
+        }
+
+        if (($inputSchema['type'] ?? null) !== 'object') {
+            return 'its top-level type is not "object"';
+        }
+
+        if ($this->carriesUnsupportedKeyword($inputSchema)) {
+            return $this->unsupportedKeywordReason($this->firstUnsupportedKeyword($inputSchema) ?? '');
+        }
+
+        $normalised = [];
+        foreach (self::RETAINED_KEYS as $key) {
+            if (array_key_exists($key, $inputSchema)) {
+                $normalised[$key] = $inputSchema[$key];
+            }
+        }
+
+        if (!$this->retainedValuesAreWellFormed($normalised)) {
+            return 'its properties or required list are not well formed';
+        }
+
+        if (!$this->isWithinDepth($normalised, 1)) {
+            $keyword = $this->firstUnsupportedKeyword($normalised);
+
+            return $keyword !== null
+                ? $this->unsupportedKeywordReason($keyword)
+                : sprintf('it nests deeper than %d levels', self::MAX_DEPTH);
+        }
+
+        $encoded = json_encode($normalised);
+        if ($encoded === false) {
+            return 'it contains bytes that are not valid UTF-8';
+        }
+
+        if (strlen($encoded) > self::MAX_ENCODED_BYTES) {
+            return sprintf('it exceeds %d bytes once stored', self::MAX_ENCODED_BYTES);
+        }
+
+        return null;
+    }
+
+    private function unsupportedKeywordReason(string $keyword): string
+    {
+        return sprintf(
+            'it uses "%s", which this import does not carry: dropping the keyword would widen what the tool '
+            . 'accepts, letting a model produce arguments the server then rejects',
+            $keyword,
+        );
+    }
+
+    /**
+     * The keyword {@see self::isWithinDepth()} tripped over, at any level.
+     *
+     * @param array<array-key, mixed> $node
+     */
+    private function firstUnsupportedKeyword(array $node): ?string
+    {
+        foreach (self::UNSUPPORTED_KEYWORDS as $keyword) {
+            if (array_key_exists($keyword, $node)) {
+                return $keyword;
+            }
+        }
+
+        foreach ($node as $value) {
+            if (is_array($value)) {
+                $nested = $this->firstUnsupportedKeyword($value);
+                if ($nested !== null) {
+                    return $nested;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * @param array<array-key, mixed> $node
      */
     private function carriesUnsupportedKeyword(array $node): bool

--- a/Tests/Unit/Service/Tool/Mcp/McpSchemaNormalizerTest.php
+++ b/Tests/Unit/Service/Tool/Mcp/McpSchemaNormalizerTest.php
@@ -234,4 +234,80 @@ final class McpSchemaNormalizerTest extends TestCase
 
         return $schema;
     }
+
+    #[Test]
+    public function rejectionReasonNamesTheKeywordForARealWorldSchema(): void
+    {
+        // Verbatim from https://mcp.deepwiki.com/mcp (tools/list, 2026-08-20):
+        // the `ask_question` tool, whose `repoName` accepts either one repo or
+        // a list. Two sibling tools on the same server import fine — this is
+        // the one an operator sees skipped, and "no usable parameter schema"
+        // gave them nothing to act on.
+        $schema = [
+            'type'       => 'object',
+            'properties' => [
+                'repoName' => [
+                    'anyOf' => [
+                        ['type' => 'string'],
+                        ['items' => ['type' => 'string'], 'type' => 'array'],
+                    ],
+                    'description' => 'GitHub repository or list of repositories (max 10) in owner/repo format.',
+                ],
+                'question' => [
+                    'description' => 'The question to ask about the repository.',
+                    'type'        => 'string',
+                ],
+            ],
+            'required' => ['repoName', 'question'],
+        ];
+
+        $subject = new McpSchemaNormalizer();
+
+        self::assertNull($subject->normalise($schema), 'the schema is still refused');
+
+        $reason = $subject->rejectionReason($schema);
+        self::assertIsString($reason);
+        self::assertStringContainsString('anyOf', $reason);
+    }
+
+    #[Test]
+    public function rejectionReasonIsNullForASchemaThatPasses(): void
+    {
+        $subject = new McpSchemaNormalizer();
+
+        // The sibling tool from the same server, which does import.
+        $schema = [
+            'type'       => 'object',
+            'properties' => [
+                'repoName' => [
+                    'description' => 'GitHub repository in owner/repo format.',
+                    'type'        => 'string',
+                ],
+            ],
+            'required' => ['repoName'],
+        ];
+
+        self::assertNotNull($subject->normalise($schema));
+        self::assertNull($subject->rejectionReason($schema));
+    }
+
+    #[Test]
+    public function rejectionReasonDoesNotBlameAKeywordInADroppedKey(): void
+    {
+        // `outputSchema`-style siblings and other non-retained keys are filtered
+        // out before the walk, so a keyword sitting in one of them is not what
+        // refused the schema — reporting it would send the operator after the
+        // wrong thing.
+        $subject = new McpSchemaNormalizer();
+
+        $schema = [
+            'type'       => 'object',
+            'properties' => ['q' => ['type' => 'string']],
+            'required'   => ['q'],
+            'examples'   => [['anyOf' => [['type' => 'string']]]],
+        ];
+
+        self::assertNotNull($subject->normalise($schema));
+        self::assertNull($subject->rejectionReason($schema));
+    }
 }


### PR DESCRIPTION
Reported from the demo instance: the MCP module's last import error read

> `"ask_question" has no usable parameter schema and was skipped.`

That sentence is true and gives the operator nothing. It does not separate a malformed schema from an oversized one from a well-formed one this import deliberately refuses, and there is no way to tell which of the three happened without reading the normaliser.

**What it says now:** the reason, and for the common case the keyword whose removal would widen what the tool accepts:

> `"ask_question" was skipped: it uses "anyOf", which this import does not carry: dropping the keyword would widen what the tool accepts, letting a model produce arguments the server then rejects.`

**Verified against the real server.** `https://mcp.deepwiki.com/mcp` declares `ask_question`'s `repoName` as `anyOf[string, array<string>]`; its two sibling tools import fine, which is exactly the "two imported DeepWiki tools" the demo seeds. The new unit test carries that schema verbatim rather than a constructed one.

**The rejection rules are unchanged.** `rejectionReason()` mirrors `normalise()` step for step, in the same order, on the same data — including that the keyword walk runs over the FILTERED schema. A keyword sitting in a key that gets dropped anyway (an `examples` block, say) is therefore never reported as the cause; there is a test for that, because a plausible-but-wrong reason would be worse than the vague one it replaces.

Whether the union should be refused at all is a separate question, filed as #848 rather than decided here.

Tests: three new unit tests (real schema refused with the keyword named, a passing sibling schema reports no reason, a keyword in a dropped key is not blamed). Gates run locally: cgl, PHPStan level 10, the normaliser unit suite, and the functional `McpImport` suite on sqlite — all green; CI covers the eight-cell matrix.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_0144iD1P22LotW8rxmxrNGro)_
