### PR TITLE
fix(provider): resolve the default configuration's adapter, not its row id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `toArray()` deliberately still omits the identity: it builds the provider payload, and the caller's extension key is attribution metadata that must never be sent upstream — the same reason `configuration` and the budget fields are absent there. A test asserts that absence so a later symmetry-minded change cannot turn it into a data leak.
 
   Not covered: `DallEImageService::variation()` and `::edit()` take no options object and stay unattributed, and DeepL's language-detection and metadata calls are internal sub-steps rather than consumer-attributable spend.
+- **`vision()` and `embed()` look up the provider by adapter type, not by the configuration row's identifier.** 0.32.0 gave both methods the default-configuration fallback `chat()` already had, and then handed `KeyedProviderRegistry` the wrong kind of key: the registry is keyed by `ProviderInterface::getIdentifier()` — the adapter's own name, `openai` — while `Domain\Model\Provider::getIdentifier()` is the `tx_nrllm_provider` row's identifier, `openai-dcbd8f` on any installation set up through the wizard. Two namespaces behind one method name. The result was that 0.32.0 replaced *"No provider specified and no default provider configured"* with *"Provider … not found"* — a different message for the same dead end, on exactly the installations the fallback was written for (#873).
+
+  The regression tests that were supposed to cover this could not: their fixture returned the same string for the row identifier and the adapter key, so nothing distinguished them. The fixture now uses different values, and with it the existing tests reproduce the production failure.
 
 ## [0.32.0] - 2026-08-21
 

--- a/Classes/Service/LlmServiceManager.php
+++ b/Classes/Service/LlmServiceManager.php
@@ -1396,8 +1396,16 @@ final readonly class LlmServiceManager implements LlmServiceManagerInterface, Si
         // lookups below are answered — but a model without a provider record
         // would leave the key null, and then the registry throws as before
         // rather than this method inventing a provider.
+        //
+        // The ADAPTER TYPE, not the record identifier: KeyedProviderRegistry is
+        // keyed by ProviderInterface::getIdentifier() — the adapter's own name
+        // ('openai', 'claude', …) — while Provider::getIdentifier() is the
+        // tx_nrllm_provider row's identifier ('openai-dcbd8f'). The two are
+        // different namespaces behind the same method name, and handing the
+        // registry the row identifier turned "no provider specified" into
+        // "Provider ... not found" (#873).
         $model      = $configuration->getLlmModel();
-        $identifier = $model?->getProvider()?->getIdentifier();
+        $identifier = $model?->getProvider()?->getAdapterType();
         if ($identifier === null || $identifier === '') {
             return [null, null, $optionsArray];
         }

--- a/Tests/Unit/Service/LlmServiceManagerTest.php
+++ b/Tests/Unit/Service/LlmServiceManagerTest.php
@@ -2080,7 +2080,13 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $provider = new TestableVisionProvider();
 
         $providerRecord = self::createStub(Provider::class);
-        $providerRecord->method('getIdentifier')->willReturn('openai-vision');
+        // The row identifier and the adapter key are DIFFERENT on a real
+        // installation ('openai-dcbd8f' vs 'openai') and must differ here too:
+        // the previous fixture returned the same string for both, so it could
+        // not tell which one reached the registry, and #873 shipped (the
+        // registry is keyed by the adapter, and it was handed the row id).
+        $providerRecord->method('getIdentifier')->willReturn('openai-vision-7f3a1c');
+        $providerRecord->method('getAdapterType')->willReturn('openai-vision');
 
         $model = self::createStub(Model::class);
         $model->method('getProvider')->willReturn($providerRecord);
@@ -2119,7 +2125,13 @@ class LlmServiceManagerTest extends AbstractUnitTestCase
         $provider = new TestableVisionProvider();
 
         $providerRecord = self::createStub(Provider::class);
-        $providerRecord->method('getIdentifier')->willReturn('openai-vision');
+        // The row identifier and the adapter key are DIFFERENT on a real
+        // installation ('openai-dcbd8f' vs 'openai') and must differ here too:
+        // the previous fixture returned the same string for both, so it could
+        // not tell which one reached the registry, and #873 shipped (the
+        // registry is keyed by the adapter, and it was handed the row id).
+        $providerRecord->method('getIdentifier')->willReturn('openai-vision-7f3a1c');
+        $providerRecord->method('getAdapterType')->willReturn('openai-vision');
 
         $model = self::createStub(Model::class);
         $model->method('getProvider')->willReturn($providerRecord);


### PR DESCRIPTION
Closes #873. Regression from #859, shipped in 0.32.0 and live on typo3-demo.

`KeyedProviderRegistry` is keyed by `ProviderInterface::getIdentifier()` — the adapter's own name, `openai`. `Domain\\Model\\Provider::getIdentifier()` is the `tx_nrllm_provider` row's identifier, `openai-dcbd8f` on any installation set up through the wizard. Two namespaces behind one method name, and `applyDefaultConfiguration()` read the wrong one. The rest of the codebase already uses `getAdapterType()` where it needs the adapter (`EligibilityEvaluator`, `CapabilityVerifier`, `ProviderHealthReport`).

So 0.32.0 did not fix the failure it was written for — it renamed it. `No provider specified and no default provider configured` became `Provider … not found`, on exactly the installations that have a perfectly good default. Confirmed on typo3-demo: the provider row is present, active and correct; only the lookup key was wrong.

**The tests could not have caught it.** `visionUsesTheDefaultConfigurationWhenNoProviderIsPinned` stubbed the row's `getIdentifier()` as `openai-vision` and registered the test adapter under that same string, so the two namespaces coincided in the fixture and no assertion could tell which one reached the registry. The fixture now returns `openai-vision-7f3a1c` for the row and `openai-vision` for the adapter.

**Guard seen failing:** with the one-line code change reverted, both vision tests fail with `Provider "openai-vision-7f3a1c" not found` — the same shape as the live `Provider "openai-dcbd8f" not found`. Restored, both pass.

**Gates** (PHP 8.2 × TYPO3 ^13.4, the cell Rector runs in): `cgl` clean, `phpstan` level 10 clean, `rector -n` clean, full `unit` suite 7288 tests green.

A hotfix of this one line is already applied to the demo host's vendor copy so today's demo works; it is overwritten by the next deployment, which is what this release is for.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_0144iD1P22LotW8rxmxrNGro)_