### PR TITLE
docs(adr): retire every line citation in the corpus, and three of them were wrong

### DIFF
--- a/Documentation/Adr/Adr140EffectivePolicyReadoutWithoutApplyPath.rst
+++ b/Documentation/Adr/Adr140EffectivePolicyReadoutWithoutApplyPath.rst
@@ -67,7 +67,7 @@ A read-only view, in an existing module, reading through the runtime resolvers.
    resolver exposes provenance, and it is not reconstructable from the stored
    configuration either: TYPO3's own
    :php:`ExtensionConfiguration::synchronizeExtConfTemplateWithLocalConfigurationOfAllExtensions()`
-   (``ExtensionConfiguration.php:197-218``) merges every ``ext_conf_template.txt``
+   merges every ``ext_conf_template.txt``
    default into ``settings.php`` whenever an unknown key is read or the Install
    Tool is entered. By the time anything could ask, the shipped defaults are
    already stored values.
@@ -92,21 +92,21 @@ The only API for writing extension configuration is
 :php:`ExtensionConfiguration::set()`. Three properties, each verified against
 the shipped core:
 
-- **It is ``@internal``** (``ExtensionConfiguration.php:150``) and documented as
-  *"Set a full extension configuration"* — it takes the whole array and calls
-  :php:`setLocalConfigurationValueByPath('EXTENSIONS/' . $extension, $value)`
-  (``:166``). There is no per-key write.
+- **It is ``@internal``** and documented as *"Set a full extension
+  configuration"* — it takes the whole array and calls
+  :php:`setLocalConfigurationValueByPath('EXTENSIONS/' . $extension, $value)`.
+  There is no per-key write.
 - **It materialises every shipped default.** A caller has no source for the
   array other than :php:`get()`, which returns the template-merged result. Our
-  own :php:`DataClassEnforcementDefaultUpdateWizard::executeUpdate()`
-  (``Classes/Updates/DataClassEnforcementDefaultUpdateWizard.php:77-85``) does
+  own :php:`DataClassEnforcementDefaultUpdateWizard::executeUpdate()` does
   exactly this: ``get()`` → mutate one key → ``set()``. Every default in
   ``ext_conf_template.txt`` becomes an explicitly stored value.
-  :php:`storedEnforcement()` (``:121-131``) — the "did the operator ever choose
+  :php:`storedEnforcement()` — the "did the operator ever choose
   a mode?" probe :ref:`ADR-115 <adr-115>`'s wizard depends on — could then never
   return ``null`` again.
-- **``additional.php`` spoils it.** The core docblock says so outright
-  (``ExtensionConfiguration.php:145-146``): if that file overwrites a setting,
+- **``additional.php`` spoils it.** The core docblock on
+  :php:`ExtensionConfiguration::set()` says so outright: if that file
+  overwrites a setting,
   ``->set()`` "may not end up as expected". An apply button would report success
   and the next request would serve the old value — the worst failure mode a
   governance UI can have.

--- a/Documentation/Adr/Adr169RecordManagementUsesTypo3Permissions.rst
+++ b/Documentation/Adr/Adr169RecordManagementUsesTypo3Permissions.rst
@@ -50,17 +50,17 @@ its enforcement point (its Decision, "Grants, not roles"). That rule exists
 because :ref:`ADR-023 <adr-023>` shipped backend-group checkboxes that gated
 nothing and :ref:`ADR-117 <adr-117>` had to remove them: "a control that has to
 be labelled 'has no effect' is worse than its absence"
-(``Adr117WithdrawCapabilityPermissions.rst:78-79``).
+(:ref:`ADR-117 <adr-117-decision-alternatives>`).
 
 Issue `#768` asks seven questions that have to be answered together before that
 surface is built. This record recommends answers and settles none of them.
 
 **Version scoping.** Every claim about core reach is read off the TYPO3 version
-resolved in this worktree — 14.3.5 (``Typo3Version.php:22``). The blocking
+resolved in this worktree — 14.3.5 (:php:`Typo3Version`). The blocking
 matrix is ``^13.4 || ^14.3`` (``composer.json``). 13.4 reaches the same
 capability through :php:`BackendUtility::isRootLevelRestrictionIgnored()`,
-deprecated in 14.0 in favour of the Schema API
-(``BackendUtility.php:2963-2967``); its call sites were not enumerated here.
+deprecated in 14.0 in favour of the Schema API; its call sites were not
+enumerated here.
 
 .. _adr-169-decision:
 
@@ -75,27 +75,26 @@ Decision
 `#768` asks how ``rootLevel => -1`` is solved technically. The prior question is
 where the records should live.
 
-**``rootLevel => -1`` is not root-only.** ``RootLevelCapability.php:26-28``
+**``rootLevel => -1`` is not root-only.** :php:`RootLevelCapability`
 defines the three values: ``TYPE_ONLY_ON_PAGES = 0``,
 ``TYPE_ONLY_ON_ROOTLEVEL = 1``, ``TYPE_BOTH = -1 // does not matter``. All nine
 ``tx_nrllm_*`` tables use ``-1``, and none sets
 ``security.ignoreRootLevelRestriction`` (zero hits repo-wide).
 
