### PR TITLE
fix(docs): a merge conflict marker shipped in the ADR index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A merge conflict marker shipped in the ADR index.** `Documentation/Adr/Index.rst` ended on `||||||| c6503022` — a hand-resolved merge kept both sides and left the diff3 base marker behind as the file's last line, so the toctree carried a stray entry through v0.32.0. Nothing failed: the other guards read structure (status fields, citations, a rendered page) and a stray line at the end of a toctree is none of those to any of them. `NoConflictMarkersTest` now reads the bytes, and both marker shapes were watched failing before it was trusted.
+
 ## [0.32.0] - 2026-08-21
 
 ### Fixed

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -533,4 +533,3 @@ Tools
    Adr179ADroppedForcedSourceIsRecordedOnTheRun
    Adr180TheSixthWriterCreatesAPage
    Adr181EventStreamFramedAnswers
-||||||| c6503022

--- a/Tests/Unit/NoConflictMarkersTest.php
+++ b/Tests/Unit/NoConflictMarkersTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrLlm\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+/**
+ * No file in this repository carries a merge conflict marker.
+ *
+ * `Documentation/Adr/Index.rst` shipped one in v0.32.0. A hand-resolved merge
+ * (`41bb809a`, "Merge branch 'main' into fix/mcp-accept-sse") kept both sides
+ * and left the diff3 BASE marker behind as the file's last line, so the ADR
+ * toctree ended on `||||||| c6503022`. Nothing failed: every suite passed, the
+ * docs job rendered, the release went out.
+ *
+ * The reason nothing failed is worth stating, because it is what makes this
+ * test necessary rather than redundant. The other guards read STRUCTURE — the
+ * lifecycle test reads status fields, the citation test reads citations, the
+ * docs job renders a page. A stray line at the end of a toctree is none of
+ * those things to any of them. Only a check that reads the bytes finds it.
+ *
+ * The `<<<<<<<` and `>>>>>>>` markers are checked too, although the case that
+ * happened was the middle one: a resolution that drops those two and forgets
+ * the base marker is exactly the shape that survives a careless `git add -A`,
+ * because the file no longer looks conflicted at a glance.
+ */
+#[CoversNothing]
+final class NoConflictMarkersTest extends AbstractUnitTestCase
+{
+    /**
+     * Directories that are not this repository's source: the composer install,
+     * git's own storage, the JS toolchain, and the docs render output.
+     *
+     * @var list<string>
+     */
+    private const SKIPPED = ['.Build', '.git', 'node_modules', 'var', '.ddev', 'Documentation-GENERATED-temp'];
+
+    /**
+     * A line that opens, bases or closes a conflict hunk. Anchored at the start
+     * of the line and requiring the trailing space git writes, so a row of
+     * seven equals signs underlining an RST heading is not mistaken for one —
+     * which is why `=======` is deliberately NOT in this list.
+     */
+    private const MARKERS = ['<<<<<<< ', '||||||| ', '>>>>>>> '];
+
+    #[Test]
+    public function noTrackedFileCarriesAConflictMarker(): void
+    {
+        $root  = dirname(__DIR__, 2);
+        $found = [];
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($root, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::SELF_FIRST,
+        );
+
+        /** @var SplFileInfo $entry */
+        foreach ($iterator as $entry) {
+            $relative = ltrim(str_replace($root, '', $entry->getPathname()), '/');
+            if (in_array(explode('/', $relative)[0], self::SKIPPED, true)) {
+                continue;
+            }
+
+            if (!$entry->isFile() || $entry->getSize() > 2_000_000) {
+                continue;
+            }
+
+            // This file names the markers it looks for and would report itself.
+            if ($relative === 'Tests/Unit/NoConflictMarkersTest.php') {
+                continue;
+            }
+
+            $lines = explode("\n", (string)file_get_contents($entry->getPathname()));
+            foreach ($lines as $number => $line) {
+                foreach (self::MARKERS as $marker) {
+                    if (str_starts_with($line, $marker)) {
+                        $found[] = sprintf('%s:%d  %s', $relative, $number + 1, $line);
+                    }
+                }
+            }
+        }
+
+        self::assertSame(
+            [],
+            $found,
+            "A merge conflict marker reached the tree. A resolution that keeps both sides and drops only the\n"
+            . "<<<<<<< and >>>>>>> lines leaves the base marker behind, and the file stops looking conflicted:\n"
+            . implode("\n", $found),
+        );
+    }
+
+    /**
+     * The guard is only worth having if it fires, and the shape it has to catch
+     * is the one that already got through: a lone base marker with no opening
+     * and no closing line.
+     */
+    #[Test]
+    public function aLoneBaseMarkerIsRecognised(): void
+    {
+        $line = '||||||| c6503022';
+
+        $hit = false;
+        foreach (self::MARKERS as $marker) {
+            $hit = $hit || str_starts_with($line, $marker);
+        }
+
+        self::assertTrue($hit, 'The marker that shipped in v0.32.0 must be one this test recognises.');
+    }
+
+    /**
+     * An RST heading underline is seven or more equals signs at the start of a
+     * line, which is why `=======` is not a marker here. Stated as a test so
+     * nobody "completes" the list and turns every heading in the corpus into a
+     * finding.
+     */
+    #[Test]
+    public function anRstHeadingUnderlineIsNotAConflictMarker(): void
+    {
+        foreach (self::MARKERS as $marker) {
+            self::assertStringStartsNotWith(
+                $marker,
+                '=======',
+                'An RST underline must not match a conflict marker.',
+            );
+        }
+    }
+}


