### PR TITLE
docs(adr): propose the write-target contract #772 is blocked on

### DIFF
--- a/Documentation/Adr/Adr122ToolEffectContractDeferred.rst
+++ b/Documentation/Adr/Adr122ToolEffectContractDeferred.rst
@@ -8,7 +8,7 @@ ADR-122: The side-effecting tool contract waits for a side-effecting tool
 
 :Status: Accepted (premise expired — see :ref:`ADR-135 <adr-135>` and :ref:`ADR-136 <adr-136>`)
 :Date: 2026-07-29
-:Amended: 2026-08-09 by :ref:`ADR-135 <adr-135>` and :ref:`ADR-136 <adr-136>`
+:Amended: 2026-08-09 by :ref:`ADR-135 <adr-135>` and :ref:`ADR-136 <adr-136>`; 2026-08-21 by :ref:`ADR-182 <adr-182>`
 :Authors: Netresearch DTT GmbH
 
 .. note::

--- a/Documentation/Adr/Adr182AWriteToolNamesTheRecordItWrote.rst
+++ b/Documentation/Adr/Adr182AWriteToolNamesTheRecordItWrote.rst
@@ -1,0 +1,159 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-182:
+
+============================================================================
+ADR-182: A write tool names the record it wrote
+============================================================================
+
+:Status: Proposed
+:Date: 2026-08-21
+:Amends: :ref:`ADR-122 <adr-122>` (the deferral whose premise expired)
+:Authors: Netresearch DTT GmbH
+
+.. _adr-182-context:
+
+Context
+=======
+
+:ref:`ADR-176 <adr-176>` made a per-call outcome recordable and shipped the
+explicit half: a person rates a result, the row is written against the call's
+``correlation_id``. It also found the observed half blocked on something it did
+not expect to look for — **nothing persists which record a tool write
+produced**. The uid the model chose sits inside
+:php:`ToolInvocation::$arguments` as free-form JSON, and
+:php:`ToolEffectInterface` declares only :php:`getEffect()`, a classification
+rather than an identity. Without a
+queryable write target there is no join to ``sys_history``, so
+``ACCEPTED_UNCHANGED``, ``EDITED`` and ``DISCARDED`` cannot be derived.
+
+:php:`CallOutcome::isImplemented()` says so in code rather than in prose, and
+returns false for exactly those three. `#772` is that gap.
+
+:ref:`ADR-122 <adr-122>` is where the missing fact was deferred. It declined to
+build a side-effecting tool contract with a plain reason: "A contract designed
+before the first writing tool guesses at the shape that tool needs, and this
+codebase has just spent three changes removing exactly that kind of guess." Its
+``:Status:`` already records that premise as expired.
+
+**Seven writers exist now** — ``grep -rl 'use WritesThroughDataHandlerTrait'
+Classes/Service/Tool/Builtin/`` — and the outcome signal is the first reader the
+contract lacked. The shape is no longer a guess; it can be read off what those
+seven already do.
+
+.. _adr-182-decision:
+
+Decision
+========
+
+**A tool that creates or changes a record says which one, and nothing else.**
+
+- A new ``final readonly`` value object carries a table name and a uid. Two
+  fields, both scalar, because that is what the join needs.
+- :php:`ToolResult` gains it as an optional property with a null default. That
+  class is on the frozen surface (``Tests/Unit/Api/api-surface.txt``), so this
+  is an additive change: regenerate the file and announce it under
+  ``### Added``.
+- :php:`RunTrace` persists it as its own step kind, the way
+  :ref:`ADR-179 <adr-179>` persists a dropped forced source. The run already
+  carries the ``correlation_id`` the outcome row is keyed by, so no new
+  identifier is invented.
+- The observed outcome reads that step and joins ``sys_history``.
+
+**Only a writer sets it.** A read-only tool returning a write target is a
+defect, not a curiosity, and ``ToolEffectCoverageTest`` already knows which
+tools declare a write effect — the same list gates this.
+
+.. _adr-182-rebuild:
+
+The one place this will be lost, named before it is
+====================================================
+
+:php:`ToolLoopService` does not return the tool's result. It **rebuilds** it::
+
+    return $result->isError
+        ? ToolResult::error($this->bounder->content($result->content))
+        : ToolResult::text(
+            $this->bounder->content($result->content),
+            ...$this->bounder->artifacts($result->artifacts),
+        );
+
+A field added to :php:`ToolResult` without touching those five lines would be
+dropped on every path, and every test that asserts on the tool's own return
+value would still pass. The tool would declare a write target, the loop would
+answer with one that has none, and the outcome signal would find nothing —
+a surface that holds nothing, arrived at by omission.
+
+This is worth naming because it is the **third** time this shape has cost
+something here. `#845` and `#846` lost values to an options rebuild; `#844`
+found :php:`withCallerSource()` callable on the specialized services and
+dropped by :php:`fromArray()`. In each case the field existed, the reader
+existed, and the rebuild in between answered without it.
+
+So the acceptance for this record includes a test that runs a write tool
+**through the loop** and asserts the target survives — not one that calls
+:php:`execute()` directly, which is the assertion that would have passed in all
+three earlier cases.
+
+.. _adr-182-not:
+
+What this does not build
+========================
+
+ADR-122 deferred three things. This record takes one of them and leaves the
+other two deferred, with their reasons intact.
+
+**No idempotency scope.** ADR-122 declined it for want of a reader, and it still
+has none: :php:`ToolEffect` already tells the reaper what may be retried
+(:ref:`ADR-122 <adr-122>`, :ref:`ADR-141 <adr-141>`), and no caller asks a finer
+question. A scope key would be a second answer to a question already answered.
+
+**No preview contract.** :ref:`ADR-136 <adr-136>` shipped
+:php:`ToolPreviewInterface` for the approval card, driven by the arguments
+rather than by a declared effect shape. That is the preview this codebase has a
+consumer for.
+
+**It does not make the outcome signal true.** It makes it computable. Whether an
+edit within some window means the model did badly is a question for `#772` and
+for :ref:`ADR-156 <adr-156>`'s second criterion; this record only removes the
+reason it cannot be asked.
+
+**It does not touch approval.** ADR-176 separated the two deliberately: an
+approval withheld for governance reasons says nothing about quality, and joining
+them would poison the metric with policy behaviour.
+
+.. _adr-182-consequences:
+
+Consequences
+============
+
+- ✅ ``ACCEPTED_UNCHANGED``, ``EDITED`` and ``DISCARDED`` become derivable, and
+  :php:`CallOutcome::isImplemented()` can start returning true for them —
+  a change that test will notice.
+- ✅ ADR-122's expired premise is discharged for the part that has a reader,
+  and its other two deferrals keep their reasons rather than being quietly
+  swept in alongside.
+- ⚠️ :php:`ToolResult` is on the frozen surface. Additive, but the file must be
+  regenerated in the same change or the surface test fails — which is the
+  intended behaviour, not an obstacle.
+- ⚠️ Seven tools gain one line each. A writer that forgets it reports no
+  outcome and fails no test unless the coverage test above is written to
+  require one from every declared writer. It is, for that reason.
+- ⚠️ The join reads ``sys_history``, which is subject to its own retention
+  (:ref:`ADR-064 <adr-064>`). An outcome derived after the history row was
+  purged is not "no change"; it is unknown, and must be recorded as neither.
+
+.. _adr-182-revisit:
+
+Revisit when
+============
+
+- **A tool writes more than one record per call.** :ref:`ADR-180 <adr-180>` kept
+  the one-record rule and named its own trigger; a writer that breaks it makes
+  this a list rather than a pair, and the outcome join has to decide what a
+  partial edit means.
+- **A second reader appears.** One reader is what justifies this record. A
+  second one is when the shape should be re-examined rather than extended by
+  habit.
+- **The idempotency scope finds a consumer.** ADR-122's remaining deferral ends
+  the same way this one did: when something asks.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -533,3 +533,4 @@ Tools
    Adr179ADroppedForcedSourceIsRecordedOnTheRun
    Adr180TheSixthWriterCreatesAPage
    Adr181EventStreamFramedAnswers
