### PR TITLE
fix(ci): shard the directories the functional config names, not two of them

### DIFF
--- a/Build/Scripts/ciFunctionalParallel.sh
+++ b/Build/Scripts/ciFunctionalParallel.sh
@@ -48,7 +48,11 @@ mkdir -p .Build/Web/typo3temp/var/tests/functional-sqlite-dbs .Build/logs/functi
 # walking two directories. One invariant, one place to state it.
 CONFIG="Build/FunctionalTests.xml"
 mapfile -t DIRS < <(
-    awk '/<testsuites?[ >]/{inside=1} /<\/testsuites?>/{inside=0} inside' "${CONFIG}" \
+    # Closing tag WITHOUT the optional s: `</testsuites?>` also matches
+    # `</testsuite>`, which switches the block off before a one-line testsuite's
+    # own <directory> is read — zero directories, and the guard below only fires
+    # on an empty set, which this would not be if any suite were multi-line.
+    awk '/<testsuites[ >]/{inside=1} /<\/testsuites>/{inside=0} inside' "${CONFIG}" \
         | grep -oE '<directory[^>]*>[^<]+</directory>' \
         | sed 's|.*<directory[^>]*>||; s|</directory>||' \
         | while IFS= read -r dir; do

--- a/Build/Scripts/ciFunctionalParallel.sh
+++ b/Build/Scripts/ciFunctionalParallel.sh
@@ -41,12 +41,34 @@ export XDEBUG_MODE=off
 rm -rf .Build/logs/functional
 mkdir -p .Build/Web/typo3temp/var/tests/functional-sqlite-dbs .Build/logs/functional
 
-mapfile -t CLASSES < <(find Tests/Functional Tests/E2E/Backend -name '*Test.php' | sort)
+# The directories come out of Build/FunctionalTests.xml rather than being listed
+# here. Hardcoding them is how Tests/E2E/TCA ended up running in no job at all:
+# the `e2e-tca` testsuite was added to that config on 2026-08-09 — in a commit
+# titled "run the three PHP tests that were in no suite" — while this glob kept
+# walking two directories. One invariant, one place to state it.
+CONFIG="Build/FunctionalTests.xml"
+mapfile -t DIRS < <(
+    awk '/<testsuites?[ >]/{inside=1} /<\/testsuites?>/{inside=0} inside' "${CONFIG}" \
+        | grep -oE '<directory[^>]*>[^<]+</directory>' \
+        | sed 's|.*<directory[^>]*>||; s|</directory>||' \
+        | while IFS= read -r dir; do
+            # Paths in a phpunit config are relative to the config file.
+            realpath -m --relative-to=. "$(dirname "${CONFIG}")/${dir}"
+        done | sort -u
+)
+
+if [ "${#DIRS[@]}" -eq 0 ]; then
+    echo "::error::No <directory> entries under a testsuite in ${CONFIG} — nothing to shard."
+    exit 1
+fi
+echo "Sharding across: ${DIRS[*]}"
+
+mapfile -t CLASSES < <(find "${DIRS[@]}" -name '*Test.php' | sort)
 
 # A glob that matches nothing must not pass as success. This is how #272 rotted:
 # the suite stopped running and CI stayed green.
 if [ "${#CLASSES[@]}" -eq 0 ]; then
-    echo "::error::No functional test classes found under Tests/Functional or Tests/E2E/Backend."
+    echo "::error::No functional test classes found under ${DIRS[*]}."
     exit 1
 fi
 


### PR DESCRIPTION
`Tests/E2E/TCA/TcaFieldCompletionTest.php` runs in **no pull-request job today**.

`Build/FunctionalTests.xml` has declared three testsuites since [`5252b52`](https://github.com/netresearch/t3x-nr-llm/commit/5252b525) (2026-08-09) — `functional`, `e2e-backend`, `e2e-tca`. `Build/Scripts/ciFunctionalParallel.sh` walked two:

```bash
mapfile -t CLASSES < <(find Tests/Functional Tests/E2E/Backend -name '*Test.php' | sort)
```

That commit is titled *"run the three PHP tests that were in no suite"*. The suite was added to the config and the shard glob was not, so the class went straight back into no job — and the script's own comment warns about this failure mode, citing #272. The guard beneath it only fires when the set is **empty**, which it never was.

## The fix

The directory list comes out of the config: every `<directory>` under a `<testsuite>`, resolved relative to the config file, deduplicated. Adding a suite to the XML now shards it. Two statements of one invariant become one — the same move the shared runner made in typo3-ci-workflows v1.7.0, which is how this gap was found: the runner derives `Tests/E2E/Backend Tests/E2E/TCA Tests/Functional` while this script found two.

## Verified

```
Sharding across: Tests/E2E/Backend Tests/E2E/TCA Tests/Functional
```

The previously orphaned class passes on its own — 15 tests, 50 assertions. **It was never broken; it was never executed.**

## One unrelated failure in that run, stated rather than hidden

The full sharded run exits non-zero on `Tests/Functional/Provider/ProviderConnectionTest::testProviderConnectionReturnsWithinTimeout`. It asserts a wall-clock bound, and it fails under this script's four-way parallelism on a machine that is also running containers, while passing in isolation (4 tests, 13 assertions). It is not caused by this change — this change only adds a third directory to the walk — and it is not fixed here. Filed as its own issue: a timing assertion that holds serially and not in parallel is a flake waiting for a busy runner.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01GSptxPLHWsttu9FuqVkvYZ)_
