### PR TITLE
feat(mcp): import a catalogue from the CLI, so a deploy needs no click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`nrllm:mcp:import` imports an MCP catalogue from the CLI**, so a seeded server gets its tools on deploy instead of waiting for somebody to press **Import catalogue** in the module. Takes a server identifier, or `--all` for every enabled server; prints imported, skipped and orphaned counts per server plus the reason for each skipped tool, and exits non-zero when a server refused. It is the module's button rather than a second path — the same refusals, the same guard rails and the same reconciliation, so a second run against an unchanged catalogue writes nothing. With `--all` a refusing server does not stop the others, and an installation with no enabled server is not a failure (#836).
+
 ### Fixed
 
 - **A merge conflict marker shipped in the ADR index.** `Documentation/Adr/Index.rst` ended on `||||||| c6503022` — a hand-resolved merge kept both sides and left the diff3 base marker behind as the file's last line, so the toctree carried a stray entry through v0.32.0. Nothing failed: the other guards read structure (status fields, citations, a rendered page) and a stray line at the end of a toctree is none of those to any of them. `NoConflictMarkersTest` now reads the bytes, and both marker shapes were watched failing before it was trusted.

--- a/Classes/Command/ImportMcpCatalogueCommand.php
+++ b/Classes/Command/ImportMcpCatalogueCommand.php
@@ -1,0 +1,198 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Command;
+
+use Netresearch\NrLlm\Domain\ValueObject\McpImportReport;
+use Netresearch\NrLlm\Domain\ValueObject\McpServerRecord;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpImportService;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpServerRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Imports an MCP server's advertised catalogue from the CLI.
+ *
+ * A server record can be seeded, but until this existed its catalogue could
+ * only arrive by a person opening the MCP Servers module and pressing **Import
+ * catalogue**. An instance rebuilt by a deploy therefore had one manual step
+ * after every fresh install, and no tools for that server until somebody
+ * clicked.
+ *
+ * This is the module's button, not a second path: it calls the same
+ * {@see McpImportService::import()} and adds nothing. Every refusal reason, the
+ * SSRF gate, the operation budget (ADR-170) and the catalogue reconciliation
+ * live in that service, which is why this class holds no policy of its own.
+ *
+ * It lives in `Classes/Command/` with every other command but belongs to the
+ * tool module, and `ModuleSeamTest` names it for that reason: in a package
+ * split it moves to nr_llm_tools with the MCP code it drives (ADR-090).
+ *
+ * Servers are addressed by identifier rather than uid, because a uid is not
+ * knowable to whoever writes the deploy script and an identifier is what the
+ * seed sets. Identifiers are not unique in the table — soft-deleted rows keep
+ * theirs, which is why the service refuses an import when two ENABLED servers
+ * share one rather than relying on a database constraint. The same ambiguity
+ * can reach this command, so it is reported here rather than resolved by
+ * picking a row.
+ */
+#[AsCommand(
+    name: 'nrllm:mcp:import',
+    description: "Import an MCP server's advertised tool catalogue.",
+)]
+/**
+ * @internal Not part of the @api surface; may change without notice (ADR-127).
+ */
+final class ImportMcpCatalogueCommand extends Command
+{
+    public function __construct(
+        private readonly McpImportService $importer,
+        private readonly McpServerRepository $servers,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument(
+            'identifier',
+            InputArgument::OPTIONAL,
+            "The MCP server's identifier, as set on the record. Omit it and pass --all instead.",
+        );
+
+        $this->addOption(
+            'all',
+            'a',
+            InputOption::VALUE_NONE,
+            'Import every enabled server. One failing server does not stop the others.',
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io         = new SymfonyStyle($input, $output);
+        $identifier = $input->getArgument('identifier');
+        $identifier = is_string($identifier) ? $identifier : null;
+
+        $all = $input->getOption('all') === true;
+
+        if ($all && $identifier !== null) {
+            $io->error('Pass either an identifier or --all, not both.');
+
+            return Command::INVALID;
+        }
+
+        if (!$all && ($identifier === null || $identifier === '')) {
+            $io->error('Name a server identifier, or pass --all to import every enabled server.');
+
+            return Command::INVALID;
+        }
+
+        $servers = $all ? $this->servers->findEnabled() : $this->resolve($identifier ?? '', $io);
+        if ($servers === null) {
+            return Command::FAILURE;
+        }
+
+        if ($servers === []) {
+            // Not a failure: an installation with no enabled server is a valid
+            // state, and a deploy that runs --all unconditionally must not go
+            // red because this one has none yet.
+            $io->warning('No enabled MCP server to import.');
+
+            return Command::SUCCESS;
+        }
+
+        $refused = 0;
+        foreach ($servers as $server) {
+            if (!$this->report($this->importer->import($server), $server, $io)) {
+                ++$refused;
+            }
+        }
+
+        if ($refused > 0) {
+            $io->error(sprintf('%d of %d server(s) refused the import.', $refused, count($servers)));
+
+            return Command::FAILURE;
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * The one enabled server carrying this identifier, or null with the reason printed.
+     *
+     * @return list<McpServerRecord>|null
+     */
+    private function resolve(string $identifier, SymfonyStyle $io): ?array
+    {
+        $matches = array_values(array_filter(
+            $this->servers->findEnabled(),
+            static fn(McpServerRecord $server): bool => $server->identifier === $identifier,
+        ));
+
+        if ($matches === []) {
+            $io->error(sprintf('No enabled MCP server has the identifier "%s".', $identifier));
+
+            return null;
+        }
+
+        if (count($matches) > 1) {
+            // The service refuses this case too, but it would refuse it once per
+            // row and read as two unrelated failures. Said here, once, in the
+            // terms the operator has to act on.
+            $io->error(sprintf(
+                '%d enabled servers share the identifier "%s". Identifiers name the imported tools, so they must be unique among enabled servers.',
+                count($matches),
+                $identifier,
+            ));
+
+            return null;
+        }
+
+        return $matches;
+    }
+
+    /**
+     * Prints one server's outcome. Returns false when the import was refused.
+     */
+    private function report(McpImportReport $report, McpServerRecord $server, SymfonyStyle $io): bool
+    {
+        if ($report->refused) {
+            $io->writeln(sprintf(
+                '<error>%s: refused</error> — %s',
+                $server->identifier,
+                $report->skipReasons[0] ?? 'no reason given',
+            ));
+
+            return false;
+        }
+
+        // Printed even when all three are zero: "imported 0" after a successful
+        // contact means the catalogue matched what was already stored, which is
+        // the expected result of the second run and worth seeing.
+        $io->writeln(sprintf(
+            '<info>%s</info>: %d imported, %d skipped, %d orphaned',
+            $server->identifier,
+            $report->imported,
+            $report->skipped,
+            $report->orphaned,
+        ));
+
+        foreach ($report->skipReasons as $reason) {
+            $io->writeln('    skipped: ' . $reason);
+        }
+
+        return true;
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -508,6 +508,17 @@ services:
         description: 'Store a provider API key read from STDIN and link it to the provider record.'
         schedulable: false
 
+  # The only schedulable one of the four: the import is idempotent — a second
+  # run against an unchanged catalogue reconciles to the same rows — and a
+  # catalogue changes on the server's schedule, not ours. Registered explicitly
+  # rather than left to autoconfigure so the flag is a decision, not a default.
+  Netresearch\NrLlm\Command\ImportMcpCatalogueCommand:
+    tags:
+      - name: 'console.command'
+        command: 'nrllm:mcp:import'
+        description: "Import an MCP server's advertised tool catalogue."
+        schedulable: true
+
 
   # ========================================
   # nr-vault integration

--- a/Documentation/Administration/McpServers.rst
+++ b/Documentation/Administration/McpServers.rst
@@ -24,6 +24,30 @@ How it works
    rendered. Tool input schemas are normalised into the supported subset
    on import; a tool whose schema cannot be expressed is skipped rather
    than silently weakened.
+
+   The same import runs from the CLI, which is what a deploy needs: a
+   seeded server has a record but no catalogue until somebody presses the
+   button, and on a rebuilt instance that is a manual step after every
+   fresh install.
+
+   .. code-block:: bash
+      :caption: Import one server, or every enabled one
+
+      vendor/bin/typo3 nrllm:mcp:import deepwiki
+      vendor/bin/typo3 nrllm:mcp:import --all
+
+   The command is the module's button, not a second path: the same
+   refusals, the same guard rails, the same reconciliation. It prints one
+   line per server — imported, skipped and orphaned counts, plus the
+   reason for each skipped tool — and exits non-zero when a server refused.
+   With ``--all`` a refusing server does not stop the others, and an
+   installation with no enabled server is not a failure. Running it twice
+   changes nothing: the second run reconciles against the same catalogue.
+
+   Servers are named by their identifier rather than their uid, because a
+   uid is not knowable to whoever writes the deploy script. Two *enabled*
+   servers sharing an identifier is refused with both named — identifiers
+   name the imported tools, so they cannot collide.
 3. **Enable individual tools** — imported tools start disabled and are
    switched on one by one, exactly like the builtin tools in the
    :ref:`Tools module <administration-tools>`.

--- a/Tests/Architecture/ModuleSeamTest.php
+++ b/Tests/Architecture/ModuleSeamTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrLlm\Tests\Architecture;
 
 use Netresearch\NrLlm\Command\CancelAgentRunCommand;
+use Netresearch\NrLlm\Command\ImportMcpCatalogueCommand;
 use Netresearch\NrLlm\Command\PurgePrivacyDataCommand;
 use Netresearch\NrLlm\Command\ReapStaleAgentRunsCommand;
 use Netresearch\NrLlm\Form\Tca\ToolGroupItems;
@@ -181,13 +182,18 @@ final class ModuleSeamTest
      * into `nr_llm_tools` would make the two packages mutually dependent.
      *
      * "Core" here is the remainder: everything that is not one of the mapped
-     * module namespaces above. Seven classes are excluded BY NAME rather than by
-     * directory, because they are the tool module's own operational surface
-     * living in shared directories — in a split each moves WITH its module,
-     * so their coupling is ownership, not leakage:
+     * module namespaces above. The classes listed below are excluded BY NAME
+     * rather than by directory, because they are the tool module's own
+     * operational surface living in shared directories — in a split each moves
+     * WITH its module, so their coupling is ownership, not leakage. The list is
+     * not counted here: it said "seven" while carrying six, because a class
+     * left it without the number following.
      *
      * - `CancelAgentRunCommand`, `ReapStaleAgentRunsCommand` — CLI entry
      *   points of the agent runtime (→ nr_llm_tools)
+     * - `ImportMcpCatalogueCommand` — the CLI entry point of the MCP
+     *   catalogue import, the same operation the MCP Servers module runs
+     *   (→ nr_llm_tools)
      * - `PurgePrivacyDataCommand` — sweeps, among others, the agent-run
      *   tables through their repository (→ split into per-module sweeps when
      *   the packages separate)
@@ -227,6 +233,7 @@ final class ModuleSeamTest
                     Selector::inNamespace(self::NS_WIDGETS),
                     Selector::inNamespace(self::NS_TESTS),
                     Selector::classname(CancelAgentRunCommand::class),
+                    Selector::classname(ImportMcpCatalogueCommand::class),
                     Selector::classname(PurgePrivacyDataCommand::class),
                     Selector::classname(ReapStaleAgentRunsCommand::class),
                     Selector::classname(ToolGroupItems::class),

--- a/Tests/Functional/Command/ImportMcpCatalogueCommandTest.php
+++ b/Tests/Functional/Command/ImportMcpCatalogueCommandTest.php
@@ -1,0 +1,308 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Functional\Command;
+
+use Netresearch\NrLlm\Command\ImportMcpCatalogueCommand;
+use Netresearch\NrLlm\Domain\ValueObject\McpServerRecord;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpClient;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpDeadlineFactory;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpHttpTransport;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpImportService;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpSchemaNormalizer;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpServerRepository;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpToolNameMapper;
+use Netresearch\NrLlm\Service\Tool\Mcp\McpToolRepository;
+use Netresearch\NrLlm\Service\Tool\ToolRegistry;
+use Netresearch\NrLlm\Tests\Fixtures\Mcp\McpTestServer;
+use Netresearch\NrLlm\Tests\Fixtures\Mcp\RecordedContacts;
+use Netresearch\NrLlm\Tests\Functional\AbstractFunctionalTestCase;
+use Netresearch\NrVault\Http\SecureHttpClientFactory;
+use Netresearch\NrVault\Service\VaultServiceInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Http\Client\GuzzleClientFactory;
+use TYPO3\CMS\Core\Http\RequestFactory;
+use TYPO3\CMS\Core\Http\StreamFactory;
+
+/**
+ * The command against a scripted server and a real database.
+ *
+ * Functional rather than unit for the same reason
+ * {@see \Netresearch\NrLlm\Tests\Functional\Service\Tool\Mcp\McpImportServiceTest}
+ * is: the importer and both repositories are `final readonly`, so a faked
+ * import service is not constructible — and the acceptance criterion that
+ * matters most, that a second run changes nothing, cannot be shown by a fake
+ * that never writes a row. Only the HTTP client is scripted.
+ */
+#[CoversClass(ImportMcpCatalogueCommand::class)]
+final class ImportMcpCatalogueCommandTest extends AbstractFunctionalTestCase
+{
+    private ConnectionPool $connectionPool;
+
+    private McpServerRepository $servers;
+
+    private McpToolRepository $catalogue;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connectionPool = $this->get(ConnectionPool::class);
+        self::assertInstanceOf(ConnectionPool::class, $connectionPool);
+
+        $this->connectionPool = $connectionPool;
+        $this->servers        = new McpServerRepository($connectionPool);
+        $this->catalogue      = new McpToolRepository($connectionPool);
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     */
+    private function insertServer(array $overrides = []): McpServerRecord
+    {
+        $connection = $this->connectionPool->getConnectionForTable('tx_nrllm_mcp_server');
+        $connection->insert('tx_nrllm_mcp_server', $overrides + [
+            'pid'              => 0,
+            'identifier'       => 'srv',
+            'name'             => 'A server',
+            'description'      => '',
+            'url'              => 'https://mcp.example.com/rpc',
+            'auth_credential'  => '',
+            'auth_placement'   => 'bearer',
+            'auth_header_name' => '',
+            'data_class'       => 'publicContent',
+            'enabled'          => 1,
+            'import_status'    => 'never_imported',
+            'import_error'     => '',
+            'last_imported'    => 0,
+            'tool_count'       => 0,
+            'tstamp'           => 0,
+            'crdate'           => 0,
+            'deleted'          => 0,
+            'hidden'           => 0,
+        ]);
+
+        $server = $this->servers->findByUid((int)$connection->lastInsertId());
+        self::assertInstanceOf(McpServerRecord::class, $server);
+
+        return $server;
+    }
+
+    /**
+     * The scripted server answers a fixed QUEUE of requests, one entry per
+     * contact, so a test that imports two servers has to script two — passed in
+     * rather than defaulted, because getting it wrong reads as a refusal from
+     * the second server rather than as an exhausted fixture.
+     *
+     * @param array<string, mixed> ...$tools
+     */
+    private function tester(int $contacts, array ...$tools): CommandTester
+    {
+        $fake = new McpTestServer();
+        for ($i = 0; $i < $contacts; ++$i) {
+            $fake = $fake->willHandshake()->willReturn(['tools' => array_values($tools)]);
+        }
+
+        $transport = new McpHttpTransport(
+            self::createStub(VaultServiceInterface::class),
+            new SecureHttpClientFactory(),
+            new RequestFactory(new GuzzleClientFactory()),
+            new StreamFactory(),
+        );
+        $transport->setHttpClient($fake);
+
+        $importer = new McpImportService(
+            new McpClient($transport, new RecordedContacts(), $this->get(McpDeadlineFactory::class)),
+            $this->servers,
+            $this->catalogue,
+            new McpToolNameMapper(),
+            new McpSchemaNormalizer(),
+            new ToolRegistry(),
+            new NullLogger(),
+            new Context(),
+        );
+
+        return new CommandTester(new ImportMcpCatalogueCommand($importer, $this->servers));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function tool(string $name): array
+    {
+        return [
+            'name'        => $name,
+            'description' => 'does a thing',
+            'inputSchema' => ['type' => 'object', 'properties' => ['id' => ['type' => 'integer']]],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function liveToolNames(int $serverUid): array
+    {
+        return array_map(
+            static fn(object $tool): string => $tool->toolName,
+            $this->catalogue->findLiveByServer($serverUid),
+        );
+    }
+
+    #[Test]
+    public function importsTheCatalogueOfTheNamedServer(): void
+    {
+        $server = $this->insertServer(['identifier' => 'deepwiki']);
+        $tester = $this->tester(1, $this->tool('read'), $this->tool('write'));
+
+        $exit = $tester->execute(['identifier' => 'deepwiki']);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertStringContainsString('deepwiki', $tester->getDisplay());
+        self::assertStringContainsString('2 imported', $tester->getDisplay());
+        self::assertSame(['mcp_deepwiki_read', 'mcp_deepwiki_write'], $this->liveToolNames($server->uid));
+    }
+
+    /**
+     * The acceptance criterion a faked importer cannot show: running twice
+     * against an unchanged catalogue reconciles to the same rows rather than
+     * adding a second copy of each tool.
+     */
+    #[Test]
+    public function aSecondRunAgainstAnUnchangedCatalogueAddsNothing(): void
+    {
+        $server = $this->insertServer(['identifier' => 'deepwiki']);
+
+        $first = $this->tester(1, $this->tool('read'), $this->tool('write'));
+        self::assertSame(Command::SUCCESS, $first->execute(['identifier' => 'deepwiki']));
+        $afterFirst = $this->liveToolNames($server->uid);
+
+        $second = $this->tester(1, $this->tool('read'), $this->tool('write'));
+        self::assertSame(Command::SUCCESS, $second->execute(['identifier' => 'deepwiki']));
+
+        self::assertSame($afterFirst, $this->liveToolNames($server->uid));
+        self::assertCount(2, $afterFirst);
+    }
+
+    #[Test]
+    public function allWalksEveryEnabledServer(): void
+    {
+        $one = $this->insertServer(['identifier' => 'one']);
+        $two = $this->insertServer(['identifier' => 'two']);
+
+        $tester = $this->tester(2, $this->tool('read'));
+        $exit   = $tester->execute(['--all' => true]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertSame(['mcp_one_read'], $this->liveToolNames($one->uid));
+        self::assertSame(['mcp_two_read'], $this->liveToolNames($two->uid));
+    }
+
+    /**
+     * A disabled server is not part of `--all`, so the catalogue it may already
+     * hold is neither refreshed nor orphaned by this command.
+     */
+    #[Test]
+    public function allSkipsADisabledServer(): void
+    {
+        $enabled  = $this->insertServer(['identifier' => 'on']);
+        $disabled = $this->insertServer(['identifier' => 'off', 'enabled' => 0]);
+
+        $tester = $this->tester(1, $this->tool('read'));
+        self::assertSame(Command::SUCCESS, $tester->execute(['--all' => true]));
+
+        self::assertSame(['mcp_on_read'], $this->liveToolNames($enabled->uid));
+        self::assertSame([], $this->liveToolNames($disabled->uid));
+        self::assertStringNotContainsString('off', $tester->getDisplay());
+    }
+
+    /**
+     * A deploy that imports every server must not stop at the first bad one,
+     * and must not report success when one of them refused.
+     */
+    #[Test]
+    public function oneRefusingServerDoesNotStopTheOthersButFailsTheRun(): void
+    {
+        $broken  = $this->insertServer(['identifier' => 'broken', 'data_class' => '']);
+        $working = $this->insertServer(['identifier' => 'working']);
+
+        $tester = $this->tester(1, $this->tool('read'));
+        $exit   = $tester->execute(['--all' => true]);
+
+        self::assertSame(Command::FAILURE, $exit);
+        self::assertStringContainsString('data class', $tester->getDisplay());
+        self::assertSame([], $this->liveToolNames($broken->uid));
+        self::assertSame(['mcp_working_read'], $this->liveToolNames($working->uid), 'The healthy server must still have been imported.');
+        self::assertStringContainsString('1 of 2', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function refusesWhenNeitherAnIdentifierNorAllIsGiven(): void
+    {
+        $tester = $this->tester(0, $this->tool('read'));
+
+        self::assertSame(Command::INVALID, $tester->execute([]));
+        self::assertStringContainsString('--all', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function refusesWhenBothAnIdentifierAndAllAreGiven(): void
+    {
+        $this->insertServer(['identifier' => 'one']);
+        $tester = $this->tester(0, $this->tool('read'));
+
+        self::assertSame(Command::INVALID, $tester->execute(['identifier' => 'one', '--all' => true]));
+        self::assertStringContainsString('not both', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function failsOnAnIdentifierNoEnabledServerCarries(): void
+    {
+        $this->insertServer(['identifier' => 'one']);
+        $tester = $this->tester(0, $this->tool('read'));
+
+        self::assertSame(Command::FAILURE, $tester->execute(['identifier' => 'other']));
+        self::assertStringContainsString('"other"', $tester->getDisplay());
+    }
+
+    /**
+     * The table has no unique index on the identifier — soft-deleted rows keep
+     * theirs — so two enabled twins are reachable. Reported once, in the terms
+     * the operator has to act on, rather than as two unrelated refusals.
+     */
+    #[Test]
+    public function namesTheAmbiguityWhenTwoEnabledServersShareAnIdentifier(): void
+    {
+        $this->insertServer(['identifier' => 'twin']);
+        $this->insertServer(['identifier' => 'twin']);
+
+        $tester = $this->tester(0, $this->tool('read'));
+
+        self::assertSame(Command::FAILURE, $tester->execute(['identifier' => 'twin']));
+        self::assertStringContainsString('2 enabled servers share', $tester->getDisplay());
+    }
+
+    /**
+     * A deploy runs `--all` unconditionally. An installation that carries no
+     * enabled server yet is a valid state, not a red pipeline.
+     */
+    #[Test]
+    public function allSucceedsWithNothingToImport(): void
+    {
+        $tester = $this->tester(0, $this->tool('read'));
+
+        self::assertSame(Command::SUCCESS, $tester->execute(['--all' => true]));
+        self::assertStringContainsString('No enabled MCP server', $tester->getDisplay());
+    }
+}


### PR DESCRIPTION
Closes #836. A seeded MCP server has a record and no tools until somebody opens the module and presses **Import catalogue**. On an instance rebuilt by a deploy that is a manual step after every fresh install, and the server supplies nothing until it happens.

```bash
vendor/bin/typo3 nrllm:mcp:import deepwiki
vendor/bin/typo3 nrllm:mcp:import --all
```

## It is the module's button, not a second path

Checked before writing anything: `McpServerController::importAction()` resolves the record and formats the report — that is all it does. Every refusal reason, the SSRF gate, the ADR-170 operation budget and the catalogue reconciliation live in `McpImportService::import()`. So the command holds **no policy of its own**, and the issue's "not a second path" is a property of the code rather than an intention.

## Three decisions the issue did not settle

**Identifier, not uid** — a uid is not knowable to whoever writes the deploy script. This needs no new repository method: `findEnabled()` is filtered in the command. That matters, because identifiers are deliberately **not unique** in the table — soft-deleted rows keep theirs, which is exactly why the service refuses on a twin instead of relying on an index. The ambiguity is therefore reachable here too, and is reported once naming both rather than resolved by picking a row.

**`--all` walks `findEnabled()`, not `findUsable()`** — the latter filters out servers without a data class. Silently skipping one is worse than importing it and printing the service's reason, which names the missing setting.

**An empty installation exits zero.** A deploy runs `--all` unconditionally; "no enabled server yet" is a valid state, not a red pipeline. A *refusing* server does fail the run, and does not stop the others.

## Registered explicitly, because `schedulable` is a decision

`autoconfigure: true` and the `../Classes/*` resource import would have picked up `#[AsCommand]` on its own. The entry exists so the flag is chosen rather than defaulted: this is the only one of the four registered commands that is **schedulable**, because the import is idempotent and a catalogue changes on the server's schedule rather than ours.

## Functional, and not by preference

The importer and both repositories are `final readonly`, so a faked import service is not constructible. More to the point: **the acceptance criterion that matters most — a second run writes nothing — cannot be shown by a fake that never writes a row.** Only the HTTP client is scripted, which is what the neighbouring `McpImportServiceTest` does and says why.

One trap worth naming: `McpTestServer` answers a *queue*, one entry per contact. A test importing two servers must script two, and getting that wrong reads as a refusal from the second server rather than as an exhausted fixture — which is how the `--all` test failed first. The queue depth is now an explicit argument at every call site.

## Three controls, each observed

| defect injected | result |
|---|---|
| `break` out of the loop on the first refusal | fails — the healthy server was no longer imported |
| return SUCCESS regardless of refusals | fails — exit-code assertion |
| silently take the first of two twins | fails — ambiguity assertion |

Restored tree: 10 tests green.

## An architecture rule said no, and it was right

`Classes/Command/` is "core"; the MCP importer is the tool module. `ModuleSeamTest` rejected the dependency (ADR-090), and the fix is the established one — three commands are already named in its exception list because they are a module's operational surface living in a shared directory. This is the fourth, and where it moves in a split (`nr_llm_tools`) is recorded both in the test and in the command's own docblock, as that docblock demands.

**Found while doing it:** the docblock said "**Seven** classes are excluded BY NAME" and listed **six** — a class left the list without the number following. The count is gone rather than corrected, for the reason #793 is about.

## Verification

| gate | result |
|---|---|
| `-s functional -d sqlite` (this class) | 10 tests, 52 assertions, exit 0 |
| `-s unit` (full) | 7288 tests, 24766 assertions, exit 0 |
| `-s phpstan` (carries phpat) | No errors |
| `-s cgl -n` | SUCCESS |
| `composer ci:test:changelog` | exit 0 |

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01MNg1MysJVugv1xo2husknU)_