### PR TITLE
security(js): make the sanitizer rule an error, and earn it

### DIFF
--- a/Resources/Public/JavaScript/Backend/ModelIdField.js
+++ b/Resources/Public/JavaScript/Backend/ModelIdField.js
@@ -432,8 +432,12 @@ import { readAjaxError } from '@netresearch/nr-llm/Backend/AjaxError.js';
             })
             .finally(function () {
                 button.disabled = false;
-                // Restore the original server-rendered button content (icon + text)
-                button.innerHTML = originalHTML; // eslint-disable-line no-unsanitized/property
+                // Restore the original server-rendered button content (icon +
+                // text) read from this same element before the spinner. Nothing
+                // external enters; the rule treats any value read out of
+                // innerHTML as unsafe regardless of where it came from.
+                // eslint-disable-next-line no-unsanitized/property
+                button.innerHTML = originalHTML;
             });
     }
 

--- a/Resources/Public/JavaScript/Backend/SetupWizard.js
+++ b/Resources/Public/JavaScript/Backend/SetupWizard.js
@@ -263,10 +263,13 @@ class SetupWizard {
             }
         } catch (e) {
             document.getElementById('models-loading').style.display = 'none';
-            // SECURITY: Escape error message to prevent XSS (unchanged pattern; transport-only change)
-            const discoverError = escapeHtml(await readAjaxError(e));
+            // SECURITY: escape the error before it reaches innerHTML. Called
+            // here rather than through a const: the rule cannot follow a
+            // binding declared inside a catch block, and an escaper it can see
+            // beats one it has to be told about.
             document.getElementById('models-list').innerHTML =
-                '<div class="alert alert-danger">Failed to discover models: ' + discoverError + '</div>';
+                '<div class="alert alert-danger">Failed to discover models: '
+                + escapeHtml(await readAjaxError(e)) + '</div>';
         }
     }
 
@@ -278,11 +281,15 @@ class SetupWizard {
             // SECURITY: Escape all external data to prevent XSS
             const safeName = escapeHtml(model.name);
             const safeModelId = escapeHtml(model.modelId);
-            const safeDescription = model.description ? escapeHtml(model.description) : '';
+            const safeDescription = escapeHtml(model.description || '');
 
-            const capabilities = (model.capabilities || ['chat']).map(cap =>
-                `<span class="badge bg-secondary">${escapeHtml(cap)}</span>`
-            ).join('');
+            // Accumulated rather than `.map().join('')`: the rule cannot see
+            // through map/join and would report the assignment below, which
+            // would then also hide a genuinely removed escapeHtml() there.
+            let capabilities = '';
+            for (const cap of (model.capabilities || ['chat'])) {
+                capabilities += `<span class="badge bg-secondary">${escapeHtml(cap)}</span>`;
+            }
 
             let contextStr = '-';
             if (model.contextLength) {
@@ -291,24 +298,39 @@ class SetupWizard {
                     `${(model.contextLength / 1000).toFixed(0)}K`;
             }
 
+            // The four interpolations below were ternaries. The rule rejects a
+            // conditional whose test is a member expression even when both
+            // branches are literals, and it reports the assignment ONCE — so a
+            // suppression here would also have hidden a removed escapeHtml().
+            // Verified: it does. Same strings, same conditions, shape the rule
+            // can follow.
+            let descriptionHtml = '';
+            if (safeDescription) {
+                descriptionHtml = `<div class="small text-muted">${safeDescription}</div>`;
+            }
+
+            let recommendedBadge = '<span class="text-muted">-</span>';
+            if (model.recommended) {
+                recommendedBadge = '<span class="badge bg-success">Recommended</span>';
+            }
+
             const row = document.createElement('tr');
             row.innerHTML = `
                 <td>
                     <input type="checkbox" class="form-check-input model-checkbox"
-                           data-index="${index}" ${model.recommended ? 'checked' : ''}
+                           data-index="${escapeHtml(String(index))}"
+                           ${escapeHtml(model.recommended ? 'checked' : '')}
                            aria-label="Select model ${safeName}">
                 </td>
                 <td>
                     <strong>${safeName}</strong>
                     <div class="small text-muted">${safeModelId}</div>
-                    ${safeDescription ? `<div class="small text-muted">${safeDescription}</div>` : ''}
+                    ${descriptionHtml}
                 </td>
-                <td>${contextStr}</td>
+                <td>${escapeHtml(contextStr)}</td>
                 <td>${capabilities}</td>
                 <td>
-                    ${model.recommended ?
-                        '<span class="badge bg-success">Recommended</span>' :
-                        '<span class="text-muted">-</span>'}
+                    ${recommendedBadge}
                 </td>
             `;
             tbody.appendChild(row);
@@ -380,10 +402,11 @@ class SetupWizard {
             }
         } catch (e) {
             document.getElementById('configs-loading').style.display = 'none';
-            // SECURITY: Escape error message to prevent XSS (unchanged pattern; transport-only change)
-            const generateError = escapeHtml(await readAjaxError(e));
+            // SECURITY: escape the error before it reaches innerHTML — see
+            // the catch block in discoverModels() for why it is not a const.
             document.getElementById('configs-list').innerHTML =
-                '<div class="alert alert-danger">Failed to generate configurations: ' + generateError + '</div>';
+                '<div class="alert alert-danger">Failed to generate configurations: '
+                + escapeHtml(await readAjaxError(e)) + '</div>';
         }
     }
 
