### PR TITLE
fix(agent): keep the caller source across resume and the queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - **A merge conflict marker shipped in the ADR index.** `Documentation/Adr/Index.rst` ended on `||||||| c6503022` — a hand-resolved merge kept both sides and left the diff3 base marker behind as the file's last line, so the toctree carried a stray entry through v0.32.0. Nothing failed: the other guards read structure (status fields, citations, a rendered page) and a stray line at the end of a toctree is none of those to any of them. `NoConflictMarkersTest` now reads the bytes, and both marker shapes were watched failing before it was trusted.
+- **A resumed or queued agent run keeps the caller that started it.** The identity survived only while the `AgentRunRequest` was in memory: `AgentRunRequestCodec` persisted the options through `toArray()`, which omits the caller source by design, and the resume paths rebuilt them the same way. Every provider round-trip after an approval or an input submission was therefore unattributed, and a queued run was unattributed for its whole length even though the enqueuing request named its caller. That is worse than a missing row — the same logical run appeared partly under its extension and partly under *Unattributed*, so neither figure was the run's cost. For an agent whose writing tools all suspend for approval (ADR-134) it was most of the interesting traffic (#847).
+
+  The pair now travels beside the serialised options rather than inside them, in the channel the codec already uses for `plannedCost` and the idempotency key, and the resume paths re-inject it exactly as they re-inject the acting user's uid (ADR-084). `toArray()` stays provider-clean: widening it would have sent the calling extension's key upstream and taken the reason those other fields are excluded down with it.
 
 ## [0.32.0] - 2026-08-21
 

--- a/Classes/Service/Agent/AgentRunRequestCodec.php
+++ b/Classes/Service/Agent/AgentRunRequestCodec.php
@@ -76,6 +76,14 @@ final readonly class AgentRunRequestCodec
             // request hit the identical budget gate and dedup.
             'plannedCost'      => $request->options?->getPlannedCost(),
             'idempotencyKey'   => $request->options?->getIdempotencyKey(),
+            // Same channel, same reason (#847): the caller identity is call
+            // metadata, not a provider option, so it is absent from toArray() —
+            // and a queued run would otherwise be unattributed for its whole
+            // length even though the enqueuing request named its caller. That is
+            // worse than a missing row: one logical run splits between its own
+            // extension and "Unattributed", and neither figure is its cost.
+            'callerSourceExtension' => $request->options?->getCallerSourceExtension(),
+            'callerSourceOperation' => $request->options?->getCallerSourceOperation(),
             'maxIterations'    => $request->maxIterations,
             'captureRaw'       => $request->captureRaw,
             // null stays null: a non-null augmentation makes the loop bake the
@@ -150,6 +158,15 @@ final readonly class AgentRunRequestCodec
             $idempotencyKey = $data['idempotencyKey'] ?? null;
             if (is_string($idempotencyKey) && $idempotencyKey !== '') {
                 $options = $options->withIdempotencyKey($idempotencyKey);
+            }
+
+            $callerSourceExtension = $data['callerSourceExtension'] ?? null;
+            if (is_string($callerSourceExtension) && $callerSourceExtension !== '') {
+                $callerSourceOperation = $data['callerSourceOperation'] ?? null;
+                $options               = $options->withCallerSource(
+                    $callerSourceExtension,
+                    is_string($callerSourceOperation) ? $callerSourceOperation : '',
+                );
             }
         }
 

--- a/Classes/Service/Tool/ToolLoopService.php
+++ b/Classes/Service/Tool/ToolLoopService.php
@@ -395,7 +395,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                             // SAME allow-list and options instead of falling back to
                             // defaults (ADR-084).
                             $allowedToolNames,
-                            $options?->toArray() ?? [],
+                            $this->persistedRunOptions($options),
                             // What the turn WOULD do, captured here and not at
                             // approval time: this is the run's actor context, the
                             // only identity allowed to read the targets (ADR-136).
@@ -435,7 +435,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                             $promptTokens,
                             $completionTokens,
                             $allowedToolNames,
-                            $options?->toArray() ?? [],
+                            $this->persistedRunOptions($options),
                             inputToolName: $call->name,
                             inputSchema: $schema,
                             forcedSnippetUids: $this->uidsOf($augmentation->forcedSnippets ?? []),
@@ -633,7 +633,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
         // Restore the run's options and re-inject the acting user's uid so the
         // resumed continuation is budget-checked — the uid is intentionally not
         // part of the persisted options (ADR-084).