+   Adr182AWriteToolNamesTheRecordItWrote


### PR DESCRIPTION
Refs #772. **`Proposed`, not `Accepted`** — this names a decision to take, and the implementation lands after it rather than inside it, as `Classes/AGENTS.md` requires for a contract change.

## The gap, stated by the code rather than by me

ADR-176 shipped the explicit half of the per-call outcome and found the observed half blocked on a fact nothing persists: **which record a tool write produced**. `CallOutcome::isImplemented()` returns false for `ACCEPTED_UNCHANGED`, `EDITED` and `DISCARDED` — a checkable statement, not a sentence in a record. #772 is that gap.

ADR-122 is where it was deferred, and its reason was good:

> A contract designed before the first writing tool guesses at the shape that tool needs, and this codebase has just spent three changes removing exactly that kind of guess.

**Seven writers exist now** (`grep -rl 'use WritesThroughDataHandlerTrait' Classes/Service/Tool/Builtin/`), and the outcome signal is the first reader the contract lacked. The shape can be read off what those seven already do.

## Scope: identity, and nothing else

A table and a uid. Carried on `ToolResult`, persisted through `RunTrace` against the run's existing `correlation_id`, read by the observed outcome joining `sys_history`.

**The other two things ADR-122 deferred stay deferred, with their reasons intact** — that is deliberate, and it is the part most likely to be "helpfully" widened later:

