### PR TITLE
fix(provider): let vision() and embed() use the default configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`vision()` and `embed()` use the default configuration when no provider is pinned**, as `chat()` has since ADR-034. Handing them no provider used to throw "No provider specified and no default provider configured" on an installation that has a perfectly good default — which is what the feature services invite, since model selection is nr-llm's job. The resolved configuration drives the call (its model reaches the provider) and shows up in telemetry as itself rather than as an ad-hoc entry; a provider or model the caller named wins, and with no default configuration the call still refuses rather than picking one (#851).
+
 ### Changed
 
 - **An MCP tool whose schema uses a union now imports.** `anyOf`, `oneOf`, `allOf` and `not` are carried to the provider verbatim instead of causing the whole tool to be skipped. The rule they were caught by protects against *dropping* a constraint — which would let a model produce arguments the server rejects — and carrying one unchanged does not do that. References (`$ref`, `$defs`) and the draft-2019/2020 applicators (`if`/`then`/`else`, `dependentRequired`, `unevaluatedProperties`, …) stay refused: the first would arrive dangling because the definition block is not carried, the second have no dependable provider support. Concretely, DeepWiki's `ask_question` imports now (#848).

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -619,6 +619,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
     {
         $options ??= new EmbeddingOptions();
         [$providerKey, $optionsArray] = $this->splitProviderKey($options->toArray());
+        [$configuration, $providerKey, $optionsArray] = $this->applyDefaultConfiguration($providerKey, $optionsArray);
 
         // Cache metadata: EmbedCacheKeyBuilder returns an empty array when
         // cache_ttl <= 0 (the EmbeddingOptions::noCache() contract), so the key
@@ -640,7 +641,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         $raw = $this->pipeline->run(
             ProviderCallContext::forConfiguration(
                 ProviderOperation::Embedding,
-                $this->synthesizeTransientConfiguration(ProviderOperation::Embedding, $providerKey),
+                $configuration ?? $this->synthesizeTransientConfiguration(ProviderOperation::Embedding, $providerKey),
                 $metadata,
             ),
             function () use ($input, $optionsArray, $providerKey): array {
@@ -681,6 +682,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
     {
         $options ??= new VisionOptions();
         [$providerKey, $optionsArray] = $this->splitProviderKey($options->toArray());
+        [$configuration, $providerKey, $optionsArray] = $this->applyDefaultConfiguration($providerKey, $optionsArray);
 
         $normalisedContent = array_values(array_map(
             static function (VisionContent|array $item): VisionContent {
@@ -711,7 +713,7 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         );
 
         return $this->runThroughPipeline(
-            $this->synthesizeTransientConfiguration(ProviderOperation::Vision, $providerKey),
+            $configuration ?? $this->synthesizeTransientConfiguration(ProviderOperation::Vision, $providerKey),
             ProviderOperation::Vision,
             function () use ($normalisedContent, $optionsArray, $providerKey): VisionResponse {
                 $provider = $this->getProvider($providerKey);
@@ -1354,6 +1356,58 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         unset($optionsArray['provider']);
 
         return [$providerKey, $optionsArray];
+    }
+
+    /**
+     * Let the backend-managed default configuration drive an entry point that
+     * takes no configuration argument.
+     *
+     * `chat()` has done this since ADR-034: with no provider pinned it resolves
+     * the default configuration rather than handing `null` to the provider
+     * registry, which throws. `vision()` and `embed()` did hand it `null`, so
+     * the usage the feature services invite — options without a provider,
+     * because model selection is nr-llm's job — failed with "No provider
+     * specified and no default provider configured" on an installation that
+     * has a perfectly good default. nr-llm-compat's ai_filemetadata bridge is
+     * exactly that caller, and an image upload on a site running it died with
+     * a 500 rather than a missing alt text.
+     *
+     * The caller's own choices win: an explicitly pinned provider skips this
+     * entirely (the resolver returns null for a non-null key), and a model
+     * named in the options is left alone.
+     *
+     * @param array<string, mixed> $optionsArray
+     *
+     * @return array{0: LlmConfiguration|null, 1: string|null, 2: array<string, mixed>}
+     *                                                                                  the resolved configuration (null when none applies), the provider key to use, and the options
+     */
+    private function applyDefaultConfiguration(?string $providerKey, array $optionsArray): array
+    {
+        if ($providerKey !== null) {
+            return [null, $providerKey, $optionsArray];
+        }
+
+        $configuration = $this->configurationResolver->resolveDefaultConfiguration(null);
+        if (!$configuration instanceof LlmConfiguration) {
+            return [null, null, $optionsArray];
+        }
+
+        // The resolver only returns a configuration that HAS a model, so both
+        // lookups below are answered — but a model without a provider record
+        // would leave the key null, and then the registry throws as before
+        // rather than this method inventing a provider.
+        $model      = $configuration->getLlmModel();
+        $identifier = $model?->getProvider()?->getIdentifier();
+        if ($identifier === null || $identifier === '') {
+            return [null, null, $optionsArray];
+        }
+
+        $modelId = $model?->getModelId() ?? '';
+        if ($modelId !== '' && ($optionsArray['model'] ?? null) === null) {
+            $optionsArray['model'] = $modelId;
+        }
+
+        return [$configuration, $identifier, $optionsArray];
     }
 
     /**

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -18,6 +18,7 @@ use Netresearch\NrLlm\Domain\Model\CompletionResponse;
 use Netresearch\NrLlm\Domain\Model\EmbeddingResponse;
 use Netresearch\NrLlm\Domain\Model\LlmConfiguration;
 use Netresearch\NrLlm\Domain\Model\Model;
+use Netresearch\NrLlm\Domain\Model\Provider;
 use Netresearch\NrLlm\Domain\Model\UsageStatistics;
 use Netresearch\NrLlm\Domain\Model\VisionResponse;
 use Netresearch\NrLlm\Domain\Repository\LlmConfigurationRepository;
@@ -2067,6 +2068,114 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
     }
 
     #[Test]
+    public function visionUsesTheDefaultConfigurationWhenNoProviderIsPinned(): void
+    {
+        // The regression this exists for: a caller that names no provider —
+        // which is what the feature services invite, since model selection is
+        // nr-llm's job — used to hand null to the provider registry and get
+        // "No provider specified and no default provider configured" on an
+        // installation that has a perfectly good default. nr-llm-compat's
+        // ai_filemetadata bridge is that caller, and an image upload on a site
+        // running it answered HTTP 500.
+        $provider = new TestableVisionProvider();
+
+        $providerRecord = self::createStub(Provider::class);
+        $providerRecord->method('getIdentifier')->willReturn('openai-vision');
+
+        $model = self::createStub(Model::class);
+        $model->method('getProvider')->willReturn($providerRecord);
+        $model->method('getModelId')->willReturn('gpt-5.2-vision');
+
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn($model);
+        $config->method('hasAccessRestrictions')->willReturn(false);
+
+        $configRepo = $this->createMock(LlmConfigurationRepository::class);
+        $configRepo->method('findDefault')->willReturn($config);
+
+        $manager = $this->createLlmServiceManager(
+            $this->extensionConfigStub,
+            $this->loggerStub,
+            $this->adapterRegistryStub,
+            $this->emptyMiddlewarePipeline(),
+            self::createStub(CacheManagerInterface::class),
+            $configRepo,
+        );
+        $manager->registerProvider($provider);
+
+        $result = $manager->vision([['type' => 'text', 'text' => 'What is on this image?']]);
+
+        self::assertInstanceOf(VisionResponse::class, $result);
+
+        // The configuration drives the call rather than merely unblocking it:
+        // its model reaches the provider, which would otherwise fall back to
+        // its own hardcoded default.
+        self::assertSame('gpt-5.2-vision', $provider->capturedVisionOptions['model'] ?? null);
+    }
+
+    #[Test]
+    public function visionKeepsAModelTheCallerNamedItself(): void
+    {
+        $provider = new TestableVisionProvider();
+
+        $providerRecord = self::createStub(Provider::class);
+        $providerRecord->method('getIdentifier')->willReturn('openai-vision');
+
+        $model = self::createStub(Model::class);
+        $model->method('getProvider')->willReturn($providerRecord);
+        $model->method('getModelId')->willReturn('gpt-5.2-vision');
+
+        $config = self::createStub(LlmConfiguration::class);
+        $config->method('getLlmModel')->willReturn($model);
+        $config->method('hasAccessRestrictions')->willReturn(false);
+
+        $configRepo = $this->createMock(LlmConfigurationRepository::class);
+        $configRepo->method('findDefault')->willReturn($config);
+
+        $manager = $this->createLlmServiceManager(
+            $this->extensionConfigStub,
+            $this->loggerStub,
+            $this->adapterRegistryStub,
+            $this->emptyMiddlewarePipeline(),
+            self::createStub(CacheManagerInterface::class),
+            $configRepo,
+        );
+        $manager->registerProvider($provider);
+
+        $manager->vision(
+            [['type' => 'text', 'text' => 'What is on this image?']],
+            new VisionOptions(model: 'a-model-the-caller-picked'),
+        );
+
+        self::assertSame('a-model-the-caller-picked', $provider->capturedVisionOptions['model'] ?? null);
+    }
+
+    #[Test]
+    public function visionStillThrowsWhenThereIsNoDefaultConfigurationEither(): void
+    {
+        // The fallback resolves a default, it does not invent one: with no
+        // default configuration and no pinned provider the call must still say
+        // so rather than picking a provider silently (ADR-034).
+        $configRepo = $this->createMock(LlmConfigurationRepository::class);
+        $configRepo->method('findDefault')->willReturn(null);
+
+        $manager = $this->createLlmServiceManager(
+            $this->extensionConfigStub,
+            $this->loggerStub,
+            $this->adapterRegistryStub,
+            $this->emptyMiddlewarePipeline(),
+            self::createStub(CacheManagerInterface::class),
+            $configRepo,
+        );
+        $manager->registerProvider($this->provider);
+
+        $this->expectException(ProviderException::class);
+        $this->expectExceptionMessage('No provider specified and no default provider configured');
+
+        $manager->vision([['type' => 'text', 'text' => 'test']]);
+    }
+
+    #[Test]
     public function chatThrowsWhenNoDefaultConfigurationAndNoProviderPinned(): void
     {
         $configRepo = $this->createMock(LlmConfigurationRepository::class);
@@ -2917,6 +3026,14 @@ class TestableProvider extends AbstractProvider
      */
     public array $capturedMessages = [];
 
+    /**
+     * The options the last analyzeImage() call was handed — the caller's own,
+     * plus whatever the manager resolved on their behalf.
+     *
+     * @var array<string, mixed>
+     */
+    public array $capturedVisionOptions = [];
+
     public function __construct(
         private readonly string $id = 'openai',
         private readonly string $providerName = 'OpenAI',
@@ -3045,6 +3162,7 @@ class TestableVisionProvider extends TestableProvider implements VisionCapableIn
     public function analyzeImage(array $content, array $options = []): VisionResponse
     {
         $this->capturedContent = $content;
+        $this->capturedVisionOptions = $options;
 
         return $this->nextVisionResponse ?? new VisionResponse(
             description: 'Default description',


### PR DESCRIPTION
Fixes #851: `vision()` and `embed()` now resolve the backend-managed default configuration when the caller pins no provider, which `chat()` has done since ADR-034.

**What was happening.** Both handed the provider key straight to the registry, so a `null` key threw `No provider specified and no default provider configured` — on installations that have a perfectly good default. That is the usage the feature services invite: options without a provider, because model selection is nr-llm's job rather than the caller's.

**Two user-visible failures on typo3-demo came from this one gap.** An image upload in the AI-chat module answered `HTTP 500`, because `mfd/ai-filemetadata` generates an alt text inside the upload request and nr-llm-compat routes that through `VisionServiceInterface`. And with vision resolution failing, `getProviderCapabilities()` reported `visionSupported: false`, so a *selected* image was never expanded into the message and the assistant answered that it saw no image. The instance log carries the exception with `request_url = /typo3/ajax/ai-chat/file-upload`.

**What the fix does, and what it deliberately does not.** The resolved configuration drives the call rather than merely unblocking it: its model reaches the provider (which would otherwise fall back to its own hardcoded default), and the pipeline context carries the real configuration instead of a synthesised ad-hoc one, so budget and telemetry attribute the call to it. The caller keeps precedence — an explicitly pinned provider skips the resolution entirely, and a model named in the options is left alone. With no default configuration, or one that is model-less or access-restricted, the call still refuses: the resolver's existing guards apply unchanged, so this resolves a default rather than inventing one.

`embed()` had the identical asymmetry and is fixed in the same commit; the issue asked for the siblings to be checked rather than only the reported one. The specialized services (image, speech, DeepL) resolve differently and are not touched here — their attribution gap is #844.

**Tests.** Three new cases: the default configuration is used and its model arrives at the provider; a caller-named model survives; and with no default configuration the call still throws. Watched failing before being kept — removing the fallback again reproduces the demo's exception verbatim in two of them.

Gates run locally: cgl, PHPStan level 10, the full unit suite (7288 tests), and the changelog check. CI covers the eight-cell matrix.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_0144iD1P22LotW8rxmxrNGro)_
