### PR TITLE
chore: normalize XLIFF formatting to fractor's canonical form

### DIFF
--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="module.title">
                 <source>LLM Providers</source>
                 <target>LLM-Anbieter</target>
             </trans-unit>
-
             <!-- Provider List -->
             <trans-unit id="provider.field.name">
                 <source>Name</source>
@@ -52,7 +52,6 @@
                 <source>(default)</source>
                 <target>(Standard)</target>
             </trans-unit>
-
             <!-- Model List -->
             <trans-unit id="model.field.identifier">
                 <source>Identifier</source>
@@ -114,7 +113,6 @@
                 <source>No provider</source>
                 <target>Kein Anbieter</target>
             </trans-unit>
-
             <!-- Configuration List -->
             <trans-unit id="configuration.list.title">
                 <source>LLM Configurations</source>
@@ -172,7 +170,6 @@
                 <source>Tokens used</source>
                 <target>Verbrauchte Token</target>
             </trans-unit>
-
             <!-- Shared labels -->
             <trans-unit id="configured">
                 <source>Configured</source>
@@ -326,7 +323,6 @@
                 <source>All Providers</source>
                 <target>Alle Anbieter</target>
             </trans-unit>
-
             <!-- Button actions -->
             <trans-unit id="btn.provider.new">
                 <source>New Provider</source>
@@ -356,7 +352,6 @@
                 <source>Refresh</source>
                 <target>Aktualisieren</target>
             </trans-unit>
-
             <!-- Docheader tab menu -->
             <trans-unit id="tab.dashboard">
                 <source>Dashboard</source>
@@ -370,7 +365,6 @@
                 <source>Help</source>
                 <target>Hilfe</target>
             </trans-unit>
-
             <!-- Effective policy readout (ADR-140) -->
             <trans-unit id="governance.page.title">
                 <source>Effective policy</source>
@@ -744,7 +738,6 @@
                 <source>Applies to built-in tools only. Tools provided by an MCP server are always enforced against the trust-zone ceiling, never observed.</source>
                 <target>Gilt nur für eingebaute Tools. Tools von einem MCP-Server werden immer gegen die Trust-Zone-Obergrenze durchgesetzt, nie nur beobachtet.</target>
             </trans-unit>
-
             <!-- Routing readout (ADR-148) -->
             <trans-unit id="routing.heading">
                 <source>Why this model?</source>
@@ -1006,7 +999,6 @@
                 <source>Nothing in the window chose a model automatically. Either no call ran, every configuration names a fixed model, or telemetry is switched off.</source>
                 <target>Im Zeitraum hat nichts ein Modell automatisch gewählt. Entweder lief kein Aufruf, jede Konfiguration nennt ein festes Modell, oder die Telemetrie ist abgeschaltet.</target>
             </trans-unit>
-
             <!-- Dashboard overview cards -->
             <trans-unit id="snippet.card.title">
                 <source>Prompt Snippets</source>
@@ -1048,7 +1040,6 @@
                 <source>Open Analytics</source>
                 <target>Statistik öffnen</target>
             </trans-unit>
-
             <!-- Task controller messages -->
             <trans-unit id="task.notFound">
                 <source>Task not found.</source>
@@ -1114,7 +1105,6 @@
                 <source>Error reading sys_log. See system log for details.</source>
                 <target>Fehler beim Lesen des sys_log. Details siehe Systemlog.</target>
             </trans-unit>
-
             <!-- Configuration controller -->
             <trans-unit id="configuration.notConfigured">
                 <source>(not configured)</source>
@@ -1136,7 +1126,6 @@
                 <source>Generation failed. See system log for details.</source>
                 <target>Generierung fehlgeschlagen. Details siehe Systemlog.</target>
             </trans-unit>
-
             <!-- Model test results -->
             <trans-unit id="model.test.responded">
                 <source>Model "%s" responded: "%s" (tokens: %d in, %d out)</source>
@@ -1158,7 +1147,6 @@
                 <source>Model "%s" connected successfully (tokens: %d in, %d out) - response content empty, model may use internal reasoning</source>
                 <target>Modell "%s" erfolgreich verbunden (Token: %d rein, %d raus) - Antwortinhalt leer, Modell nutzt möglicherweise internes Reasoning</target>
             </trans-unit>
-
             <!-- Analytics dashboard -->
             <trans-unit id="analytics.title">
                 <source>LLM Usage Analytics</source>
@@ -1408,7 +1396,6 @@
                 <source>No active provider is configured and no provider was called recently.</source>
                 <target>Es ist kein aktiver Provider konfiguriert, und zuletzt wurde keiner aufgerufen.</target>
             </trans-unit>
-
             <!-- Skills backend module -->
             <trans-unit id="skill.list.title">
                 <source>Skills</source>
@@ -1514,7 +1501,6 @@
                 <source>No skills have been ingested yet. Add a source and run a sync.</source>
                 <target>Es wurden noch keine Skills importiert. Fügen Sie eine Quelle hinzu und starten Sie eine Synchronisierung.</target>
             </trans-unit>
-
             <!-- Glossary partial -->
             <trans-unit id="glossary.title">
                 <source>Terms &amp; Parameters</source>
@@ -1640,7 +1626,6 @@
                 <source>Encourages introducing new topics (typically -2 to 2). Higher values push the model toward novelty.</source>
                 <target>Fördert das Einbringen neuer Themen (typisch -2 bis 2). Höhere Werte drängen das Modell zu mehr Abwechslung.</target>
             </trans-unit>
-
             <!-- Per-module help / admin / see-also -->
             <trans-unit id="module.adminOnly">
                 <source>This module is admin-only. Records and actions here affect every editor using LLM features.</source>
@@ -1674,7 +1659,6 @@
                 <source>Open Help</source>
                 <target>Hilfe öffnen</target>
             </trans-unit>
-
             <!-- Readiness (overview) -->
             <trans-unit id="readiness.title">
                 <source>Setup readiness</source>
@@ -2080,7 +2064,6 @@
                 <source>Open Help</source>
                 <target>Hilfe öffnen</target>
             </trans-unit>
-
             <!-- Readiness signals (lists) -->
             <trans-unit id="configuration.noModel.badge">
                 <source>No model assigned</source>
@@ -2162,7 +2145,6 @@
                 <source>Edit source</source>
                 <target>Quelle bearbeiten</target>
             </trans-unit>
-
             <!-- Empty-state standardization -->
             <trans-unit id="provider.empty.hint">
                 <source>Providers are the first tier of setup (Provider → Model → Configuration). Launch the Setup Wizard to add one.</source>
@@ -2176,7 +2158,6 @@
                 <source>Configurations are the third tier of setup and require a Model first (Provider → Model → Configuration).</source>
                 <target>Konfigurationen sind die dritte Stufe der Einrichtung und erfordern zuerst ein Modell (Anbieter → Modell → Konfiguration).</target>
             </trans-unit>
-
             <!-- Configuration presets (ADR-056) -->
             <trans-unit id="configuration.presets.title">
                 <source>Pending presets</source>
@@ -2282,7 +2263,6 @@
                 <source>Developers: implement Netresearch\NrLlm\Service\Tool\ToolInterface and tag it with nr_llm.tool to register a new tool.</source>
                 <target>Entwickler: Implementieren Sie Netresearch\NrLlm\Service\Tool\ToolInterface und versehen Sie die Klasse mit dem Tag nr_llm.tool, um ein neues Werkzeug zu registrieren.</target>
             </trans-unit>
-
             <!-- Tasks list (translation sweep) -->
             <trans-unit id="task.list.title">
                 <source>Tasks</source>
@@ -2340,7 +2320,6 @@
                 <source>Each task uses a &lt;strong&gt;Configuration&lt;/strong&gt; that defines &lt;strong&gt;how&lt;/strong&gt; the AI behaves (model, temperature, system prompt). You can assign different configurations to tasks depending on the use case — a translation task might use a precise, low-temperature configuration, while a creative writing task uses a high-temperature one.</source>
                 <target>Jede Aufgabe verwendet eine &lt;strong&gt;Konfiguration&lt;/strong&gt;, die festlegt, &lt;strong&gt;wie&lt;/strong&gt; sich die KI verhält (Modell, Temperatur, System-Prompt). Je nach Anwendungsfall können Sie Aufgaben unterschiedliche Konfigurationen zuweisen — eine Übersetzungsaufgabe nutzt vielleicht eine präzise Konfiguration mit niedriger Temperatur, während eine kreative Schreibaufgabe eine mit hoher Temperatur verwendet.</target>
             </trans-unit>
-
             <!-- Overview AI task callout (translation sweep) -->
             <trans-unit id="taskAi.callout.title">
                 <source>Create Tasks with AI</source>
@@ -2358,7 +2337,6 @@
                 <source>Create with AI</source>
                 <target>Mit KI erstellen</target>
             </trans-unit>
-
             <!-- Configuration list intro (translation sweep) -->
             <trans-unit id="configuration.intro.line1">
                 <source>Configurations define &lt;strong&gt;how&lt;/strong&gt; the AI behaves: which model to use, creativity level (temperature), response length, and a system prompt that sets the AI's role. Each configuration is a reusable preset — for example, a "Translator" config with low temperature and a translation-focused system prompt.</source>
@@ -2368,7 +2346,6 @@
                 <source>Configurations are shared across &lt;strong&gt;Tasks&lt;/strong&gt;. A Task defines &lt;strong&gt;what&lt;/strong&gt; to do (the prompt template), while a Configuration defines &lt;strong&gt;how&lt;/strong&gt; to do it (model, temperature, system prompt). One configuration can power many different tasks.</source>
                 <target>Konfigurationen werden von mehreren &lt;strong&gt;Aufgaben&lt;/strong&gt; gemeinsam genutzt. Eine Aufgabe legt fest, &lt;strong&gt;was&lt;/strong&gt; zu tun ist (die Prompt-Vorlage), während eine Konfiguration festlegt, &lt;strong&gt;wie&lt;/strong&gt; es zu tun ist (Modell, Temperatur, System-Prompt). Eine Konfiguration kann viele verschiedene Aufgaben antreiben.</target>
             </trans-unit>
-
             <!-- Prompt snippet list intro + empty (translation sweep) -->
             <trans-unit id="snippet.list.title">
                 <source>Prompt Snippets</source>
@@ -2402,7 +2379,6 @@
                 <source>Tags</source>
                 <target>Tags</target>
             </trans-unit>
-
             <!-- Setup wizard (translation sweep) -->
             <trans-unit id="wizard.step.connect">
                 <source>Connect</source>
@@ -2560,7 +2536,6 @@
                 <source>Setup wizard progress</source>
                 <target>Fortschritt des Einrichtungsassistenten</target>
             </trans-unit>
-
             <!-- Test page (translation sweep) -->
             <trans-unit id="test.page.title">
                 <source>Test LLM Provider</source>
@@ -2686,7 +2661,6 @@
                 <source>Sending request...</source>
                 <target>Anfrage wird gesendet …</target>
             </trans-unit>
-
             <!-- Help page (translation sweep) -->
             <trans-unit id="help.page.title">
                 <source>LLM Management Help</source>
