### PR TITLE
chore(release): 0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.33.0] - 2026-08-21
+
 ### Added
 
 - **`attach_file_to_content_element` references an existing file from a content element** — the seventh purpose-built writer and the first that creates a `sys_file_reference`. It appends one existing `sys_file` to a content element's `image`, `assets` or `media` field through the DataHandler as the acting backend user, in the live workspace and the default language. It never uploads, moves or renames anything: the file must already lie in a permitted storage inside the acting user's file mounts, and the element must sit on a page that user may edit — either failure is refused in the same words as an element that does not exist. The file's extension must be one the chosen field accepts, and the field is only inferred when the element's type offers exactly one candidate. Ships disabled, in the `editing` group, and pauses for approval on every call like every other writer (#834).

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -11,8 +11,8 @@
 >
     <project
         title="TYPO3 LLM Extension"
-        version="0.32.0"
-        release="0.32.0"
+        version="0.33.0"
+        release="0.33.0"
         copyright="since 2025 by Netresearch DTT GmbH"
     />
 

--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
                 "providesPackages": {}
             },
             "extension-key": "nr_llm",
-            "version": "0.32.0",
+            "version": "0.33.0",
             "web-dir": ".Build/Web"
         }
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => '',
     'author_company' => 'Netresearch DTT GmbH',
     'state' => 'beta',
-    'version' => '0.32.0',
+    'version' => '0.33.0',
     'constraints' => [
         // composer.json is the authoritative dependency constraint
         // ("typo3/cms-core": "^13.4 || ^14.3"). The TER `depends` format only


### PR DESCRIPTION
Cuts the four version surfaces (`ext_emconf.php`, `extra.typo3/cms.version`, `guides.xml` `version=` and `release=`) and dates the changelog section. Sixteen commits since v0.32.0.

**A minor, not a patch.** Two features landed since 0.32.0, and a caret constraint on a 0.x version means `^0.32` would have carried them into every installation automatically. One of them is `attach_file_to_content_element` — a *writing* tool that creates a `sys_file_reference`. Handing that to an installation that pinned `^0.32` and asked for nothing new is not a patch, whatever the churn cost of a minor is. The consumers get a constraint wave; that is the correct price.

**What ships**

- **`attach_file_to_content_element`** (#834) — the seventh purpose-built writer and the first to create a `sys_file_reference`. Appends an existing `sys_file` to a content element's `image`, `assets` or `media` field through the DataHandler, as the acting backend user. Ships disabled, in the `editing` group, and pauses for approval like every other writer.
- **`nrllm:mcp:import`** (#836) — the module's *Import catalogue* button as a CLI command, so a seeded MCP server gets its tools on deploy instead of waiting for a click. Same refusals, same guard rails, same reconciliation.

**What is fixed**

- **`vision()` and `embed()` resolve the provider by adapter type** (#873). This is a regression 0.32.0 introduced and this release removes: the default-configuration fallback added there passed `KeyedProviderRegistry` the `tx_nrllm_provider` row's identifier (`openai-dcbd8f`) where the registry is keyed by the adapter's own name (`openai`). Two namespaces behind one method name. **0.32.0 did not fix the failure it was written for — it renamed it**, from *"No provider specified"* to *"Provider … not found"*, on exactly the installations the fallback existed for. Confirmed live and confirmed fixed: alt-text generation through nr-llm-compat's `ai_filemetadata` bridge works again.
- **The specialized services attribute their spend** (#844). Image generation, speech synthesis, transcription and DeepL translation offered `withCallerSource()` and silently dropped it, which is worse than not offering it. Both losses are closed, so the per-extension cost breakdown no longer leaves image generation — among the most expensive single operations an installation can trigger — in *Unattributed*.
- **A resumed or queued agent run keeps its caller** (#847). The identity lived only as long as the request was in memory; every provider round-trip after an approval was unattributed, so one logical run split between its extension and *Unattributed* and neither figure was its cost.
- **A merge conflict marker shipped in the ADR index** — `Documentation/Adr/Index.rst` ended on a diff3 base marker that reached v0.32.0 and the published documentation. Every existing guard reads structure; a stray line at the end of a toctree is nothing to any of them. `NoConflictMarkersTest` reads the bytes now.

**Gates run locally** at the runner's default, PHP 8.5 — no `-p`: `cgl` clean, `phpstan` level 10 clean, `unit` 7318 tests green, changelog check clean. `rector` is pinned to PHP 8.2 by design (its PHPUnit rules bind to the *installed* phpunit version, and the 8.2 matrix leg resolves phpunit 11) and cannot run against a tree resolved at 8.5 — CI is the only place it runs, and it ran there on every PR in this range.

After merge: signed tag `v0.33.0` on the merge commit; `release.yml` publishes to TER, Packagist and docs.typo3.org.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_0144iD1P22LotW8rxmxrNGro)_
