### PR TITLE
chore(release): 0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.32.0] - 2026-08-21
+
 ### Fixed
 
 - **`vision()` and `embed()` use the default configuration when no provider is pinned**, as `chat()` has since ADR-034. Handing them no provider used to throw "No provider specified and no default provider configured" on an installation that has a perfectly good default — which is what the feature services invite, since model selection is nr-llm's job. The resolved configuration drives the call (its model reaches the provider) and shows up in telemetry as itself rather than as an ad-hoc entry; a provider or model the caller named wins, and with no default configuration the call still refuses rather than picking one (#851).

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -11,8 +11,8 @@
 >
     <project
         title="TYPO3 LLM Extension"
-        version="0.31.1"
-        release="0.31.1"
+        version="0.32.0"
+        release="0.32.0"
         copyright="since 2025 by Netresearch DTT GmbH"
     />
 

--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
                 "providesPackages": {}
             },
             "extension-key": "nr_llm",
-            "version": "0.31.1",
+            "version": "0.32.0",
             "web-dir": ".Build/Web"
         }
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => '',
     'author_company' => 'Netresearch DTT GmbH',
     'state' => 'beta',
-    'version' => '0.31.1',
+    'version' => '0.32.0',
     'constraints' => [
         // composer.json is the authoritative dependency constraint
         // ("typo3/cms-core": "^13.4 || ^14.3"). The TER `depends` format only


### PR DESCRIPTION
Cuts the CHANGELOG and bumps the four version surfaces (ext_emconf.php, `extra.typo3/cms.version`, `guides.xml` `version=` and `release=`) to 0.32.0. 20 commits since v0.31.1, 9 of them feat/fix.

**Why this one is worth cutting now:** it carries the fix for a live failure on typo3-demo. `vision()` and `embed()` had no default-configuration fallback while `chat()` did, so an image upload in the AI-chat module answered `HTTP 500` and a *selected* image never reached the model at all (#859, closes #851).

**What ships:**

- **Vision and embeddings honour the default configuration** when the caller pins no provider (#859). The resolved configuration drives the call — its model reaches the provider, and telemetry attributes the call to it instead of an ad-hoc entry.
- **Caller-source attribution actually arrives** (#852). Three places rebuilt the options object and dropped the identity on the way, so the per-extension breakdown reported *Unattributed* however carefully a consumer annotated. All five consuming extensions have been annotated since, and now show up under their own keys.
- **MCP tools with a union in their schema import** (#853). `anyOf`, `oneOf`, `allOf` and `not` are carried to the provider verbatim rather than causing the whole tool to be skipped; references and the draft-2019/2020 applicators stay refused. DeepWiki's `ask_question` was the concrete casualty.
- **A skipped MCP tool says why** (#849), naming the keyword instead of reporting an unactionable "no usable parameter schema".
- **A queued agent run reports the forced source it did not get** (#842, ADR-179).

**Release safety was checked with the other session working in this repository**, not assumed: its #842 is complete on `main` as a single commit, and its remaining open PRs are documentation plus one test, with nothing half-landed.

After merge: signed tag `v0.32.0` on the merge commit; release.yml publishes to TER and Packagist.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_0144iD1P22LotW8rxmxrNGro)_
