### PR TITLE
feat(backend)!: the AI section exists, and editor surfaces live in it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING: the backend modules moved into a shared `AI` section** — nr_llm no longer registers a `nrllm` container under Administration. A top-level section `netresearch_ai` now holds five entries: the editor task module, the overview, and three subject containers (`nrllm_setup`, `nrllm_authoring`, `nrllm_operation`) holding the fourteen former flat entries. A section carries no access check of its own, which is the point: the module menu hides a top-level module whose access check fails together with all its children, so an admin-only container could never hold an editor surface — `nrllm_aitasks` had to sit under `web` for that reason, and every further editor surface would have landed there too. Submodule identifiers and paths are unchanged; `nrllm_overview` carries `'aliases' => ['nrllm']`, so backend shortcuts keep resolving and a foreign module anchored `['after' => 'nrllm']` keeps its position (the core rewrites `position` through aliases, not only `parent`). What does NOT survive is the container's own URL `/module/nrllm`, which had no successor by design. ADR-183 amends ADR-119; closes #812.
+
 ## [0.33.0] - 2026-08-21
 
 ### Added

--- a/Classes/Controller/Backend/LlmModuleController.php
+++ b/Classes/Controller/Backend/LlmModuleController.php
@@ -103,7 +103,7 @@ final class LlmModuleController extends ActionController
 
         if (method_exists($moduleTemplate->getDocHeaderComponent(), 'setShortcutContext')) {
             $moduleTemplate->getDocHeaderComponent()->setShortcutContext(
-                routeIdentifier: 'nrllm',
+                routeIdentifier: 'nrllm_overview',
                 displayName: 'LLM - Dashboard',
             );
         }