| deferred | still deferred because |
|---|---|
| idempotency scope | `ToolEffect` already tells the reaper what may be retried; no caller asks a finer question |
| preview contract | ADR-136 shipped `ToolPreviewInterface` for the approval card, driven by arguments |

## The place this will be lost, named before it is

`ToolLoopService` does not return the tool's result. It **rebuilds** it:

```php
return $result->isError
    ? ToolResult::error($this->bounder->content($result->content))
    : ToolResult::text(
        $this->bounder->content($result->content),
        ...$this->bounder->artifacts($result->artifacts),
    );
```

A new property on `ToolResult` would be dropped on every path, **and every test that asserts on the tool's own return value would still pass.** The tool would declare a write target, the loop would answer with one that has none, and the outcome signal would find nothing.

This is the **third** time this shape has cost something here — [#845](https://github.com/netresearch/t3x-nr-llm/issues/845) and [#846](https://github.com/netresearch/t3x-nr-llm/issues/846) lost values to an options rebuild; [#844](https://github.com/netresearch/t3x-nr-llm/issues/844) found `withCallerSource()` callable on the specialized services and dropped by `fromArray()`. In each case the field existed, the reader existed, and the rebuild in between answered without it.

So the acceptance asks for a test that runs a writer **through the loop**, not one that calls `execute()` directly — which is the assertion that would have passed in all three earlier cases.

## Consequences worth reading before accepting

- `ToolResult` is on the frozen surface. The change is **additive**, and the surface file has to be regenerated in the same change — a consequence to accept, not an obstacle to work around.
- Seven tools gain one line each, and a writer that forgets it reports no outcome silently. `ToolEffectCoverageTest` already knows which tools declare a write effect, so the same list is what makes the omission fail.
- The join reads `sys_history`, which has its own retention (ADR-064). An outcome derived after the history row was purged is **unknown**, not "no change", and has to be recorded as neither.

ADR-122 carries the counterpart `:Amended:` field; `AdrLifecycleTest` enforces the pairing in both directions.

## Verification

| gate | result |
|---|---|
| `-s unit` (full, incl. `AdrLifecycleTest` and `AdrReferenceIntegrityTest`) | 7288 tests, 24782 assertions, exit 0 |
| `-s phpstan` | No errors |
| `-s cgl -n` | SUCCESS |
| `composer ci:test:changelog` | exit 0 |
| line length | every line ≤ 80 |

## Correction: this is stacked on #869, and the reason is worth reading

I first wrote here that this PR and [#869](https://github.com/netresearch/t3x-nr-llm/pull/869) "merge cleanly in either order", because one adds a toctree line and the other removes the line below it. **I then tested that claim instead of leaving it, and it was false.** The two lines are adjacent, git cannot decide, and the merge conflicts:

```
CONFLICT (content): Merge conflict in Documentation/Adr/Index.rst
```

The resolution left behind — before anyone touches it — is this:

```
   Adr182AWriteToolNamesTheRecordItWrote
||||||| c6503022
=======
>>>>>>> origin/fix/adr-index-conflict-marker
```

**Three markers, in the file whose single stray marker is the entire subject of #869.** A careless resolution here reproduces the defect being fixed, three times over, in the same place.

So this branch is now rebased onto `fix/adr-index-conflict-marker` and targets it. When #869 merges, GitHub retargets this to `main`. The guard from #869 runs in this branch and passes — 0 markers, one `Adr182` entry.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01MNg1MysJVugv1xo2husknU)_