### PR TITLE
fix(telemetry): carry the caller source across every options rebuild

### DIFF
--- a/Classes/Service/Feature/TranslationService.php
+++ b/Classes/Service/Feature/TranslationService.php
@@ -99,14 +99,14 @@ final readonly class TranslationService implements TranslationServiceInterface
             ChatMessage::user($prompt['user']),
         ];
 
-        $chatOptions = new ChatOptions(
+        $chatOptions = $this->carryCallerSource(new ChatOptions(
             temperature: $options->getTemperature() ?? 0.3,
             maxTokens: $options->getMaxTokens() ?? 2000,
             provider: $options->getProvider(),
             model: $options->getModel(),
             beUserUid: $this->resolveBeUserUid($options),
             plannedCost: $options->getPlannedCost(),
-        );
+        ), $options);
 
         $response = $this->llmManager->chat($messages, $chatOptions);
 
@@ -305,14 +305,14 @@ final readonly class TranslationService implements TranslationServiceInterface
                 ['temperature' => 0.1, 'max_tokens' => 10],
             );
         } else {
-            $chatOptions = (new ChatOptions(
+            $chatOptions = $this->carryCallerSource((new ChatOptions(
                 temperature: 0.1,
                 maxTokens: 10,
                 provider: $options->getProvider(),
                 model: $options->getModel(),
                 beUserUid: $this->resolveBeUserUid($options),
                 plannedCost: $options->getPlannedCost(),
-            ))->withSuppressRequestCount(!$countsAsRequest);
+            ))->withSuppressRequestCount(!$countsAsRequest), $options);
 
             $response = $this->llmManager->chat($messages, $chatOptions);
         }
@@ -356,14 +356,14 @@ final readonly class TranslationService implements TranslationServiceInterface
             )),
         ];
 
-        $chatOptions = new ChatOptions(
+        $chatOptions = $this->carryCallerSource(new ChatOptions(
             temperature: 0.1,
             maxTokens: 10,
             provider: $options->getProvider(),
             model: $options->getModel(),
             beUserUid: $this->resolveBeUserUid($options),
             plannedCost: $options->getPlannedCost(),
-        );
+        ), $options);
 
         $response = $this->llmManager->chat($messages, $chatOptions);
 
@@ -675,5 +675,22 @@ final readonly class TranslationService implements TranslationServiceInterface
     private function resolveBeUserUid(TranslationOptions $options): ?int
     {
         return $options->getBeUserUid() ?? $this->beUserContextResolver?->resolveBeUserUid();
+    }
+
+    /**
+     * Carry the caller identity across an options rebuild.
+     *
+     * Every `new ChatOptions(...)` in this service builds a fresh object from a
+     * fixed parameter list, and the caller source is set by a wither rather than
+     * a constructor parameter — so without this it is silently dropped and the
+     * call lands in the "Unattributed" bucket of the per-extension breakdown
+     * (ADR-177/ADR-178), no matter what the caller annotated.
+     */
+    private function carryCallerSource(ChatOptions $rebuilt, TranslationOptions $source): ChatOptions
+    {
+        return $rebuilt->withCallerSource(
+            $source->getCallerSourceExtension() ?? '',
+            $source->getCallerSourceOperation() ?? '',
+        );
     }
 }

--- a/Classes/Service/Feature/VisionService.php
+++ b/Classes/Service/Feature/VisionService.php
@@ -198,6 +198,16 @@ final readonly class VisionService implements VisionServiceInterface
             plannedCost: $options->getPlannedCost(),
         );
 
+        // The caller identity is not a constructor parameter, so the rebuild
+        // above cannot carry it — exactly the trap the comment warns about,
+        // one field further on. Without this line every vision call made
+        // through this service is unattributed in the per-extension breakdown
+        // (ADR-177/ADR-178), including the ones nr-llm-compat's bridges annotate.
+        $visionOptions = $visionOptions->withCallerSource(
+            $options->getCallerSourceExtension() ?? '',
+            $options->getCallerSourceOperation() ?? '',
+        );
+
         return $this->llmManager->vision($content, $visionOptions);
     }
 

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -29,6 +29,7 @@ use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Exception\ContextTruncatedException;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\TelemetryMiddleware;
 use Netresearch\NrLlm\Service\Context\ContextWindowManagerInterface;
 use Netresearch\NrLlm\Service\Governance\GovernanceEventRepositoryInterface;
 use Netresearch\NrLlm\Service\LlmServiceManagerInterface;