@@ -2848,7 +2822,6 @@
                 <source>&lt;strong&gt;Tasks&lt;/strong&gt; are simple one-shot prompts defined here in the LLM module. They are exposed to consuming extensions and the API as preset options. A consuming extension provides the editor-facing UI where editors pick a task or write a custom instruction.</source>
                 <target>&lt;strong&gt;Aufgaben&lt;/strong&gt; sind einfache einmalige Prompts, die hier im LLM-Modul definiert werden. Sie werden nutzenden Erweiterungen und der API als vorgegebene Optionen bereitgestellt. Eine nutzende Erweiterung stellt die redakteursseitige Oberfläche bereit, in der Redakteure eine Aufgabe auswählen oder eine eigene Anweisung schreiben.</target>
             </trans-unit>
-
             <!-- Backend AJAX error messages -->
             <trans-unit id="error.provider.noUid">
                 <source>No provider UID specified</source>
@@ -2994,7 +2967,6 @@
                 <source>Failed to load records. See system log for details.</source>
                 <target>Datensätze konnten nicht geladen werden. Siehe Systemprotokoll für Details.</target>
             </trans-unit>
-
             <!-- Task wizard flash messages -->
             <trans-unit id="flash.task.missingDescription.body">
                 <source>Please describe what this task should do.</source>
@@ -3900,7 +3872,6 @@
                 <source>Everything you configure here is reachable from PHP via LlmServiceManager. Your extension inherits the providers, models, configurations, budgets and the middleware pipeline — no per-extension API wiring.</source>
                 <target>Alles, was Sie hier konfigurieren, ist aus PHP über den LlmServiceManager erreichbar. Ihre Extension erbt Anbieter, Modelle, Konfigurationen, Budgets und die Middleware-Pipeline – ohne eigene API-Anbindung.</target>
             </trans-unit>
-
             <!-- Agent Runs approvals inbox (ADR-109) -->
             <trans-unit id="runs.heading.waiting">
                 <source>Awaiting your decision</source>

--- a/Resources/Private/Language/de.locallang_dashboard.xlf
+++ b/Resources/Private/Language/de.locallang_dashboard.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="widget.monthly_cost.title">

--- a/Resources/Private/Language/de.locallang_mod.xlf
+++ b/Resources/Private/Language/de.locallang_mod.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/de.locallang_mod_aitasks.xlf
+++ b/Resources/Private/Language/de.locallang_mod_aitasks.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/de.locallang_mod_analytics.xlf
+++ b/Resources/Private/Language/de.locallang_mod_analytics.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/de.locallang_mod_authoring.xlf
+++ b/Resources/Private/Language/de.locallang_mod_authoring.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/de.locallang_mod_config.xlf
+++ b/Resources/Private/Language/de.locallang_mod_config.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/de.locallang_mod_mcp.xlf
+++ b/Resources/Private/Language/de.locallang_mod_mcp.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">
@@ -56,7 +57,7 @@
             </trans-unit>
             <trans-unit id="server.approval.notRequired">
                 <source>Tools run without asking</source>
-                <target>Tools laufen ohne R&#252;ckfrage</target>
+                <target>Tools laufen ohne Rückfrage</target>
             </trans-unit>
             <trans-unit id="server.lastImport">
                 <source>Last import</source>
@@ -112,7 +113,7 @@
             </trans-unit>
             <trans-unit id="server.lastContact.hint">
                 <source>Any completed round trip counts: a tool call, an import or a connection test. It is not the same as the last import — a server that has been answering tool calls for weeks can have an old import date.</source>
-                <target>Z&#228;hlt jede abgeschlossene Anfrage: Tool-Aufruf, Import oder Verbindungstest. Das ist nicht der letzte Import — ein Server, der seit Wochen Tool-Aufrufe beantwortet, kann ein altes Import-Datum haben.</target>
+                <target>Zählt jede abgeschlossene Anfrage: Tool-Aufruf, Import oder Verbindungstest. Das ist nicht der letzte Import — ein Server, der seit Wochen Tool-Aufrufe beantwortet, kann ein altes Import-Datum haben.</target>
             </trans-unit>
             <trans-unit id="server.latency">
                 <source>Latency</source>

--- a/Resources/Private/Language/de.locallang_mod_model.xlf
+++ b/Resources/Private/Language/de.locallang_mod_model.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/de.locallang_mod_operation.xlf
+++ b/Resources/Private/Language/de.locallang_mod_operation.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/de.locallang_mod_overview.xlf
+++ b/Resources/Private/Language/de.locallang_mod_overview.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/de.locallang_mod_playground.xlf
+++ b/Resources/Private/Language/de.locallang_mod_playground.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/de.locallang_mod_provider.xlf
+++ b/Resources/Private/Language/de.locallang_mod_provider.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/de.locallang_mod_runs.xlf
+++ b/Resources/Private/Language/de.locallang_mod_runs.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/de.locallang_mod_section.xlf
+++ b/Resources/Private/Language/de.locallang_mod_section.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/de.locallang_mod_setup.xlf
+++ b/Resources/Private/Language/de.locallang_mod_setup.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/de.locallang_mod_skill.xlf
+++ b/Resources/Private/Language/de.locallang_mod_skill.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/de.locallang_mod_snippet.xlf
+++ b/Resources/Private/Language/de.locallang_mod_snippet.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/de.locallang_mod_task.xlf
+++ b/Resources/Private/Language/de.locallang_mod_task.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/de.locallang_mod_tool.xlf
+++ b/Resources/Private/Language/de.locallang_mod_tool.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/de.locallang_mod_usecase.xlf
+++ b/Resources/Private/Language/de.locallang_mod_usecase.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="messages" date="2026-08-11T00:00:00Z" product-name="nr_llm">
         <header/>
         <body>

--- a/Resources/Private/Language/de.locallang_mod_wizard.xlf
+++ b/Resources/Private/Language/de.locallang_mod_wizard.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="messages" date="2025-12-29T00:00:00Z" product-name="nr_llm">
         <header/>
         <body>

--- a/Resources/Private/Language/de.locallang_tca.xlf
+++ b/Resources/Private/Language/de.locallang_tca.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="messages">
         <body>
             <!-- Table title -->
@@ -11,7 +12,6 @@
                 <source>LLM User Budget</source>
                 <target>LLM-Nutzerbudget</target>
             </trans-unit>
-
             <!-- User budget tabs -->
             <trans-unit id="tab.daily_limits">
                 <source>Daily Limits</source>
@@ -21,7 +21,6 @@
                 <source>Monthly Limits</source>
                 <target>Monatslimits</target>
             </trans-unit>
-
             <!-- User budget fields -->
             <trans-unit id="tx_nrllm_user_budget.be_user">
                 <source>Backend User</source>
@@ -59,7 +58,6 @@
                 <source>Max Cost/Month ($)</source>
                 <target>Max. Kosten/Monat ($)</target>
             </trans-unit>
-
             <!-- Tabs -->
             <trans-unit id="tab.parameters">
                 <source>Parameters</source>
@@ -81,7 +79,6 @@
                 <source>Fallback Chain</source>
                 <target>Fallback-Kette</target>
             </trans-unit>
-
             <!-- Palettes -->
             <trans-unit id="palette.identity">
                 <source>Identity</source>
@@ -103,7 +100,6 @@
                 <source>Status</source>
                 <target>Status</target>
             </trans-unit>
-
             <!-- Fields -->
             <trans-unit id="tx_nrllm_configuration.identifier">
                 <source>Identifier</source>
@@ -113,7 +109,6 @@
                 <source>Unique technical identifier (lowercase, no spaces)</source>
                 <target>Eindeutiger technischer Bezeichner (Kleinbuchstaben, keine Leerzeichen)</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.name">
                 <source>Name</source>
                 <target>Name</target>
@@ -122,17 +117,14 @@
                 <source>Human-readable display name for this configuration</source>
                 <target>Lesbarer Anzeigename für diese Konfiguration</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.description">
                 <source>Description</source>
                 <target>Beschreibung</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.provider">
                 <source>Provider</source>
                 <target>Anbieter</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.model">
                 <source>Model</source>
                 <target>Modell</target>
@@ -141,7 +133,6 @@
                 <source>Model identifier (e.g., gpt-4o, claude-3-5-sonnet-20241022)</source>
                 <target>Modellbezeichner (z. B. gpt-4o, claude-3-5-sonnet-20241022)</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.translator">
                 <source>Specialized Translator</source>
                 <target>Spezialisierter Übersetzer</target>
@@ -150,7 +141,6 @@
                 <source>Use a specialized translation service instead of LLM-based translation</source>
                 <target>Einen spezialisierten Übersetzungsdienst anstelle der LLM-basierten Übersetzung verwenden</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.system_prompt">
                 <source>System Prompt</source>
                 <target>System-Prompt</target>
@@ -159,7 +149,6 @@
                 <source>Initial instructions to define the AI's behavior and context</source>
                 <target>Anfängliche Anweisungen zur Definition des KI-Verhaltens und -Kontexts</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.system_prompt_data_class">
                 <source>System prompt data class</source>
                 <target>Datenklasse des System-Prompts</target>
@@ -168,7 +157,6 @@
                 <source>How sensitive the system prompt above is. A configuration that declares one cannot send to a provider in a lower trust zone — in criteria mode the class is checked against the model routing actually selected, and a send that resolves to a weaker zone is refused. Leave empty to declare nothing; an unclassified system prompt places no restriction, exactly as before this field existed.</source>
                 <target>Wie vertraulich der System-Prompt oben ist. Eine Konfiguration mit Angabe kann nicht an einen Provider in einer niedrigeren Vertrauenszone senden — im Kriterien-Modus wird die Klasse gegen das tatsächlich gewählte Modell geprüft; ein Aufruf, der auf ein Modell in einer schwächeren Zone auflöst, wird abgelehnt. Leer lassen heißt: keine Angabe; ein nicht eingestufter System-Prompt schränkt nichts ein, genau wie vor Einführung dieses Feldes.</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.temperature">
                 <source>Temperature</source>
                 <target>Temperatur</target>
@@ -177,7 +165,6 @@
                 <source>Controls randomness (0.0 = deterministic, 2.0 = very creative)</source>
                 <target>Steuert die Zufälligkeit (0,0 = deterministisch, 2,0 = sehr kreativ)</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.max_tokens">
                 <source>Max Tokens</source>
                 <target>Max. Token</target>
@@ -186,7 +173,6 @@
                 <source>Maximum number of tokens in the response</source>
                 <target>Maximale Anzahl der Token in der Antwort. 0 = die im Modell hinterlegten maximalen Ausgabe-Token (oder der Anbieter-Standard) gelten.</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.top_p">
                 <source>Top P</source>
                 <target>Top P</target>
@@ -195,7 +181,6 @@
                 <source>Nucleus sampling (0.0-1.0). Lower values focus on more likely tokens.</source>
                 <target>Nucleus Sampling (0,0-1,0). Niedrigere Werte bevorzugen wahrscheinlichere Token.</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.frequency_penalty">
                 <source>Frequency Penalty</source>
                 <target>Häufigkeitsstrafe</target>
@@ -204,7 +189,6 @@
                 <source>Reduces repetition based on frequency (-2.0 to 2.0)</source>
                 <target>Reduziert Wiederholungen basierend auf der Häufigkeit (-2,0 bis 2,0)</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.presence_penalty">
                 <source>Presence Penalty</source>
                 <target>Präsenzstrafe</target>