### PR DESCRIPTION
`Documentation/Adr/Index.rst` ends on this, on `main`, and shipped that way in **v0.32.0**:

```
   Adr180TheSixthWriterCreatesAPage
   Adr181EventStreamFramedAnswers
||||||| c6503022
```

[`41bb809a`](https://github.com/netresearch/t3x-nr-llm/commit/41bb809a) — "Merge branch 'main' into fix/mcp-accept-sse" — resolved a conflict by hand, kept both sides, and dropped only the `<<<<<<<` and `>>>>>>>` lines. The diff3 **base** marker stayed as the file's last line, so the ADR toctree carries a stray entry. `c6503022` is [#829](https://github.com/netresearch/t3x-nr-llm/pull/829), the other side of that merge.

One occurrence repo-wide; found by accident while reading the index for something else.

## It is published, not just committed

`https://docs.typo3.org/p/netresearch/nr-llm/0.32/en-us/Adr/Index.html` answers **200** and contains, verbatim:

```html
<p>||||||| c6503022</p>
```

Sphinx did not read the stray line as a broken toctree entry and drop it — it rendered it as an ordinary **paragraph after the list**. That is why the `docs` job was green: there was no unresolved reference to complain about. The page builds without error and shows a conflict marker to anyone reading the ADR index for the released version.

So "it renders and returns 200" was not evidence here either. Same shape as the guards one level down: the check reads structure, the defect is bytes.

## Why nothing caught it, which is the argument for the guard

Every existing check on this corpus reads **structure**:

| check | reads |
|---|---|
| `AdrLifecycleTest` | status vocabulary, `:Amends:`/`:Amended:` pairing |
| `AdrReferenceIntegrityTest` | that `:ref:` targets resolve |
| `AdrCodeCitationTest` | citations against the tree |
| the `docs` job | a rendered page |

A stray line at the end of a toctree is none of those things to any of them. The suites passed, the docs job rendered, the release went out. **Only a check that reads the bytes finds it**, so that is what `NoConflictMarkersTest` does — repo-wide, not just the ADR corpus.

## Two controls, each observed

| injected | reported |
|---|---|
| the shipped marker put back | `Documentation/Adr/Index.rst:536  \|\|\|\|\|\|\| c6503022` |
| `<<<<<<< HEAD` appended to `README.md` | `README.md:375  <<<<<<< HEAD` |

Clean tree: 3 tests green.

## `=======` is deliberately not a marker, and there is a test saying so

Seven equals signs at the start of a line are how RST underlines a heading. "Completing" the marker list would turn every heading in the corpus into a finding, so the omission is pinned by an assertion rather than left as a comment somebody helpfully fixes later.

The base marker is the one that matters anyway: a resolution that forgets it leaves a file that **no longer looks conflicted at a glance**, which is precisely how this one got through review and a release.

## Verification

| gate | result |
|---|---|
| `-s unit` (full) | 7291 tests, 24770 assertions, exit 0 |
| `-s phpstan` | No errors |
| `-s cgl -n` | SUCCESS |
| `-s rector -n` (pinned 8.2) | Rector is done |
| `composer ci:test:changelog` | exit 0 |

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01MNg1MysJVugv1xo2husknU)_