@@ -1127,9 +1128,16 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
     }
 
     /**
-     * Forward the budget pre-flight context (BE-user uid, planned cost) onto the
-     * synthesis completion so the cap-hit final call stays budget-gated and
-     * cost-attributed, matching the per-iteration tool calls.
+     * Forward the budget pre-flight context (BE-user uid, planned cost) and the
+     * caller identity onto a completion this service places itself, so the
+     * tool-free turn and the cap-hit synthesis stay budget-gated and attributed
+     * exactly like the per-iteration tool calls.
+     *
+     * The caller source needs carrying by hand here because these two calls go
+     * through `chatWithConfiguration()`, whose channel is the metadata array —
+     * the options object the run was started with does not reach them. Without
+     * it an annotated run splits across two rows in the per-extension
+     * breakdown: the tool-capable turns attributed, these two not (ADR-178).
      *
      * @return array<string, mixed>
      */
@@ -1148,6 +1156,19 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         $plannedCost = $options->getPlannedCost();
         if ($plannedCost !== null) {
             $metadata[BudgetMiddleware::METADATA_PLANNED_COST] = $plannedCost;
+        }
+
+        // Null and '' both mean "named nobody" — the getter is nullable while
+        // the wither writes '' for an omitted operation, so both have to be
+        // treated the same or an unannotated run writes empty metadata keys.
+        $sourceExtension = $options->getCallerSourceExtension() ?? '';
+        if ($sourceExtension !== '') {
+            $metadata[TelemetryMiddleware::METADATA_SOURCE_EXTENSION] = $sourceExtension;
+
+            $sourceOperation = $options->getCallerSourceOperation() ?? '';
+            if ($sourceOperation !== '') {
+                $metadata[TelemetryMiddleware::METADATA_SOURCE_OPERATION] = $sourceOperation;
+            }
         }
 
         return $metadata;