@@ -213,7 +197,6 @@
                 <source>Encourages new topics based on token presence (-2.0 to 2.0)</source>
                 <target>Fördert neue Themen basierend auf Token-Präsenz (-2,0 bis 2,0)</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.options">
                 <source>Additional Options</source>
                 <target>Zusätzliche Optionen</target>
@@ -222,7 +205,6 @@
                 <source>Additional options as JSON (optional)</source>
                 <target>Zusätzliche Optionen als JSON (optional)</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.max_requests_per_day">
                 <source>Max Requests/Day</source>
                 <target>Max. Anfragen/Tag</target>
@@ -231,7 +213,6 @@
                 <source>Maximum requests per day (0 = unlimited)</source>
                 <target>Maximale Anfragen pro Tag (0 = unbegrenzt)</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.timeout">
                 <source>Timeout (seconds)</source>
                 <target>Timeout (Sekunden)</target>
@@ -240,7 +221,6 @@
                 <source>Maximum time to wait for API response (0 = use model default)</source>
                 <target>Maximale Wartezeit auf API-Antwort (0 = Modell-Standard verwenden)</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.max_tokens_per_day">
                 <source>Max Tokens/Day</source>
                 <target>Max. Token/Tag</target>
@@ -249,7 +229,6 @@
                 <source>Daily token usage limit (0 = unlimited)</source>
                 <target>Tägliches Token-Nutzungslimit (0 = unbegrenzt)</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.max_cost_per_day">
                 <source>Max Cost/Day ($)</source>
                 <target>Max. Kosten/Tag ($)</target>
@@ -258,7 +237,6 @@
                 <source>Daily cost limit in dollars (0.00 = unlimited)</source>
                 <target>Tägliches Kostenlimit in Dollar (0,00 = unbegrenzt)</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.fallback_chain">
                 <source>Fallback Chain</source>
                 <target>Fallback-Kette</target>
@@ -267,7 +245,6 @@
                 <source>Ordered list of configuration identifiers to retry against when the primary fails with a connection error, 5xx, or 429. JSON format: {"configurationIdentifiers":["claude-sonnet","ollama-local"]}. Leave empty to disable fallback. Does not apply to streaming requests.</source>
                 <target>Geordnete Liste von Konfigurations-Bezeichnern, die bei Verbindungsfehlern, 5xx oder 429 nacheinander versucht werden. JSON-Format: {"configurationIdentifiers":["claude-sonnet","ollama-local"]}. Leer lassen, um Fallback zu deaktivieren. Gilt nicht für Streaming-Anfragen.</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.is_active">
                 <source>Active</source>
                 <target>Aktiv</target>
@@ -276,7 +253,6 @@
                 <source>Enable this configuration for use</source>
                 <target>Diese Konfiguration zur Nutzung aktivieren</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.is_default">
                 <source>Default Configuration</source>
                 <target>Standardkonfiguration</target>
@@ -285,7 +261,6 @@
                 <source>Use as the default configuration when none is specified</source>
                 <target>Als Standardkonfiguration verwenden, wenn keine angegeben ist</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.allowed_groups">
                 <source>Allowed Backend Groups</source>
                 <target>Erlaubte Backend-Gruppen</target>
@@ -310,7 +285,6 @@
                 <source>Which optional guardrails apply to runs with this configuration. Empty = all apply. Security-critical guardrails (secret redaction) always run and are not listed here.</source>
                 <target>Welche optionalen Schutzmechanismen für Läufe mit dieser Konfiguration gelten. Leer = alle aktiv. Sicherheitskritische Schutzmechanismen (Schwärzung von Geheimnissen) laufen immer und werden hier nicht aufgeführt.</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.require_second_approver">
                 <source>Require a second approver</source>
                 <target>Zweite freigebende Person verlangen</target>
@@ -319,7 +293,6 @@
                 <source>Whoever starts a run cannot approve its own suspended write; someone else has to. Turn this on where the approval is the audit control rather than a confirmation dialog — a shared backend login, or a workflow that has to record that a second person looked. The initiator can still deny the run, and an administrator is not exempt.</source>
                 <target>Wer einen Lauf startet, kann dessen angehaltenen Schreibzugriff nicht selbst freigeben; das muss jemand anderes tun. Einschalten, wo die Freigabe die Prüfinstanz ist und nicht bloß ein Bestätigungsdialog — etwa bei einem geteilten Backend-Zugang oder wenn festgehalten werden muss, dass eine zweite Person hingesehen hat. Ablehnen kann die startende Person weiterhin, und Administratoren sind nicht ausgenommen.</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.snippet_tags">
                 <source>Prompt snippet tags</source>
                 <target>Tags für Prompt-Bausteine</target>
@@ -328,7 +301,6 @@
                 <source>Active prompt snippets carrying any of the selected tags are appended to this configuration's system prompt. Empty = no snippets. Tags are matched as whole tokens and case-insensitively, so "style" does not match "lifestyle".</source>
                 <target>Aktive Prompt-Bausteine mit einem der gewählten Tags werden an den System-Prompt dieser Konfiguration angehängt. Leer = keine Bausteine. Tags werden als ganze Token und ohne Beachtung der Groß-/Kleinschreibung verglichen, „style“ trifft also nicht „lifestyle“.</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.skills">
                 <source>Attached Skills</source>
                 <target>Zugewiesene Skills</target>
@@ -337,7 +309,6 @@
                 <source>Skills attached here form the baseline injected into every text generation that uses this configuration</source>
                 <target>Hier zugewiesene Skills bilden die Grundlage, die in jede Textgenerierung mit dieser Konfiguration eingefügt wird</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.model_selection_mode">
                 <source>Model Selection</source>
                 <target>Modellauswahl</target>
@@ -354,7 +325,6 @@
                 <source>Dynamic (Criteria-based)</source>
                 <target>Dynamisch (kriterienbasiert)</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.model_uid">
                 <source>Model</source>
                 <target>Modell</target>
@@ -363,7 +333,6 @@
                 <source>Select a configured LLM model</source>
                 <target>Ein konfiguriertes LLM-Modell auswählen</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.model_selection_criteria">
                 <source>Selection Criteria</source>
                 <target>Auswahlkriterien</target>
@@ -372,7 +341,6 @@
                 <source>Define criteria for automatic model selection. Models matching all selected criteria will be considered.</source>
                 <target>Definieren Sie Kriterien für die automatische Modellauswahl. Modelle, die alle ausgewählten Kriterien erfüllen, werden berücksichtigt.</target>
             </trans-unit>
-
             <!-- Model Selection Criteria Groups -->
             <trans-unit id="tx_nrllm_configuration.criteria.group.capabilities">
                 <source>Required Capabilities</source>
@@ -390,13 +358,11 @@
                 <source>Prefer Lowest Cost</source>
                 <target>Niedrigste Kosten bevorzugen</target>
             </trans-unit>
-
             <!-- Provider Table -->
             <trans-unit id="tx_nrllm_provider">
                 <source>LLM API Provider</source>
                 <target>LLM-API-Anbieter</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.identifier">
                 <source>Identifier</source>
                 <target>Bezeichner</target>
@@ -405,7 +371,6 @@
                 <source>Unique technical identifier (lowercase, no spaces)</source>
                 <target>Eindeutiger technischer Bezeichner (Kleinbuchstaben, keine Leerzeichen)</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.name">
                 <source>Name</source>
                 <target>Name</target>
@@ -414,12 +379,10 @@
                 <source>Human-readable display name for this provider</source>
                 <target>Lesbarer Anzeigename für diesen Anbieter</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.description">
                 <source>Description</source>
                 <target>Beschreibung</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.trust_zone">
                 <source>Trust zone</source>
                 <target>Vertrauenszone</target>
@@ -500,7 +463,6 @@
                 <source>Custom (OpenAI-compatible)</source>
                 <target>Benutzerdefiniert (OpenAI-kompatibel)</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.endpoint_url">
                 <source>Endpoint URL</source>
                 <target>Endpunkt-URL</target>
@@ -509,7 +471,6 @@
                 <source>Custom API endpoint URL (leave empty for default)</source>
                 <target>Benutzerdefinierte API-Endpunkt-URL (leer lassen für Standard)</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.api_key">
                 <source>API Key</source>
                 <target>API-Schlüssel</target>
@@ -518,7 +479,6 @@
                 <source>Your API key for authentication</source>
                 <target>Ihr API-Schlüssel zur Authentifizierung</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.organization_id">
                 <source>Organization ID</source>
                 <target>Organisations-ID</target>
@@ -527,7 +487,6 @@
                 <source>Optional organization ID (OpenAI, Azure)</source>
                 <target>Optionale Organisations-ID (OpenAI, Azure)</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.api_timeout">
                 <source>API Timeout (seconds)</source>
                 <target>API-Timeout (Sekunden)</target>
@@ -536,7 +495,6 @@
                 <source>Maximum time in seconds to wait for the complete API response, including connection (max 10s) and model processing time. Large or reasoning models may need 120-300 seconds. A configuration- or model-level timeout overrides this value per request.</source>
                 <target>Maximale Wartezeit in Sekunden auf die vollständige API-Antwort, einschließlich Verbindungsaufbau (max. 10 s) und Modellverarbeitungszeit. Große Modelle oder Reasoning-Modelle benötigen möglicherweise 120-300 Sekunden. Ein Timeout auf Konfigurations- oder Modellebene überschreibt diesen Wert pro Anfrage.</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.max_retries">
                 <source>Max Retries</source>
                 <target>Max. Wiederholungsversuche</target>
@@ -545,7 +503,6 @@
                 <source>Number of retries after the first failed request (0 = try once, no retries)</source>
                 <target>Anzahl der Wiederholungsversuche nach der ersten fehlgeschlagenen Anfrage (0 = ein Versuch, keine Wiederholung)</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.options">
                 <source>Additional Options</source>
                 <target>Zusätzliche Optionen</target>
@@ -554,7 +511,6 @@
                 <source>Additional provider-specific options as JSON. Supported: {"customHeaders": {"X-Custom-Header": "value"}} to send extra HTTP headers.</source>
                 <target>Zusätzliche anbieterspezifische Optionen als JSON. Unterstützt: {"customHeaders": {"X-Custom-Header": "value"}} für zusätzliche HTTP-Header.</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.is_active">
                 <source>Active</source>
                 <target>Aktiv</target>
@@ -563,7 +519,6 @@
                 <source>Enable this provider for use in models</source>
                 <target>Diesen Anbieter zur Verwendung in Modellen aktivieren</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.priority">
                 <source>Priority</source>
                 <target>Priorität</target>
@@ -572,38 +527,31 @@
                 <source>Higher priority providers are preferred for auto-selection (0-100)</source>
                 <target>Anbieter mit höherer Priorität werden bei der automatischen Auswahl bevorzugt (0-100)</target>
             </trans-unit>
-
             <trans-unit id="palette.connection">
                 <source>Connection Settings</source>
                 <target>Verbindungseinstellungen</target>
             </trans-unit>
-
             <trans-unit id="palette.request">
                 <source>Request Settings</source>
                 <target>Anfrage-Einstellungen</target>
             </trans-unit>
-
             <trans-unit id="palette.advanced">
                 <source>Advanced Settings</source>
                 <target>Erweiterte Einstellungen</target>
             </trans-unit>
