### PR TITLE
chore(ddev): bump MariaDB 11.4 to 12.3

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -10,7 +10,7 @@ router_https_port: "443"
 xdebug_enabled: false
 database:
   type: mariadb
-  version: "11.4"
+  version: "12.3"
 additional_hostnames:
   - docs.nr-llm
   - v14.nr-llm


### PR DESCRIPTION
## What

Bumps the ddev database from MariaDB 11.4 to 12.3 (`.ddev/config.yaml`), aligning local dev with the newest current LTS.

## Context

- `e2e.yml` already runs `mariadb:12.3`; local ddev was three minor series behind.
- `ci.yml`'s functional job deliberately stays on `mariadb:11.8` — its comment names 11.8 and 12.3 as the two current LTS series, so that spread is intentional and untouched here.

## Operator note

ddev does not migrate data across this jump in place. After pulling, run:

```
ddev export-db > dump.sql.gz
ddev delete --omit-snapshot
ddev start
ddev import-db < dump.sql.gz
```

## Scope note

No CHANGELOG entry: `.ddev/` is developer-local configuration and ships to no consumer of the extension.

_Assisted by sisyphus:x-preview-f-free — session ses_fc4fa40efffed6DRreictQgSlJ_