@@ -219,7 +219,7 @@ final class LlmModuleController extends ActionController
 
         if (method_exists($moduleTemplate->getDocHeaderComponent(), 'setShortcutContext')) {
             $moduleTemplate->getDocHeaderComponent()->setShortcutContext(
-                routeIdentifier: 'nrllm',
+                routeIdentifier: 'nrllm_overview',
                 displayName: 'LLM - Test',
                 arguments: ['action' => 'test'],
             );
@@ -305,7 +305,7 @@ final class LlmModuleController extends ActionController
 
         if (method_exists($moduleTemplate->getDocHeaderComponent(), 'setShortcutContext')) {
             $moduleTemplate->getDocHeaderComponent()->setShortcutContext(
-                routeIdentifier: 'nrllm',
+                routeIdentifier: 'nrllm_overview',
                 displayName: 'LLM - Governance',
                 arguments: ['action' => 'governance'],
             );

--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -29,54 +29,110 @@ use Netresearch\NrLlm\Controller\Backend\UseCasePackController;
 /**
  * Backend module registration for nr_llm.
  *
- * Structure: Main module under 'tools', sub-modules as children of main module.
- * Sub-modules only appear in docheader dropdown, not in main navigation.
+ * Structure (ADR-119, decided in #812):
  *
- * Uses 'tools' as parent for v13+v14 compatibility:
- * - v13: 'tools' exists natively as the admin tools group
- * - v14: 'tools' is an alias for the new 'admin' group
+ *   netresearch_ai            top-level section, shared with the sibling
+ *                             extensions; no access check of its own
+ *   ├── nrllm_aitasks         editor surface        (access => user)
+ *   ├── nrllm_overview        landing page          (access => admin)
+ *   ├── nrllm_setup           providers, models, configurations, use-case
+ *   ├── nrllm_authoring       tasks, skills, snippets
+ *   └── nrllm_operation       tools, MCP, playground, runs, analytics
  *
- * Pattern follows TYPO3 Styleguide extension:
- * - Main module identifier without prefix (e.g., 'nrllm' not 'tools_nrllm')
- * - Child modules with parent as prefix (e.g., 'nrllm_providers')
- * - Nested paths under main module path
+ * The section replaces 'tools' as the top-level parent; the depth is unchanged
+ * (a section held one container holding fourteen entries before, and now holds
+ * five entries holding their own).
  *
- * v13 compatibility: 'nrllm_overview' is registered as first submodule so that
- * v13 (which redirects to the first submodule) shows the overview page.
- * v14 uses 'showSubmoduleOverview' on the parent module for the same effect.
+ * WHY A SECTION AND NOT A CONTAINER UNDER ADMINISTRATION. The module menu drops
+ * every top-level module whose own access check FAILS, together with all its
+ * children (ADR-131). Under the admin-only 'nrllm' container an editor surface
+ * was therefore invisible, and 'nrllm_aitasks' had to be parented to 'web' to
+ * be reachable at all. Every further editor surface would have landed there for
+ * the same reason, one flat entry at a time. A section carries no 'access' key
+ * of its own — exactly like the core's own sections — so it never filters; its
+ * children filter individually, and admin-only and editor-facing modules can
+ * finally live in one place.
+ *
+ * WHY THE IDENTIFIER IS VENDOR-SCOPED. Module identifiers merge last-package-
+ * wins. A bare 'ai' would be a shared namespace with no owner: the label and
+ * icon would depend on package load order, and removing the owning extension
+ * would strip the routes of any foreign submodule parented to it.
+ *
+ * OLD ROUTES. 'nrllm' is no longer a registered identifier, so 'nrllm_overview'
+ * carries it as an alias — an alias is shadowed by a real module of the same
+ * name, which is why the container had to go first. Backend shortcuts store the
+ * module identifier, so they resolve through that alias. ModuleFactory also
+ * rewrites 'position' references through aliases, so a foreign module anchored
+ * with ['after' => 'nrllm'] keeps its place without changing.
+ *
+ * Submodule identifiers and explicit paths are unchanged on purpose: a regroup
+ * that also renamed the leaves would break every bookmark for no gain.
+ *
+ * v13 compatibility: each container registers 'nrllm_*' children and carries
+ * both 'dependsOnSubmodules' (v13 redirects to the first submodule) and
+ * 'showSubmoduleOverview' (v14 renders an overview instead).
  */
 return [
-    // Main dashboard module (parent container)
-    'nrllm' => [
-        'parent' => 'tools',
-        'position' => ['after' => 'styleguide'],
-        'access' => 'admin',
+    // The shared top-level section. No 'parent', no 'path', no 'access' and no
+    // 'controllerActions' — that is the shape of a section rather than a module,
+    // and it is what the core's own sections look like. The absent access check
+    // is load-bearing, not an omission: see the header.
+    //
+    // Positioned after 'media' rather than at the end with the admin sections,
+    // because the audience that makes the section necessary is editors.
+    'netresearch_ai' => [
+        'position' => ['after' => 'media'],
         'iconIdentifier' => 'module-nrllm',
-        'path' => '/module/nrllm',
-        'labels' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod.xlf',
+        'labels' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_section.xlf',
+    ],
+    // Setup: what has to exist before anything can run.
+    'nrllm_setup' => [
+        'parent' => 'netresearch_ai',
+        'access' => 'admin',
+        'iconIdentifier' => 'module-nrllm-provider',
+        'path' => '/module/nrllm/setup',
+        'labels' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_setup.xlf',
         'extensionName' => 'NrLlm',
         'appearance' => [
             'dependsOnSubmodules' => true,
         ],
-        // v14+: Show overview page for parent module
         'showSubmoduleOverview' => true,
-        'controllerActions' => [
-            LlmModuleController::class => [
-                'index',
-                'test',
-                'executeTest',
-                'governance',
-                'help',
-            ],
-        ],
     ],
-    // Overview submodule - v13 compatibility
-    // In v13, dependsOnSubmodules redirects to the first submodule.
-    // This ensures the overview page is shown instead of providers.
-    // In v14, showSubmoduleOverview on the parent handles this natively.
+    // Authoring: what the models are asked to do.
+    'nrllm_authoring' => [
+        'parent' => 'netresearch_ai',
+        'access' => 'admin',
+        'iconIdentifier' => 'module-nrllm-snippet',
+        'path' => '/module/nrllm/authoring',
+        'labels' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_authoring.xlf',
+        'extensionName' => 'NrLlm',
+        'appearance' => [
+            'dependsOnSubmodules' => true,
+        ],
+        'showSubmoduleOverview' => true,
+    ],
+    // Operation: what is running, and what it cost.
+    'nrllm_operation' => [
+        'parent' => 'netresearch_ai',
+        'access' => 'admin',
+        'iconIdentifier' => 'module-nrllm-runs',
+        'path' => '/module/nrllm/operation',
+        'labels' => 'LLL:EXT:nr_llm/Resources/Private/Language/locallang_mod_operation.xlf',
+        'extensionName' => 'NrLlm',
+        'appearance' => [
+            'dependsOnSubmodules' => true,
+        ],
+        'showSubmoduleOverview' => true,
+    ],
+    // The section's landing page, and the holder of the old container's
+    // identifier. 'aliases' resolves backend shortcuts stored against 'nrllm'
+    // and re-anchors foreign modules positioned ['after' => 'nrllm'] — both
+    // only work because 'nrllm' is no longer registered as a real module, which
+    // would shadow the alias.
     'nrllm_overview' => [
-        'parent' => 'nrllm',
+        'parent' => 'netresearch_ai',
         'position' => ['before' => '*'],
+        'aliases' => ['nrllm'],
         'access' => 'admin',
         'iconIdentifier' => 'module-nrllm',
         'path' => '/module/nrllm/overview',
@@ -99,7 +155,7 @@ return [
     // Provider management - child of main module
     // Note: AJAX actions (toggleActive, testConnection) are registered via AjaxRoutes.php
     'nrllm_providers' => [
-        'parent' => 'nrllm',
+        'parent' => 'nrllm_setup',
         'access' => 'admin',
         'iconIdentifier' => 'module-nrllm-provider',
         'path' => '/module/nrllm/providers',
@@ -114,7 +170,7 @@ return [
     // Model management - child of main module
     // Note: AJAX actions (toggleActive, setDefault, etc.) are registered via AjaxRoutes.php
     'nrllm_models' => [
-        'parent' => 'nrllm',
+        'parent' => 'nrllm_setup',
         'access' => 'admin',
         'iconIdentifier' => 'module-nrllm-model',
         'path' => '/module/nrllm/models',
@@ -129,7 +185,7 @@ return [
     // Configuration management - child of main module
     // Note: AJAX actions (toggleActive, setDefault, testConfiguration) are registered via AjaxRoutes.php
     'nrllm_configurations' => [
-        'parent' => 'nrllm',
+        'parent' => 'nrllm_setup',
         'access' => 'admin',
         'iconIdentifier' => 'module-nrllm',
         'path' => '/module/nrllm/configurations',
@@ -146,7 +202,7 @@ return [
     // Task management - child of main module
     // Note: new/edit/save/delete use FormEngine (record_edit route), AJAX actions via AjaxRoutes.php
     'nrllm_tasks' => [
-        'parent' => 'nrllm',
+        'parent' => 'nrllm_authoring',
         'access' => 'admin',
         'iconIdentifier' => 'module-nrllm-task',
         'path' => '/module/nrllm/tasks',
@@ -170,7 +226,7 @@ return [
     // Prompt snippet library - child of main module
     // Note: new/edit/save/delete use FormEngine (record_edit route)
     'nrllm_snippets' => [
-        'parent' => 'nrllm',
+        'parent' => 'nrllm_authoring',
         'access' => 'admin',
         'iconIdentifier' => 'module-nrllm-snippet',
         'path' => '/module/nrllm/snippets',
@@ -190,7 +246,7 @@ return [
     // Shares the wizard's icon deliberately: the two are one entry path, and a
     // second wizard-family glyph would suggest a second kind of thing.
     'nrllm_usecase' => [
-        'parent' => 'nrllm',
+        'parent' => 'nrllm_setup',
         'access' => 'admin',
         'iconIdentifier' => 'module-nrllm-wizard',
         'path' => '/module/nrllm/use-case',
@@ -207,7 +263,7 @@ return [
     // Setup wizard - child of main module
     // Note: AJAX actions (detect, test, discover, generate, save) are registered via AjaxRoutes.php
     'nrllm_wizard' => [
-        'parent' => 'nrllm',
+        'parent' => 'nrllm_setup',
         'access' => 'admin',
         'iconIdentifier' => 'module-nrllm-wizard',
         'path' => '/module/nrllm/wizard',
@@ -222,7 +278,7 @@ return [
     // Skills management - child of main module
     // Note: AJAX actions (sync, toggleSkill, setToken) are registered via AjaxRoutes.php
     'nrllm_skills' => [
-        'parent' => 'nrllm',
+        'parent' => 'nrllm_authoring',
         'access' => 'admin',
         'iconIdentifier' => 'module-nrllm-skill',
         'path' => '/module/nrllm/skills',
@@ -240,7 +296,7 @@ return [
     // (nrllm_tool_toggle) and additionally guards itself with
     // RequiresBackendAdminTrait (ADR-037).
     'nrllm_tools' => [
-        'parent' => 'nrllm',
+        'parent' => 'nrllm_operation',
         'access' => 'admin',
         'iconIdentifier' => 'module-nrllm-tool',
         'path' => '/module/nrllm/tools',
@@ -260,7 +316,7 @@ return [
     // RequiresBackendAdminTrait because a backend route bypasses this
     // module's access setting (ADR-037).
     'nrllm_mcp' => [
-        'parent' => 'nrllm',
+        'parent' => 'nrllm_operation',
         'access' => 'admin',
         'iconIdentifier' => 'module-nrllm-tool',
         'path' => '/module/nrllm/mcp',
@@ -278,7 +334,7 @@ return [
     // Note: the AJAX runAction is registered via AjaxRoutes.php (nrllm_tool_run)
     // and additionally guards itself with RequiresBackendAdminTrait.
     'nrllm_playground' => [
-        'parent' => 'nrllm',
+        'parent' => 'nrllm_operation',
         'access' => 'admin',
         'iconIdentifier' => 'module-nrllm-tool',
         'path' => '/module/nrllm/playground',
@@ -297,7 +353,7 @@ return [
     // gates the three list/write actions, and `show` is additionally authorised
     // per run by the runtime (AGENT_READ).
     'nrllm_runs' => [
-        'parent' => 'nrllm',
+        'parent' => 'nrllm_operation',
         'access' => 'admin',
         'iconIdentifier' => 'module-nrllm-runs',
         'path' => '/module/nrllm/runs',
@@ -317,7 +373,7 @@ return [
     ],
     // Usage analytics dashboard - child of main module
     'nrllm_analytics' => [
-        'parent' => 'nrllm',
+        'parent' => 'nrllm_operation',
         'access' => 'admin',
         'iconIdentifier' => 'module-nrllm-analytics',
         'path' => '/module/nrllm/analytics',
@@ -340,7 +396,7 @@ return [
     // ticked in be_groups; the tasks_use/agent_approve grants are checked per
     // action on top — the module switch alone never grants execution.
     'nrllm_aitasks' => [
-        'parent' => 'web',
+        'parent' => 'netresearch_ai',
         'access' => 'user',
         'iconIdentifier' => 'module-nrllm-task',
         'path' => '/module/web/nrllm-aitasks',

--- a/Documentation/Administration/AgentRuns.rst
+++ b/Documentation/Administration/AgentRuns.rst
@@ -12,7 +12,7 @@ wants to make, or to supply a piece of typed input it asked for. The
 :guilabel:`Agent Runs` module is the inbox where you make those decisions and
 review runs that have finished.
 
-The admin inbox lives in :guilabel:`Admin Tools > LLM > Agent Runs`;
+The admin inbox lives in :guilabel:`AI > Operation > Agent Runs`;
 the same actions are also reachable through the editor module
 :guilabel:`Web > AI Tasks` (:ref:`ADR-131 <adr-131>`). Visibility is
 actor-scoped: an administrator or a holder of the *Approve suspended AI

--- a/Documentation/Administration/Analytics.rst
+++ b/Documentation/Administration/Analytics.rst
@@ -28,7 +28,7 @@ against this month's budget.
 Opening the module
 ==================
 
-Open :guilabel:`Admin Tools > LLM > Analytics`. The submodule sits next
+Open :guilabel:`AI > Operation > Analytics`. The submodule sits next
 to the other LLM sections in the left-hand navigation and is
 admin-only, like the rest of the module.
 

--- a/Documentation/Administration/Configurations.rst
+++ b/Documentation/Administration/Configurations.rst
@@ -25,7 +25,7 @@ configurations by identifier in their code.
 Adding a configuration manually
 ===============================
 
-1. Navigate to :guilabel:`Admin Tools > LLM >
+1. Navigate to :guilabel:`AI > Setup >
    Configurations`.
 2. Click :guilabel:`Add Configuration`.
 3. Fill in the required fields:

--- a/Documentation/Administration/Governance.rst
+++ b/Documentation/Administration/Governance.rst
@@ -18,7 +18,7 @@ puts the values in force on one page.
 Where the values are shown
 ==========================
 
-:guilabel:`Admin Tools > LLM > Overview`, docheader tab
+:guilabel:`AI > Overview`, docheader tab
 :guilabel:`Governance` (admin-only, like every other nr_llm admin surface).
 The table has three columns: the setting, the value the runtime applies
 right now, and the class that resolved it.

--- a/Documentation/Administration/Index.rst
+++ b/Documentation/Administration/Index.rst
@@ -17,7 +17,7 @@ The LLM backend module
 ======================
 
 All AI **management** happens in
-:guilabel:`Admin Tools > LLM`; editors run prepared tasks and decide
+:guilabel:`AI`; editors run prepared tasks and decide
 approvals in the separate :guilabel:`Web > AI Tasks` module
 (:ref:`administration-permissions`). The **Overview** is a guided starting point:
 

--- a/Documentation/Administration/Models.rst
+++ b/Documentation/Administration/Models.rst
@@ -24,7 +24,7 @@ through a provider (e.g., ``gpt-5``,
 Adding a model manually
 =======================
 
-1. Navigate to :guilabel:`Admin Tools > LLM >
+1. Navigate to :guilabel:`AI > Setup >
    Models`.
 2. Click :guilabel:`Add Model`.
 3. Fill in the required fields:

--- a/Documentation/Administration/PromptSnippets.rst
+++ b/Documentation/Administration/PromptSnippets.rst
@@ -24,7 +24,7 @@ model binding.
 Adding a snippet
 ================
 
-1. Navigate to :guilabel:`Admin Tools > LLM >
+1. Navigate to :guilabel:`AI > Authoring >
    Snippets`.
 2. Click :guilabel:`New Snippet`.
 3. Fill in the fields:
@@ -90,7 +90,7 @@ request made with that configuration then carries
 them — chat, single-prompt completion, streaming and
 agent runs alike — without any extension code.
 
-1. Navigate to :guilabel:`Admin Tools > LLM >
+1. Navigate to :guilabel:`AI > Setup >
    Configurations` and edit a configuration.
 2. Open the :guilabel:`Parameters` tab.
 3. Tick the wanted tags under :guilabel:`Prompt

--- a/Documentation/Administration/Providers.rst
+++ b/Documentation/Administration/Providers.rst
@@ -24,7 +24,7 @@ credentials, and adapter-specific settings.
 Adding a provider
 =================
 
-1. Navigate to :guilabel:`Admin Tools > LLM >
+1. Navigate to :guilabel:`AI > Setup >
    Providers`.
 2. Click :guilabel:`Add Provider`.
 3. Fill in the required fields:

--- a/Documentation/Administration/Skills.rst
+++ b/Documentation/Administration/Skills.rst
@@ -13,7 +13,7 @@ source** that points at GitHub, sync it, and then enable the individual
 skills you want.
 
 Skill management is **admin-only**. It lives in
-:guilabel:`Admin Tools > LLM > Skills` and is not delegated to other
+:guilabel:`AI > Authoring > Skills` and is not delegated to other
 backend groups: a skill body becomes prompt context, so the two skill
 tables are treated as a privilege-escalation surface.
 
@@ -52,7 +52,7 @@ A source has one of three types:
 Adding a source
 ===============
 
-1. Navigate to :guilabel:`Admin Tools > LLM > Skills`.
+1. Navigate to :guilabel:`AI > Authoring > Skills`.
 2. Click :guilabel:`New Skill Source`.
 3. Fill in the fields:
 

--- a/Documentation/Administration/Tasks.rst
+++ b/Documentation/Administration/Tasks.rst
@@ -25,7 +25,7 @@ extensions can execute with a single call.
 Adding a task manually
 ======================
 
-1. Navigate to :guilabel:`Admin Tools > LLM >
+1. Navigate to :guilabel:`AI > Authoring >
    Tasks`.
 2. Click :guilabel:`Add Task`.
 3. Fill in the required fields:

--- a/Documentation/Administration/Tools.rst
+++ b/Documentation/Administration/Tools.rst
@@ -493,7 +493,7 @@ and never return secrets — the result leaves the instance.
 Managing tools
 ==============
 
-The :guilabel:`Admin Tools > LLM > Tools` module lists every registered tool
+The :guilabel:`AI > Operation > Tools` module lists every registered tool
 with its global enable state and lets an admin toggle it. A **disabled** tool
 is refused on every run, everywhere — the runtime gate is fail-closed, so a
 disabled tool can never be offered to the model regardless of a skill's
@@ -697,7 +697,7 @@ request, so the grant does not loosen them.
 Using the Tool Playground
 =========================
 
-The playground lives in :guilabel:`Admin Tools > LLM > Playground` and is
+The playground lives in :guilabel:`AI > Operation > Playground` and is
 admin-only. It is a sibling of the :ref:`Tools
 <administration-tools-manage>` management module: the playground *runs* the
 loop, while the Tools module governs *which* tools exist and are enabled.

--- a/Documentation/Administration/UseCasePacks.rst
+++ b/Documentation/Administration/UseCasePacks.rst
@@ -6,7 +6,7 @@
 Get Started: use-case packs
 ===========================
 
-:guilabel:`Admin Tools > LLM > Get Started` asks what you want to do before it
+:guilabel:`AI > Setup > Get Started` asks what you want to do before it
 asks anything technical — editorial assistance, translation, metadata, media
 accessibility, agent workflows, developer integration — and answers with a
 **use-case pack**: a named bundle of one configuration, several tasks and

--- a/Documentation/Administration/Wizards.rst
+++ b/Documentation/Administration/Wizards.rst
@@ -54,7 +54,7 @@ configuration using AI. Instead of filling in each
 field manually, describe your use case in plain
 language and the wizard generates everything.
 
-1. Navigate to :guilabel:`Admin Tools > LLM >
+1. Navigate to :guilabel:`AI > Setup >
    Configurations`.
 2. Click :guilabel:`Create with AI`.
 3. Describe your use case (e.g., *"summarize blog
@@ -82,7 +82,7 @@ The task wizard creates a complete task setup — a
 task **and** a dedicated configuration — in one
 step.
 
-1. Navigate to :guilabel:`Admin Tools > LLM >
+1. Navigate to :guilabel:`AI > Authoring >
    Tasks`.
 2. Click :guilabel:`Create with AI`.
 3. Describe the task (e.g., *"extract the five most

--- a/Documentation/Adr/Adr119BackendModulePlacement.rst
+++ b/Documentation/Adr/Adr119BackendModulePlacement.rst
@@ -6,8 +6,10 @@
 ADR-119: Where the backend modules live — Administration, for now
 ============================================================================
 
-:Status: Accepted (deferred — the placement is not finally settled, see Revisit)
+:Status: Accepted (its placement decision was overturned; the section now
+         exists and the four pre-settled answers below have been applied)
 :Date: 2026-07-28
+:Amended: 2026-08-22 by :ref:`ADR-183 <adr-183>`
 :Authors: Netresearch DTT GmbH
 
 .. _adr-119-context:

--- a/Documentation/Adr/Adr183AiSectionExists.rst
+++ b/Documentation/Adr/Adr183AiSectionExists.rst
@@ -1,0 +1,145 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-183:
+
+============================================================================
+ADR-183: The AI section exists, and editor surfaces live in it
+============================================================================
+
+:Status: Accepted
+:Date: 2026-08-22
+:Amends: :ref:`ADR-119 <adr-119>` (backend module placement)
+:Authors: Netresearch DTT GmbH
+
+.. _adr-183-context:
+
+Context
+=======
+
+:ref:`ADR-119 <adr-119>` decided *Administration, for now*, and left the
+placement open with a named revisit trigger: the first cross-consumer editor
+surface. Issue #812 carried that open question so the next surface would not
+settle it by accident.
+
+The question was put and answered rather than triggered. The section is
+created, and it is called **AI**.
+
+Two arguments were weighed once more before deciding, and both are recorded
+because the second overturns a reason ADR-119 gave for the name.
+
+**"LLM" is the more precise name.** It is not. Of the four products that share
+the section, ``nr_repurpose`` generates audio and images, ``nr_ai_search``
+fuses BM25 keyword search with embeddings, and the cowriter drives CKEditor —
+only nr_llm is a language-model product. A section named LLM holding a product
+called *AI Search* that runs no language model would be wrong, not merely
+unfashionable.
+
+**"Integrators look for AI."** ADR-119 gave this as a reason and it does not
+hold: :ref:`ADR-131 <adr-131>` establishes that the section exists for
+*editor*-facing modules, so the label is read by editors. The conclusion
+survives its reason — "AI" is what an editor recognises, "LLM" is a
+developer's word — but the reason itself is withdrawn here.
+
+.. _adr-183-decision:
+
+Decision
+========
+
+A shared top-level section ``netresearch_ai`` holds five entries:
+
+.. code-block:: text
+   :caption: The registered structure
+
+   netresearch_ai            no access check of its own
+   ├── nrllm_aitasks         access => user     (editors)
+   ├── nrllm_overview        access => admin    (aliases: nrllm)
+   ├── nrllm_setup           providers, models, configurations, use-case, wizard
+   ├── nrllm_authoring       tasks, skills, snippets
+   └── nrllm_operation       tools, MCP, playground, runs, analytics
+
+Four of those five come from the fourteen entries ADR-119 called a dumping
+ground, which is the "three or four entries" it asks for. ``nrllm_aitasks``
+is the fifth and was never one of the fourteen: it sat under ``web``.
+
+.. _adr-183-mechanic:
+
+The access check is the whole mechanic
+--------------------------------------
+
+The module menu drops every top-level module whose own access check fails,
+together with its children (:ref:`ADR-131 <adr-131>`). That is why
+``nrllm_aitasks`` was parented to ``web``: under the admin-only ``nrllm``
+container it would have been invisible to the editors it exists for. Every
+further editor surface would have landed flat under ``web`` for the same
+reason, one entry at a time — the accretion #812 was filed to prevent.
+
+A section carries **no** ``access`` key, exactly like the core's own sections
+in ``cms-core/Configuration/Backend/Modules.php``. It therefore never filters,
+and its children filter individually. Admin-only and editor-facing modules can
+share one place for the first time.
+
+The nesting depth is unchanged. ``tools → nrllm → nrllm_providers`` was
+already three levels; ``netresearch_ai → nrllm_setup → nrllm_providers`` is
+the same shape with the top level owned rather than borrowed.
+
+.. _adr-183-settled:
+
+The four pre-settled answers, as applied
+----------------------------------------
+
+ADR-119 settled four things in advance for this moment. Three are applied
+verbatim; the fourth is applied with its reason corrected above.
+
+- **The name is "AI"** — applied, reason revised.
+- **The identifier is vendor-scoped** (``netresearch_ai``) — applied. Module
+  identifiers merge last-package-wins, so a bare ``ai`` would be a shared
+  namespace with no owner.
+- **The flat entries do not move as they are** — applied. Three subject
+  containers, holding five, three and five entries.
+- **Old routes keep working** — applied. Submodule identifiers and explicit
+  paths are unchanged, ``setShortcutContext`` is repointed from ``nrllm`` to
+  ``nrllm_overview``, and that module carries ``'aliases' => ['nrllm']``.
+
+.. _adr-183-consequences:
+
+Consequences
+============
+
+**Backend shortcuts survive.** They store the module identifier, and the alias
+resolves it. This works only because ``nrllm`` is no longer registered as a
+real module — an alias is shadowed by a real module of the same name.
+
+**Foreign anchors survive, and this was verified rather than assumed.**
+``t3_cowriter`` positions itself with ``['after' => 'nrllm']``.
+``ModuleFactory::adaptAliasMappingFromModuleConfiguration()`` rewrites
+``position.before`` and ``position.after`` through aliases, not just
+``parent``, so that anchor re-resolves to ``nrllm_overview`` with no change in
+the cowriter.
+
+**The container URL does not survive.** ``/module/nrllm`` was the container's
+own path and has no successor; ``/module/nrllm/overview`` and every submodule
+path are unchanged. ADR-119 accepted this when it settled on keeping the
+submodule paths.
+
+**The three sibling extensions are not changed by this record.** They may
+register under ``netresearch_ai`` when they choose to; nothing breaks while
+they do not. What this decision gives them is a place that exists.
+
+**The revisit trigger is spent.** ADR-119's open question is closed, so a new
+editor surface is now an ordinary addition to an existing section rather than
+an occasion to decide where the section should be.
+
+.. _adr-183-alternatives:
+
+Alternatives
+============
+
+**A container under Administration**, the shape the core uses for
+``integrations``. Rejected for the access-check reason above: a container
+inherits its parent's visibility, and Administration is admin-only, so the
+editor surfaces this exists for would still have had nowhere to live.
+
+**Leaving it until the trigger fired.** Rejected because the trigger fires
+*inside* a change that is about something else, which is exactly how a
+placement gets settled by accretion. #812 existed to take the decision out of
+that moment.

--- a/Documentation/Adr/Index.rst
+++ b/Documentation/Adr/Index.rst
@@ -565,3 +565,4 @@ Tools
    Adr180TheSixthWriterCreatesAPage
    Adr181EventStreamFramedAnswers
    Adr182AWriteToolNamesTheRecordItWrote
+   Adr183AiSectionExists

--- a/Documentation/Developer/IntegrationGuide.rst
+++ b/Documentation/Developer/IntegrationGuide.rst
@@ -182,7 +182,7 @@ nr-llm throws typed exceptions so you can provide meaningful feedback:
    } catch (ProviderConfigurationException) {
        // No provider configured — guide the admin
        return 'AI features require LLM configuration. '
-            . 'An administrator can set this up in Admin Tools > LLM.';
+            . 'An administrator can set this up in AI > Setup.';
    } catch (ProviderConnectionException) {
        // Network issue — suggest retry
        return 'Could not reach the AI provider. Please try again.';
@@ -318,4 +318,4 @@ Integration checklist
 5. **Testing** — Mock :php:`LlmServiceManagerInterface` in unit tests
 
 6. **Documentation** — Tell your users they need to
-   configure a provider in Admin Tools > LLM
+   configure a provider in AI > Setup

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -49,7 +49,7 @@ Ollama, and more.
    :class: with-border with-shadow
    :zoom: lightbox
 
-   The :guilabel:`Admin Tools > LLM` backend module.
+   The :guilabel:`AI` backend module.
 
 ----
 

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -22,9 +22,9 @@ After installation:
 
 1. Activate the extension in :guilabel:`Admin Tools > Extension Manager`.
 2. Configure providers and API keys in
-   :guilabel:`Admin Tools > LLM > Providers`.
-3. Define available models in :guilabel:`Admin Tools > LLM > Models`.
-4. Create configurations in :guilabel:`Admin Tools > LLM > Configurations`.
+   :guilabel:`AI > Setup > Providers`.
+3. Define available models in :guilabel:`AI > Setup > Models`.
+4. Create configurations in :guilabel:`AI > Setup > Configurations`.
 5. Clear caches.
 
 .. _installation-composer:
@@ -66,7 +66,7 @@ Installation steps
 3. **Configure API keys**
 
    Use the setup wizard at
-   :guilabel:`Admin Tools > LLM > Setup Wizard`
+   :guilabel:`AI > Setup > Setup Wizard`
    to auto-detect your provider and discover models.
 
    .. figure:: /Images/backend-setup-wizard.png
@@ -79,7 +79,7 @@ Installation steps
 
    .. tip::
 
-      Not sure which provider you need? :guilabel:`Admin Tools > LLM > Get
+      Not sure which provider you need? :guilabel:`AI > Setup > Get
       Started` asks what you want to do first — editorial assistance,
       translation, metadata, media accessibility, agent workflows, developer
       integration — and can install a use-case pack for it: a configuration,

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ nr-llm provides the missing shared layer:
 │         Provider Abstraction Layer              │
 │  OpenAI · Anthropic · Gemini · Ollama · …       │
 ├─────────────────────────────────────────────────┤
-│     Admin Tools > LLM (Backend Module)          │
+│     AI (Backend Section)                        │
 │  Encrypted keys · Usage tracking · Setup wizard │
 └─────────────────────────────────────────────────┘
 ```
@@ -141,7 +141,7 @@ nr-llm solves this once for the entire TYPO3 ecosystem.
 
 ### One dashboard for all AI
 
-The **Admin Tools > LLM** backend module gives you full control:
+The **AI** backend section gives you full control:
 
 ![LLM module overview — 30-day usage and cost KPIs, a per-provider request breakdown with live reachability, and a card grid where every module shows its readiness state](Documentation/Images/backend-dashboard.png)
 
@@ -296,7 +296,7 @@ See [ADR-090](Documentation/Adr/Adr090SingleExtensionUntil10.rst) for the full r
 composer require netresearch/nr-llm
 ```
 
-Then activate in **Admin Tools > Extensions** and run **Admin Tools > LLM > Setup Wizard**.
+Then activate in **Admin Tools > Extensions** and run **AI > Setup > Setup Wizard**.
 
 ---
 

--- a/Resources/Private/Language/de.locallang_mod_authoring.xlf
+++ b/Resources/Private/Language/de.locallang_mod_authoring.xlf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="de" datatype="plaintext" original="messages">
+        <body>
+            <trans-unit id="mlang_labels_tablabel">
+                <source>LLM Authoring</source>
+                <target>LLM-Inhalte</target>
+            </trans-unit>
+            <trans-unit id="mlang_tabs_tab">
+                <source>Authoring</source>
+                <target>Inhalte</target>
+            </trans-unit>
+            <trans-unit id="mlang_labels_tabdescr">
+                <source>Tasks, skills and prompt snippets — what the models are asked to do</source>
+                <target>Aufgaben, Skills und Prompt-Bausteine — was die Modelle tun sollen</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Language/de.locallang_mod_operation.xlf
+++ b/Resources/Private/Language/de.locallang_mod_operation.xlf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="de" datatype="plaintext" original="messages">
+        <body>
+            <trans-unit id="mlang_labels_tablabel">
+                <source>LLM Operation</source>
+                <target>LLM-Betrieb</target>
+            </trans-unit>
+            <trans-unit id="mlang_tabs_tab">
+                <source>Operation</source>
+                <target>Betrieb</target>
+            </trans-unit>
+            <trans-unit id="mlang_labels_tabdescr">
+                <source>Tools, MCP servers, playground, agent runs and usage analytics</source>
+                <target>Werkzeuge, MCP-Server, Playground, Agentenläufe und Nutzungsauswertung</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Language/de.locallang_mod_section.xlf
+++ b/Resources/Private/Language/de.locallang_mod_section.xlf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="de" datatype="plaintext" original="messages">
+        <body>
+            <trans-unit id="mlang_labels_tablabel">
+                <source>AI</source>
+                <target>AI</target>
+            </trans-unit>
+            <trans-unit id="mlang_tabs_tab">
+                <source>AI</source>
+                <target>AI</target>
+            </trans-unit>
+            <trans-unit id="mlang_labels_tabdescr">
+                <source>AI capabilities from Netresearch: tasks for editors, and the provider, model and agent administration behind them</source>
+                <target>KI-Funktionen von Netresearch: Aufgaben für Redakteure und die Verwaltung von Anbietern, Modellen und Agenten dahinter</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Language/de.locallang_mod_setup.xlf
+++ b/Resources/Private/Language/de.locallang_mod_setup.xlf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="de" datatype="plaintext" original="messages">
+        <body>
+            <trans-unit id="mlang_labels_tablabel">
+                <source>LLM Setup</source>
+                <target>LLM-Einrichtung</target>
+            </trans-unit>
+            <trans-unit id="mlang_tabs_tab">
+                <source>Setup</source>
+                <target>Einrichtung</target>
+            </trans-unit>
+            <trans-unit id="mlang_labels_tabdescr">
+                <source>Providers, models, configurations and the guided setup routes</source>
+                <target>Anbieter, Modelle, Konfigurationen und die geführten Einrichtungswege</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Language/locallang_mod_authoring.xlf
+++ b/Resources/Private/Language/locallang_mod_authoring.xlf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="messages">
+        <body>
+            <trans-unit id="mlang_labels_tablabel">
+                <source>LLM Authoring</source>
+            </trans-unit>
+            <trans-unit id="mlang_tabs_tab">
+                <source>Authoring</source>
+            </trans-unit>
+            <trans-unit id="mlang_labels_tabdescr">
+                <source>Tasks, skills and prompt snippets — what the models are asked to do</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Language/locallang_mod_operation.xlf
+++ b/Resources/Private/Language/locallang_mod_operation.xlf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="messages">
+        <body>
+            <trans-unit id="mlang_labels_tablabel">
+                <source>LLM Operation</source>
+            </trans-unit>
+            <trans-unit id="mlang_tabs_tab">
+                <source>Operation</source>
+            </trans-unit>
+            <trans-unit id="mlang_labels_tabdescr">
+                <source>Tools, MCP servers, playground, agent runs and usage analytics</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Language/locallang_mod_section.xlf
+++ b/Resources/Private/Language/locallang_mod_section.xlf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="messages">
+        <body>
+            <trans-unit id="mlang_labels_tablabel">
+                <source>AI</source>
+            </trans-unit>
+            <trans-unit id="mlang_tabs_tab">
+                <source>AI</source>
+            </trans-unit>
+            <trans-unit id="mlang_labels_tabdescr">
+                <source>AI capabilities from Netresearch: tasks for editors, and the provider, model and agent administration behind them</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Language/locallang_mod_setup.xlf
+++ b/Resources/Private/Language/locallang_mod_setup.xlf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="messages">
+        <body>
+            <trans-unit id="mlang_labels_tablabel">
+                <source>LLM Setup</source>
+            </trans-unit>
+            <trans-unit id="mlang_tabs_tab">
+                <source>Setup</source>
+            </trans-unit>
+            <trans-unit id="mlang_labels_tabdescr">
+                <source>Providers, models, configurations and the guided setup routes</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Tests/E2E/Playwright/accessibility.spec.ts
+++ b/Tests/E2E/Playwright/accessibility.spec.ts
@@ -51,7 +51,7 @@ test.describe('Accessibility Tests @accessibility', () => {
       const page = authenticatedPage;
 
       // Navigate to main module
-      await page.goto('/typo3/module/nrllm');
+      await page.goto('/typo3/module/nrllm/overview');
       await page.waitForLoadState('networkidle');
 
       const results = await runAxeAnalysis(page, 'Main Dashboard');
@@ -245,7 +245,7 @@ test.describe('Accessibility Tests @accessibility', () => {
     test('should have sufficient color contrast in main module @accessibility', async ({ authenticatedPage }) => {
       const page = authenticatedPage;
 
-      await page.goto('/typo3/module/nrllm');
+      await page.goto('/typo3/module/nrllm/overview');
       await page.waitForLoadState('networkidle');
 
       const results = await new AxeBuilder({ page })
@@ -328,7 +328,7 @@ test.describe('Accessibility Tests @accessibility', () => {
     test('should have proper landmark regions @accessibility', async ({ authenticatedPage }) => {
       const page = authenticatedPage;
 
-      await page.goto('/typo3/module/nrllm');
+      await page.goto('/typo3/module/nrllm/overview');
       await page.waitForLoadState('networkidle');
 
       const results = await new AxeBuilder({ page })

--- a/Tests/E2E/Playwright/fixtures.ts
+++ b/Tests/E2E/Playwright/fixtures.ts
@@ -44,7 +44,7 @@ async function loginToBackend(page: Page): Promise<void> {
  */
 async function navigateToLlmModule(page: Page): Promise<FrameLocator> {
   // Navigate directly to the module URL (module is under 'admin' parent)
-  await page.goto('/typo3/module/nrllm');
+  await page.goto('/typo3/module/nrllm/overview');
 
   // TYPO3 v14 loads module content in an iframe
   const moduleFrame = getModuleFrame(page);

--- a/Tests/E2E/Playwright/wizard.spec.ts
+++ b/Tests/E2E/Playwright/wizard.spec.ts
@@ -556,7 +556,7 @@ test.describe('Wizard Navigation from List Pages', () => {
       const page = authenticatedPage;
 
       // Dashboard is the main LLM module
-      await page.goto('/typo3/module/nrllm');
+      await page.goto('/typo3/module/nrllm/overview');
       const moduleFrame = getModuleFrame(page);
       await moduleFrame.getByRole('heading', { level: 1 }).waitFor({ state: 'visible', timeout: 10000 });
 

--- a/Tests/Unit/Configuration/OverviewCardCoverageTest.php
+++ b/Tests/Unit/Configuration/OverviewCardCoverageTest.php
@@ -36,10 +36,19 @@ final class OverviewCardCoverageTest extends TestCase
     private const NOT_A_CARD_TARGET = 'nrllm_overview';
 
     /**
-     * Only the children of the LLM module get a card. 'nrllm' itself is the
-     * module the overview belongs to and sits under 'tools'.
+     * Only the LEAF modules get a card. Until the AI section existed these were
+     * the children of the single 'nrllm' container; they are now spread across
+     * three subject containers (ADR-119, #812). The containers themselves get
+     * no card — they hold nothing a card could describe — and neither does the
+     * section, which is not a module of this extension in the first place.
+     *
+     * A list rather than one name on purpose: a fourth container will be added
+     * here, and a card check that silently covers only one third of the modules
+     * is worse than none.
+     *
+     * @var list<string>
      */
-    private const CARD_PARENT = 'nrllm';
+    private const CARD_PARENTS = ['nrllm_setup', 'nrllm_authoring', 'nrllm_operation'];
 
     /**
      * Both files are read as source rather than executed. This is a
@@ -119,7 +128,15 @@ final class OverviewCardCoverageTest extends TestCase
                 continue;
             }
 
-            if (!\str_contains($block, "'parent' => '" . self::CARD_PARENT . "'")) {
+            $isCardTarget = false;
+            foreach (self::CARD_PARENTS as $parent) {
+                if (\str_contains($block, "'parent' => '" . $parent . "'")) {
+                    $isCardTarget = true;
+                    break;
+                }
+            }
+
+            if (!$isCardTarget) {
                 continue;
             }
 


### PR DESCRIPTION
Closes #812. Amends ADR-119 with **ADR-183**.

ADR-119 deferred the placement with a named revisit trigger — the first cross-consumer editor surface — and #812 carried that open question so the next surface would not settle it by accident. **The question was put and answered rather than triggered.**

## The structure

```text
netresearch_ai            no access check of its own
├── nrllm_aitasks         access => user     (editors)      ← moved out of `web`
├── nrllm_overview        access => admin    (aliases: nrllm)
├── nrllm_setup           providers, models, configurations, use-case, wizard
├── nrllm_authoring       tasks, skills, snippets
└── nrllm_operation       tools, MCP, playground, runs, analytics
```

Four of the five entries come from the fourteen ADR-119 called a dumping ground — the *"three or four entries"* it asks for. `nrllm_aitasks` is the fifth and was never one of them.

## The access check is the whole mechanic

The module menu hides a top-level module whose own access check fails, **together with all its children** (ADR-131). That is why `nrllm_aitasks` was parented to `web`: under the admin-only container it would have been invisible to the editors it exists for, and every further editor surface would have landed flat under `web` for the same reason — the accretion #812 was filed to prevent.

A section carries **no** `access` key, exactly like the core's own sections in `cms-core/Configuration/Backend/Modules.php`. It therefore never filters, and its children filter individually. Admin-only and editor-facing modules share one place for the first time.

Nesting depth is unchanged: `tools → nrllm → nrllm_providers` was already three levels.

## Breaking

`nrllm` is no longer a registered module identifier, and the container URL `/module/nrllm` has no successor. Submodule identifiers and explicit paths are unchanged.

- **Backend shortcuts survive** — they store the identifier, and `nrllm_overview` carries `'aliases' => ['nrllm']`. This works only because `nrllm` is no longer registered: an alias is shadowed by a real module of the same name.
- **The cowriter needs no change.** Read rather than assumed: `ModuleFactory::adaptAliasMappingFromModuleConfiguration()` rewrites `position.before` and `position.after` through aliases, not only `parent` — so `t3_cowriter`'s `['after' => 'nrllm']` anchor re-resolves on its own. This was the one breakage I expected and it is not there.

## Scope, measured rather than estimated

A raw grep for `nrllm` answers **1912 hits in 305 files** — and conflates four namespaces: the module identifier, the `tx_nrllm_` table prefix, the cache and dashboard group names, and a `uniqid` prefix. Only the first is a module reference.

It came to **three** `setShortcutContext` route identifiers (repointed to `nrllm_overview`, as ADR-119 pre-settled) and **five** Playwright navigations to the retired container path. Every Fluid template link still resolves to a registered module — asserted in this branch, not eyeballed.

## Tests

`OverviewCardCoverageTest` asserted card coverage for children of the single `nrllm` parent; that parent set is now three containers. It is a **list constant** rather than one name because a fourth container will be added, and a coverage check that silently covers one third of the modules is worse than none. The required card set is unchanged at thirteen, so the overview template needed no edit.

## ADR-183, and a reason withdrawn

ADR-183 records the decision and amends ADR-119, whose `:Status:` and `:Amended:` are edited in the same change.

It also **withdraws one of ADR-119's two reasons for the name.** *"Integrators look for AI"* aims at the wrong audience: ADR-131 establishes that the section exists for **editors**, so the label is read by them. The conclusion survives on accuracy instead — of the four products sharing the section, `nr_repurpose` generates audio and images, `nr_ai_search` fuses BM25 with embeddings, and the cowriter drives CKEditor. Only nr_llm is a language-model product, so a section named "LLM" holding *AI Search* would be wrong, not merely unfashionable.

## Not in this change

**The sixteen backend screenshots are now stale.** They are full-window captures (the repo requires ≥1440px), so every one shows `Administration > LLM` in the module menu — I opened `backend-dashboard.png` to confirm rather than assume. Recapturing them needs a running instance *and* seed data matching each image (the overview shows `$7.31`, 2,216 requests, 4 providers), which makes it its own task rather than a mechanical re-shoot. The DDEV instance is currently stopped.

**The three sibling extensions are untouched.** They may register under `netresearch_ai` when they choose to; nothing breaks while they do not. What this gives them is a place that exists.

## Gates

| Suite | Result |
|---|---|
| unit | 7318 tests, 24703 assertions |
| functional (sqlite) | 1765 tests, 17831 assertions |
| cgl | pass |
| phpstan level 10 | pass |

All on PHP 8.4. **Rector was not run**: it is pinned to PHP 8.2 and this worktree's `.Build` is resolved at 8.4, so `platform_check.php` fatals — the documented trap in `Tests/AGENTS.md`. CI covers that leg, and the eight-cell matrix generally: a local run covers one cell.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01MNg1MysJVugv1xo2husknU)_