-:php:`DataHandler::isTableAllowedForThisPage()` (``DataHandler.php:7484-7503``)
-splits on the pid, not on the flag:
+:php:`DataHandler::isTableAllowedForThisPage()` splits on the pid, not on the
+flag:
 
-- the rootLevel early return is skipped entirely for ``TYPE_BOTH`` (``:7491-7496``);
-- at pid 0 the test is :php:`isAdmin() || shallIgnoreRootLevelRestriction()`
-  (``:7498-7499``);
+- the rootLevel early return is skipped entirely for ``TYPE_BOTH``;
+- at pid 0 the test is :php:`isAdmin() || shallIgnoreRootLevelRestriction()`;
 - at a non-zero pid the only remaining test is
-  :php:`isRecordTypeAllowedForDoktype()` (``:7502``).
+  :php:`isRecordTypeAllowedForDoktype()`.
 
 The permission check runs alongside it and splits the same way.
 :php:`hasPermissionToInsert()` passes :php:`VirtualRecord::RootPage` only when
-the pid is 0 (``:7466``), and the update path resolves the real page record
-whenever ``pid > 0`` (``:872-876``). :php:`hasPageContextPermission()` then
-answers a root page from the flag (``:7669-7674``) but a real page from the web
-mount (``:7677``) and the ``perms_*`` bitmask (``:7696-7705``).
+the pid is 0, and :php:`DataHandler::process_datamap()` resolves the real page
+record whenever ``pid > 0``. :php:`hasPageContextPermission()` then answers a
+root page from the flag, but a real page from the web mount and the ``perms_*``
+bitmask.
 
 .. list-table::
    :header-rows: 1
@@ -110,24 +109,28 @@ mount (``:7677``) and the ``perms_*`` bitmask (``:7696-7705``).
 **This is not theoretical for this extension.** The setup wizard renders a
 "Storage Folder (Page ID)" input
 (``Resources/Private/Templates/Backend/SetupWizard/Index.html#wizard.field.pid``),
-whose value reaches ``saveAction`` (``SetupWizardController.php:301``) and is
-written onto the provider (``:372-374``), every model (``:449``) and every
-configuration (``:525``) with no page check. All eight Extbase repositories set
-:php:`setRespectStoragePage(false)`, and the ninth table's plain repository
-issues no pid predicate at all (``McpServerRepository.php:48-49``, ``:83-85``,
-``:98-100``). A page-stored record is found by the runtime exactly like a
+whose value reaches :php:`SetupWizardController::saveAction()` and is written
+onto the provider by :php:`persistWizardResult()`, onto every model by
+:php:`createModels()` and onto every configuration by
+:php:`createConfigurations()`, with no page check. All eight Extbase
+repositories set :php:`setRespectStoragePage(false)`, and the ninth table's
+plain repository issues no pid predicate at all —
+:php:`McpServerRepository::findAll()`, :php:`findEnabled()` and
+:php:`findByUid()`. A page-stored record is found by the runtime exactly like a
 pid-0 one.
 
 **Option R — open ``security.ignoreRootLevelRestriction`` and keep the records
 at pid 0.** It is a table capability, so it answers for the whole installation
 at once. Every core pid-0 branch opens with it: the FormEngine edit and create
 forms, which set :php:`Permission::ALL` on the root node
-(``DatabaseUserPermissionCheck.php:100-102``, ``:133-135``), clipboard
-copy/cut/paste (``Clipboard.php:709-712``), the suggest wizard on any relation
-field in any extension (``SuggestWizardController.php:213-217``), record
-information (``ElementInformationController.php:109``, ``:769``), history and
-rollback (``ElementHistoryController.php:539-541``, ``RecordHistory.php:527``)
-and the list module's hide/show toggle (``RecordListController.php:273-279``).
+(:php:`DatabaseUserPermissionCheck::addData()`), clipboard copy/cut/paste
+(:php:`Clipboard::isRecordAccessAllowed()`), the suggest wizard on any relation
+field in any extension
+(:php:`SuggestWizardController::currentBackendUserMayAccessTable()`), record
+information (:php:`ElementInformationController::canAccessPage()`), history and
+rollback (:php:`ElementHistoryController::getEditLockFromElement()`,
+:php:`RecordHistory::hasPageAccess()`) and the list module's hide/show toggle
+(:php:`RecordListController::toggleRecordVisibilityAction()`).
 
 **Option P — store management-owned records on a page inside a web mount.** It
 needs no core-permission change and gives page-level granularity a global flag
@@ -150,9 +153,9 @@ blast radius.
 storage-folder field and granted a non-admin group ``tables_modify`` on a
 ``tx_nrllm_*`` table has an editing surface nobody decided to open. ``api_key``
 and ``auth_credential`` are still gated there, because
-:php:`VaultFieldHelper::getSecureFieldConfig()` sets ``exclude => true``
-(``VaultFieldHelper.php:94-97``, ``:120``) and ``DataHandler.php:1114`` reads
-it. Nothing else is: the extension's own TCA declares zero ``exclude`` keys, so
+:php:`VaultFieldHelper::getSecureFieldConfig()` sets ``exclude => true`` and
+:php:`DataHandler::fillInFieldArray()` reads it. Nothing else is: the
+extension's own TCA declares zero ``exclude`` keys, so
 ``endpoint_url``, ``allowed_groups``, the ``cost_*`` fields and the
 ``max_*_per_day`` caps travel with ``tables_modify``. That is not acceptable,
 and choosing a UI does not fix it — the remedy is the field boundary in
@@ -172,20 +175,19 @@ on different reasons, which matters when one of them is argued back in:
 - Provider, MCP server and skill source hold credentials and name the host the
   extension talks to. ``trust_zone`` on the provider is the ceiling forced
   context sources bind against (:ref:`ADR-164 <adr-164>`;
-  :php:`TrustZoneResolver::zoneForProvider()`, ``TrustZoneResolver.php:48-50``).
+  :php:`TrustZoneResolver::zoneForProvider()`).
 - ``tx_nrllm_skill`` is written by the sync and its ``trust_level`` is
   denormalised from the source, where the authoritative edit lives