--- a/Tests/Unit/Service/Feature/TranslationServiceTest.php
+++ b/Tests/Unit/Service/Feature/TranslationServiceTest.php
@@ -91,6 +91,40 @@ class TranslationServiceTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function translateCarriesTheCallerSourceOntoTheChatOptionsItBuilds(): void
+    {
+        // The service translates by building a fresh ChatOptions from the
+        // TranslationOptions it was given. The caller source is set by a wither
+        // rather than a constructor parameter, so the rebuild has to carry it
+        // deliberately — otherwise every translation is unattributed in the
+        // per-extension breakdown, whatever the caller annotated (ADR-178).
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $llmManagerMock->expects(self::once())
+            ->method('chat')
+            ->with(
+                self::anything(),
+                self::callback(static fn(ChatOptions $options): bool
+                    => $options->getCallerSourceExtension() === 'my_extension'
+                    && $options->getCallerSourceOperation() === 'translateTitle'),
+            )
+            ->willReturn($this->createChatResponse('Hallo Welt'));
+
+        $subject = new TranslationService(
+            $llmManagerMock,
+            $this->translatorRegistryMock,
+            $this->configServiceStub,
+            new TranslationPromptBuilder(),
+        );
+
+        $subject->translate(
+            'Hello World',
+            'de',
+            'en',
+            (new TranslationOptions())->withCallerSource('my_extension', 'translateTitle'),
+        );
+    }
+
+    #[Test]
     public function translateThrowsOnEmptyText(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/Tests/Unit/Service/Feature/VisionServiceTest.php
+++ b/Tests/Unit/Service/Feature/VisionServiceTest.php
@@ -254,6 +254,34 @@ class VisionServiceTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function analyzeImageFullPreservesTheCallerSourceThroughTheRebuild(): void
+    {
+        // Twin of the budget-field test above, for the field that arrived with
+        // ADR-177 and was missed by the same rebuild: the caller source is set
+        // by a wither, not a constructor parameter, so it is invisible in the
+        // parameter list the rebuild copies. nr-llm-compat's ai_filemetadata
+        // bridge routes its vision calls through exactly this method.
+        $llmManagerMock = $this->createMock(LlmServiceManagerInterface::class);
+        $subject = new VisionService($llmManagerMock);
+
+        $llmManagerMock->expects(self::once())
+            ->method('vision')
+            ->with(
+                self::anything(),
+                self::callback(static fn(VisionOptions $options): bool
+                    => $options->getCallerSourceExtension() === 'ai_filemetadata'
+                    && $options->getCallerSourceOperation() === 'buildAltText'),
+            )
+            ->willReturn($this->createMockVisionResponse('Alt text'));
+
+        $subject->analyzeImageFull(
+            'https://example.com/image.jpg',
+            'describe',
+            (new VisionOptions(detailLevel: 'high'))->withCallerSource('ai_filemetadata', 'buildAltText'),
+        );
+    }
+
+    #[Test]
     public function analyzeImageFullPreservesBudgetFieldsThroughDetailLevelRebuild(): void
     {
         // Regression test for the same class of bug Gemini caught on

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -41,6 +41,7 @@ use Netresearch\NrLlm\Domain\ValueObject\ToolResult;
 use Netresearch\NrLlm\Domain\ValueObject\ToolSpec;
 use Netresearch\NrLlm\Exception\BudgetExceededException;
 use Netresearch\NrLlm\Provider\Middleware\BudgetMiddleware;
+use Netresearch\NrLlm\Provider\Middleware\TelemetryMiddleware;
 use Netresearch\NrLlm\Service\Context\ContextWindowManagerInterface;
 use Netresearch\NrLlm\Service\Governance\DataClassEnforcementResolver;
 use Netresearch\NrLlm\Service\Governance\TrustZoneResolver;
@@ -2479,6 +2480,32 @@ final class ToolLoopServiceTest extends TestCase
         $result = (new ReflectionClass($service))->getMethod('budgetMetadata')->invoke($service, $options);
 
         return $result;
+    }
+
+    #[Test]
+    public function budgetMetadataCarriesTheCallerSource(): void
+    {
+        // The tool loop places two completions itself — the tool-free turn and
+        // the post-cap synthesis — through chatWithConfiguration(), whose only
+        // channel is this metadata array. Without the caller source here, an
+        // annotated run splits across two rows in the per-extension breakdown:
+        // the tool-capable turns attributed, these two not (ADR-178).
+        $meta = $this->budgetMetadata(
+            (new ToolOptions(beUserUid: 42))->withCallerSource('nr_mcp_agent', 'chatTurn'),
+        );
+
+        self::assertSame('nr_mcp_agent', $meta[TelemetryMiddleware::METADATA_SOURCE_EXTENSION] ?? null);
+        self::assertSame('chatTurn', $meta[TelemetryMiddleware::METADATA_SOURCE_OPERATION] ?? null);
+        self::assertSame(42, $meta[BudgetMiddleware::METADATA_BE_USER_UID] ?? null);
+    }
+
+    #[Test]
+    public function budgetMetadataOmitsTheCallerSourceWhenTheRunNamedNobody(): void
+    {
+        $meta = $this->budgetMetadata(new ToolOptions(beUserUid: 42));
+
+        self::assertArrayNotHasKey(TelemetryMiddleware::METADATA_SOURCE_EXTENSION, $meta);
+        self::assertArrayNotHasKey(TelemetryMiddleware::METADATA_SOURCE_OPERATION, $meta);
     }
 
     #[Test]


### PR DESCRIPTION
The caller identity from ADR-177 only reaches the middleware when the options object the caller annotated is the one that arrives. Three places rebuilt it on the way and dropped the identity, so the per-extension breakdown (ADR-178) reported *Unattributed* no matter how carefully the caller named itself.

**What was losing it:**

- `VisionService::analyzeImageFull()` rebuilds `VisionOptions` from a fixed parameter list to strip `detail_level`. The caller source is set by a wither, not a constructor parameter, so it was invisible to that list — the same trap the comment right above that rebuild already warns about for the budget fields, one field further on.
- `TranslationService` builds `ChatOptions` from `TranslationOptions` at three sites.
- `ToolLoopService` places two completions itself (the tool-free turn and the post-cap synthesis) through `chatWithConfiguration()`, whose channel is the metadata array; `budgetMetadata()` emitted only the two budget keys, so an annotated tool run split across two rows — the tool-capable turns attributed, these two not.

**Why it matters beyond tidiness:** nr-llm-compat's `ai_filemetadata` bridge routes its vision calls through exactly `analyzeImageFull()`, and making third-party AI usage attributable is the whole point of that bridge. It was annotating into a void. The same held for every consumer being annotated right now (nr-landingpage, nr-mcp-agent, nr-repurpose, t3-cowriter, nr-ai-search) on their vision and translation paths.

Found by two independent subagents while annotating consumers, then verified in the source here.

**Tests** — the vision guard was watched failing before it was kept: removing the copy again makes `analyzeImageFullPreservesTheCallerSourceThroughTheRebuild` fail on the options object handed to the manager, and it passes once restored. It sits next to the existing budget-field regression test, which is the same defect class one field earlier.

A second test pins the tool-loop metadata, and writing it caught a real bug in this change: the getter is nullable while the wither writes `''` for an omitted operation, so a first version wrote an empty `sourceExtension` key for unannotated runs. Both cases are asserted now.

Gates run locally: cgl, PHPStan level 10, and the three touched unit suites (`VisionServiceTest`, `TranslationServiceTest`, `ToolLoopServiceTest`). CI covers the eight-cell matrix.

Closes #845, closes #846.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_0144iD1P22LotW8rxmxrNGro)_