-        $options = ToolOptions::fromArray($state->options, $beUserUid);
+        $options = $this->restoreCallerSource(ToolOptions::fromArray($state->options, $beUserUid), $state->options);
         // Re-apply the gate NOW (a tool may have been disabled or restricted while
         // the run was suspended) rather than trusting the names captured at
         // suspend time.
@@ -724,7 +724,7 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
 
         $messages     = $state->messages;
         $pendingCalls = $state->toolCalls();
-        $options      = ToolOptions::fromArray($state->options, $beUserUid);
+        $options      = $this->restoreCallerSource(ToolOptions::fromArray($state->options, $beUserUid), $state->options);
         $offered      = $this->resolveOfferedNames($state->allowedToolNames, $configuration, $context);
         $remoteCalls  = new RemoteCallBudget();
 
@@ -1138,6 +1138,59 @@ final readonly class ToolLoopService implements ToolLoopServiceInterface
                 $this->bounder->content($result->content),
                 ...$this->bounder->artifacts($result->artifacts),
             );
+    }
+
+    /**
+     * The run's options as they are persisted at suspend: the serialised
+     * `ToolOptions`, plus the caller identity carried alongside them.
+     *
+     * @return array<string, mixed>
+     */
+    private function persistedRunOptions(?ToolOptions $options): array
+    {
+        $persisted = $options?->toArray() ?? [];
+
+        $extension = $options?->getCallerSourceExtension();
+        if ($extension === null || $extension === '') {
+            return $persisted;
+        }
+
+        // Carried BESIDE the serialised options, not inside them: `toArray()`
+        // builds the provider payload and deliberately omits the caller identity,
+        // exactly as it omits the idempotency key and the budget fields. Widening
+        // it here would send the calling extension's key upstream and would take
+        // the reason those other two are excluded down with it (#847).
+        //
+        // `ToolOptions::fromArray()` ignores keys it does not know, so these two
+        // survive the round trip without reaching a provider; resume reads them
+        // back explicitly in {@see self::restoreCallerSource()}.
+        return $persisted + [
+            'callerSourceExtension' => $extension,
+            'callerSourceOperation' => $options?->getCallerSourceOperation() ?? '',
+        ];
+    }
+
+    /**
+     * Put the caller identity back on options rehydrated from a suspended state.
+     *
+     * The same shape as the backend-user uid the resume paths already re-inject
+     * by hand (ADR-084): persisted out-of-band, restored explicitly. Without it
+     * every provider round-trip after an approval or an input submission is
+     * unattributed, so one logical run splits between its own extension and
+     * *Unattributed* and neither figure is the run's cost (#847).
+     *
+     * @param array<string, mixed> $persisted
+     */
+    private function restoreCallerSource(ToolOptions $options, array $persisted): ToolOptions
+    {
+        $extension = $persisted['callerSourceExtension'] ?? null;
+        if (!is_string($extension) || $extension === '') {
+            return $options;
+        }
+
+        $operation = $persisted['callerSourceOperation'] ?? null;
+
+        return $options->withCallerSource($extension, is_string($operation) ? $operation : '');
     }
 
     /**

--- a/Tests/Unit/Service/Agent/AgentRunRequestCodecTest.php
+++ b/Tests/Unit/Service/Agent/AgentRunRequestCodecTest.php
@@ -140,6 +140,72 @@ final class AgentRunRequestCodecTest extends TestCase
     }
 
     /**
+     * Same channel and same reason as the budget fields above (#847): the caller
+     * identity is call metadata, not a provider option, so `toArray()` omits it.
+     * Without carrying it out of band a queued run is unattributed for its whole
+     * length even though the enqueuing request named its caller — and the run
+     * then splits between its own extension and "Unattributed", so neither
+     * number is the run's cost.
+     */
+    #[Test]
+    public function roundTripCarriesTheCallerIdentityOutOfBand(): void
+    {
+        $options = (new ToolOptions())->withCallerSource('nr_mcp_agent', 'chatTurn');
+
+        $request = new AgentRunRequest(
+            configuration: $this->configuration,
+            messages: [],
+            actor: AiActorContext::backendUser(7),
+            options: $options,
+        );
+
+        $dehydrated = $this->codec()->dehydrate($request);
+        self::assertSame('nr_mcp_agent', $dehydrated['callerSourceExtension']);
+        self::assertSame('chatTurn', $dehydrated['callerSourceOperation']);
+
+        // It must travel out of band, not inside the serialised options: that
+        // array is what rebuilds the provider request, and the calling
+        // extension's key must never be sent upstream.
+        self::assertIsArray($dehydrated['options']);
+        self::assertArrayNotHasKey('callerSourceExtension', $dehydrated['options']);
+
+        $payload = json_encode($dehydrated);
+        self::assertIsString($payload);
+
+        $this->configurationRepository->method('findByUid')->willReturn($this->configuration);
+        $restored = $this->codec()->rehydrate($this->queuedRun($payload));
+
+        self::assertNotNull($restored->options);
+        self::assertSame('nr_mcp_agent', $restored->options->getCallerSourceExtension());
+        self::assertSame('chatTurn', $restored->options->getCallerSourceOperation());
+    }
+
+    /**
+     * An unannotated request must rehydrate unannotated rather than picking up
+     * an empty identity: `''` on the row reads as "attributed to nothing", which
+     * is a different claim from "not attributed".
+     */
+    #[Test]
+    public function anUnannotatedRequestRehydratesWithoutACallerIdentity(): void
+    {
+        $request = new AgentRunRequest(
+            configuration: $this->configuration,
+            messages: [],
+            actor: AiActorContext::backendUser(7),
+            options: new ToolOptions(),
+        );
+
+        $payload = json_encode($this->codec()->dehydrate($request));
+        self::assertIsString($payload);
+
+        $this->configurationRepository->method('findByUid')->willReturn($this->configuration);
+        $restored = $this->codec()->rehydrate($this->queuedRun($payload));
+
+        self::assertNotNull($restored->options);
+        self::assertNull($restored->options->getCallerSourceExtension());
+    }
+
+    /**
      * A null augmentation must stay null: a non-null one makes the loop bake the
      * effective system prompt into the transcript, which a null-augmentation run
      * would not do.

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -1208,6 +1208,99 @@ final class ToolLoopServiceTest extends TestCase
     }
 
     #[Test]
+    public function anApprovedRunContinuesUnderTheCallerThatStartedIt(): void
+    {
+        // #847: the caller identity survived only as long as the AgentRunRequest
+        // was in memory. Everything that rehydrates a run from persisted state
+        // got it back as null, so every provider round-trip after an approval
+        // was unattributed. For an agent whose writing tools all suspend for
+        // approval (ADR-134) that is the majority of the interesting traffic,
+        // and the effect is worse than a missing row: the same logical run shows
+        // up partly under its extension and partly under "Unattributed", so
+        // neither number is the run's cost.
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+
+        $resumedOptions = null;
+        $queue          = [
+            $this->response('', [new ToolCall('call_1', 'delete_thing', [])]),
+            $this->response('done', []),
+        ];
+        $mgr->method('chatWithToolsForConfiguration')->willReturnCallback(
+            function (
+                array $messages,
+                array $tools,
+                LlmConfiguration $configuration,
+                ?ToolOptions $options = null,
+            ) use (&$queue, &$resumedOptions): CompletionResponse {
+                // The first call suspends; anything after it is the continuation.
+                if ($resumedOptions === null && count($queue) === 1) {
+                    $resumedOptions = $options;
+                }
+
+                return array_shift($queue) ?? $this->response('done', []);
+            },
+        );
+
+        $service = $this->service($mgr, new ToolRegistry([$this->approvalTool()]));
+        $options = (new ToolOptions())->withCallerSource('nr_mcp_agent', 'chatTurn');
+
+        $state = null;
+        try {
+            $service->runLoop(
+                [$this->userTurn('delete it')],
+                $this->localConfiguration(),
+                ToolExecutionContext::none(),
+                ['delete_thing'],
+                $options,
+            );
+        } catch (ToolApprovalRequiredException $e) {
+            $state = $e->state;
+        }
+
+        self::assertNotNull($state);
+        // Persisted BESIDE the serialised options, never inside them: that array
+        // rebuilds the provider request, and the calling extension's key must
+        // not reach a provider.
+        self::assertSame('nr_mcp_agent', $state->options['callerSourceExtension'] ?? null);
+        self::assertSame('chatTurn', $state->options['callerSourceOperation'] ?? null);
+
+        $service->resume($state, true, $this->localConfiguration(), ToolExecutionContext::none());
+
+        self::assertInstanceOf(ToolOptions::class, $resumedOptions);
+        self::assertSame('nr_mcp_agent', $resumedOptions->getCallerSourceExtension());
+        self::assertSame('chatTurn', $resumedOptions->getCallerSourceOperation());
+    }
+
+    #[Test]
+    public function anUnannotatedRunSuspendsWithoutACallerIdentity(): void
+    {
+        // The absence needs its own assertion: writing '' would put "attributed
+        // to nothing" on the row, which is a different claim from "not
+        // attributed", and it would hide a wiring mistake that always writes.
+        $mgr = self::createStub(LlmServiceManagerInterface::class);
+        $mgr->method('chatWithToolsForConfiguration')
+            ->willReturn($this->response('', [new ToolCall('call_1', 'delete_thing', [])]));
+        $service = $this->service($mgr, new ToolRegistry([$this->approvalTool()]));
+
+        $state = null;
+        try {
+            $service->runLoop(
+                [$this->userTurn('go')],
+                $this->localConfiguration(),
+                ToolExecutionContext::none(),
+                ['delete_thing'],
+                new ToolOptions(temperature: 0.3),
+            );
+        } catch (ToolApprovalRequiredException $e) {
+            $state = $e->state;
+        }
+
+        self::assertNotNull($state);
+        self::assertArrayNotHasKey('callerSourceExtension', $state->options);
+        self::assertArrayNotHasKey('callerSourceOperation', $state->options);
+    }
+
+    #[Test]
     public function resumeReAppliesTheGateAndRefusesANoLongerOfferedTool(): void
     {
         $mgr = self::createStub(LlmServiceManagerInterface::class);

--- a/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
+++ b/Tests/Unit/Service/Tool/ToolLoopServiceTest.php
@@ -1233,7 +1233,7 @@ final class ToolLoopServiceTest extends TestCase
                 ?ToolOptions $options = null,
             ) use (&$queue, &$resumedOptions): CompletionResponse {
                 // The first call suspends; anything after it is the continuation.
-                if ($resumedOptions === null && count($queue) === 1) {
+                if (!$resumedOptions instanceof ToolOptions && count($queue) === 1) {
                     $resumedOptions = $options;
                 }
 


### PR DESCRIPTION
Closes #847. Sibling of #866; the two are independent and can land in either order.

The caller identity survived only as long as the `AgentRunRequest` was in memory. `AgentRunRequestCodec::dehydrate()` persists the options as `$request->options?->toArray()`, and `toArray()` omits the caller source by design; `rehydrate()` rebuilds them with `ToolOptions::fromArray()`, which does not read it either. `ToolLoopService::resume()` and its input-submission twin do the same from the suspended state. So a run that named its caller lost it the moment it was persisted.

The effect is worse than a missing row. The same logical run shows up partly under its extension and partly under *Unattributed*, so **neither number is the run's cost**. For an agent whose writing tools all suspend for approval (ADR-134), the unattributed part is most of the interesting traffic.

**Where it is carried.** Beside the serialised options, not inside them — the channel the codec already uses for `plannedCost` and the idempotency key, with the rationale already written down there. Putting it inside `toArray()` would have sent the calling extension's key upstream as a provider parameter, and it would have taken the reason those other two are excluded down with it. That argument is the peer session's, not mine, and it is better than the one I had.

**What changed**

- `AgentRunRequestCodec` — the pair is written next to `plannedCost` / `idempotencyKey` and re-injected on rehydrate in the same shape.
- `ToolLoopService::persistedRunOptions()` — what goes into the suspended state at both suspend sites (approval and input pauses).
- `ToolLoopService::restoreCallerSource()` — used by both resume paths, mirroring how they already re-inject the acting user's uid by hand (ADR-084).

`SuspendedRunState` is untouched: it is frozen `@api`, and the pair rides in the `options` array it already carries. `ToolOptions::fromArray()` ignores keys it does not know, so the two survive the round trip without reaching a provider, and resume reads them back explicitly.

`AgentRuntimeInterface::approve()` still takes no options object — it does not need one. The identity now comes from the persisted state, which is where an approval's context has always come from.

**The guards were watched failing.** With `AgentRunRequestCodec` reverted, exactly one test fails: `roundTripCarriesTheCallerIdentityOutOfBand`. With `ToolLoopService` reverted, exactly one fails: `anApprovedRunContinuesUnderTheCallerThatStartedIt`. In both cases the paired absence tests stay green, which is correct — they assert behaviour that must hold before and after. Both were restored and re-run green.

The end-to-end assertion is the one that matters: a run is started with `withCallerSource('nr_mcp_agent', 'chatTurn')`, suspends for approval, and the options the manager receives on the *resumed* call are checked for the identity — not the helper in isolation.

**Gates run locally** (PHP 8.4 × one matrix cell — CI covers eight): `cgl` clean, `phpstan` level 10 clean, full `unit` suite 7292 tests green. The functional suite was not run locally; the persisted shape is exercised by the codec's round-trip test rather than against a database.

No ADR: this restores ADR-177/ADR-178 on a path they already claimed. The decision worth recording — that the identity travels beside `toArray()` and not inside it — is stated at both writers and pinned by tests.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_0144iD1P22LotW8rxmxrNGro)_