-  (``Configuration/TCA/tx_nrllm_skill_source.php:119-122``).
+  (``tx_nrllm_skill_source.php#trust_level``).
 - ``tx_nrllm_model`` holds no credential. It is out because
   ``cost_input`` / ``cost_output`` are what :php:`Model::estimateCost()`
-  multiplies (``Model.php:668-673``) when the provider reports no cost
-  (``UsageMiddleware.php:186-187``). Halving them doubles everyone's effective
+  multiplies when the provider reports no cost, in
+  :php:`UsageMiddleware::track()`. Halving them doubles everyone's effective
   spend without touching a budget record.
 - ``tx_nrllm_user_budget`` names a ``be_user`` and sets that user's ceiling.
 
-Within ``tx_nrllm_configuration``, ``allowed_groups`` (``:413``) is the one
-gate that already works for non-admins
-(:php:`LlmConfigurationService::hasAccess()`, ``:127-143``, per
+Within ``tx_nrllm_configuration``, ``allowed_groups`` is the one gate that
+already works for non-admins (:php:`LlmConfigurationService::hasAccess()`, per
 :ref:`ADR-070 <adr-070>`). Whoever can edit it can grant their own group access
 to every configuration.
 
@@ -198,25 +200,26 @@ and what replaces the reason above.
 -------------------------------------------
 
 Both wizards write through Extbase repositories and :php:`persistAll()`:
-:php:`TaskWizardController::wizardCreateAction()` (``:234-235``, ``:254-255``)
-and :php:`SetupWizardController::persistWizardResult()` (``:376-377``,
-``:379-383``). Nothing in ``Classes/`` constructs a :php:`DataHandler` for a
+:php:`TaskWizardController::wizardCreateAction()` and
+:php:`SetupWizardController::persistWizardResult()`. Nothing in ``Classes/``
+constructs a :php:`DataHandler` for a
 ``tx_nrllm_*`` table. Five tools construct one, and they write ``tt_content``,
 ``pages`` and ``sys_file_metadata``: :php:`CreateContentElementDraftTool`,
 :php:`MoveContentElementTool`, :php:`CreateTranslationDraftTool`,
 :php:`SetFileAlternativeTextTool` and :php:`UpdatePageMetadataTool`.
 
 **Does not run on the repository path:** record permissions
-(``DataHandler.php:7428-7443``, ``:7657-7707``), the insert check
-(``:7466-7473``), exclude fields (``:1114``), TCA ``eval`` / ``required`` /
+(:php:`DataHandler::hasPermissionToUpdate()`,
+:php:`DataHandler::hasPageContextPermission()`), the insert check
+(:php:`DataHandler::hasPermissionToInsert()`), exclude fields
+(:php:`DataHandler::fillInFieldArray()`), TCA ``eval`` / ``required`` /
 ``range`` / ``items``, ``sys_history``, the reference index, and the
-extension's own hook :php:`ProviderEndpointNormalizationHook`
-(``:39-60``).
+extension's own hook :php:`ProviderEndpointNormalizationHook`.
 
-**Does run:** whatever the controller wrote by hand. ``TaskWizardController``
-clamps temperature, ``max_tokens``, ``top_p`` and both penalties (``:224-228``)
-and allow-lists ``category`` and ``output_format`` (``:243-251``);
-``SetupWizardController`` truncates the label (``:367``). Those are hand-rolled
+**Does run:** whatever the controller wrote by hand. The same
+:php:`wizardCreateAction()` clamps temperature, ``max_tokens``, ``top_p`` and
+both penalties and allow-lists ``category`` and ``output_format``; the same
+:php:`persistWizardResult()` truncates the label. Those are hand-rolled
 equivalents of TCA ``range``, ``eval`` and ``items``, kept in step with the TCA
 by nothing.
 
@@ -228,11 +231,12 @@ by nothing.
 **Option A — link into FormEngine.** What it buys is already written: 27
 ``required`` declarations, 7 ``eval`` rules, 30 ``select`` fields with their
 item sets, 3 MM relations, 3 ``displayCond``, three ``itemsProcFunc`` providers
-(``tx_nrllm_configuration.php:433``, ``:443``, ``:453``), the
-``modelIdWithFetch`` render type (``tx_nrllm_model.php:132``), the
-``modelConstraintsWizard`` field wizard (``tx_nrllm_configuration.php:152-153``),
-``sys_history`` with rollback, the reference index, and the exclude boundary at
-``DataHandler.php:1114``.
+(``grep -c itemsProcFunc Configuration/TCA/tx_nrllm_configuration.php``), the
+``modelIdWithFetch`` render type (``tx_nrllm_model.php#modelIdWithFetch``), the
+``modelConstraintsWizard`` field wizard
+(``tx_nrllm_configuration.php#modelConstraintsWizard``), ``sys_history`` with
+rollback, the reference index, and the exclude boundary at
+:php:`DataHandler::fillInFieldArray()`.
 
 **Option B — a purpose-built write path, TCA untouched.** One door, so an
 nr_llm grant would be a real control. It costs every validation above,
@@ -240,20 +244,18 @@ re-expressed in PHP and kept in step by hand; it costs ``sys_history``, so no
 audit of who changed a system prompt and no rollback; and the exclude boundary
 becomes an explicit field allow-list, because a generic field mapper writes
 ``github_token`` precisely because FormEngine cannot see it
-(``type => 'passthrough'``, ``tx_nrllm_skill_source.php:114-118``).
+(``type => 'passthrough'``, ``tx_nrllm_skill_source.php#github_token``).
 
 **Option C — Option A plus ``exclude => true`` on the fields that must not
 travel with ``tables_modify``:** ``tx_nrllm_configuration``'s
-``system_prompt_data_class`` (``:222``), ``max_requests_per_day`` (``:339``),
-``max_tokens_per_day`` (``:351``), ``max_cost_per_day`` (``:363``),
-``allowed_groups`` (``:413``), ``allowed_tool_groups`` (``:427``),
-``allowed_guardrails`` (``:437``), and ``tx_nrllm_promptsnippet``'s
-``data_class`` (``:100``).
+``system_prompt_data_class``, ``max_requests_per_day``, ``max_tokens_per_day``,
+``max_cost_per_day``, ``allowed_groups``, ``allowed_tool_groups`` and
+``allowed_guardrails``, and ``tx_nrllm_promptsnippet``'s ``data_class``.
 
 **Recommendation: Option C**, and it does not depend on section 1's outcome.
 :php:`TcaItemsProcessorFunctions::getGroupedExcludeFields()` skips a table only
-when it is ``TYPE_ONLY_ON_ROOTLEVEL`` without the flag
-(``TcaItemsProcessorFunctions.php:271``), so these ``TYPE_BOTH`` tables already
+when it is ``TYPE_ONLY_ON_ROOTLEVEL`` without the flag, so these ``TYPE_BOTH``
+tables already
 appear in the be_groups picker. The flags are assignable today, and under
 Option P they are the field boundary from the first day the surface exists.
 
@@ -297,8 +299,9 @@ now" (:ref:`ADR-119 <adr-119-decision>`) and already carries the status
 ``Accepted (deferred — the placement is not finally settled, see Revisit)``. Its
 trigger is "the first cross-consumer editor surface … a personal
 usage-and-budget view, a personal run history, or a lead-editor view over a
-group" (``:105-108``), and it pre-settles four answers for that case
-(``:110-129``): the section is called "AI"; the identifier is
+group" (:ref:`ADR-119 <adr-119-decision>`), and it pre-settles four answers for
+that case (:ref:`ADR-119 <adr-119-revisit>`): the section is called "AI"; the
+identifier is
 ``netresearch_ai``, never a bare ``ai``; the flat entries are grouped by subject
 first; old routes keep working through kept identifiers plus
 ``'aliases' => ['nrllm']``.
@@ -313,10 +316,11 @@ what that surface will become, not what it is.
 What has changed is the count and the constraint. ADR-119 describes twelve
 submodules; ``nrllm`` now has fourteen children, with ``nrllm_aitasks``
 registered outside it under ``parent => 'web'``
-(``Configuration/Backend/Modules.php:342-344``; 16 ``'parent'`` keys in the
-file). It sits there for a verified platform reason: the module menu drops every
-top-level module whose own access check fails, so a child of the admin-only
-``nrllm`` (``:53``) would be invisible to non-admins
+(``Configuration/Backend/Modules.php#nrllm_aitasks``; ``grep -c "'parent'"
+Configuration/Backend/Modules.php`` returns 16). It sits there for a verified
+platform reason: the module menu drops every top-level module whose own access
+check fails, so a child of the admin-only ``nrllm`` would be invisible to
+non-admins
 (:ref:`ADR-131 <adr-131>`, Context). A management surface has that same
 constraint.
 
@@ -338,37 +342,44 @@ settled, so nothing is misrepresented by leaving it.
 ``grep -rn 'denyNonAdmin()) instanceof' Classes/Controller/`` returns 40 sites.
 All 40, by what the action touches:
 
-- **Credential- or egress-bearing** (18): ``SetupWizardController`` ``:144``,
-  ``:170``, ``:204``, ``:241``, ``:288``;
-  ``ProviderController::testConnection`` ``:203``;
-  ``ConfigurationController::testConfiguration`` ``:369``;
-  ``ModelController::verifyCapabilities`` ``:238``;
-  ``ModelDiscoveryController`` ``:63``, ``:156``; ``ModelTestController``
-  ``:97``; ``SpecializedTestController`` ``:69``, ``:154``;
-  ``SkillSourceController::sync`` ``:107`` and ``::setToken`` ``:176``;
-  ``McpServerController::namedServer`` ``:240``; ``LlmModuleController``
-  ``:206``, ``:249``.
+- **Credential- or egress-bearing** (18): :php:`SetupWizardController` —
+  ``detectAction()``, ``testAction()``, ``discoverAction()``,
+  ``generateAction()``, ``saveAction()``;
+  :php:`ProviderController::testConnectionAction()`;
+  :php:`ConfigurationController::testConfigurationAction()`;
+  :php:`ModelController::verifyCapabilitiesAction()`;
+  :php:`ModelDiscoveryController` — ``fetchAvailableModelsAction()``,
+  ``detectLimitsAction()``; :php:`ModelTestController::testModelAction()`;
+  :php:`SpecializedTestController` — ``translateAction()``,
+  ``generateImageAction()``; :php:`SkillSourceController` — ``syncAction()``,
+  ``setTokenAction()``; :php:`McpServerController::namedServer()`;
+  :php:`LlmModuleController` — ``reachabilityAction()``,
+  ``executeTestAction()``.
 - **Arbitrary table reads** (3), reserved admin-only by ADR-130 constraint 5:
-  ``TaskRecordsController`` ``:67``, ``:90``, ``:158``.
+  :php:`TaskRecordsController` — ``listTablesAction()``,
+  ``fetchRecordsAction()``, ``loadRecordDataAction()``.
 - **Agent execution on the admin playground** (3, :ref:`ADR-038 <adr-038>`):
-  ``ToolPlaygroundController`` ``:155``, ``:294``, ``:367``.
+  :php:`ToolPlaygroundController` — ``runAction()``, ``resumeAction()``,
+  ``submitInputAction()``.
 - **Site-wide tool kill switch** (2, :ref:`ADR-039 <adr-039>`):
-  ``ToolController`` ``:80``, ``:108``.
+  :php:`ToolController` — ``toggleToolAction()``, ``toggleToolGroupAction()``.
 - **Record-state toggles duplicating a TCA field** (6):
-  ``ProviderController::toggleActive`` ``:150``; ``ModelController`` ``:164``,
-  ``:200``; ``ConfigurationController`` ``:256``, ``:290``;
-  ``SkillSourceController::toggleSkill`` ``:132``.
+  :php:`ProviderController::toggleActiveAction()`; :php:`ModelController` —
+  ``toggleActiveAction()``, ``setDefaultAction()``;
+  :php:`ConfigurationController` — ``toggleActiveAction()``,
+  ``setDefaultAction()``; :php:`SkillSourceController::toggleSkillAction()`.
 - **Read-only lookups behind the admin gate** (6):
-  ``ModelController::getByProvider`` ``:287``; ``ConfigurationController``
-  ``:321``, ``:448``; ``SpecializedTestController::translators`` ``:135``;
-  ``PresetController`` ``:71``, ``:145``.
+  :php:`ModelController::getByProviderAction()`; :php:`ConfigurationController`
+  — ``getModelsAction()``, ``getModelConstraintsAction()``;
+  :php:`SpecializedTestController::translatorsAction()`;
+  :php:`PresetController` — ``listPresetsAction()``, ``diffAction()``.
 - **Bulk creation of AI-behaviour records, no credential** (2):
-  ``PresetController::import`` ``:112``, ``::update`` ``:183``.
+  :php:`PresetController` — ``importAction()``, ``updateAction()``.
 
 Two module-route actions write without a per-action gate, module-gated only, as
 ADR-130 constraint 4 states: :php:`TaskWizardController::wizardCreateAction()`
-(``:193``) and :php:`UseCasePackController::installAction()` (``:129``, via
-``UseCasePackInstaller.php:150-172``).
+and :php:`UseCasePackController::installAction()`, the latter writing through
+:php:`UseCasePackInstaller::install()`.
 
 **Recommendation: no grant case is added; the last bucket moves onto the
 DataHandler.** Once preset import and use-case-pack install write as the acting
@@ -377,7 +388,7 @@ same control as every other write.
 
 **The tool kill switch does not fit that argument.** ``tx_nrllm_tool_state`` has
 no TCA
-(``Classes/Service/Tool/ToolStateRepository.php:30``; ``Configuration/TCA/``
+(``ToolStateRepository.php#tx_nrllm_tool_state``; ``Configuration/TCA/``
 holds nine files, none of them this table), so ``tables_modify`` cannot express
 it even in principle. It stays admin-only because :ref:`ADR-039 <adr-039>`
 decided it is a hard admin kill switch — an earlier decision, not a consequence
@@ -395,24 +406,26 @@ Four extension-owned fields. Three are protected by where the code is, not by
 the TCA.
 
 ``tx_nrllm_provider.api_key`` and ``tx_nrllm_mcp_server.auth_credential`` carry
-``exclude => true`` from ``VaultFieldHelper.php:120``, read at
-``DataHandler.php:1114``. That holds on the DataHandler path only:
-``SetupWizardController.php:370`` and ``SetProviderApiKeyCommand.php:161`` write
-``api_key`` directly, while ``auth_credential`` has no setter in ``Classes/`` at
-all, only a read (``McpServerRepository.php:174``) — safe by the absence of a
-writer, which is a fact about the current code, not a boundary.
+``exclude => true`` from :php:`VaultFieldHelper::getSecureFieldConfig()`, read
+by :php:`DataHandler::fillInFieldArray()`. That holds on the DataHandler path
+only: :php:`SetupWizardController::persistWizardResult()` and
+:php:`SetProviderApiKeyCommand::execute()` write ``api_key`` directly, while
+``auth_credential`` has no setter in ``Classes/`` at all, only a read
+(:php:`McpServerRepository::hydrate()`) — safe by the absence of a writer, which
+is a fact about the current code, not a boundary.
 ``tx_nrllm_provider.endpoint_url`` has no flag on either path
-(``tx_nrllm_provider.php:145-155``). ``tx_nrllm_skill_source.github_token`` is
-``type => 'passthrough'`` (``:114-118``) and written only by
-``SkillSourceController.php:190`` behind :php:`denyNonAdmin()`; a generic field
+(``tx_nrllm_provider.php#endpoint_url``). ``tx_nrllm_skill_source.github_token``
+is ``type => 'passthrough'`` (``tx_nrllm_skill_source.php#github_token``) and
+written only by :php:`SkillSourceController::setTokenAction()` behind
+:php:`denyNonAdmin()`; a generic field
 mapper would write it precisely because FormEngine cannot see it.
 
 Two more are outside nr_llm's authority. Vault configuration lives in nr-vault's
 modules, which are ``access => 'user'`` with per-action ``VaultPermission``
 assertions and a comment forbidding re-tightening to ``admin``
-(``nr-vault/Configuration/Backend/Modules.php:33-39``). Extension configuration
-is edited in the Settings module, ``'access' => 'systemMaintainer'``
-(``cms-install/Configuration/Backend/Modules.php:32``) — stricter than admin.
+(``nr-vault/Configuration/Backend/Modules.php``). Extension configuration is
+edited in the Settings module, ``'access' => 'systemMaintainer'``
+(``cms-install/Configuration/Backend/Modules.php``) — stricter than admin.
 
 .. _adr-169-routing:
 
@@ -421,15 +434,15 @@ Routing policy: closed, not deferred
 
 :ref:`ADR-140 <adr-140>` decided a read-only view — decision item 4 is "No apply
 path. See below — this is the actual decision"
-(``Adr140EffectivePolicyReadoutWithoutApplyPath.rst:64``, reasoning at ``:88``);
-:ref:`ADR-145 <adr-145>` amends it as "the readout gains consumers, not an apply
-path" (``:10``, ``:47``); the code repeats it at
-``EffectivePolicyReadout.php:38``, ``GovernanceProfileEvaluator.php:21``,
-``GovernanceProfileDeviation.php:15`` and ``LlmModuleController.php:296``. The
-policy mode itself is a per-call argument
-(:php:`RoutingDecisionService::decide()`, ``:62``), defaulting from extension
-configuration (``:106``, ``:110``, ``:120-122``; ``ext_conf_template.txt:132``)
-in the ``systemMaintainer`` Settings module. A grant over it would sit in front
+(:ref:`ADR-140 <adr-140>`); :ref:`ADR-145 <adr-145>` amends it as "the readout
+gains consumers, not an apply path"; the code repeats it in the class docblocks
+of :php:`EffectivePolicyReadout`, :php:`GovernanceProfileEvaluator` and
+:php:`GovernanceProfileDeviation`, and in
+:php:`LlmModuleController::executeTestAction()`. The policy mode itself is a
+per-call argument (:php:`RoutingDecisionService::decide()`), defaulting from
+extension configuration in :php:`RoutingDecisionService::policyMode()`, which
+reads ``ext_conf_template.txt#routing.policyMode`` in the ``systemMaintainer``
+Settings module. A grant over it would sit in front
 of a read-only view and a function argument. Dropped from scope.
 
 .. _adr-169-consequences:

--- a/Documentation/Adr/Adr174PerCallCostAndPreRoutingFacts.rst
+++ b/Documentation/Adr/Adr174PerCallCostAndPreRoutingFacts.rst
@@ -159,9 +159,9 @@ percent, with the fit's figure the larger one.
 bounded list, ``facts_token_estimate`` the list the caller handed over.
 
 *The configuration's system prompt, when the transcript does not already open
-with one.* ``missingSystemPromptTokens()`` returns 0 when ``$messages[0]`` is a
-system message, and 0 again when the effective prompt is empty
-(``ContextWindowManager.php:231``); otherwise it charges that prompt — per-call
+with one.* :php:`ContextWindowManager::missingSystemPromptTokens()` returns 0
+when ``$messages[0]`` is a system message, and 0 again when the effective prompt
+is empty; otherwise it charges that prompt — per-call
 override and composed snippets included. On a configuration without a system
 prompt this difference is therefore absent. Neither figure holds that prompt as text; it is a
 charge the fit adds beside its transcript estimate, which is why it moves this

--- a/Tests/Unit/AdrCodeCitationTest.php
+++ b/Tests/Unit/AdrCodeCitationTest.php
@@ -60,28 +60,16 @@ final class AdrCodeCitationTest extends AbstractUnitTestCase
      * by this suite; the list exists so a NEW unverifiable citation fails
      * rather than passing as one of these.
      *
+     * It shrank from fifteen entries to one when ADR-169 stopped citing core
+     * by line: a core symbol survives a patch release, a core line number does
+     * not, and this repository does not pin the dependency whose line numbers
+     * those were.
+     *
      * @var array<string, list<string>>
      */
     private const CITATIONS_OUTSIDE_THE_REPOSITORY = [
         'Adr140EffectivePolicyReadoutWithoutApplyPath.rst' => [
             'ExtensionConfiguration.php',
-        ],
-        'Adr169RecordManagementUsesTypo3Permissions.rst' => [
-            'BackendUtility.php',
-            'Clipboard.php',
-            'DataHandler.php',
-            'DatabaseUserPermissionCheck.php',
-            'ElementHistoryController.php',
-            'ElementInformationController.php',
-            'RecordHistory.php',
-            'RecordListController.php',
-            'RootLevelCapability.php',
-            'SuggestWizardController.php',
-            'TcaItemsProcessorFunctions.php',
-            'Typo3Version.php',
-            'VaultFieldHelper.php',
-            'cms-install/Configuration/Backend/Modules.php',
-            'nr-vault/Configuration/Backend/Modules.php',
         ],
     ];
 

--- a/Tests/Unit/AdrCodeCitationTest.php
+++ b/Tests/Unit/AdrCodeCitationTest.php
@@ -42,37 +42,21 @@ use SplFileInfo;
  * `path#anchor` naming a string the file must still contain. The last of those
  * is the only citation form in this corpus a test can hold to its claim.
  *
- * Citations into TYPO3 core and sibling extensions cannot be checked here at
- * all: that code lives in .Build/vendor, which is not committed, and its line
- * numbers move with every patch release of a dependency this repository does
- * not pin. They are listed instead, so adding one is a deliberate act rather
- * than something the resolver quietly skips.
+ * Only `Adr*.rst` is scanned, and that is load-bearing rather than incidental:
+ * `Adr/Index.rst` states the citation convention and quotes two rotted
+ * citations as the examples of what not to write. Widening this glob to
+ * `*.rst` would fail the build on the page that documents the rule.
+ *
+ * Citations into TYPO3 core and sibling extensions used to be listed as
+ * unverifiable — sixteen of them, in .Build/vendor, whose line numbers move
+ * with every patch release of a dependency this repository does not pin. The
+ * corpus now names those symbols instead, so the list emptied and went with
+ * it: an escape hatch nothing reaches for is a declaration nothing reads.
+ * A record that cites a file this suite cannot open now simply fails.
  */
 #[CoversNothing]
 final class AdrCodeCitationTest extends AbstractUnitTestCase
 {
-    /**
-     * Citations that resolve to no file in this repository, as
-     * ADR basename => list of cited paths.
-     *
-     * Every entry is TYPO3 core or a sibling extension, read from
-     * .Build/vendor while the record was written. Nothing here is verifiable
-     * by this suite; the list exists so a NEW unverifiable citation fails
-     * rather than passing as one of these.
-     *
-     * It shrank from fifteen entries to one when ADR-169 stopped citing core
-     * by line: a core symbol survives a patch release, a core line number does
-     * not, and this repository does not pin the dependency whose line numbers
-     * those were.
-     *
-     * @var array<string, list<string>>
-     */
-    private const CITATIONS_OUTSIDE_THE_REPOSITORY = [
-        'Adr140EffectivePolicyReadoutWithoutApplyPath.rst' => [
-            'ExtensionConfiguration.php',
-        ],
-    ];
-
     /** Suffixes an ADR in this corpus cites by line. */
     private const CITED_EXTENSIONS = ['php', 'rst', 'html', 'xlf', 'txt'];
 
@@ -187,9 +171,8 @@ final class AdrCodeCitationTest extends AbstractUnitTestCase
     #[Test]
     public function everyCitationNamesAFileThatStillExists(): void
     {
-        $index    = $this->basenameIndex();
-        $declared = self::CITATIONS_OUTSIDE_THE_REPOSITORY;
-        $orphans  = [];
+        $index   = $this->basenameIndex();
+        $orphans = [];
 
         foreach ($this->citations() as $citation) {
             $where = sprintf('%s:%d', $citation['adr'], $citation['adrLine']);
@@ -197,11 +180,12 @@ final class AdrCodeCitationTest extends AbstractUnitTestCase
                 continue;
             }
 
-            if (in_array($citation['path'], $declared[$citation['adr']] ?? [], true)) {
-                continue;
-            }
-
-            $orphans[] = sprintf('%s cites %s, which is in neither the tree nor the declared list', $where, $citation['path']);
+            $orphans[] = sprintf(
+                '%s cites %s, which is not a file in this repository. A record cites what this suite '
+                . 'can open: a symbol for code we do not ship, never a path into .Build/vendor.',
+                $where,
+                $citation['path'],
+            );
         }
 
         self::assertSame([], $orphans, implode("\n", $orphans));
@@ -234,42 +218,6 @@ final class AdrCodeCitationTest extends AbstractUnitTestCase
         }
 
         self::assertSame([], $stale, implode("\n", $stale));
-    }
-
-    #[Test]
-    public function theListOfUncheckableCitationsMatchesTheCorpus(): void
-    {
-        $index  = $this->basenameIndex();
-        $actual = [];
-
-        foreach ($this->citations() as $citation) {
-            $where = sprintf('%s:%d', $citation['adr'], $citation['adrLine']);
-            if ($this->resolve($citation['path'], $index, $where) !== null) {
-                continue;
-            }
-
-            $actual[$citation['adr']][$citation['path']] = true;
-        }
-
-        $normalised = [];
-        foreach ($actual as $adr => $paths) {
-            $names = array_keys($paths);
-            sort($names);
-            $normalised[$adr] = $names;
-        }
-
-        ksort($normalised);
-
-        $declared = self::CITATIONS_OUTSIDE_THE_REPOSITORY;
-        ksort($declared);
-
-        self::assertSame(
-            $declared,
-            $normalised,
-            'The citations that resolve to no file in this repository have changed. Every one of them is '
-            . 'unverifiable by this suite, so the list is maintained by hand: add the new entry deliberately, '
-            . 'or drop one that no longer appears.',
-        );
     }
 
     /**


### PR DESCRIPTION
Closes #793. Stacked on #858 — review that one first; this PR's diff against it is ADR-169, ADR-140, ADR-174 and the test.

Together with #858 this takes the corpus to **zero line citations**. The two left in `Adr/Index.rst` are the convention's own examples of what not to write.

ADR-169 alone carried **137**, 92 of them bare `:NNN` continuations. Converting each one means reading what it points at, and that is where the value turned out to be.

## Three citations no longer said what the record claims

**Section 7 enumerates the 40 `denyNonAdmin()` sites**, and one entry had drifted onto the wrong method:

| | |
|---|---|
| Record said | `ToolPlaygroundController` `:155`, `:294`, `:367` |
| The three gates are at | `:156`, `:295`, `:381` |
| `:367` resolves to | `resumeAction()` — already the second entry |
| So the record | named `resumeAction()` twice, never named `submitInputAction()`, and still totalled three |

The list now names all 40 by method, and it **reconciles exactly** against the grep the section opens with:

```
real denyNonAdmin() sites:      40
named in the record:            40
  in code, missing from record: —
  in the record, not in code:   —
```

**`UseCasePackController` was cited at `:129`**, which is inside `showAction()`; `installAction()` begins at `:141`. The prose named the right method — the line number was the only wrong part, which is rather the point.

**`ext_conf_template.txt:132` is `mcpOperationTimeout`**, cited for the routing policy mode. That key is `routing.policyMode` at `:139`. A citation seven rows off landed on an unrelated setting and read as precise.

And the method names throughout were uniformly missing their `Action` suffix — `testConnection` for `testConnectionAction` — so **not one of them would have resolved** as a symbol.

## Most citations were deleted, not converted

Same finding as #858, more pronounced here:

```rst
:php:`DataHandler::isTableAllowedForThisPage()` (``DataHandler.php:7484-7503``)
```

The symbol is right there. Section 4's seven field citations are the clearest case — `` ``system_prompt_data_class`` (``:222``) `` — the field name is a better anchor than any line, and it is already in the sentence. ADR-140's six and ADR-174's one are all this shape.

## The escape hatch that emptied, and PHPStan's objection

Twenty of ADR-169's citations reach into TYPO3 core. Those become symbols too: a core symbol survives a patch release, a core line number does not, and this repository does not pin the dependency whose line numbers those were.

That left the test's declared list of unverifiable citations — sixteen entries — completely **empty**, and PHPStan refused the result at level 10:

```
Call to function in_array() with arguments mixed, array{} and true
will always evaluate to false.
```

It is right, and the fix is not a suppression. The list, the branch consulting it and the test reconciling it are gone. `everyCitationNamesAFileThatStillExists` is now absolute and says what to do instead in its own failure message. **An escape hatch nothing reaches for is a declaration nothing reads** — and the convention that replaced it is what made it unreachable.

## One thing that is load-bearing and looks incidental

The suite globs `Adr*.rst`, so `Adr/Index.rst` is not scanned. That is what lets the convention page quote `ResumeCoordinator.php:204` and `AgentRunController.php:267` as examples of rotted citations. Widening the glob to `*.rst` would fail the build on the page documenting the rule — now stated in the test docblock so nobody "fixes" it.

## One caution for anyone repeating this

I first tried to resolve all 137 mechanically, carrying the "current file" forward across the bare `:NNN` continuations. **That mapping was wrong for all 44 citations in section 7** — the numbers index the controller classes named in the surrounding prose, not the file the previous citation named, and the script happily resolved them against `Configuration/Backend/Modules.php` and produced 40 plausible `#controllerActions` anchors. The automation is usable as a lookup table; it is not usable as an applier, because the correct target is in the sentence, not in the syntax.

## Verification

| gate | result |
|---|---|
| `-s unit` (full) | 7285 tests, 24592 assertions, exit 0 |
| `-s phpstan` | No errors |
| `-s cgl -n` | SUCCESS |
| line citations in `Adr*.rst` | **0** |
| anchors / `:ref:` / repo symbols | all resolve |
| control: reintroduce `ExtensionConfiguration.php:150` | fails, naming the file and what to write instead |

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01MNg1MysJVugv1xo2husknU)_