@@ -395,14 +418,17 @@ class SetupWizard {
             // SECURITY: Escape all external data to prevent XSS
             const safeName = escapeHtml(config.name);
             const safeDescription = escapeHtml(config.description);
-            // temperature and maxTokens are numbers, safe to use directly
-            const safeTemp = Number.parseFloat(config.temperature) || 0;
-            const safeMaxTokens = Number.parseInt(config.maxTokens, 10) || 0;
+            // Coerced to numbers, then escaped anyway: `|| 0` guarantees a
+            // number, but the rule cannot see that through Number.parseFloat,
+            // and an escaper it can verify beats a comment it cannot.
+            const safeTemp = escapeHtml(String(Number.parseFloat(config.temperature) || 0));
+            const safeMaxTokens = escapeHtml(String(Number.parseInt(config.maxTokens, 10) || 0));
 
             const col = document.createElement('div');
             col.className = 'col-md-6 mb-3';
             col.innerHTML = `
-                <div class="card config-card selected" data-index="${index}">
+                <div class="card config-card selected"
+                     data-index="${escapeHtml(String(index))}">
                     <div class="card-header">
                         <input type="checkbox" class="form-check-input config-check" checked
                                aria-label="Select configuration ${safeName}">
@@ -493,22 +519,30 @@ class SetupWizard {
         // Models list
         document.getElementById('review-models-count').textContent = selectedModels.length;
         const modelsUl = document.getElementById('review-models');
-        modelsUl.innerHTML = selectedModels.map(m => `
+        let modelsHtml = '';
+        for (const m of selectedModels) {
+            modelsHtml += `
             <li class="list-group-item">
                 <span class="badge bg-primary">${escapeHtml(m.modelId)}</span>
                 <span>${escapeHtml(m.name)}</span>
             </li>
-        `).join('');
+        `;
+        }
+        modelsUl.innerHTML = modelsHtml;
 
         // Configurations list
         document.getElementById('review-configs-count').textContent = selectedConfigs.length;
         const configsUl = document.getElementById('review-configs');
-        configsUl.innerHTML = selectedConfigs.map(c => `
+        let configsHtml = '';
+        for (const c of selectedConfigs) {
+            configsHtml += `
             <li class="list-group-item">
                 <span class="badge bg-info">${escapeHtml(c.identifier)}</span>
                 <span>${escapeHtml(c.name)}</span>
             </li>
-        `).join('');
+        `;
+        }
+        configsUl.innerHTML = configsHtml;
 
         // Show review content
         document.getElementById('review-content').style.display = 'block';

--- a/Resources/Public/JavaScript/Backend/TaskExecute.js
+++ b/Resources/Public/JavaScript/Backend/TaskExecute.js
@@ -212,6 +212,10 @@ class TaskExecute {
             Notification.error('Error', error.message || 'Failed to load record data');
         } finally {
             this.loadRecordsBtn.disabled = false;
+            // Restores the markup this element already held, read at the top of
+            // this method. Nothing external enters here; the rule treats any
+            // value read out of innerHTML as unsafe regardless of origin.
+            // eslint-disable-next-line no-unsanitized/property
             this.loadRecordsBtn.innerHTML = originalBtnHtml;
         }
     }
@@ -244,6 +248,9 @@ class TaskExecute {
             Notification.error('Error', error.message || 'Failed to refresh input data');
         } finally {
             this.refreshInputBtn.disabled = false;
+            // Same round-trip as loadRecords(): the element's own markup, put
+            // back after the spinner.
+            // eslint-disable-next-line no-unsanitized/property
             this.refreshInputBtn.innerHTML = originalHtml;
         }
     }
@@ -351,10 +358,13 @@ class TaskExecute {
     /**
      * Render the stored raw content in the active format.
      *
-     * Security approach per format:
-     * - plain/markdown/json: Content is HTML-escaped via escapeHtml() before insertion.
-     *   Markdown transformations operate on already-escaped content (safe).
-     * - html: Rendered in a fully sandboxed iframe (sandbox="") which prevents
+     * Security approach per format, corrected against what the helpers do:
+     * - plain and json write through textContent, so nothing is escaped and
+     *   nothing needs to be. The previous wording claimed escapeHtml() ran for
+     *   these two; it never did.
+     * - markdown escapes inside renderMarkdownOutput(), which is the only path
+     *   here that reaches innerHTML.
+     * - html renders in a fully sandboxed iframe (sandbox=""), which prevents
      *   script execution and blocks access to the parent page's DOM.
      */
     renderOutput() {
@@ -365,7 +375,6 @@ class TaskExecute {
         }
 
         const content = this._rawContent;
-        const escaped = escapeHtml(content);
 
         switch (this._activeFormat) {
             case 'html':
@@ -373,7 +382,7 @@ class TaskExecute {
                 break;
 
             case 'markdown':
-                this.renderMarkdownOutput(escaped);
+                this.renderMarkdownOutput(content);
                 break;
 
             case 'json':
@@ -392,6 +401,11 @@ class TaskExecute {
     renderHtmlOutput(content) {
         this.outputContent.textContent = '';
         const iframe = document.createElement('iframe');
+        // Load-bearing, and nothing checks it: `content` below is the model's
+        // raw output, unescaped on purpose so HTML renders as HTML. An empty
+        // sandbox denies scripts, same-origin and forms, which is the only
+        // reason that is safe. `no-unsanitized` does not cover `srcdoc`, so
+        // removing this line would not fail the build.
         iframe.sandbox = '';
         iframe.style.cssText = 'width:100%;border:none;min-height:200px;background:#fff;';
         iframe.srcdoc = [
@@ -412,10 +426,18 @@ class TaskExecute {
     }
 
     /**
-     * Render escaped content with basic markdown transformations.
+     * Render content with basic markdown transformations.
+     *
+     * Takes RAW content and escapes it here rather than trusting the caller:
+     * the assignment at the end of this method carries an eslint suppression,
+     * and a suppression cannot tell a deliberate escape from a removed one. It
+     * stops detecting exactly this — that the value reaching innerHTML was
+     * escaped. Keeping the escape inside the method means breaking it requires
+     * editing the six lines below this comment, not a line eighty rows away in
+     * a different method.
      */
-    renderMarkdownOutput(escaped) {
-        const rendered = escaped
+    renderMarkdownOutput(content) {
+        const rendered = escapeHtml(content)
             // Headers
             .replace(/^(#{1,6})\s+(\S.*)$/gm, (_, hashes, text) => {
                 const level = hashes.length;
@@ -439,7 +461,12 @@ class TaskExecute {
             .replaceAll('\n', '<br>');
         const wrapper = document.createElement('div');
         wrapper.className = 'markdown-content';
-        wrapper.innerHTML = rendered; // eslint-disable-line no-unsanitized/property -- content is pre-escaped via escapeHtml()
+        // `rendered` is escapeHtml() output with our own markdown tags wrapped
+        // around it, so every captured group is already escaped. The rule
+        // cannot follow a `.replace()` chain — measured, not assumed: it breaks
+        // the trace even when the escaper is called in this same expression.
+        // eslint-disable-next-line no-unsanitized/property
+        wrapper.innerHTML = rendered;
         this.outputContent.textContent = '';
         this.outputContent.appendChild(wrapper);
     }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,9 @@
 import globals from 'globals';
 import noUnsanitized from 'eslint-plugin-no-unsanitized';
 
+// `escapeHtml()` from `Backend/HtmlEscape.js` is this codebase's sanitizer.
+const ESCAPER = { escape: { methods: ['escapeHtml'] } };
+
 export default [
     {
         files: ['Resources/Public/JavaScript/**/*.js'],
@@ -36,27 +39,24 @@ export default [
             // The rule that would have caught #825.
             'no-undef': 'error',
             'no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
-            // Warning, not error, and the reason is measured rather than
-            // cautious. Switched on as an error it reports 12 assignments —
-            // and none of them is a hole: the code escapes first, visibly, at
-            // `SetupWizard.js:471-474` ("SECURITY: Escape all external data")
-            // through `escapeHtml()`. The rule cannot recognise that helper as
-            // a sanitizer, which is a known shape for it.
+            // Both are errors, and the twelve findings that blocked that in
+            // #825 are gone rather than suppressed: `escapeHtml()` is declared
+            // to the rule as what it is. The plugin recognises a fixed set of
+            // sanitizers and a helper of ours was not among them, so every
+            // assignment downstream of it read as unsafe.
             //
-            // The plugin is still loaded, because two files carry
-            // `eslint-disable-line no-unsanitized/property` — suppressions
-            // written for a rule that never ran. Without the plugin those
-            // comments become "rule not found" errors the moment linting is
-            // switched on.
+            // Declaring it does NOT blunt the rule, which was measured rather
+            // than assumed. With the escaper declared, a bare interpolation, a
+            // direct assignment, a value laundered through `.trim()`, an
+            // `insertAdjacentHTML()` argument and — the one that matters — a
+            // template where only ONE of two interpolations is escaped all
+            // still report. Only a value that actually passed through
+            // `escapeHtml()` is accepted.
             //
-            // Making them errors would land a backlog of twelve judgements
-            // nobody asked for on a change whose job is #825. Leaving the rule
-            // out entirely would drop a real check silently. The findings are
-            // triaged in their own issue, with the escapeHtml evidence, so the
-            // security question lives somewhere it can be argued rather than
-            // in a config comment.
-            'no-unsanitized/property': 'warn',
-            'no-unsanitized/method': 'warn',
+            // `methods` is the right key, not `taggedTemplates`: our helper is
+            // called as a function, not used as a template tag.
+            'no-unsanitized/property': ['error', ESCAPER],
+            'no-unsanitized/method': ['error', ESCAPER],
         },
     },
 ];


### PR DESCRIPTION
Closes #854. #825 shipped `no-unsanitized` as a **warning** because switching it on reported 12 assignments and none of them was a hole. This makes both rules errors.

## A control failed, and it changed the plan

The issue proposed declaring `escapeHtml()` to the rule and suppressing what remained. That clears 4 of 12. I suppressed the rest, then ran the control that any relaxation deserves — **remove `escapeHtml()` from a real call site and check the gate notices**:

```
escapeHtml bei safeName entfernt:  >>> UNENTDECKT <<<
```

The rule reports **one finding per assignment**. A suppression on a template therefore hides every *other* reason that template could be unsafe — including a deliberately removed escape. That is the argument against suppressing a template, and it is why five of the six planned suppressions are gone.

After the rewrite, the same control:

| | |
|---|---|
| `escapeHtml` removed at `safeName` | **fails** |
| `escapeHtml` removed in the review list | **fails** |
| `escapeHtml` removed inside the capability accumulator | **fails** |
| markdown input no longer escaped (the one remaining suppressed site) | still undetected — stated below |

## What the rule cannot follow — measured, not assumed

Each of these was isolated with a minimal reproduction before any production code moved:

| shape | verdict | what the code does now |
|---|---|---|
| `const` declared inside a `catch` block | not traced | call the escaper at the assignment (2 error paths) |
| `.map().join('')` | opaque in every form — declaring `join` as an unwrapper does **not** help | accumulate with `+=`, which it does follow (3 sites) |
| conditional whose test is a member expression, **both branches literals** | rejected | `let` + `if` (4 in one template) |
| `Number.parseFloat` / `parseInt` output | not recognised | escaped anyway — the values are numbers, but an escaper the rule can verify beats a comment it cannot |
| `.replace()` chain, escaper called in the same expression | breaks the trace | **suppression, unavoidable** |

The ternary finding explains a dead end worth recording: **four** of them sat in one template, and because the rule reports once, removing any single one never changed the verdict. Individual bisection said "not this one" about all four. Only enumerating the interpolations and toggling them one at a time found them.

## The one remaining blind spot, and what was done about it

`renderMarkdownOutput()` keeps its suppression. Its escaping **moved from the caller into the method**, so breaking the contract now means editing the lines directly under the comment explaining it, rather than a line eighty rows away in a different method. The comment states what the suppression stops detecting, because it does stop detecting it.

Three suppressions remain for `innerHTML` round-trips — read the element's own markup, show a spinner, put it back — each with its reason.

## The rewrite is behaviour-preserving, and that was checked

Old and new template code, rendered against the same inputs — empty description, `null` capabilities, `contextLength` 0, markup in the model name, quotes in the description:

```
IDENTISCH fuer alle 3 Faelle (Whitespace normalisiert)
```

## Two things that predate this change

- **`renderOutput()`'s docblock was wrong.** It claimed `plain/markdown/json` are escaped through `escapeHtml()`. `plain` and `json` write through `textContent` and never were — correct, but not for the stated reason.
- **The sandboxed iframe is load-bearing and nothing checks it.** `renderHtmlOutput()` puts the model's raw output into `srcdoc`, which is safe *only* because `iframe.sandbox = ''` denies scripts and same-origin. `no-unsanitized` does not cover `srcdoc`, so removing that line would not fail the build. Now said at the line.

## Verification

| | |
|---|---|
| `npx eslint` | exit 0 — 0 errors, 2 pre-existing `no-unused-vars` warnings |
| `npm ci` then lint | exit 0 |
| `composer ci:test:changelog` | exit 0 |
| controls | 3 of 4 removed escapes now fail the gate; the 4th is the stated blind spot |
| render equivalence | identical output, old vs new, 3 inputs incl. edge cases |

No PHP touched, so the PHP matrix is unaffected; `js-lint` is the gate that reads this change.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01MNg1MysJVugv1xo2husknU)_