-
             <trans-unit id="tab.connection">
                 <source>Connection</source>
                 <target>Verbindung</target>
             </trans-unit>
-
             <trans-unit id="tab.advanced">
                 <source>Advanced</source>
                 <target>Erweitert</target>
             </trans-unit>
-
             <!-- Model Table -->
             <trans-unit id="tx_nrllm_model">
                 <source>LLM Model</source>
                 <target>LLM-Modell</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.identifier">
                 <source>Identifier</source>
                 <target>Bezeichner</target>
@@ -612,7 +560,6 @@
                 <source>Unique technical identifier (lowercase, no spaces)</source>
                 <target>Eindeutiger technischer Bezeichner (Kleinbuchstaben, keine Leerzeichen)</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.name">
                 <source>Name</source>
                 <target>Name</target>
@@ -621,12 +568,10 @@
                 <source>Human-readable display name for this model</source>
                 <target>Lesbarer Anzeigename für dieses Modell</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.description">
                 <source>Description</source>
                 <target>Beschreibung</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.provider_uid">
                 <source>Provider</source>
                 <target>Anbieter</target>
@@ -639,7 +584,6 @@
                 <source>-- Select Provider --</source>
                 <target>-- Anbieter auswählen --</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.model_id">
                 <source>Model ID</source>
                 <target>Modell-ID</target>
@@ -648,7 +592,6 @@
                 <source>The model identifier as used in API calls (e.g., gpt-4o, claude-3-5-sonnet)</source>
                 <target>Der Modellbezeichner wie er in API-Aufrufen verwendet wird (z. B. gpt-4o, claude-3-5-sonnet)</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.context_length">
                 <source>Context Length</source>
                 <target>Kontextlänge</target>
@@ -657,7 +600,6 @@
                 <source>Maximum context window in tokens (0 = unknown)</source>
                 <target>Maximales Kontextfenster in Token (0 = unbekannt)</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.max_output_tokens">
                 <source>Max Output Tokens</source>
                 <target>Max. Ausgabe-Token</target>
@@ -666,7 +608,6 @@
                 <source>Maximum output tokens per request (0 = unknown)</source>
                 <target>Maximale Ausgabe-Token pro Anfrage (0 = unbekannt). Dient als Standard-Obergrenze für Anfragen, die selbst keine maximalen Token setzen.</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.dimensions">
                 <source>Embedding Dimensions</source>
                 <target>Embedding-Dimensionen</target>
@@ -675,7 +616,6 @@
                 <source>Embedding vector dimensionality of the model (0 = unknown)</source>
                 <target>Dimensionalität des Embedding-Vektors des Modells (0 = unbekannt). Dient als Standard-Vektorgröße für Embedding-Anfragen, die selbst keine Dimensionen setzen.</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.capabilities">
                 <source>Capabilities</source>
                 <target>Fähigkeiten</target>
@@ -712,7 +652,6 @@
                 <source>"discovery" = the provider's own model endpoint reported these capabilities. "catalog" = it did not — either it was unreachable, or it lists model ids without capabilities — and the bundled static catalog supplied them, which is a guess, not a confirmation.</source>
                 <target>„discovery“ = der Modell-Endpunkt des Anbieters hat diese Fähigkeiten gemeldet. „catalog“ = er hat es nicht – entweder war er nicht erreichbar, oder er listet Modell-IDs ohne Fähigkeiten – und der mitgelieferte statische Katalog hat sie geliefert: eine Annahme, keine Bestätigung.</target>
             </trans-unit>
-
             <!-- Capability labels and descriptions -->
             <trans-unit id="tx_nrllm_model.capabilities.chat">
                 <source>Chat</source>
@@ -722,7 +661,6 @@
                 <source>Conversational interactions with message history. Supports system prompts, user messages, and assistant responses.</source>
                 <target>Konversationsinteraktionen mit Nachrichtenverlauf. Unterstützt System-Prompts, Benutzernachrichten und Assistenten-Antworten.</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.capabilities.completion">
                 <source>Completion</source>
                 <target>Vervollständigung</target>
@@ -731,7 +669,6 @@
                 <source>Text completion from a prompt. Legacy API format, less common in modern models.</source>
                 <target>Textvervollständigung aus einem Prompt. Veraltetes API-Format, bei modernen Modellen seltener.</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.capabilities.embeddings">
                 <source>Embeddings</source>
                 <target>Embeddings</target>
@@ -740,7 +677,6 @@
                 <source>Generate vector embeddings for semantic search, similarity comparison, and RAG applications.</source>
                 <target>Vektor-Embeddings für semantische Suche, Ähnlichkeitsvergleiche und RAG-Anwendungen generieren.</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.capabilities.vision">
                 <source>Vision</source>
                 <target>Vision</target>
@@ -749,7 +685,6 @@
                 <source>Analyze images and visual content. Accepts image URLs or base64-encoded images in messages.</source>
                 <target>Bilder und visuelle Inhalte analysieren. Akzeptiert Bild-URLs oder Base64-kodierte Bilder in Nachrichten.</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.capabilities.streaming">
                 <source>Streaming</source>
                 <target>Streaming</target>
@@ -758,7 +693,6 @@
                 <source>Receive responses token-by-token via Server-Sent Events for real-time output display.</source>
                 <target>Antworten Token für Token über Server-Sent Events für Echtzeit-Ausgabe empfangen.</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.capabilities.tools">
                 <source>Tool Use</source>
                 <target>Werkzeugnutzung</target>
@@ -767,7 +701,6 @@
                 <source>Function calling / tool use. Model can request to call defined functions with structured arguments.</source>
                 <target>Funktionsaufrufe / Werkzeugnutzung. Das Modell kann definierte Funktionen mit strukturierten Argumenten aufrufen.</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.capabilities.json_mode">
                 <source>JSON Mode</source>
                 <target>JSON-Modus</target>
@@ -776,7 +709,6 @@
                 <source>Guaranteed valid JSON output. Use for structured data extraction and API integrations.</source>
                 <target>Garantiert gültige JSON-Ausgabe. Für strukturierte Datenextraktion und API-Integrationen verwenden.</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.capabilities.audio">
                 <source>Audio</source>
                 <target>Audio</target>
@@ -785,7 +717,6 @@
                 <source>Process audio input (speech-to-text) or generate audio output (text-to-speech).</source>
                 <target>Audioeingabe verarbeiten (Sprache-zu-Text) oder Audioausgabe erzeugen (Text-zu-Sprache).</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.capabilities.image">
                 <source>Image Generation</source>
                 <target>Bilderzeugung</target>
@@ -794,7 +725,6 @@
                 <source>Generate images from text prompts. The DALL-E / gpt-image service resolves its default model from active records carrying this capability.</source>
                 <target>Bilder aus Textbeschreibungen erzeugen. Der DALL-E-/gpt-image-Dienst ermittelt sein Standardmodell aus aktiven Datensätzen mit dieser Fähigkeit.</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.capabilities.text_to_speech">
                 <source>Text to Speech</source>
                 <target>Text-zu-Sprache</target>
@@ -803,7 +733,6 @@
                 <source>Synthesize spoken audio from text. Used by the specialized TTS service to resolve its default model.</source>
                 <target>Gesprochenes Audio aus Text erzeugen. Der spezialisierte TTS-Dienst ermittelt darüber sein Standardmodell.</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.capabilities.transcription">
                 <source>Transcription</source>
                 <target>Transkription</target>
@@ -812,7 +741,6 @@
                 <source>Transcribe audio to text (speech-to-text). Used by the specialized Whisper service to resolve its default model.</source>
                 <target>Audio zu Text transkribieren (Sprache-zu-Text). Der spezialisierte Whisper-Dienst ermittelt darüber sein Standardmodell.</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.default_timeout">
                 <source>Default Timeout</source>
                 <target>Standard-Timeout</target>
@@ -821,7 +749,6 @@
                 <source>Default timeout in seconds for requests to this model. Thinking/reasoning models may need longer timeouts (120-300s).</source>
                 <target>Standard-Timeout in Sekunden für Anfragen an dieses Modell. Denkende/schlussfolgernde Modelle benötigen möglicherweise längere Timeouts (120-300 s).</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.cost_input">
                 <source>Input Cost</source>
                 <target>Eingabekosten</target>
@@ -830,7 +757,6 @@
                 <source>Cost per 1 million input tokens in cents</source>
                 <target>Kosten pro 1 Million Eingabe-Token in Cent</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.cost_output">
                 <source>Output Cost</source>
                 <target>Ausgabekosten</target>
@@ -839,7 +765,6 @@
                 <source>Cost per 1 million output tokens in cents</source>
                 <target>Kosten pro 1 Million Ausgabe-Token in Cent</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.is_active">
                 <source>Active</source>
                 <target>Aktiv</target>
@@ -848,7 +773,6 @@
                 <source>Enable this model for use in configurations</source>
                 <target>Dieses Modell zur Verwendung in Konfigurationen aktivieren</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.is_default">
                 <source>Default Model</source>
                 <target>Standardmodell</target>
@@ -857,33 +781,27 @@
                 <source>Use as the default model for new configurations</source>
                 <target>Als Standardmodell für neue Konfigurationen verwenden</target>
             </trans-unit>
-
             <trans-unit id="tab.capabilities">
                 <source>Capabilities</source>
                 <target>Fähigkeiten</target>
             </trans-unit>
-
             <trans-unit id="tab.pricing">
                 <source>Pricing</source>
                 <target>Preise</target>
             </trans-unit>
-
             <trans-unit id="palette.model_limits">
                 <source>Model Limits</source>
                 <target>Modellgrenzen</target>
             </trans-unit>
-
             <trans-unit id="palette.pricing">
                 <source>Pricing</source>
                 <target>Preise</target>
             </trans-unit>
-
             <!-- Task Table -->
             <trans-unit id="tx_nrllm_task">
                 <source>LLM Task</source>
                 <target>LLM-Aufgabe</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.identifier">
                 <source>Identifier</source>
                 <target>Bezeichner</target>
@@ -892,7 +810,6 @@
                 <source>Unique technical identifier (lowercase, no spaces)</source>
                 <target>Eindeutiger technischer Bezeichner (Kleinbuchstaben, keine Leerzeichen)</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.name">
                 <source>Name</source>
                 <target>Name</target>
@@ -901,12 +818,10 @@
                 <source>Human-readable display name for this task</source>
                 <target>Lesbarer Anzeigename für diese Aufgabe</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.description">
                 <source>Description</source>
                 <target>Beschreibung</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.category">
                 <source>Category</source>
                 <target>Kategorie</target>
@@ -915,7 +830,6 @@
                 <source>Task category for organization and filtering</source>
                 <target>Aufgabenkategorie zur Organisation und Filterung</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.configuration_uid">
                 <source>Configuration</source>
                 <target>Konfiguration</target>
@@ -924,7 +838,6 @@
                 <source>LLM configuration to use for this task</source>
                 <target>LLM-Konfiguration für diese Aufgabe</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.prompt_template">
                 <source>Prompt Template</source>
                 <target>Prompt-Vorlage</target>
@@ -933,7 +846,6 @@
                 <source>Template with placeholders like {{input}} for the LLM prompt</source>
                 <target>Vorlage mit Platzhaltern wie {{input}} für den LLM-Prompt</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.input_type">
                 <source>Input Type</source>
                 <target>Eingabetyp</target>
