### PR TITLE
docs(adr): cite symbols, not line numbers, and check what a test can check

### DIFF
--- a/Documentation/Adr/Adr169RecordManagementUsesTypo3Permissions.rst
+++ b/Documentation/Adr/Adr169RecordManagementUsesTypo3Permissions.rst
@@ -108,7 +108,8 @@ mount (``:7677``) and the ``perms_*`` bitmask (``:7696-7705``).
      - Permitted today. No TCA change.
 
 **This is not theoretical for this extension.** The setup wizard renders a
-"Storage Folder (Page ID)" input (``Backend/SetupWizard/Index.html:328-331``),
+"Storage Folder (Page ID)" input
+(``Resources/Private/Templates/Backend/SetupWizard/Index.html#wizard.field.pid``),
 whose value reaches ``saveAction`` (``SetupWizardController.php:301``) and is
 written onto the provider (``:372-374``), every model (``:449``) and every
 configuration (``:525``) with no page check. All eight Extbase repositories set
@@ -292,7 +293,7 @@ reservation in ADR-130 and ADR-131 is retired rather than fulfilled.
 -------------------
 
 :ref:`ADR-119 <adr-119>` decided "keep the modules under Administration for
-now" (``Adr119BackendModulePlacement.rst:94``) and already carries the status
+now" (:ref:`ADR-119 <adr-119-decision>`) and already carries the status
 ``Accepted (deferred — the placement is not finally settled, see Revisit)``. Its
 trigger is "the first cross-consumer editor surface … a personal
 usage-and-budget view, a personal run history, or a lead-editor view over a

--- a/Documentation/Adr/Adr171PersonasTheCodeAlreadyAssumes.rst
+++ b/Documentation/Adr/Adr171PersonasTheCodeAlreadyAssumes.rst
@@ -47,13 +47,14 @@ Personas
 ------------------------------------------
 
 **Code.** Fifteen of the sixteen registered backend modules are
-``'access' => 'admin'`` (``Configuration/Backend/Modules.php:53`` … ``:321``);
-forty ``denyNonAdmin()`` call sites in fourteen controllers restore that line on
-AJAX routes (:ref:`ADR-037 <adr-037>`, enumerated in
-``Adr169RecordManagementUsesTypo3Permissions.rst:308-341``). ``isAdmin``
-short-circuits :php:`hasGrant()`, :php:`mayAccessSession()` and
-:php:`mayActOnRun()` (``AiActorContext.php:180``, ``:196``, ``:217``) and bypasses
-the configuration group restriction (``ConfigurationResolver.php:218``). The
+``'access' => 'admin'`` — ``grep -c "'access' => 'admin'"
+Configuration/Backend/Modules.php`` returns 15. Forty ``denyNonAdmin()`` call
+sites in fourteen controllers restore that line on AJAX routes
+(:ref:`ADR-037 <adr-037>`, enumerated with its own grep in
+:ref:`ADR-169 <adr-169-q6>`). ``isAdmin`` short-circuits :php:`hasGrant()`,
+:php:`mayAccessSession()` and :php:`mayActOnRun()`, and bypasses the
+configuration group restriction (:php:`ConfigurationResolver::actorMayUse()`).
+The
 docblock records where that comes from: "Administrators hold every grant
 implicitly (the core ``check()`` short-circuits on isAdmin)"
 (:php:`BackendUserGrant`'s class docblock) — the platform's rule, not ours.
@@ -79,14 +80,15 @@ person who decides which tools an editor may run.
 ---------------------------------------------------------
 
 **Code.** ``nrllm_aitasks``, ``'parent' => 'web'``, ``'access' => 'user'``
-(``Modules.php:342-344``) — the only non-admin surface in the extension. Two
-switches are required: the module tick in ``be_groups`` and the grant. The grant
-has **nine** enforcement points in four classes: ``TaskExecutionController:198,
-293``; ``AiTaskController:69, 98``; ``EditorActionController:78, 109, 170, 210``;
-``ContextMenu/EditorActionItemProvider:101``. The module withholds what an editor
-must not reach: no FormEngine links, no record picker, ``table``-input tasks
-filtered out (``AiTaskController:106``). Entry is from the record's own context
-menu.
+(``Configuration/Backend/Modules.php#nrllm_aitasks``) — the only non-admin
+surface in the extension. Two switches are required: the module tick in
+``be_groups`` and the grant. The grant has **ten** enforcement points in four
+classes — ``grep -rc "BackendUserGrant::TASKS_USE" Classes/`` locates them in
+:php:`TaskExecutionController` (3), :php:`EditorActionController` (4),
+:php:`AiTaskController` (2) and :php:`EditorActionItemProvider` (1). The module
+withholds what an editor must not reach: no FormEngine links, no record picker,
+``table``-input tasks filtered out (:php:`AiTaskController::executableTasks()`).
+Entry is from the record's own context menu.
 
 **Human (unvalidated).** Works on one record and wants one thing done to it, does
 not know what a provider is, and is afraid of publishing something wrong under
@@ -95,13 +97,15 @@ their own name.
 **Confidence.** Enforced by code.
 
 **Blocks.** :ref:`ADR-119 <adr-119>`'s reopening, which
-``Adr169RecordManagementUsesTypo3Permissions.rst:293-296`` recommends and does
+:ref:`ADR-169 <adr-169-q6>` recommends and does
 not do. ADR-119 argued *for* leaving the modules under Administration because
-"an editor would never open an nr_llm module" (``Adr119:69``); the context-menu
+"an editor would never open an nr_llm module"
+(:ref:`ADR-119 <adr-119-context-editor>`); the context-menu
 item now sends them into one.
 
-**Point at this if you disagree:** ``AiTaskController:149-167`` offers **every**
-active non-``table`` task in the instance to **every** grant holder. There is no
+**Point at this if you disagree:** :php:`AiTaskController::executableTasks()`
+offers **every** active non-``table`` task in the instance to **every** grant
+holder. There is no
 per-task, per-category or per-group scoping, and no task ownership field.
 
 .. _adr-171-p3:
@@ -110,16 +114,16 @@ per-task, per-category or per-group scoping, and no task ownership field.
 -------------------------------
 
 **Code.** :php:`BackendUserGrant::AGENT_APPROVE`; the grant branch in
-:php:`AiActorContext::mayActOnRun()` (``:229``) — "deliberately the only scope
-with a grant equivalent" (:ref:`ADR-130 <adr-130>`, Decision); the write side at
-``ResumeCoordinator.php:205`` and ``:650``; the list viewport at
-``AgentRunController.php:267``. It sits in no recommended preset: "granting it is
-an explicit trust decision"
-(``Documentation/Administration/Permissions.rst:55-59``).
-The card renders the tool's wire name and its pretty-printed ``argumentsJson``
-(``ApprovalControls.html:8``, ``:30``), and states its own limits — "Captured
-when the run paused — the target may have changed since" (``:25``), "No preview
-— you are deciding without one" (``:16``).
+:php:`AiActorContext::mayActOnRun()` — "deliberately the only scope with a grant
+equivalent" (:ref:`ADR-130 <adr-130>`, Decision); the write side in
+:php:`ResumeCoordinator::approve()` and :php:`ResumeCoordinator::submitInput()`;
+the list viewport in :php:`AgentRunController::listAction()`. It sits in no
+recommended preset: "granting it is an explicit trust decision"
+(``Documentation/Administration/Permissions.rst``). The card renders the tool's
+wire name and its pretty-printed ``argumentsJson``
+(``ApprovalControls.html#argumentsJson``), and
+states its own limits — "Captured when the run paused — the target may have
+changed since", "No preview — you are deciding without one".
 
 **Human (unvalidated).** Decides somebody else's proposed write without editing
 it, and can predict a tool call's effect from its arguments.
@@ -132,9 +136,9 @@ it, and can predict a tool call's effect from its arguments.
 
 **Point at this if you disagree:** the approver may release a write to a record
 they hold no rights on, and the preview is withheld exactly then
-(``WaitingRunViewFactory.php:47``, ``:153-162``); the run detail page is withheld
+(:php:`WaitingRunViewFactory::buildApproval()`); the run detail page is withheld
 too, because ``AGENT_READ`` has no grant equivalent
-(``AgentRunController.php:61-64``).
+(:php:`AgentRunController`'s class docblock).
 
 .. _adr-171-p4:
 
@@ -144,11 +148,11 @@ too, because ``AGENT_READ`` has no grant equivalent
 **Code.** ``grep systemMaintainer Classes/`` returns **zero hits**. nr_llm never
 checks this role, and every remedy the governance readout names is behind it: the
 page routes the reader to "the Install Tool under Settings > Extension
-Configuration > nr_llm" (``locallang.xlf:295-296``, rendered at
-``Governance.html:20-22``), and the Settings module is
-``'access' => 'systemMaintainer'`` — "stricter than admin"
-(``Adr169…rst:383-385``, reading core's
-``cms-install/Configuration/Backend/Modules.php:32``).
+Configuration > nr_llm" (``Resources/Private/Language/locallang.xlf``, rendered
+by ``Resources/Private/Templates/Backend/Governance.html``), and the Settings
+module is ``'access' => 'systemMaintainer'`` — "stricter than admin"
+(:ref:`ADR-169 <adr-169-q7>`, reading core's
+``cms-install/Configuration/Backend/Modules.php``).
 
 **Human (unvalidated).** Holds the instance's global switches. May or may not be
 the same account as the administrator who reads the governance page.
@@ -167,7 +171,7 @@ reader no route to the fix.
 **Code.** None. The role exists only as a shipped claim: "What a task may read
 and which model and configuration it uses is defined by whoever manages the task
 — that is the trust boundary: task managers define, grant holders execute"
-(``Permissions.rst:40-43``). Nothing checks it:
+(``Documentation/Administration/Permissions.rst``). Nothing checks it:
 :php:`TaskExecutionService::execute()` takes ``(Task, string, ?int $beUserUid)`` —
 no actor, nothing to check against. ``tasks_manage`` occurs once in ``Classes/``,
 in :php:`BackendUserGrant`'s class docblock — which, since
@@ -191,10 +195,10 @@ the permissions page describes a two-party structure the code does not implement
 ------------------------
 
 **Code.** Named first of three stated audiences
-(``Documentation/Introduction/Index.rst:19-24``) and the only actor with a
-machine-enforced contract: ``Tests/Unit/Api/api-surface.txt`` (1942 lines) freezes
+(``Documentation/Introduction/Index.rst``) and the only actor with a
+machine-enforced contract: ``api-surface.txt#AgentRuntimeInterface`` freezes
 :php:`AiActorContext` as the first parameter of every
-:php:`AgentRuntimeInterface` method (``:1130-1138``), so no consumer can call the
+:php:`AgentRuntimeInterface` method, so no consumer can call the
 runtime without constructing an actor. :ref:`ADR-070 <adr-070>` exists because
 consumers were calling ``findOneByIdentifier()`` and skipping both guards.
 
@@ -243,9 +247,10 @@ Contradictions found
 ADR-130 constraint 3 read "``agent_approve`` is **doubly unreachable for
 non-admins today** — both human approval surfaces sit behind admin gates …
 only becomes exercisable for non-admins with the editing module. Stated here so
-nobody reads it as an already-active control." It shipped: ``Modules.php:375-381``
-registers ``AgentRunController::approve`` and ``submitInput`` in
-``nrllm_aitasks``, ``'access' => 'user'`` (``:344``). A non-admin who holds the
+nobody reads it as an already-active control." It shipped:
+``Configuration/Backend/Modules.php#nrllm_aitasks`` registers
+``AgentRunController::approve`` and ``submitInput`` under
+``'access' => 'user'``. A non-admin who holds the
 grant and whose group has that module ticked decides another user's write today.
 ADR-130 now carries ``:Amended:`` and a rewritten constraint 3, and
 ``Tests/Unit/Configuration/ApprovalSurfaceInventoryTest.php`` pins the module
@@ -255,29 +260,32 @@ ADR-130 says which.
 
 **B. One codebase, two answers to "may this person use this model".** The Editor
 Action Center refuses a user outside the configuration's allowed groups —
-``EditorActionCatalogue.php:206`` via :php:`hasAccess()`, with the comment "a
-fourth copy of it is the copy that ages" (``:195``). The task list in the **same
-module** does not: ``TaskExecutionService.php:63`` calls
-:php:`resolveEffectiveConfiguration($task->getConfiguration())`, which at
-``ConfigurationResolver.php:50-53`` is ``$configuration ?? …`` — the task's pinned
+:php:`EditorActionCatalogue::usableDefault()` via :php:`hasAccess()`, with the
+comment "a fourth copy of it is the copy that ages". The task list in the **same
+module** does not: :php:`TaskExecutionService::execute()` calls
+:php:`resolveEffectiveConfiguration($task->getConfiguration())`, which in
+:php:`ConfigurationResolver::resolveEffectiveConfiguration()` is
+``$configuration ?? …`` — the task's pinned
 configuration, returned unchecked; the method has no actor to check with. A task
 pinned to a restricted configuration bypasses that restriction.
 
 **C. The bound that justifies the grant is opt-in.** :ref:`ADR-130 <adr-130>`,
 Decision: "The per-user budget pre-flight … bounds what a grant holder can
 spend."
-``Permissions.rst:43-45`` states it in its own words, not this one's — "Every run
-is pre-flighted against the user's own usage budget and attributed to them."
-``BudgetService.php:76-79``: with no ``tx_nrllm_user_budget``
-record for that uid, an inactive one, or one with no limit set, the check returns
+``Documentation/Administration/Permissions.rst`` states it in its own words, not
+this one's — "Every run is pre-flighted against the user's own usage budget and
+attributed to them." :php:`BudgetService::checkUserBudget()`: with no
+``tx_nrllm_user_budget`` record for that uid, an inactive one, or one with no
+limit set, the check returns
 ``allowed()``. The budget is per user and opt-in; the grant is per group.
 Ticking ``tasks_use`` for a group without creating budget records ships an
 unbounded spend, and nothing says so.
 
 **D. The approver may decide what they may not read.**
-``AgentRunController.php:61-64`` — ``AGENT_READ`` has no grant equivalent, "so the
-approval grant widens the list but not the detail page"; the preview is withheld
-on the same ground (``WaitingRunViewFactory.php:47``, ``:153-162``). A coherent
+:php:`AgentRunController`'s class docblock — ``AGENT_READ`` has no grant
+equivalent, "so the approval grant widens the list but not the detail page"; the
+preview is withheld on the same ground
+(:php:`WaitingRunViewFactory::buildApproval()`). A coherent
 security position and an incoherent human one. Needs a decision, not a patch.
 
 **E. "Operator" is the most-used word for a person in the corpus and is defined
@@ -285,8 +293,9 @@ nowhere.** 201 occurrences across 57 of 169 ADR files, counted at ``96ee600d``
 and rising with every record that uses the word; no enum case, no gate, no
 glossary. It is used for at least three disjoint permission levels: the
 administrator configuring records, the ``systemMaintainer`` changing extension
-configuration (``Adr140:164``), and a person with shell and cron
-(``Adr103:23``). Meanwhile ``Permissions.rst:70-72`` ships a preset called "AI
+configuration (:ref:`ADR-140 <adr-140>`), and a person with shell and cron
+(:ref:`ADR-103 <adr-103-context>`). Meanwhile
+``Documentation/Administration/Permissions.rst`` ships a preset called "AI
 operator" that is a **non-admin** holding one grant, and says so: "identical to
 *AI editor* on purpose".
 
@@ -310,8 +319,9 @@ should read this section first.
   equivalent" — a design choice, not an observed org chart. Until
   contradiction A shipped, no non-admin could reach it at all. We built the
   separation before meeting anyone who wants it.
-- **The input submitter.** ``ResumeCoordinator.php:650`` calls the *same*
-  predicate as ``:205``, so submitting is the approver's grant.
+- **The input submitter.** :php:`ResumeCoordinator::submitInput()` calls the
+  *same* predicate as :php:`ResumeCoordinator::approve()`, so submitting is the
+  approver's grant.
   :ref:`ADR-150 <adr-150>` reasons about them as a distinct actor with a
   different danger model — and no production tool can produce one:
   ``InputPauseCoverageTest::INPUT_REQUIRING_TOOLS = []`` pins the empty list,
@@ -320,21 +330,23 @@ should read this section first.
   grant that does not exist, using the corpus's most loaded word to mean its
   opposite.
 - **The lead editor.** One clause, once: "and a lead editor needs the same for
-  their editors, or for a group" (``Adr119:79``). Nothing implements it; budgets
-  have no group dimension. ``Adr157:109-113`` is the one surface that tried and
+  their editors, or for a group" (:ref:`ADR-119 <adr-119-context-editor>`).
+  Nothing implements it; budgets have no group dimension.
+  :ref:`ADR-157 <adr-157>` is the one surface that tried and
   declined on principle: "A group is not resolvable to an acting backend user …
   A group entry would have been a control with no reader." It is nonetheless
   ADR-119's stated trigger for moving the whole module tree.
-- **The run owner.** ``AiActorContext.php:233`` is real, but "owner" is a column
+- **The run owner.** :php:`AiActorContext::mayActOnRun()` is real, but "owner"
+  is a column
   on ``AgentRun``, not a job; every ``tasks_use`` holder becomes one by pressing
   execute. Its concern — a write under your identity because somebody else
   approved it — belongs to the editor, where a human can be asked about it.
 - **The anonymous caller and the backend group.** A fail-closed null object
-  (``AiActorContext.php:72-79``) and the unit of entitlement
+  (:php:`AiActorContext::anonymous()`) and the unit of entitlement
   (:php:`BackendUserGrant`'s class docblock). Both are load-bearing; neither is a person.
 - **The service account.** A machine, not a persona — and the counter-example to
   ADR-023: fail-closed from its first line. One exists, ``cli:nrllm:agent:cancel``
-  (``CancelAgentRunCommand.php:69``), declaring one of the five scopes.
+  (:php:`CancelAgentRunCommand::execute()`), declaring one of the five scopes.
 
 .. _adr-171-failure:
 
@@ -347,16 +359,19 @@ each against the code:
 
 **That capability describes a job.** ADR-023 put the flags on the group rather
 than the configuration because "capability is an editor-role concern, not a
-configuration concern" (``:98``). Half the execution paths have no person on
+configuration concern" (:ref:`ADR-023 <adr-023-alternatives>`). Half the
+execution paths have no person on
 them: streaming bypasses the pipeline, and the queue worker never populates
 ``$GLOBALS['BE_USER']`` — so the same run "would be denied synchronously and
-allowed after :php:`enqueue()`" (``Adr117:49-57``). A role-shaped control could
+allowed after :php:`enqueue()`" (:ref:`ADR-117 <adr-117-decision>`). A
+role-shaped control could
 not describe a queue.
 
 **That the person being restricted can reach the product.** They could not. "All
 thirteen nr_llm backend modules are ``'access' => 'admin'`` and administrators
 bypass the check by definition, so unticking a capability would change nothing
-inside nr_llm's own interface" (``Adr117:59-63``). It was a permissions model for
+inside nr_llm's own interface" (:ref:`ADR-117 <adr-117-decision>`). It was a
+permissions model for
 a user who did not exist on the system.
 
 **That absence of a person means nothing to restrict.** :php:`isAllowed()`
@@ -364,14 +379,16 @@ returned ``true`` with no backend user — the natural code to write when thinki
 about *a human being restricted*. Take the caller seriously and "no person" is
 the case that most needs denying.
 
-Verdict, ``Adr117:78-79``: "a control that has to be labelled 'has no effect' is
+Verdict, :ref:`ADR-117 <adr-117-decision-alternatives>`: "a control that has to
+be labelled 'has no effect' is
 worse than its absence." The correction was to reason about an **actor**, which
 may not be human, rather than a **role**, which always is — and it is why
 :php:`AiActorContext` exists.
 
 One consequence is under-read. ADR-130 pushed roles out of code and into
 documentation ("Roles are documentation-level presets (named grant bundles), not
-code", ``:36``). The documentation then invented "AI operator" and "task
+code", :ref:`ADR-130 <adr-130>`). The documentation then invented "AI operator"
+and "task
 managers". **A role nothing enforces is the same defect as a grant nothing reads,
 one layer up.**
 

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -64,6 +64,37 @@ edits that earlier record's ``:Status:`` and ``:Amended:`` in the same change.
 An accepted ADR with an expired premise and a clean ``Accepted`` status is a
 defect, not history.
 
+.. _adr-citations:
+
+How a record cites code
+=======================
+
+**Records do not cite line numbers.** A line number is invalidated by any edit
+above it in the cited file, and nothing announces that. ADR-171 cited
+``ResumeCoordinator.php:204`` for an authorisation check a later commit pushed
+to :205; it cited ``AgentRunController.php:267`` for "the list viewport", which
+by then was that file's closing brace for an unrelated method. Both still read
+as verified citations, and the second is the dangerous shape: precision is what
+makes a reviewer trust a citation.
+
+Three forms replace it, in order of preference:
+
+- **A symbol** — :php:`ResumeCoordinator::approve()`, or a class docblock named
+  as such. Survives every edit that does not rename it.
+- **A** ``:ref:`` **into the record being quoted**, with the quote in the prose.
+  ``Tests/Unit/AdrLifecycleTest.php`` already fails on a target that does not
+  resolve. Quoting an ADR by line rotted three times here, all three by the
+  same ten lines: ``9b902993`` corrected the module inventory ADR-119 opens
+  with, and every citation into that record from two others moved with it.
+- **A** ``path#anchor`` — the file plus a unique string it must still contain,
+  for configuration arrays, Fluid templates and XLIFF, which have no symbols.
+  ``Tests/Unit/AdrCodeCitationTest.php`` asserts the string is still there.
+
+A countable claim carries the command that counts it, next to the number:
+:ref:`ADR-169 <adr-169-q6>` prints its grep beside "40". A bare count is a
+positional claim with no way to fail — ADR-171 said "nine enforcement points"
+and the grep now returns ten.
+
 .. _adr-symbol-legend:
 
 Symbol legend

--- a/Tests/Unit/AdrCodeCitationTest.php
+++ b/Tests/Unit/AdrCodeCitationTest.php
@@ -27,14 +27,20 @@ use SplFileInfo;
  *
  * - a citation naming a file that is no longer in the tree, or whose basename
  *   became ambiguous;
- * - a citation pointing past the end of its file, or at a blank line.
+ * - a citation pointing past the end of its file, or at a blank line;
+ * - an anchored `path#anchor` citation whose anchor the file no longer holds.
  *
  * What it does NOT catch, stated so nobody reads more into it: a line that
  * moved onto different but non-blank code. That is the common case and the
  * dangerous one — the citation then asserts something the cited code does not
- * say, and its precision is what makes a reviewer trust it. No test can tell
- * the difference, which is the argument for citing a symbol rather than a line
- * number wherever the prose allows it.
+ * say, and its precision is what makes a reviewer trust it. ADR-171 cited
+ * AgentRunController.php:267 for "the list viewport"; :267 is that file's
+ * closing brace for an unrelated method, and every assertion here passed on it.
+ *
+ * No line-based test can tell the difference, which is why ADR-171 no longer
+ * cites lines at all: a symbol, a `:ref:` into the record it quotes, or a
+ * `path#anchor` naming a string the file must still contain. The last of those
+ * is the only citation form in this corpus a test can hold to its claim.
  *
  * Citations into TYPO3 core and sibling extensions cannot be checked here at
  * all: that code lives in .Build/vendor, which is not committed, and its line
@@ -77,10 +83,14 @@ final class AdrCodeCitationTest extends AbstractUnitTestCase
             'cms-install/Configuration/Backend/Modules.php',
             'nr-vault/Configuration/Backend/Modules.php',
         ],
-        'Adr171PersonasTheCodeAlreadyAssumes.rst' => [
-            'cms-install/Configuration/Backend/Modules.php',
-        ],
     ];
+
+    /** Suffixes an ADR in this corpus cites by line. */
+    private const CITED_EXTENSIONS = ['php', 'rst', 'html', 'xlf', 'txt'];
+
+    private const LINE_CITATION = '#([A-Za-z0-9_/.-]+\.(?:php|rst|html|xlf|txt)):(\d+)(?:-(\d+))?#';
+
+    private const ANCHORED_CITATION = '#``([A-Za-z0-9_/.-]+\.(?:php|rst|html|xlf|txt))\#([^`]+)``#';
 
     private function repositoryRoot(): string
     {
@@ -88,7 +98,11 @@ final class AdrCodeCitationTest extends AbstractUnitTestCase
     }
 
     /**
-     * Every `File.php:NNN` or `File.php:NNN-MMM` in the corpus.
+     * Every `File.ext:NNN` or `File.ext:NNN-MMM` in the corpus.
+     *
+     * Restricting this to `.php` left 28% of the corpus's citations unread —
+     * ADRs cite templates, XLIFF, the frozen api-surface file and each other by
+     * line just as readily, and one of those was pointing at a blank line.
      *
      * @return list<array{adr: string, adrLine: int, path: string, from: int, to: int}>
      */
@@ -102,7 +116,7 @@ final class AdrCodeCitationTest extends AbstractUnitTestCase
         foreach ($files as $file) {
             $lines = explode("\n", (string)file_get_contents($file));
             foreach ($lines as $index => $line) {
-                preg_match_all('#([A-Za-z0-9_/.-]+\.php):(\d+)(?:-(\d+))?#', $line, $matches, PREG_SET_ORDER);
+                preg_match_all(self::LINE_CITATION, $line, $matches, PREG_SET_ORDER);
                 foreach ($matches as $match) {
                     $citations[] = [
                         'adr'     => basename($file),
@@ -144,7 +158,7 @@ final class AdrCodeCitationTest extends AbstractUnitTestCase
                 continue;
             }
 
-            if (!$entry->isFile() || $entry->getExtension() !== 'php') {
+            if (!$entry->isFile() || !in_array($entry->getExtension(), self::CITED_EXTENSIONS, true)) {
                 continue;
             }
 
@@ -268,5 +282,68 @@ final class AdrCodeCitationTest extends AbstractUnitTestCase
             . 'unverifiable by this suite, so the list is maintained by hand: add the new entry deliberately, '
             . 'or drop one that no longer appears.',
         );
+    }
+
+    /**
+     * Every `path#anchor` citation in the corpus.
+     *
+     * @return list<array{adr: string, adrLine: int, path: string, anchor: string}>
+     */
+    private function anchoredCitations(): array
+    {
+        $files = glob($this->repositoryRoot() . '/Documentation/Adr/Adr*.rst');
+        self::assertIsArray($files);
+        self::assertNotSame([], $files);
+
+        $found = [];
+        foreach ($files as $file) {
+            $lines = explode("\n", (string)file_get_contents($file));
+            foreach ($lines as $index => $line) {
+                preg_match_all(self::ANCHORED_CITATION, $line, $matches, PREG_SET_ORDER);
+                foreach ($matches as $match) {
+                    $found[] = [
+                        'adr'     => basename($file),
+                        'adrLine' => $index + 1,
+                        'path'    => $match[1],
+                        'anchor'  => $match[2],
+                    ];
+                }
+            }
+        }
+
+        return $found;
+    }
+
+    #[Test]
+    public function everyAnchoredCitationNamesAStringItsFileStillContains(): void
+    {
+        $broken = [];
+
+        $index = $this->basenameIndex();
+
+        foreach ($this->anchoredCitations() as $citation) {
+            $where    = sprintf('%s:%d', $citation['adr'], $citation['adrLine']);
+            $resolved = $this->resolve($citation['path'], $index, $where);
+
+            if ($resolved === null) {
+                $broken[] = sprintf('%s anchors into %s, which is not in the tree', $where, $citation['path']);
+                continue;
+            }
+
+            $file = $this->repositoryRoot() . '/' . $resolved;
+            if (str_contains((string)file_get_contents($file), $citation['anchor'])) {
+                continue;
+            }
+
+            $broken[] = sprintf(
+                '%s anchors on "%s", which %s no longer contains. Either the code moved on and the '
+                . 'record needs rewriting, or the anchor was never unique enough to survive an edit.',
+                $where,
+                $citation['anchor'],
+                $citation['path'],
+            );
+        }
+
+        self::assertSame([], $broken, implode("\n", $broken));
     }
 }


### PR DESCRIPTION
Refs #793 — option 2 from the issue, applied to the record that carried the most citations, plus the convention that stops the next one reinventing them.

## The citation the existing guard passes

#807 built the cheap half deliberately and said so in its own docblock: it catches a citation naming a file that is gone, or pointing past the end of a file, or at a blank line — and *not* a line that moved onto different but non-blank code, "which is the argument for citing a symbol rather than a line number wherever the prose allows it."

That case is in the corpus:

| | |
|---|---|
| ADR-171 said | `AgentRunController.php:267` — "the list viewport" |
| Line 267 is | `    }` — the closing brace of `submitInputAction()` |
| The list viewport is | `listAction()`, at :119 |
| `AdrCodeCitationTest` said | pass, on all four assertions |

## What moved the citations, exactly

[`9b902993`](https://github.com/netresearch/t3x-nr-llm/commit/9b902993) — "docs(adr): correct the module inventory ADR-119 opens with" — added **+10 lines** near the top of ADR-119. Three citations into that record, from two different ADRs, moved off their targets in one commit and nothing failed:

- ADR-171 → `Adr119:69`, quote is at :79
- ADR-171 → `Adr119:79`, quote is at :89
- ADR-169 → `Adr119:94`, the Decision is at :104

A record correcting one of its own counts silently invalidated three other records' references to it. That is the mechanism, not an accident of one commit.

## Three forms, chosen by what the citation can carry

Not every citation converts the same way, and a surprising share of them converted to *nothing*:

1. **Delete.** The symbol was already named in the same sentence. `:php:`hasGrant()`, :php:`mayAccessSession()` and :php:`mayActOnRun()` (``AiActorContext.php:180``, ``:196``, ``:217``)` — the line numbers add no information and rot anyway.
2. **A symbol.** `ResumeCoordinator.php:205` → `:php:`ResumeCoordinator::approve()``. Survives every edit that does not rename it.
3. **A `:ref:` into the quoted record**, with the quote left in the prose. `AdrLifecycleTest` already fails on a target that does not resolve, so these get a guard for free.
4. **`path#anchor`** — the file plus a unique string it must still contain — for configuration arrays, Fluid templates and XLIFF, which have no symbols. `Configuration/Backend/Modules.php#nrllm_aitasks`, `ApprovalControls.html#argumentsJson`.

Form 4 is **the only citation shape in this corpus a test can hold to its claim**, which is why it exists rather than just dropping to a bare filename.

## The parser was reading 72% of the corpus

The regex required `.php`. ADRs cite templates, XLIFF, the frozen `api-surface.txt` and *each other* by line just as readily:

| form | count | was checked |
|---|---|---|
| `.php` | 67 | yes |
| bare class name (`AiTaskController:106`) | 11 | no |
| `.rst` | 10 | no |
| `.html` | 3 | no |
| `.txt`, `.xlf` | 2 | no |

Broadening it cost nothing — the unresolvable `.php` citations are already on the declared vendor list — and immediately turned up two more defects: the blank-line citation in ADR-119 above, and `Adr169:111` citing `Backend/SetupWizard/Index.html`, a **truncated path resolving to no file at all**. The eleven bare class names all lived in ADR-171 and are gone with it.

## Both new assertions were watched failing

A green regression test on a fixed tree proves it runs, not that it catches anything.

| control | result |
|---|---|
| anchor mangled to `wizard.field.pidX` | `Adr169…rst:112 anchors on "wizard.field.pidX", which Resources/Private/Templates/Backend/SetupWizard/Index.html no longer contains` |
| a `.rst:NNN` citation reintroduced onto a blank line | `Adr171…rst:41 cites …Adr119BackendModulePlacement.rst:94, which is blank` — previously not read at all |
| tree restored | `OK (4 tests, 144 assertions)` |

## Two claims in ADR-171 were wrong, found by converting them

Converting a citation means reading what it points at, which is the point:

- **"nine enforcement points in four classes"** is now ten. `TaskExecutionController` gained a third at `:347`. The record now prints the grep next to the number, per the ADR-169 precedent the issue cites.
- **ADR-169's quote of ADR-119** — "keep the modules under Administration for now" — was cited at `:94`, a blank line. It is at :104.

`Adr/Index.rst` gains the convention, including that a countable claim carries the command that counts it. Without it the next record reintroduces exactly what this one removed.

## Verification

| gate | result |
|---|---|
| `-s unit` (full) | 7286 tests, 24719 assertions, exit 0 |
| `-s phpstan` | No errors |
| `-s cgl -n` | SUCCESS |
| `composer ci:test:changelog` | exit 0 |
| `-s rector -n` | 65 files with **and without** this change; `AdrCodeCitationTest` was among them before it was touched. The 8.2-pinned verdict is CI's — this build resolves 8.4. |

## Scope

ADR-171 (41 citations) and the four in ADR-169 that the broadened parser caught. **ADR-169's remaining 43 are not converted here** — it is the corpus's densest citer and deserves its own diff rather than being buried in this one. Its line citations still pass the checks that existed before this PR, and now the broadened ones too.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01MNg1MysJVugv1xo2husknU)_