@@ -942,7 +854,6 @@
                 <source>Type of input data source for this task</source>
                 <target>Art der Eingabedatenquelle für diese Aufgabe</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.input_source">
                 <source>Input Source</source>
                 <target>Eingabequelle</target>
@@ -951,7 +862,6 @@
                 <source>JSON configuration for the input source</source>
                 <target>JSON-Konfiguration für die Eingabequelle</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.output_format">
                 <source>Output Format</source>
                 <target>Ausgabeformat</target>
@@ -960,7 +870,6 @@
                 <source>Expected format of the LLM response</source>
                 <target>Erwartetes Format der LLM-Antwort</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.is_active">
                 <source>Active</source>
                 <target>Aktiv</target>
@@ -969,7 +878,6 @@
                 <source>Enable this task for execution</source>
                 <target>Diese Aufgabe zur Ausführung aktivieren</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.is_system">
                 <source>System Task</source>
                 <target>Systemaufgabe</target>
@@ -978,7 +886,6 @@
                 <source>System tasks are managed by extensions and should not be modified</source>
                 <target>Systemaufgaben werden von Extensions verwaltet und sollten nicht geändert werden</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.skills">
                 <source>Attached Skills</source>
                 <target>Zugewiesene Skills</target>
@@ -987,27 +894,22 @@
                 <source>Skills attached here are injected into this task's text-generation prompt, in addition to any skills on the selected configuration</source>
                 <target>Hier zugewiesene Skills werden zusätzlich zu den Skills der gewählten Konfiguration in den Textgenerierungs-Prompt dieser Aufgabe eingefügt</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.tab.input_output">
                 <source>Input / Output</source>
                 <target>Eingabe / Ausgabe</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.palette.input">
                 <source>Input Configuration</source>
                 <target>Eingabekonfiguration</target>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.palette.output">
                 <source>Output Configuration</source>
                 <target>Ausgabekonfiguration</target>
             </trans-unit>
-
             <trans-unit id="palette.settings">
                 <source>Settings</source>
                 <target>Einstellungen</target>
             </trans-unit>
-
             <!-- Task category select items -->
             <trans-unit id="tx_nrllm_task.category.log_analysis">
                 <source>Log Analysis</source>
@@ -1029,13 +931,11 @@
                 <source>General</source>
                 <target>Allgemein</target>
             </trans-unit>
-
             <!-- Task configuration_uid select items -->
             <trans-unit id="tx_nrllm_task.configuration_uid.default">
                 <source>-- Use Default Configuration --</source>
                 <target>-- Standardkonfiguration verwenden --</target>
             </trans-unit>
-
             <!-- Task input_type select items -->
             <trans-unit id="tx_nrllm_task.input_type.manual">
                 <source>Manual Input</source>
@@ -1057,7 +957,6 @@
                 <source>File</source>
                 <target>Datei</target>
             </trans-unit>
-
             <!-- Task output_format select items -->
             <trans-unit id="tx_nrllm_task.output_format.markdown">
                 <source>Markdown</source>
@@ -1075,13 +974,11 @@
                 <source>HTML</source>
                 <target>HTML</target>
             </trans-unit>
-
             <!-- Configuration model_uid select items -->
             <trans-unit id="tx_nrllm_configuration.model_uid.select">
                 <source>-- Select Model --</source>
                 <target>-- Modell auswählen --</target>
             </trans-unit>
-
             <!-- Configuration adapter select items (model_selection_criteria) -->
             <trans-unit id="tx_nrllm_configuration.adapter.openai">
                 <source>OpenAI</source>
@@ -1111,7 +1008,6 @@
                 <source>Ollama</source>
                 <target>Ollama</target>
             </trans-unit>
-
             <!-- Configuration translator select items -->
             <trans-unit id="tx_nrllm_configuration.translator.none">
                 <source>None (use LLM)</source>
@@ -1121,7 +1017,6 @@
                 <source>DeepL</source>
                 <target>DeepL</target>
             </trans-unit>
-
             <!-- Prompt snippet table -->
             <trans-unit id="tx_nrllm_promptsnippet">
                 <source>LLM Prompt Snippet</source>
@@ -1361,7 +1256,6 @@
                 <source>Enabled</source>
                 <target>Aktiviert</target>
             </trans-unit>
-
             <!-- MCP server (ADR-116) -->
             <trans-unit id="tx_nrllm_mcp_server">
                 <source>MCP Server</source>
@@ -1373,7 +1267,7 @@
             </trans-unit>
             <trans-unit id="tx_nrllm_mcp_server.identifier.description">
                 <source>Lowercase letters, digits and underscores, up to 32 characters. Prefixes every tool imported from this server and its tool group mcp_&lt;identifier&gt;. Changing it renames all of them.</source>
-                <target>Kleinbuchstaben, Ziffern und Unterstriche, maximal 32 Zeichen. Steht als Pr&#228;fix vor jedem Tool dieses Servers und vor der Tool-Gruppe mcp_&lt;Kennung&gt;. Eine &#196;nderung benennt alle um.</target>
+                <target>Kleinbuchstaben, Ziffern und Unterstriche, maximal 32 Zeichen. Steht als Präfix vor jedem Tool dieses Servers und vor der Tool-Gruppe mcp_&lt;Kennung&gt;. Eine Änderung benennt alle um.</target>
             </trans-unit>
             <trans-unit id="tx_nrllm_mcp_server.name">
                 <source>Name</source>
@@ -1397,7 +1291,7 @@
             </trans-unit>
             <trans-unit id="tx_nrllm_mcp_server.auth_credential.description">
                 <source>Stored in nr-vault. Leave empty for an unauthenticated server.</source>
-                <target>Wird in nr-vault gespeichert. F&#252;r einen Server ohne Authentifizierung leer lassen.</target>
+                <target>Wird in nr-vault gespeichert. Für einen Server ohne Authentifizierung leer lassen.</target>
             </trans-unit>
             <trans-unit id="tx_nrllm_mcp_server.auth_placement">
                 <source>Credential placement</source>
@@ -1421,7 +1315,7 @@
             </trans-unit>
             <trans-unit id="tx_nrllm_mcp_server.auth_header_name.description">
                 <source>Name of the header carrying the credential, for example X-Api-Key.</source>
-                <target>Name des Headers, der die Zugangsdaten tr&#228;gt, zum Beispiel X-Api-Key.</target>
+                <target>Name des Headers, der die Zugangsdaten trägt, zum Beispiel X-Api-Key.</target>
             </trans-unit>
             <trans-unit id="tx_nrllm_promptsnippet.data_class">
                 <source>Data class</source>
@@ -1453,7 +1347,7 @@
             </trans-unit>
             <trans-unit id="tx_nrllm_mcp_server.requires_approval.description">
                 <source>Every tool of this server pauses for a human before an agent run executes it. On by default: what a remote tool does cannot be inspected here, and the server's own annotations do not decide this.</source>
-                <target>Jedes Tool dieses Servers h&#228;lt vor der Ausf&#252;hrung f&#252;r eine menschliche Freigabe an. Standardm&#228;&#223;ig aktiv: was ein entferntes Tool tut, ist hier nicht pr&#252;fbar, und die Angaben des Servers entscheiden das nicht.</target>
+                <target>Jedes Tool dieses Servers hält vor der Ausführung für eine menschliche Freigabe an. Standardmäßig aktiv: was ein entferntes Tool tut, ist hier nicht prüfbar, und die Angaben des Servers entscheiden das nicht.</target>
             </trans-unit>
             <trans-unit id="tx_nrllm_mcp_server.import_status">
                 <source>Import status</source>
@@ -1505,13 +1399,12 @@
             </trans-unit>
             <trans-unit id="tx_nrllm_mcp_server.enabled.description">
                 <source>Off until an operator switches it on. A disabled server keeps its catalogue but contributes no tools.</source>
-                <target>Standardm&#228;&#223;ig aus, bis ein Operator ihn einschaltet. Ein deaktivierter Server beh&#228;lt seinen Katalog, steuert aber keine Tools bei.</target>
+                <target>Standardmäßig aus, bis ein Operator ihn einschaltet. Ein deaktivierter Server behält seinen Katalog, steuert aber keine Tools bei.</target>
             </trans-unit>
-
             <!-- Tool data class (ADR-094) -->
             <trans-unit id="tx_nrllm.tool_data_class.publicContent">
                 <source>Public content</source>
-                <target>&#214;ffentliche Inhalte</target>
+                <target>Öffentliche Inhalte</target>
             </trans-unit>
             <trans-unit id="tx_nrllm.tool_data_class.editorContent">
                 <source>Editor content</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="module.title">
                 <source>LLM Integration</source>
             </trans-unit>
-
             <!-- Provider List -->
             <trans-unit id="provider.field.name">
                 <source>Name</source>
@@ -40,7 +40,6 @@
             <trans-unit id="provider.endpoint.default">
                 <source>(default)</source>
             </trans-unit>
-
             <!-- Model List -->
             <trans-unit id="model.field.identifier">
                 <source>Identifier</source>
@@ -87,7 +86,6 @@
             <trans-unit id="noProvider">
                 <source>No provider</source>
             </trans-unit>
-
             <!-- Configuration List -->
             <trans-unit id="configuration.list.title">
                 <source>LLM Configurations</source>
@@ -131,7 +129,6 @@
             <trans-unit id="tokensUsed">
                 <source>Tokens used</source>
             </trans-unit>
-
             <!-- Shared labels -->
             <trans-unit id="configured">
                 <source>Configured</source>
@@ -247,7 +244,6 @@
             <trans-unit id="allProviders">
                 <source>All Providers</source>
             </trans-unit>
-
             <!-- Button actions -->
             <trans-unit id="btn.provider.new">
                 <source>New Provider</source>
@@ -270,7 +266,6 @@
             <trans-unit id="btn.refresh">
                 <source>Refresh</source>
             </trans-unit>
-
             <!-- Docheader tab menu -->
             <trans-unit id="tab.dashboard">
                 <source>Dashboard</source>
@@ -281,7 +276,6 @@
             <trans-unit id="tab.help">
                 <source>Help</source>
             </trans-unit>
-
             <!-- Effective policy readout (ADR-140) -->
             <trans-unit id="governance.page.title">
                 <source>Effective policy</source>
@@ -562,7 +556,6 @@
             <trans-unit id="governance.note.remoteAlwaysEnforced">
                 <source>Applies to built-in tools only. Tools provided by an MCP server are always enforced against the trust-zone ceiling, never observed.</source>
             </trans-unit>
-
             <!-- Routing readout (ADR-148) -->
             <trans-unit id="routing.heading">
                 <source>Why this model?</source>
@@ -759,7 +752,6 @@
             <trans-unit id="routedCalls.empty.text">
                 <source>Nothing in the window chose a model automatically. Either no call ran, every configuration names a fixed model, or telemetry is switched off.</source>
             </trans-unit>
-
             <!-- Dashboard overview cards -->
             <trans-unit id="snippet.card.title">
                 <source>Prompt Snippets</source>
@@ -791,7 +783,6 @@
             <trans-unit id="analytics.card.button">
                 <source>Open Analytics</source>
             </trans-unit>
-
             <!-- Task controller messages -->
             <trans-unit id="task.notFound">
                 <source>Task not found.</source>
@@ -841,7 +832,6 @@
             <trans-unit id="task.syslog.readError">
                 <source>Error reading sys_log. See system log for details.</source>
             </trans-unit>
-
             <!-- Configuration controller -->
             <trans-unit id="configuration.notConfigured">
                 <source>(not configured)</source>
@@ -858,7 +848,6 @@
             <trans-unit id="flash.configuration.generationFailed.generic">
                 <source>Generation failed. See system log for details.</source>
             </trans-unit>
-
             <!-- Model test results -->
             <trans-unit id="model.test.responded">
                 <source>Model "%s" responded: "%s" (tokens: %d in, %d out)</source>
@@ -875,7 +864,6 @@
             <trans-unit id="model.test.emptyResponse">
                 <source>Model "%s" connected successfully (tokens: %d in, %d out) - response content empty, model may use internal reasoning</source>
             </trans-unit>
-
             <!-- Analytics dashboard -->
             <trans-unit id="analytics.title">
                 <source>LLM Usage Analytics</source>
@@ -1063,7 +1051,6 @@
             <trans-unit id="analytics.health.empty">
                 <source>No active provider is configured and no provider was called recently.</source>
             </trans-unit>
-
             <!-- Skills backend module -->
             <trans-unit id="skill.list.title">
                 <source>Skills</source>
@@ -1143,7 +1130,6 @@
             <trans-unit id="skill.skills.empty.message">
                 <source>No skills have been ingested yet. Add a source and run a sync.</source>
             </trans-unit>
-
             <!-- Glossary partial -->
             <trans-unit id="glossary.title">
                 <source>Terms &amp; Parameters</source>
@@ -1238,7 +1224,6 @@
             <trans-unit id="glossary.param.presencePenalty">
                 <source>Encourages introducing new topics (typically -2 to 2). Higher values push the model toward novelty.</source>
             </trans-unit>
-
             <!-- Per-module help / admin / see-also -->
             <trans-unit id="module.adminOnly">
                 <source>This module is admin-only. Records and actions here affect every editor using LLM features.</source>
@@ -1264,7 +1249,6 @@
             <trans-unit id="seeAlso.help">
                 <source>Open Help</source>
             </trans-unit>
-
             <!-- Readiness (overview) -->
             <trans-unit id="readiness.title">
                 <source>Setup readiness</source>
@@ -1569,7 +1553,6 @@
             <trans-unit id="help.card.button">
                 <source>Open Help</source>
             </trans-unit>
-
             <!-- Readiness signals (lists) -->
             <trans-unit id="configuration.noModel.badge">
                 <source>No model assigned</source>
@@ -1631,7 +1614,6 @@
             <trans-unit id="skill.source.edit">
                 <source>Edit source</source>
             </trans-unit>
-
             <!-- Empty-state standardization -->
             <trans-unit id="provider.empty.hint">
                 <source>Providers are the first tier of setup (Provider → Model → Configuration). Launch the Setup Wizard to add one.</source>
@@ -1642,7 +1624,6 @@
             <trans-unit id="configuration.empty.hint">
                 <source>Configurations are the third tier of setup and require a Model first (Provider → Model → Configuration).</source>
             </trans-unit>
-
             <!-- Configuration presets (ADR-056) -->
             <trans-unit id="configuration.presets.title">
                 <source>Pending presets</source>
@@ -1722,7 +1703,6 @@
             <trans-unit id="playground.empty.developer">
                 <source>Developers: implement Netresearch\NrLlm\Service\Tool\ToolInterface and tag it with nr_llm.tool to register a new tool.</source>
             </trans-unit>
-
             <!-- Tasks list (translation sweep) -->
             <trans-unit id="task.list.title">
                 <source>Tasks</source>
@@ -1766,7 +1746,6 @@
             <trans-unit id="task.intro.line2">
                 <source>Each task uses a &lt;strong&gt;Configuration&lt;/strong&gt; that defines &lt;strong&gt;how&lt;/strong&gt; the AI behaves (model, temperature, system prompt). You can assign different configurations to tasks depending on the use case — a translation task might use a precise, low-temperature configuration, while a creative writing task uses a high-temperature one.</source>
             </trans-unit>
-
             <!-- Overview AI task callout (translation sweep) -->
             <trans-unit id="taskAi.callout.title">
                 <source>Create Tasks with AI</source>
@@ -1780,7 +1759,6 @@
             <trans-unit id="taskAi.createWithAi">
                 <source>Create with AI</source>
             </trans-unit>
-
             <!-- Configuration list intro (translation sweep) -->
             <trans-unit id="configuration.intro.line1">
                 <source>Configurations define &lt;strong&gt;how&lt;/strong&gt; the AI behaves: which model to use, creativity level (temperature), response length, and a system prompt that sets the AI's role. Each configuration is a reusable preset — for example, a "Translator" config with low temperature and a translation-focused system prompt.</source>
@@ -1788,7 +1766,6 @@
             <trans-unit id="configuration.intro.line2">
                 <source>Configurations are shared across &lt;strong&gt;Tasks&lt;/strong&gt;. A Task defines &lt;strong&gt;what&lt;/strong&gt; to do (the prompt template), while a Configuration defines &lt;strong&gt;how&lt;/strong&gt; to do it (model, temperature, system prompt). One configuration can power many different tasks.</source>
             </trans-unit>
-
             <!-- Prompt snippet list intro + empty (translation sweep) -->
             <trans-unit id="snippet.list.title">
                 <source>Prompt Snippets</source>
@@ -1814,7 +1791,6 @@
             <trans-unit id="snippet.col.tags">
                 <source>Tags</source>
             </trans-unit>
-
             <!-- Setup wizard (translation sweep) -->
             <trans-unit id="wizard.step.connect">
                 <source>Connect</source>
@@ -1933,7 +1909,6 @@
             <trans-unit id="wizard.progress.aria">
                 <source>Setup wizard progress</source>
             </trans-unit>
-
             <!-- Test page (translation sweep) -->
             <trans-unit id="test.page.title">
                 <source>Test LLM Provider</source>
@@ -2028,7 +2003,6 @@
             <trans-unit id="test.loading">
                 <source>Sending request...</source>
             </trans-unit>
-
             <!-- Help page (translation sweep) -->
             <trans-unit id="help.page.title">
                 <source>LLM Management Help</source>
@@ -2150,7 +2124,6 @@
             <trans-unit id="help.faq.a4">
                 <source>&lt;strong&gt;Tasks&lt;/strong&gt; are simple one-shot prompts defined here in the LLM module. They are exposed to consuming extensions and the API as preset options. A consuming extension provides the editor-facing UI where editors pick a task or write a custom instruction.</source>
             </trans-unit>
-
             <!-- Backend AJAX error messages -->
             <trans-unit id="error.provider.noUid">
                 <source>No provider UID specified</source>
@@ -2260,7 +2233,6 @@
             <trans-unit id="error.records.loadFailed">
                 <source>Failed to load records. See system log for details.</source>
             </trans-unit>
-
             <!-- Task wizard flash messages -->
             <trans-unit id="flash.task.missingDescription.body">
                 <source>Please describe what this task should do.</source>
@@ -2940,7 +2912,6 @@
             <trans-unit id="overview.dev.description">
                 <source>Everything you configure here is reachable from PHP via LlmServiceManager. Your extension inherits the providers, models, configurations, budgets and the middleware pipeline — no per-extension API wiring.</source>
             </trans-unit>
-
             <!-- Agent Runs approvals inbox (ADR-109) -->
             <trans-unit id="runs.heading.waiting">
                 <source>Awaiting your decision</source>

--- a/Resources/Private/Language/locallang_dashboard.xlf
+++ b/Resources/Private/Language/locallang_dashboard.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="widget.monthly_cost.title">

--- a/Resources/Private/Language/locallang_mod.xlf
+++ b/Resources/Private/Language/locallang_mod.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/locallang_mod_aitasks.xlf
+++ b/Resources/Private/Language/locallang_mod_aitasks.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/locallang_mod_analytics.xlf
+++ b/Resources/Private/Language/locallang_mod_analytics.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/locallang_mod_authoring.xlf
+++ b/Resources/Private/Language/locallang_mod_authoring.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/locallang_mod_config.xlf
+++ b/Resources/Private/Language/locallang_mod_config.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/locallang_mod_mcp.xlf
+++ b/Resources/Private/Language/locallang_mod_mcp.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/locallang_mod_model.xlf
+++ b/Resources/Private/Language/locallang_mod_model.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/locallang_mod_operation.xlf
+++ b/Resources/Private/Language/locallang_mod_operation.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/locallang_mod_overview.xlf
+++ b/Resources/Private/Language/locallang_mod_overview.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/locallang_mod_playground.xlf
+++ b/Resources/Private/Language/locallang_mod_playground.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/locallang_mod_provider.xlf
+++ b/Resources/Private/Language/locallang_mod_provider.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/locallang_mod_runs.xlf
+++ b/Resources/Private/Language/locallang_mod_runs.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/locallang_mod_section.xlf
+++ b/Resources/Private/Language/locallang_mod_section.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/locallang_mod_setup.xlf
+++ b/Resources/Private/Language/locallang_mod_setup.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/locallang_mod_skill.xlf
+++ b/Resources/Private/Language/locallang_mod_skill.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/locallang_mod_snippet.xlf
+++ b/Resources/Private/Language/locallang_mod_snippet.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/locallang_mod_task.xlf
+++ b/Resources/Private/Language/locallang_mod_task.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/locallang_mod_tool.xlf
+++ b/Resources/Private/Language/locallang_mod_tool.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" datatype="plaintext" original="messages">
         <body>
             <trans-unit id="mlang_labels_tablabel">

--- a/Resources/Private/Language/locallang_mod_usecase.xlf
+++ b/Resources/Private/Language/locallang_mod_usecase.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" datatype="plaintext" original="messages" date="2026-08-11T00:00:00Z" product-name="nr_llm">
         <header/>
         <body>

--- a/Resources/Private/Language/locallang_mod_wizard.xlf
+++ b/Resources/Private/Language/locallang_mod_wizard.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" datatype="plaintext" original="messages" date="2025-12-29T00:00:00Z" product-name="nr_llm">
         <header/>
         <body>

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+<xliff
+    xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" datatype="plaintext" original="messages">
         <body>
             <!-- Table title -->
@@ -9,7 +10,6 @@
             <trans-unit id="tx_nrllm_user_budget">
                 <source>LLM User Budget</source>
             </trans-unit>
-
             <!-- User budget tabs -->
             <trans-unit id="tab.daily_limits">
                 <source>Daily Limits</source>
@@ -17,7 +17,6 @@
             <trans-unit id="tab.monthly_limits">
                 <source>Monthly Limits</source>
             </trans-unit>
-
             <!-- User budget fields -->
             <trans-unit id="tx_nrllm_user_budget.be_user">
                 <source>Backend User</source>
@@ -46,7 +45,6 @@
             <trans-unit id="tx_nrllm_user_budget.max_cost_per_month">
                 <source>Max Cost/Month ($)</source>
             </trans-unit>
-
             <!-- Tabs -->
             <trans-unit id="tab.parameters">
                 <source>Parameters</source>
@@ -63,7 +61,6 @@
             <trans-unit id="tab.fallback">
                 <source>Fallback Chain</source>
             </trans-unit>
-
             <!-- Palettes -->
             <trans-unit id="palette.identity">
                 <source>Identity</source>
@@ -80,7 +77,6 @@
             <trans-unit id="palette.status">
                 <source>Status</source>
             </trans-unit>
-
             <!-- Fields -->
             <trans-unit id="tx_nrllm_configuration.identifier">
                 <source>Identifier</source>
@@ -88,141 +84,120 @@
             <trans-unit id="tx_nrllm_configuration.identifier.description">
                 <source>Unique technical identifier (lowercase, no spaces)</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.name">
                 <source>Name</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_configuration.name.description">
                 <source>Human-readable display name for this configuration</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.description">
                 <source>Description</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.provider">
                 <source>Provider</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.model">
                 <source>Model</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_configuration.model.description">
                 <source>Model identifier (e.g., gpt-4o, claude-3-5-sonnet-20241022)</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.translator">
                 <source>Specialized Translator</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_configuration.translator.description">
                 <source>Use a specialized translation service instead of LLM-based translation</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.system_prompt">
                 <source>System Prompt</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_configuration.system_prompt.description">
                 <source>Instructions that define the AI's role, behavior, and constraints. This is sent before every user message and shapes all responses. Be specific about tone, format, and limitations. Example for a translator: "You are a professional translator. Translate the provided text to the target language. Preserve formatting, tone, and cultural context. Do not add explanations unless asked." Example for a summarizer: "Summarize the following content in 3-5 bullet points. Focus on actionable insights. Use clear, non-technical language." Tasks can override or extend this with their own prompt templates.</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.system_prompt_data_class">
                 <source>System prompt data class</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_configuration.system_prompt_data_class.description">
                 <source>How sensitive the system prompt above is. A configuration that declares one cannot send to a provider in a lower trust zone — in criteria mode the class is checked against the model routing actually selected, and a send that resolves to a weaker zone is refused. Leave empty to declare nothing; an unclassified system prompt places no restriction, exactly as before this field existed.</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.temperature">
                 <source>Temperature</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_configuration.temperature.description">
                 <source>Controls how random or creative the output is. Low values (0.0–0.3) produce focused, deterministic responses — ideal for factual tasks, translation, or code. Medium values (0.4–0.7) balance creativity and accuracy — good for general content writing. High values (0.8–2.0) produce more creative, surprising results — useful for brainstorming or poetry. Example: A summarization task works best at 0.2–0.3, while a blog idea generator might use 0.9. Note: Reasoning models (o-series, GPT-5.x) ignore this setting. Anthropic models accept 0.0–1.0 only.</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.max_tokens">
                 <source>Max Tokens</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_configuration.max_tokens.description">
                 <source>Limits how long the response can be. One token is roughly ¾ of a word in English — so 100 tokens ≈ 75 words, 1000 tokens ≈ 750 words, 4000 tokens ≈ a 3-page article. Set this to match your use case: 256 for short answers, 1000–2000 for summaries, 4000–8000 for full articles or translations. Higher values cost more — the model stops generating when it reaches this limit. The upper bound depends on the model (check the model's max output tokens). Set 0 to use the model's configured max output tokens (or the provider default).</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.top_p">
                 <source>Top P (Nucleus Sampling)</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_configuration.top_p.description">
                 <source>An alternative to temperature for controlling randomness. At each step, the model considers only tokens whose combined probability reaches this threshold. 1.0 = consider all tokens (default). 0.1 = only consider tokens in the top 10% probability mass, producing very focused output. Generally, adjust either temperature OR top_p, not both. Most use cases work fine with the default of 1.0 while adjusting temperature instead. Note: Reasoning models (o-series, GPT-5.x) fix this at 1.0. On Anthropic, top_p and temperature are mutually exclusive.</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.frequency_penalty">
                 <source>Frequency Penalty</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_configuration.frequency_penalty.description">
                 <source>Penalizes tokens proportionally to how often they have already appeared. Positive values (0.1–2.0) reduce word repetition — higher values make the model avoid repeating the same phrases. 0.0 = no penalty (default). Negative values (-2.0 to 0) encourage repetition. Useful for preventing the model from getting stuck in loops or repeating filler phrases. Example: Set to 0.5 for content writing to reduce "the the" or repeated sentence structures. Only supported by OpenAI-compatible providers — Anthropic and Gemini do not use this parameter.</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.presence_penalty">
                 <source>Presence Penalty</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_configuration.presence_penalty.description">
                 <source>Penalizes tokens based on whether they have appeared at all (regardless of frequency). Positive values (0.1–2.0) encourage the model to introduce new topics and vocabulary. 0.0 = no penalty (default). Negative values encourage staying on-topic. Unlike frequency_penalty, this applies equally whether a word appeared once or 100 times. Example: Set to 0.6 for brainstorming to push the model toward diverse ideas. Set to 0.0 or negative for focused Q&amp;A. Only supported by OpenAI-compatible providers — Anthropic and Gemini do not use this parameter.</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.options">
                 <source>Additional Options</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_configuration.options.description">
                 <source>Provider-specific options as a JSON object. These are merged into the API request. Examples: {"stop_sequences": ["\n\n"]} to stop at double newlines, {"seed": 42} for reproducible output (OpenAI), {"response_format": {"type": "json_object"}} to force JSON output. Consult your provider's API documentation for available options.</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.max_requests_per_day">
                 <source>Max Requests/Day</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_configuration.max_requests_per_day.description">
                 <source>Maximum requests per day (0 = unlimited)</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.timeout">
                 <source>Timeout (seconds)</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_configuration.timeout.description">
                 <source>Maximum time to wait for the API to respond, in seconds. Set to 0 to use the model's default timeout. Short tasks (translation, classification) typically need 10–30s. Long content generation may need 60–120s. Reasoning models (o-series, GPT-5.x) can take 60–300s due to internal "thinking" steps. If requests frequently time out, increase this value — but note that longer timeouts also mean users wait longer if something goes wrong.</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.max_tokens_per_day">
                 <source>Max Tokens/Day</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_configuration.max_tokens_per_day.description">
                 <source>Daily token usage limit (0 = unlimited)</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.max_cost_per_day">
                 <source>Max Cost/Day ($)</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_configuration.max_cost_per_day.description">
                 <source>Daily cost limit in dollars (0.00 = unlimited)</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.fallback_chain">
                 <source>Fallback Chain</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_configuration.fallback_chain.description">
                 <source>Ordered list of configuration identifiers to retry against when the primary fails with a connection error, 5xx, or 429. JSON format: {"configurationIdentifiers":["claude-sonnet","ollama-local"]}. Leave empty to disable fallback. Does not apply to streaming requests.</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.is_active">
                 <source>Active</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_configuration.is_active.description">
                 <source>Enable this configuration for use</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.is_default">
                 <source>Default Configuration</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_configuration.is_default.description">
                 <source>Use as the default configuration when none is specified</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.allowed_groups">
                 <source>Allowed Backend Groups</source>
             </trans-unit>
@@ -247,21 +222,18 @@
             <trans-unit id="tx_nrllm_configuration.require_second_approver.description">
                 <source>Whoever starts a run cannot approve its own suspended write; someone else has to. Turn this on where the approval is the audit control rather than a confirmation dialog — a shared backend login, or a workflow that has to record that a second person looked. The initiator can still deny the run, and an administrator is not exempt.</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.snippet_tags">
                 <source>Prompt snippet tags</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_configuration.snippet_tags.description">
                 <source>Active prompt snippets carrying any of the selected tags are appended to this configuration's system prompt. Empty = no snippets. Tags are matched as whole tokens and case-insensitively, so "style" does not match "lifestyle".</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.skills">
                 <source>Attached Skills</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_configuration.skills.description">
                 <source>Skills attached here form the baseline injected into every text generation that uses this configuration</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.model_selection_mode">
                 <source>Model Selection</source>
             </trans-unit>
@@ -274,21 +246,18 @@
             <trans-unit id="tx_nrllm_configuration.model_selection_mode.criteria">
                 <source>Dynamic (Criteria-based)</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.model_uid">
                 <source>Model</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_configuration.model_uid.description">
                 <source>Select a configured LLM model</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_configuration.model_selection_criteria">
                 <source>Selection Criteria</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_configuration.model_selection_criteria.description">
                 <source>Define criteria for automatic model selection. Models matching all selected criteria will be considered.</source>
             </trans-unit>
-
             <!-- Model Selection Criteria Groups -->
             <trans-unit id="tx_nrllm_configuration.criteria.group.capabilities">
                 <source>Required Capabilities</source>
@@ -302,30 +271,25 @@
             <trans-unit id="tx_nrllm_configuration.prefer_lowest_cost">
                 <source>Prefer Lowest Cost</source>
             </trans-unit>
-
             <!-- Provider Table -->
             <trans-unit id="tx_nrllm_provider">
                 <source>LLM API Provider</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.identifier">
                 <source>Identifier</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_provider.identifier.description">
                 <source>Unique technical identifier (lowercase, no spaces)</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.name">
                 <source>Name</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_provider.name.description">
                 <source>Human-readable display name for this provider</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.description">
                 <source>Description</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.trust_zone">
                 <source>Trust zone</source>
             </trans-unit>
@@ -386,106 +350,88 @@
             <trans-unit id="tx_nrllm_provider.adapter_type.custom">
                 <source>Custom (OpenAI-compatible)</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.endpoint_url">
                 <source>Endpoint URL</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_provider.endpoint_url.description">
                 <source>Custom API endpoint URL (leave empty for default)</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.api_key">
                 <source>API Key</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_provider.api_key.description">
                 <source>Your API key for authentication</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.organization_id">
                 <source>Organization ID</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_provider.organization_id.description">
                 <source>Optional organization ID (OpenAI, Azure)</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.api_timeout">
                 <source>API Timeout (seconds)</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_provider.api_timeout.description">
                 <source>Maximum time in seconds to wait for the complete API response, including connection (max 10s) and model processing time. Large or reasoning models may need 120-300 seconds. A configuration- or model-level timeout overrides this value per request.</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.max_retries">
                 <source>Max Retries</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_provider.max_retries.description">
                 <source>Number of retries after the first failed request (0 = try once, no retries)</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.options">
                 <source>Additional Options</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_provider.options.description">
                 <source>Additional provider-specific options as JSON. Supported: {"customHeaders": {"X-Custom-Header": "value"}} to send extra HTTP headers.</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.is_active">
                 <source>Active</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_provider.is_active.description">
                 <source>Enable this provider for use in models</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_provider.priority">
                 <source>Priority</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_provider.priority.description">
                 <source>Higher priority providers are preferred for auto-selection (0-100)</source>
             </trans-unit>
-
             <trans-unit id="palette.connection">
                 <source>Connection Settings</source>
             </trans-unit>
-
             <trans-unit id="palette.request">
                 <source>Request Settings</source>
             </trans-unit>
-
             <trans-unit id="palette.advanced">
                 <source>Advanced Settings</source>
             </trans-unit>
-
             <trans-unit id="tab.connection">
                 <source>Connection</source>
             </trans-unit>
-
             <trans-unit id="tab.advanced">
                 <source>Advanced</source>
             </trans-unit>
-
             <!-- Model Table -->
             <trans-unit id="tx_nrllm_model">
                 <source>LLM Model</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.identifier">
                 <source>Identifier</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.identifier.description">
                 <source>Unique technical identifier (lowercase, no spaces)</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.name">
                 <source>Name</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.name.description">
                 <source>Human-readable display name for this model</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.description">
                 <source>Description</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.provider_uid">
                 <source>Provider</source>
             </trans-unit>
@@ -495,35 +441,30 @@
             <trans-unit id="tx_nrllm_model.provider_uid.select">
                 <source>-- Select Provider --</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.model_id">
                 <source>Model ID</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.model_id.description">
                 <source>The model identifier as used in API calls (e.g., gpt-4o, claude-3-5-sonnet)</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.context_length">
                 <source>Context Length</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.context_length.description">
                 <source>Maximum context window in tokens (0 = unknown)</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.max_output_tokens">
                 <source>Max Output Tokens</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.max_output_tokens.description">
                 <source>Maximum output tokens per request (0 = unknown). Used as the default output cap for requests that do not set max tokens themselves.</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.dimensions">
                 <source>Embedding Dimensions</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.dimensions.description">
                 <source>Embedding vector dimensionality of the model (0 = unknown). Used as the default vector size for embedding requests that do not set dimensions themselves.</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.capabilities">
                 <source>Capabilities</source>
             </trans-unit>
@@ -551,7 +492,6 @@
             <trans-unit id="tx_nrllm_model.capabilities_source.description">
                 <source>"discovery" = the provider's own model endpoint reported these capabilities. "catalog" = it did not — either it was unreachable, or it lists model ids without capabilities — and the bundled static catalog supplied them, which is a guess, not a confirmation.</source>
             </trans-unit>
-
             <!-- Capability labels and descriptions -->
             <trans-unit id="tx_nrllm_model.capabilities.chat">
                 <source>Chat</source>
@@ -559,230 +499,193 @@
             <trans-unit id="tx_nrllm_model.capabilities.chat.description">
                 <source>Conversational interactions with message history. Supports system prompts, user messages, and assistant responses.</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.capabilities.completion">
                 <source>Completion</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.capabilities.completion.description">
                 <source>Text completion from a prompt. Legacy API format, less common in modern models.</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.capabilities.embeddings">
                 <source>Embeddings</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.capabilities.embeddings.description">
                 <source>Generate vector embeddings for semantic search, similarity comparison, and RAG applications.</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.capabilities.vision">
                 <source>Vision</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.capabilities.vision.description">
                 <source>Analyze images and visual content. Accepts image URLs or base64-encoded images in messages.</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.capabilities.streaming">
                 <source>Streaming</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.capabilities.streaming.description">
                 <source>Receive responses token-by-token via Server-Sent Events for real-time output display.</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.capabilities.tools">
                 <source>Tool Use</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.capabilities.tools.description">
                 <source>Function calling / tool use. Model can request to call defined functions with structured arguments.</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.capabilities.json_mode">
                 <source>JSON Mode</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.capabilities.json_mode.description">
                 <source>Guaranteed valid JSON output. Use for structured data extraction and API integrations.</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.capabilities.audio">
                 <source>Audio</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.capabilities.audio.description">
                 <source>Process audio input (speech-to-text) or generate audio output (text-to-speech).</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.capabilities.image">
                 <source>Image Generation</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.capabilities.image.description">
                 <source>Generate images from text prompts. The DALL-E / gpt-image service resolves its default model from active records carrying this capability.</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.capabilities.text_to_speech">
                 <source>Text to Speech</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.capabilities.text_to_speech.description">
                 <source>Synthesize spoken audio from text. Used by the specialized TTS service to resolve its default model.</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.capabilities.transcription">
                 <source>Transcription</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.capabilities.transcription.description">
                 <source>Transcribe audio to text (speech-to-text). Used by the specialized Whisper service to resolve its default model.</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.default_timeout">
                 <source>Default Timeout</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.default_timeout.description">
                 <source>Default timeout in seconds for requests to this model. Thinking/reasoning models may need longer timeouts (120-300s).</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.cost_input">
                 <source>Input Cost</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.cost_input.description">
                 <source>Cost per 1 million input tokens in cents</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.cost_output">
                 <source>Output Cost</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.cost_output.description">
                 <source>Cost per 1 million output tokens in cents</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.is_active">
                 <source>Active</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.is_active.description">
                 <source>Enable this model for use in configurations</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_model.is_default">
                 <source>Default Model</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_model.is_default.description">
                 <source>Use as the default model for new configurations</source>
             </trans-unit>
-
             <trans-unit id="tab.capabilities">
                 <source>Capabilities</source>
             </trans-unit>
-
             <trans-unit id="tab.pricing">
                 <source>Pricing</source>
             </trans-unit>
-
             <trans-unit id="palette.model_limits">
                 <source>Model Limits</source>
             </trans-unit>
-
             <trans-unit id="palette.pricing">
                 <source>Pricing</source>
             </trans-unit>
-
             <!-- Task Table -->
             <trans-unit id="tx_nrllm_task">
                 <source>LLM Task</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.identifier">
                 <source>Identifier</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_task.identifier.description">
                 <source>Unique technical identifier (lowercase, no spaces)</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.name">
                 <source>Name</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_task.name.description">
                 <source>Human-readable display name for this task</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.description">
                 <source>Description</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.category">
                 <source>Category</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_task.category.description">
                 <source>Task category for organization and filtering</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.configuration_uid">
                 <source>Configuration</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_task.configuration_uid.description">
                 <source>LLM configuration to use for this task</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.prompt_template">
                 <source>Prompt Template</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_task.prompt_template.description">
                 <source>Template with placeholders like {{input}} for the LLM prompt</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.input_type">
                 <source>Input Type</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_task.input_type.description">
                 <source>Type of input data source for this task</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.input_source">
                 <source>Input Source</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_task.input_source.description">
                 <source>JSON configuration for the input source</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.output_format">
                 <source>Output Format</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_task.output_format.description">
                 <source>Expected format of the LLM response</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.is_active">
                 <source>Active</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_task.is_active.description">
                 <source>Enable this task for execution</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.is_system">
                 <source>System Task</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_task.is_system.description">
                 <source>System tasks are managed by extensions and should not be modified</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.skills">
                 <source>Attached Skills</source>
             </trans-unit>
             <trans-unit id="tx_nrllm_task.skills.description">
                 <source>Skills attached here are injected into this task's text-generation prompt, in addition to any skills on the selected configuration</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.tab.input_output">
                 <source>Input / Output</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.palette.input">
                 <source>Input Configuration</source>
             </trans-unit>
-
             <trans-unit id="tx_nrllm_task.palette.output">
                 <source>Output Configuration</source>
             </trans-unit>
-
             <trans-unit id="palette.settings">
                 <source>Settings</source>
             </trans-unit>
-
             <!-- Task category select items -->
             <trans-unit id="tx_nrllm_task.category.log_analysis">
                 <source>Log Analysis</source>
@@ -799,12 +702,10 @@
             <trans-unit id="tx_nrllm_task.category.general">
                 <source>General</source>
             </trans-unit>
-
             <!-- Task configuration_uid select items -->
             <trans-unit id="tx_nrllm_task.configuration_uid.default">
                 <source>-- Use Default Configuration --</source>
             </trans-unit>
-
             <!-- Task input_type select items -->
             <trans-unit id="tx_nrllm_task.input_type.manual">
                 <source>Manual Input</source>
@@ -821,7 +722,6 @@
             <trans-unit id="tx_nrllm_task.input_type.file">
                 <source>File</source>
             </trans-unit>
-
             <!-- Task output_format select items -->
             <trans-unit id="tx_nrllm_task.output_format.markdown">
                 <source>Markdown</source>
@@ -835,12 +735,10 @@
             <trans-unit id="tx_nrllm_task.output_format.html">
                 <source>HTML</source>
             </trans-unit>
-
             <!-- Configuration model_uid select items -->
             <trans-unit id="tx_nrllm_configuration.model_uid.select">
                 <source>-- Select Model --</source>
             </trans-unit>
-
             <!-- Configuration adapter select items (model_selection_criteria) -->
             <trans-unit id="tx_nrllm_configuration.adapter.openai">
                 <source>OpenAI</source>
@@ -863,7 +761,6 @@
             <trans-unit id="tx_nrllm_configuration.adapter.ollama">
                 <source>Ollama</source>
             </trans-unit>
-
             <!-- Configuration translator select items -->
             <trans-unit id="tx_nrllm_configuration.translator.none">
                 <source>None (use LLM)</source>
@@ -871,7 +768,6 @@
             <trans-unit id="tx_nrllm_configuration.translator.deepl">
                 <source>DeepL</source>
             </trans-unit>
-
             <!-- Prompt snippet table -->
             <trans-unit id="tx_nrllm_promptsnippet">
                 <source>LLM Prompt Snippet</source>
@@ -1053,7 +949,6 @@
             <trans-unit id="tx_nrllm_skill.enabled">
                 <source>Enabled</source>
             </trans-unit>
-
             <!-- MCP server (ADR-116) -->
             <trans-unit id="tx_nrllm_mcp_server">
                 <source>MCP Server</source>
@@ -1163,7 +1058,6 @@
             <trans-unit id="tx_nrllm_mcp_server.enabled.description">
                 <source>Off until an operator switches it on. A disabled server keeps its catalogue but contributes no tools.</source>
             </trans-unit>
-
             <!-- Tool data class (ADR-094) -->
             <trans-unit id="tx_nrllm.tool_data_class.publicContent">
                 <source>Public content</source>


### PR DESCRIPTION
`runTests.sh -s fractor -n` (typo3-ci-workflows v1.11.0) fails on this repository: 46 language files differ from PrettyXml's canonical formatting, so every fractor run reports `46 files would have been changed`. This is the one-time write run that settles it — from here on, `-s fractor -n` is a meaningful gate.

**Formatting only, proven rather than asserted.** All 46 files were compared old-vs-new as parsed XML:

- every attribute identical,
- every leaf text (`source`, `target`, `note`) identical — exact comparison, including internal whitespace,
- none of the files contains mixed content (text around inline elements) that such a comparison could miss.

The diff is −329/+100 lines of indentation and attribute order; the largest file (`de.locallang.xlf`, 248 KB) shrinks by 26 bytes.

**Verified:** `-s fractor -n` exit 1 before (`would change 46 file(s)`), exit 0 after (`Fractor is done!`). Gate: changelog, cgl, phpstan, unit (7318 tests), fuzzy (86 tests) all green locally. The **rector leg did not run locally** — this worktree's `.Build` is resolved for PHP ≥ 8.4 and the 8.2 pin hits composer's `platform_check`, exactly the case the Makefile names ("CI is the only place it will [run]. Say so rather than reporting it green."). No PHP file is touched by this change, and CI runs rector on this PR.

No CHANGELOG entry: nothing user-facing changes.

Background: this is the reproduction case behind [FriendsOfTYPO3/fractor#432](https://github.com/FriendsOfTYPO3/fractor/issues/432) — fractor's dry run used to exit 0 over exactly these 46 files. Upstream fixes it properly in [fractor#430](https://github.com/FriendsOfTYPO3/fractor/pull/430); this PR removes the pending changes on our side either way.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01GSptxPLHWsttu9FuqVkvYZ)_
